### PR TITLE
feat: 终端新增行号/时间侧栏，支持独立开关与快捷键

### DIFF
--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -368,6 +368,20 @@ public class TerminalBehaviorOptions : ObservableOptions
         set => Set(ref field, value);
     }
 
+    /// <summary>开 = 侧栏显示折叠标记列,可折叠标记之前的历史内容(WindTerm 式,默认关)。</summary>
+    public bool ShowFoldMarker
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
+    /// <summary>开 = 在侧栏与命令输出之间插入约 5px 的空白间隔(默认关)。</summary>
+    public bool GutterBlank
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
     public bool ScrollOnKeystroke
     {
         get;

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -354,6 +354,20 @@ public class TerminalBehaviorOptions : ObservableOptions
         set => Set(ref field, value);
     }
 
+    /// <summary>开 = 每行左侧显示 [HH:mm:ss] 收行时间(默认关,占用左侧宽度)。与 <see cref="ShowLineNumber" /> 独立。</summary>
+    public bool ShowLineTimestamp
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
+    /// <summary>开 = 每行左侧显示缓冲区行号(默认关,占用左侧宽度)。与 <see cref="ShowLineTimestamp" /> 独立。</summary>
+    public bool ShowLineNumber
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
     public bool ScrollOnKeystroke
     {
         get;

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2045,6 +2045,30 @@
   <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
     <value>各行のバッファ行番号を左側の余白に表示します(幅を消費します)。</value>
   </data>
+  <data name="SetTerm_ShowFoldMarker" xml:space="preserve">
+    <value>折り畳みマーカーの余白</value>
+  </data>
+  <data name="SetTerm_ShowFoldMarkerDesc" xml:space="preserve">
+    <value>折り畳み列を表示し、以前の出力を展開可能な領域に折り畳めます。</value>
+  </data>
+  <data name="SetTerm_GutterBlank" xml:space="preserve">
+    <value>余白の間隔</value>
+  </data>
+  <data name="SetTerm_GutterBlankDesc" xml:space="preserve">
+    <value>余白と出力の間に約 5px の空白を追加します。</value>
+  </data>
+  <data name="Gutter_LineNumber" xml:space="preserve">
+    <value>行番号</value>
+  </data>
+  <data name="Gutter_Timestamp" xml:space="preserve">
+    <value>タイムスタンプ</value>
+  </data>
+  <data name="Gutter_FoldMarker" xml:space="preserve">
+    <value>折り畳みマーカー</value>
+  </data>
+  <data name="Gutter_Blank" xml:space="preserve">
+    <value>空白</value>
+  </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 履歴の閲覧中に新しい出力があると最下部へ移動します。オフの場合は現在位置を維持</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -118,6 +118,9 @@
   <data name="Cmd_ClearScreen" xml:space="preserve">
     <value>画面をクリア</value>
   </data>
+  <data name="Cmd_ToggleLineGutter" xml:space="preserve">
+    <value>行番号/時刻の余白を切り替え</value>
+  </data>
   <data name="Cmd_CloneSession" xml:space="preserve">
     <value>セッションを複製</value>
   </data>
@@ -2029,6 +2032,18 @@
   </data>
   <data name="SetTerm_ScrollOnOutput" xml:space="preserve">
     <value>出力時に自動スクロール</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestamp" xml:space="preserve">
+    <value>行の時刻余白</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestampDesc" xml:space="preserve">
+    <value>各行の受信時刻(HH:mm:ss)を左側の余白に表示します(幅を消費します)。</value>
+  </data>
+  <data name="SetTerm_ShowLineNumber" xml:space="preserve">
+    <value>行番号の余白</value>
+  </data>
+  <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
+    <value>各行のバッファ行番号を左側の余白に表示します(幅を消費します)。</value>
   </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 履歴の閲覧中に新しい出力があると最下部へ移動します。オフの場合は現在位置を維持</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2045,6 +2045,30 @@
   <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
     <value>각 줄의 버퍼 줄 번호를 왼쪽 여백에 표시합니다(너비를 차지함).</value>
   </data>
+  <data name="SetTerm_ShowFoldMarker" xml:space="preserve">
+    <value>접기 마커 여백</value>
+  </data>
+  <data name="SetTerm_ShowFoldMarkerDesc" xml:space="preserve">
+    <value>접기 열을 표시하여 이전 출력을 펼칠 수 있는 영역으로 접습니다.</value>
+  </data>
+  <data name="SetTerm_GutterBlank" xml:space="preserve">
+    <value>여백 간격</value>
+  </data>
+  <data name="SetTerm_GutterBlankDesc" xml:space="preserve">
+    <value>여백과 출력 사이에 약 5px의 공백을 추가합니다.</value>
+  </data>
+  <data name="Gutter_LineNumber" xml:space="preserve">
+    <value>행 번호</value>
+  </data>
+  <data name="Gutter_Timestamp" xml:space="preserve">
+    <value>타임스탬프</value>
+  </data>
+  <data name="Gutter_FoldMarker" xml:space="preserve">
+    <value>접기 마커</value>
+  </data>
+  <data name="Gutter_Blank" xml:space="preserve">
+    <value>공백</value>
+  </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 기록을 보는 중 새 출력이 있으면 맨 아래로 이동, 끄면 현재 위치 유지</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -118,6 +118,9 @@
   <data name="Cmd_ClearScreen" xml:space="preserve">
     <value>화면 지우기</value>
   </data>
+  <data name="Cmd_ToggleLineGutter" xml:space="preserve">
+    <value>행 번호/시간 여백 전환</value>
+  </data>
   <data name="Cmd_CloneSession" xml:space="preserve">
     <value>세션 복제</value>
   </data>
@@ -2029,6 +2032,18 @@
   </data>
   <data name="SetTerm_ScrollOnOutput" xml:space="preserve">
     <value>출력 시 자동 스크롤</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestamp" xml:space="preserve">
+    <value>행 시각 여백</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestampDesc" xml:space="preserve">
+    <value>각 줄의 수신 시각(HH:mm:ss)을 왼쪽 여백에 표시합니다(너비를 차지함).</value>
+  </data>
+  <data name="SetTerm_ShowLineNumber" xml:space="preserve">
+    <value>행 번호 여백</value>
+  </data>
+  <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
+    <value>각 줄의 버퍼 줄 번호를 왼쪽 여백에 표시합니다(너비를 차지함).</value>
   </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 기록을 보는 중 새 출력이 있으면 맨 아래로 이동, 끄면 현재 위치 유지</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2114,6 +2114,30 @@ Paste anyway?</value>
   <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
     <value>Show each line's buffer line number in a left gutter.</value>
   </data>
+  <data name="SetTerm_ShowFoldMarker" xml:space="preserve">
+    <value>Fold marker gutter</value>
+  </data>
+  <data name="SetTerm_ShowFoldMarkerDesc" xml:space="preserve">
+    <value>Show a fold column to collapse earlier output into expandable regions.</value>
+  </data>
+  <data name="SetTerm_GutterBlank" xml:space="preserve">
+    <value>Gutter spacing</value>
+  </data>
+  <data name="SetTerm_GutterBlankDesc" xml:space="preserve">
+    <value>Add a small blank gap between the gutter and the output.</value>
+  </data>
+  <data name="Gutter_LineNumber" xml:space="preserve">
+    <value>Line number</value>
+  </data>
+  <data name="Gutter_Timestamp" xml:space="preserve">
+    <value>Timestamp</value>
+  </data>
+  <data name="Gutter_FoldMarker" xml:space="preserve">
+    <value>Fold marker</value>
+  </data>
+  <data name="Gutter_Blank" xml:space="preserve">
+    <value>Spacing</value>
+  </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// Jump to the bottom on new output while viewing history; off keeps the current position</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -463,6 +463,9 @@ If this keeps happening, close any other VelaShell windows and try again.</value
   <data name="Cmd_ClearScreen" xml:space="preserve">
     <value>Clear Screen</value>
   </data>
+  <data name="Cmd_ToggleLineGutter" xml:space="preserve">
+    <value>Toggle line number &amp; time gutter</value>
+  </data>
   <data name="Cmd_CloneSession" xml:space="preserve">
     <value>Clone Session</value>
   </data>
@@ -2098,6 +2101,18 @@ Paste anyway?</value>
   </data>
   <data name="SetTerm_ScrollOnOutput" xml:space="preserve">
     <value>Scroll on output</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestamp" xml:space="preserve">
+    <value>Line timestamp gutter</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestampDesc" xml:space="preserve">
+    <value>Show each line's receive time (HH:mm:ss) in a left gutter.</value>
+  </data>
+  <data name="SetTerm_ShowLineNumber" xml:space="preserve">
+    <value>Line number gutter</value>
+  </data>
+  <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
+    <value>Show each line's buffer line number in a left gutter.</value>
   </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// Jump to the bottom on new output while viewing history; off keeps the current position</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2206,6 +2206,30 @@
   <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
     <value>在左侧栏显示每行的缓冲区行号,会占用一定宽度。</value>
   </data>
+  <data name="SetTerm_ShowFoldMarker" xml:space="preserve">
+    <value>折叠标记侧栏</value>
+  </data>
+  <data name="SetTerm_ShowFoldMarkerDesc" xml:space="preserve">
+    <value>显示折叠列,可把较早的输出折叠成可展开的区域。</value>
+  </data>
+  <data name="SetTerm_GutterBlank" xml:space="preserve">
+    <value>侧栏间隔</value>
+  </data>
+  <data name="SetTerm_GutterBlankDesc" xml:space="preserve">
+    <value>在侧栏与输出之间加一段约 5px 的空白间隔。</value>
+  </data>
+  <data name="Gutter_LineNumber" xml:space="preserve">
+    <value>行号</value>
+  </data>
+  <data name="Gutter_Timestamp" xml:space="preserve">
+    <value>时间戳</value>
+  </data>
+  <data name="Gutter_FoldMarker" xml:space="preserve">
+    <value>折叠标记</value>
+  </data>
+  <data name="Gutter_Blank" xml:space="preserve">
+    <value>空白</value>
+  </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 翻看历史时有新输出立即拉回底部;关闭则停留在当前位置</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -555,6 +555,9 @@
   <data name="Cmd_ClearScreen" xml:space="preserve">
     <value>清屏</value>
   </data>
+  <data name="Cmd_ToggleLineGutter" xml:space="preserve">
+    <value>切换行号/时间侧栏</value>
+  </data>
   <data name="Cmd_CloneSession" xml:space="preserve">
     <value>克隆会话</value>
   </data>
@@ -2190,6 +2193,18 @@
   </data>
   <data name="SetTerm_ScrollOnOutput" xml:space="preserve">
     <value>有输出时自动滚动</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestamp" xml:space="preserve">
+    <value>行时间侧栏</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestampDesc" xml:space="preserve">
+    <value>在左侧栏显示每行的收行时间(HH:mm:ss),会占用一定宽度。</value>
+  </data>
+  <data name="SetTerm_ShowLineNumber" xml:space="preserve">
+    <value>行号侧栏</value>
+  </data>
+  <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
+    <value>在左侧栏显示每行的缓冲区行号,会占用一定宽度。</value>
   </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 翻看历史时有新输出立即拉回底部;关闭则停留在当前位置</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2045,6 +2045,30 @@
   <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
     <value>在左側欄顯示每行的緩衝區行號,會佔用一定寬度。</value>
   </data>
+  <data name="SetTerm_ShowFoldMarker" xml:space="preserve">
+    <value>摺疊標記側欄</value>
+  </data>
+  <data name="SetTerm_ShowFoldMarkerDesc" xml:space="preserve">
+    <value>顯示摺疊列,可把較早的輸出摺疊成可展開的區域。</value>
+  </data>
+  <data name="SetTerm_GutterBlank" xml:space="preserve">
+    <value>側欄間隔</value>
+  </data>
+  <data name="SetTerm_GutterBlankDesc" xml:space="preserve">
+    <value>在側欄與輸出之間加一段約 5px 的空白間隔。</value>
+  </data>
+  <data name="Gutter_LineNumber" xml:space="preserve">
+    <value>行號</value>
+  </data>
+  <data name="Gutter_Timestamp" xml:space="preserve">
+    <value>時間戳</value>
+  </data>
+  <data name="Gutter_FoldMarker" xml:space="preserve">
+    <value>摺疊標記</value>
+  </data>
+  <data name="Gutter_Blank" xml:space="preserve">
+    <value>空白</value>
+  </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 檢視歷史時有新輸出立即捲回底部;關閉則停留在目前位置</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -118,6 +118,9 @@
   <data name="Cmd_ClearScreen" xml:space="preserve">
     <value>清除畫面</value>
   </data>
+  <data name="Cmd_ToggleLineGutter" xml:space="preserve">
+    <value>切換行號/時間側欄</value>
+  </data>
   <data name="Cmd_CloneSession" xml:space="preserve">
     <value>複製工作階段</value>
   </data>
@@ -2029,6 +2032,18 @@
   </data>
   <data name="SetTerm_ScrollOnOutput" xml:space="preserve">
     <value>有輸出時自動捲動</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestamp" xml:space="preserve">
+    <value>行時間側欄</value>
+  </data>
+  <data name="SetTerm_ShowLineTimestampDesc" xml:space="preserve">
+    <value>在左側欄顯示每行的收行時間(HH:mm:ss),會佔用一定寬度。</value>
+  </data>
+  <data name="SetTerm_ShowLineNumber" xml:space="preserve">
+    <value>行號側欄</value>
+  </data>
+  <data name="SetTerm_ShowLineNumberDesc" xml:space="preserve">
+    <value>在左側欄顯示每行的緩衝區行號,會佔用一定寬度。</value>
   </data>
   <data name="SetTerm_ScrollOnOutputDesc" xml:space="preserve">
     <value>// 檢視歷史時有新輸出立即捲回底部;關閉則停留在目前位置</value>

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -176,7 +176,7 @@ public sealed class TerminalEmulator : IVtActions
             case '\v': // VT
             case '\f': // FF
                 _pendingWrap = false;
-                Screen.Index(Blank());
+                IndexAndStamp();
                 if (Modes.NewLineMode)
                 {
                     Screen.SetCursorX(0);
@@ -225,14 +225,14 @@ public sealed class TerminalEmulator : IVtActions
         switch (final)
         {
             case 'D':
-                Screen.Index(Blank());
+                IndexAndStamp();
                 break; // IND
             case 'M':
                 Screen.ReverseIndex(Blank());
                 break; // RI
             case 'E':
                 Screen.SetCursorX(0);
-                Screen.Index(Blank());
+                IndexAndStamp();
                 break; // NEL
             case 'H':
                 _tabStops[Math.Clamp(Screen.CursorX, 0, _tabStops.Length - 1)] = true;
@@ -548,7 +548,17 @@ public sealed class TerminalEmulator : IVtActions
     private void CarriageReturnLineFeed()
     {
         Screen.SetCursorX(0);
+        IndexAndStamp();
+    }
+
+    /// <summary>
+    /// Line feed 并给落到的行盖上本次 Feed 的时间戳。这样即使是输出里的空行(仅 \r\n,无可打印字符),
+    /// 也被视为「该次输出产生的真实行」,侧栏据此显示其行号/时间;而光标从未到过的屏幕底部空行不会被盖章。
+    /// </summary>
+    private void IndexAndStamp()
+    {
         Screen.Index(Blank());
+        Screen.ActiveLine(Screen.CursorY).Timestamp = _feedTimestamp;
     }
 
     private void HorizontalTab()

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -34,6 +34,7 @@ public sealed class TerminalEmulator : IVtActions
     private int _gl; // active GL set index
 
     private bool _pendingWrap; // deferred autowrap at end of line
+    private DateTime _feedTimestamp = DateTime.Now; // 当前 Feed 到达时刻,用于给写入的行盖时间戳(行号侧栏)
 
     // Saved cursor (DECSC / DECRC, CSI s/u, DECSET 1048)
     private SavedCursor? _saved;
@@ -121,6 +122,9 @@ public sealed class TerminalEmulator : IVtActions
             Flags = _flags
         };
         Screen.SetCell(Screen.CursorX, Screen.CursorY, cell);
+        // 行时间戳取「本次 Feed 到达时刻」——按 chunk 取一次,避免逐字符 DateTime.Now;
+        // 同一行被多次写入时以最后一次为准(= 该行最后收到输出的时间)。
+        Screen.ActiveLine(Screen.CursorY).Timestamp = _feedTimestamp;
         if (width == 2)
         {
             TerminalCell trailing = cell;
@@ -479,6 +483,7 @@ public sealed class TerminalEmulator : IVtActions
     /// <summary>Feeds raw bytes from the host. UTF-8 is decoded before parsing.</summary>
     public void Feed(ReadOnlySpan<byte> bytes)
     {
+        _feedTimestamp = DateTime.Now;
         string decoded = _utf8.Decode(bytes);
         if (decoded.Length > 0)
         {

--- a/src/VelaShell.Terminal/Emulation/TerminalRow.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalRow.cs
@@ -13,6 +13,12 @@ public sealed class TerminalRow(int columns)
     /// <summary>True when the line was ended by autowrap rather than an explicit newline.</summary>
     public bool Wrapped { get; set; }
 
+    /// <summary>
+    /// Wall-clock time the row last received output (行号/时间侧栏用)。Null 表示尚未写入过内容
+    /// 的空行——侧栏据此对空行不显示时间。行对象在滚动/换行时按引用迁入 scrollback,时间戳随之保留。
+    /// </summary>
+    public DateTime? Timestamp { get; set; }
+
     public int Columns => _cells.Length;
 
     public TerminalCell this[int col]
@@ -30,6 +36,7 @@ public sealed class TerminalRow(int columns)
             _cells[i] = cell;
         }
         Wrapped = false;
+        Timestamp = null; // 整行清空(擦除/复用作滚动新行)→ 视为未写入,时间戳作废。
     }
 
     public void FillRange(int start, int endExclusive, in TerminalCell cell)
@@ -112,7 +119,7 @@ public sealed class TerminalRow(int columns)
 
     public TerminalRow Clone()
     {
-        var clone = new TerminalRow(_cells.Length) { Wrapped = Wrapped };
+        var clone = new TerminalRow(_cells.Length) { Wrapped = Wrapped, Timestamp = Timestamp };
         Array.Copy(_cells, clone._cells, _cells.Length);
         return clone;
     }

--- a/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
@@ -488,9 +488,16 @@ public sealed class TerminalScreen
             // segment is trimmed at the last non-blank cell (extended to cover the cursor).
             var cells = new List<TerminalCell>();
             int cursorOffset = -1;
+            DateTime? lineTimestamp = null;
             for (int r = i; r <= j; r++)
             {
                 TerminalRow row = physical[r];
+                // 行时间戳(时间/行号侧栏)必须穿过 reflow —— 否则改列宽(含开关侧栏导致的列变化)
+                // 会把历史行的时间戳清空。取该逻辑行各物理段中最后一个非空时间戳(= 最后收到输出的时间)。
+                if (row.Timestamp is { } t)
+                {
+                    lineTimestamp = t;
+                }
                 int len = r < j ? row.Columns : row.LastNonBlank() + 1;
                 if (r == cursorAbs)
                 {
@@ -503,7 +510,12 @@ public sealed class TerminalScreen
                     cells.Add(row[c]);
                 }
             }
+            int emittedStart = rebuilt.Count;
             EmitLogicalLine(cells, cursorOffset, newCols, blank, rebuilt, ref newCursorRow, ref newCursorCol);
+            for (int r = emittedStart; r < rebuilt.Count; r++)
+            {
+                rebuilt[r].Timestamp = lineTimestamp;
+            }
             i = j + 1;
         }
         if (rebuilt.Count == 0)

--- a/src/VelaShell.Terminal/Rendering/GutterFoldModel.cs
+++ b/src/VelaShell.Terminal/Rendering/GutterFoldModel.cs
@@ -1,0 +1,186 @@
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Rendering;
+
+/// <summary>
+/// 侧栏折叠模型(WindTerm 式历史折叠)。折叠区域按「<see cref="TerminalRow" /> 对象引用」锚定:
+/// 内容滚入 scrollback 时行对象按引用迁移,折叠随之保留;列宽 reflow 会重建行对象,届时由
+/// <see cref="Clear" /> 使折叠失效。本类 UI 无关(只依赖 <see cref="TerminalScreen" />),可独立单测。
+/// </summary>
+public sealed class GutterFoldModel
+{
+    private sealed class Region
+    {
+        public required TerminalRow Anchor; // 折叠后仍可见的折叠头(区域末行 = 用户点击的那一行)
+        public required TerminalRow[] Rows; // 区域全部行(含 Anchor),按缓冲区顺序
+    }
+
+    private readonly List<Region> _regions = [];
+
+    /// <summary>当前是否存在折叠。无折叠时调用方走连续快路径,零开销。</summary>
+    public bool HasFolds => _regions.Count > 0;
+
+    /// <summary>折叠区域数量。</summary>
+    public int Count => _regions.Count;
+
+    public void Clear() => _regions.Clear();
+
+    /// <summary>绝对行 <paramref name="abs" /> 是否某折叠区域的折叠头(可点击展开)。</summary>
+    public bool IsAnchor(TerminalScreen screen, int abs)
+    {
+        if (_regions.Count == 0 || abs < 0 || abs >= screen.TotalRows)
+        {
+            return false;
+        }
+        TerminalRow row = screen.ViewLine(abs);
+        foreach (Region r in _regions)
+        {
+            if (ReferenceEquals(r.Anchor, row))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 本帧可见的绝对行序列(隐藏被折叠的非折叠头行);无折叠返回 null 表示走连续快路径。
+    /// </summary>
+    public List<int>? VisibleRowsOrNull(TerminalScreen screen)
+    {
+        if (_regions.Count == 0)
+        {
+            return null;
+        }
+        PruneStale(screen);
+        if (_regions.Count == 0)
+        {
+            return null;
+        }
+        var hidden = new HashSet<TerminalRow>();
+        foreach (Region reg in _regions)
+        {
+            foreach (TerminalRow r in reg.Rows)
+            {
+                if (!ReferenceEquals(r, reg.Anchor))
+                {
+                    hidden.Add(r);
+                }
+            }
+        }
+        var vis = new List<int>(screen.TotalRows);
+        for (int abs = 0; abs < screen.TotalRows; abs++)
+        {
+            if (!hidden.Contains(screen.ViewLine(abs)))
+            {
+                vis.Add(abs);
+            }
+        }
+        return vis;
+    }
+
+    /// <summary>
+    /// 点击绝对行 <paramref name="abs" />:若它是折叠头则展开;否则把「上一折叠边界 .. abs」折叠成
+    /// 一个新区域(点击的这一行作折叠头保留可见)。返回折叠状态是否发生变化。
+    /// </summary>
+    public bool Toggle(TerminalScreen screen, int abs)
+    {
+        if (abs < 0 || abs >= screen.TotalRows)
+        {
+            return false;
+        }
+        TerminalRow row = screen.ViewLine(abs);
+        for (int i = 0; i < _regions.Count; i++)
+        {
+            if (ReferenceEquals(_regions[i].Anchor, row))
+            {
+                _regions.RemoveAt(i); // 再点折叠头 → 展开
+                return true;
+            }
+        }
+        int startAbs = NearestBoundaryAbove(screen, abs);
+        if (abs <= startAbs)
+        {
+            return false; // 该行之前没有可折叠内容
+        }
+        int len = abs - startAbs + 1;
+        var rows = new TerminalRow[len];
+        for (int i = 0; i < len; i++)
+        {
+            rows[i] = screen.ViewLine(startAbs + i);
+        }
+        _regions.Add(new Region { Anchor = rows[^1], Rows = rows });
+        return true;
+    }
+
+    /// <summary>解析既有折叠,返回 <paramref name="abs" /> 之上最近折叠头的下一行(无则 0)。</summary>
+    private int NearestBoundaryAbove(TerminalScreen screen, int abs)
+    {
+        if (_regions.Count == 0)
+        {
+            return 0;
+        }
+        var absOf = new Dictionary<TerminalRow, int>();
+        for (int a = 0; a < screen.TotalRows; a++)
+        {
+            absOf[screen.ViewLine(a)] = a;
+        }
+        int boundary = 0;
+        foreach (Region reg in _regions)
+        {
+            int last = -1;
+            foreach (TerminalRow r in reg.Rows)
+            {
+                if (absOf.TryGetValue(r, out int a))
+                {
+                    last = Math.Max(last, a);
+                }
+            }
+            if (last >= 0 && last < abs)
+            {
+                boundary = Math.Max(boundary, last + 1);
+            }
+        }
+        return boundary;
+    }
+
+    /// <summary>
+    /// 填充「屏幕行 → 绝对缓冲行」映射(<paramref name="dest" />,长度 = 屏幕行数,-1 = 空):
+    /// <paramref name="visibleRows" /> 为 null 时走连续快路径(dest[sr]=top+sr),否则按可见序列取值。
+    /// 同时把 <paramref name="scrollOffset" /> 夹到可见范围(折叠会缩短可滚动范围)。纯计算,可单测。
+    /// </summary>
+    public static void FillScreenRowMap(int[] dest, List<int>? visibleRows, int totalRows, int screenRows, ref int scrollOffset)
+    {
+        int total = visibleRows?.Count ?? totalRows;
+        int maxOffset = Math.Max(0, total - screenRows);
+        if (scrollOffset > maxOffset)
+        {
+            scrollOffset = maxOffset;
+        }
+        if (scrollOffset < 0)
+        {
+            scrollOffset = 0;
+        }
+        int top = Math.Max(0, total - screenRows - scrollOffset);
+        for (int sr = 0; sr < screenRows; sr++)
+        {
+            int vi = top + sr;
+            dest[sr] = vi < total ? visibleRows?[vi] ?? vi : -1;
+        }
+    }
+
+    /// <summary>折叠头行已被 scrollback 淘汰(不在当前缓冲区)则折叠失效,清除之。</summary>
+    public void PruneStale(TerminalScreen screen)
+    {
+        if (_regions.Count == 0)
+        {
+            return;
+        }
+        var present = new HashSet<TerminalRow>();
+        for (int abs = 0; abs < screen.TotalRows; abs++)
+        {
+            present.Add(screen.ViewLine(abs));
+        }
+        _regions.RemoveAll(reg => !present.Contains(reg.Anchor));
+    }
+}

--- a/src/VelaShell.Terminal/Rendering/GutterLayout.cs
+++ b/src/VelaShell.Terminal/Rendering/GutterLayout.cs
@@ -1,0 +1,45 @@
+namespace VelaShell.Terminal.Rendering;
+
+/// <summary>
+/// 侧栏几何:各部件(时间戳 / 行号 / 折叠列 / 空白,按左→右顺序)的像素宽度、x 偏移与命中区间。
+/// 纯计算(只依赖单元格宽 + 四个开关),与控件解耦,可单测——折叠点击是否落在折叠列即由此判定。
+/// </summary>
+public readonly struct GutterLayout
+{
+    /// <summary>行号列固定 5 位(右对齐):默认 1 万行 scrollback 的最大行号约 5 位,宽度全程恒定。</summary>
+    public const int NumberDigits = 5;
+
+    /// <summary>“空白”部件:侧栏与正文间的固定间隔(px)。</summary>
+    public const double BlankPixels = 5.0;
+
+    public GutterLayout(double cellWidth, bool showTimestamp, bool showNumber, bool showFold, bool blank)
+    {
+        TimeWidth = showTimestamp ? 11 * cellWidth : 0;                // "[HH:mm:ss] " = 11 cells
+        NumberWidth = showNumber ? (NumberDigits + 1) * cellWidth : 0; // "NNNNN " = 6 cells
+        FoldWidth = showFold ? Math.Ceiling(cellWidth * 1.6) : 0;
+        BlankWidth = blank ? BlankPixels : 0;
+    }
+
+    public double TimeWidth { get; }
+    public double NumberWidth { get; }
+    public double FoldWidth { get; }
+    public double BlankWidth { get; }
+
+    /// <summary>行号列左边缘 x。</summary>
+    public double NumberLeft => TimeWidth;
+
+    /// <summary>折叠列左边缘 x。</summary>
+    public double FoldLeft => TimeWidth + NumberWidth;
+
+    /// <summary>侧栏总宽(全部部件关时为 0)。</summary>
+    public double TotalWidth => TimeWidth + NumberWidth + FoldWidth + BlankWidth;
+
+    /// <summary>是否有任一部件开启(需绘制侧栏)。</summary>
+    public bool Enabled => TotalWidth > 0;
+
+    /// <summary>控件坐标 x 是否落在侧栏区域内。</summary>
+    public bool ContainsX(double x) => Enabled && x < TotalWidth;
+
+    /// <summary>控件坐标 x 是否落在折叠列的可点击区间(折叠列 + 其右侧空白,便于命中)。</summary>
+    public bool IsFoldColumnHit(double x) => FoldWidth > 0 && x >= FoldLeft && x < TotalWidth;
+}

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -91,6 +91,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private int _runStyle = -1; // -1 = no active run; else (bold?1) | (italic?2)
 
     private int _scrollOffset; // lines scrolled up from the bottom (0 = live)
+    private bool _showLineTimestamp; // 左侧栏:显示收行时间(见 ShowLineTimestamp)
+    private bool _showLineNumber; // 左侧栏:显示缓冲区行号(见 ShowLineNumber)
 
     /// <summary>Search spans per absolute buffer row; the current hit is tinted differently.</summary>
     private Dictionary<int, List<(int Start, int End, bool Current)>>? _searchHighlights;
@@ -217,6 +219,41 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     /// <summary>BEL handling: "system" (beep), "none" (silent) or "visual" (screen flash).</summary>
     public string BellMode { get; set; } = "system";
+
+    /// <summary>
+    /// 左侧栏显示每行的收行时间 <c>[HH:mm:ss]</c>(设置 → 终端)。与 <see cref="ShowLineNumber" />
+    /// 相互独立:可只开时间、只开行号或都开。任一开启都会占用左侧宽度(减少可用列数,PTY 随之改列宽)。
+    /// </summary>
+    public bool ShowLineTimestamp
+    {
+        get => _showLineTimestamp;
+        set
+        {
+            if (_showLineTimestamp == value)
+            {
+                return;
+            }
+            _showLineTimestamp = value;
+            RelayoutFromBounds(); // 侧栏宽度变化 → 立即重算列数并通知 PTY。
+            InvalidateVisual();
+        }
+    }
+
+    /// <summary>左侧栏显示每行的缓冲区行号(设置 → 终端)。与 <see cref="ShowLineTimestamp" /> 相互独立。</summary>
+    public bool ShowLineNumber
+    {
+        get => _showLineNumber;
+        set
+        {
+            if (_showLineNumber == value)
+            {
+                return;
+            }
+            _showLineNumber = value;
+            RelayoutFromBounds();
+            InvalidateVisual();
+        }
+    }
 
     /// <summary>
     /// Enables the OS input method (Chinese/Japanese/Korean composition). Off = the
@@ -586,7 +623,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         int topAbsolute = screen.TotalRows - screen.Rows - _scrollOffset;
         int cursorAbsolute = screen.TotalRows - screen.Rows + screen.CursorY;
         int screenRow = cursorAbsolute - topAbsolute;
-        return new(screen.CursorX * _cellWidth, screenRow * _cellHeight, _cellWidth, _cellHeight);
+        return new(screen.CursorX * _cellWidth + GutterWidth(), screenRow * _cellHeight, _cellWidth, _cellHeight);
     }
 
     // ---- Palette ------------------------------------------------------------
@@ -809,7 +846,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             return;
         }
-        int cols = (int)(size.Width / _cellWidth);
+        int cols = (int)((size.Width - GutterWidth()) / _cellWidth);
         int rows = (int)(size.Height / _cellHeight);
 
         // Ignore early/degenerate layout passes (zero or sub-cell size). Collapsing the grid
@@ -852,6 +889,65 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         int cols = screen.Columns;
         int topAbsolute = Math.Max(0, screen.TotalRows - rows - _scrollOffset);
         ((int Row, int Col) Start, (int Row, int Col) End)? sel = NormalizedSelection();
+
+        // 行号/时间侧栏在正文左侧:先画侧栏,再把正文(含光标、选区)整体右移一个侧栏宽度绘制,
+        // 这样所有 col*_cellWidth 的坐标计算保持不变,只在命中测试处减去侧栏宽度即可。
+        if (GutterEnabled)
+        {
+            RenderGutter(context, screen, palette, topAbsolute, rows);
+        }
+        using (context.PushTransform(Matrix.CreateTranslation(GutterWidth(), 0)))
+        {
+            for (int screenRow = 0; screenRow < rows; screenRow++)
+            {
+                int absoluteRow = topAbsolute + screenRow;
+                if (absoluteRow >= screen.TotalRows)
+                {
+                    break;
+                }
+                TerminalRow line = screen.ViewLine(absoluteRow);
+                double y = screenRow * _cellHeight;
+                RenderLine(context, palette, line, cols, y, absoluteRow, sel);
+            }
+            if (_scrollOffset == 0)
+            {
+                RenderCursor(context, screen, palette, topAbsolute);
+            }
+        }
+
+        // Visual bell: a brief translucent flash over the whole terminal (§终端 → 视觉闪烁).
+        if (_bellFlashUntil > DateTime.UtcNow)
+        {
+            context.FillRectangle(BellFlashBrush, new(Bounds.Size));
+        }
+    }
+
+    // ---- Line gutter(时间/行号侧栏) ---------------------------------------
+
+    // 数字列固定 5 位(右对齐):默认 1 万行 scrollback 的最大行号约 5 位。取固定宽度而非按当前行数
+    // 动态计算,是为了侧栏宽度全程恒定 —— 既不在行数跨越 10/100/1000 时抖动,也不在主/备用屏(vim、
+    // htop:scrollback=0)切换时变宽,从而不会无谓地重排 PTY 列宽。
+    private const int GutterNumberWidth = 5;
+    private const string GutterTimeFormat = "HH:mm:ss";
+
+    /// <summary>时间/行号任一开启即绘制侧栏。</summary>
+    private bool GutterEnabled => _showLineTimestamp || _showLineNumber;
+
+    // 字符数按启用的部分累加:时间段 "[HH:mm:ss] "(11)、行号段 "NNNNN "(6);两者拼接即
+    // "[HH:mm:ss] NNNNN "。任一关闭则该段不占宽度。
+    private int GutterChars() => (_showLineTimestamp ? 11 : 0) + (_showLineNumber ? GutterNumberWidth + 1 : 0);
+
+    /// <summary>侧栏像素宽度(时间/行号都关时为 0)。</summary>
+    private double GutterWidth() => GutterChars() * _cellWidth;
+
+    private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int topAbsolute, int rows)
+    {
+        double gutter = GutterWidth();
+        // 侧栏底色:在默认底色上叠一层极淡前景,与正文区分;文本用前景/底色混出的暗色(不依赖具体主题)。
+        context.FillRectangle(BrushFor(Blend(palette.DefaultBackground, palette.DefaultForeground, 0.05)), new Rect(0, 0, gutter, Bounds.Height));
+        Rgba dim = Blend(palette.DefaultForeground, palette.DefaultBackground, 0.45);
+        ImmutableSolidColorBrush dimBrush = BrushFor(dim);
+        var typeface = new Typeface(FontFamily);
         for (int screenRow = 0; screenRow < rows; screenRow++)
         {
             int absoluteRow = topAbsolute + screenRow;
@@ -860,19 +956,31 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 break;
             }
             TerminalRow line = screen.ViewLine(absoluteRow);
-            double y = screenRow * _cellHeight;
-            RenderLine(context, palette, line, cols, y, absoluteRow, sel);
+            var sb = new StringBuilder(GutterChars());
+            if (_showLineTimestamp)
+            {
+                // 未写入过内容的空行不显示时间(留空占位以保持后续行号对齐)。
+                sb.Append(line.Timestamp is { } ts
+                    ? "[" + ts.ToString(GutterTimeFormat, CultureInfo.InvariantCulture) + "]"
+                    : new string(' ', 10)).Append(' ');
+            }
+            if (_showLineNumber)
+            {
+                sb.Append((absoluteRow + 1).ToString(CultureInfo.InvariantCulture).PadLeft(GutterNumberWidth)).Append(' ');
+            }
+            var ft = new FormattedText(sb.ToString(), CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, typeface, FontSize, dimBrush);
+            context.DrawText(ft, new Point(0, screenRow * _cellHeight + _glyphYOffset));
         }
-        if (_scrollOffset == 0)
-        {
-            RenderCursor(context, screen, palette, topAbsolute);
-        }
+        // 侧栏与正文之间一条细分隔线。
+        context.DrawLine(new Pen(dimBrush, 0.5), new Point(gutter - 0.5, 0), new Point(gutter - 0.5, rows * _cellHeight));
+    }
 
-        // Visual bell: a brief translucent flash over the whole terminal (§终端 → 视觉闪烁).
-        if (_bellFlashUntil > DateTime.UtcNow)
-        {
-            context.FillRectangle(BellFlashBrush, new(Bounds.Size));
-        }
+    /// <summary>按比例 <paramref name="t" /> 在两色间线性插值(0=a,1=b),用于混出侧栏暗色。</summary>
+    private static Rgba Blend(Rgba a, Rgba b, double t)
+    {
+        static byte Lerp(byte x, byte y, double f) => (byte)Math.Round(x + (y - x) * f);
+        return new Rgba(0xFF, Lerp(a.R, b.R, t), Lerp(a.G, b.G, t), Lerp(a.B, b.B, t));
     }
 
     private void RenderLine(DrawingContext context,
@@ -1266,7 +1374,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private (int Row, int Col) PointToCell(Point p)
     {
         int screenRow = (int)(p.Y / _cellHeight);
-        int col = (int)(p.X / _cellWidth);
+        int col = (int)((p.X - GutterWidth()) / _cellWidth);
         int topAbsolute = Math.Max(0, Emulator.Screen.TotalRows - Emulator.Rows - _scrollOffset);
         // Clamp the row: while the pointer is captured a drag can leave the control (negative
         // p.Y), and a negative absolute row used to crash selection copy (#用户反馈).
@@ -1613,7 +1721,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <summary>Maps a pointer position to a 0-based cell within the visible screen.</summary>
     private (int Col, int Row) ScreenCell(Point p)
     {
-        int col = Math.Clamp((int)(p.X / _cellWidth), 0, Math.Max(0, Emulator.Columns - 1));
+        int col = Math.Clamp((int)((p.X - GutterWidth()) / _cellWidth), 0, Math.Max(0, Emulator.Columns - 1));
         int row = Math.Clamp((int)(p.Y / _cellHeight), 0, Math.Max(0, Emulator.Rows - 1));
         return (col, row);
     }

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -951,27 +951,22 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     // ---- Line gutter(时间/行号/折叠侧栏,WindTerm 式) ---------------------
 
-    // 数字列固定 5 位(右对齐):默认 1 万行 scrollback 的最大行号约 5 位。取固定宽度而非按当前行数
-    // 动态计算,是为了侧栏宽度全程恒定 —— 既不在行数跨越 10/100/1000 时抖动,也不在主/备用屏(vim、
-    // htop:scrollback=0)切换时变宽,从而不会无谓地重排 PTY 列宽。
-    private const int GutterNumberWidth = 5;
     private const string GutterTimeFormat = "HH:mm:ss";
-    private const double GutterBlankPixels = 5.0; // “空白”部件:侧栏与正文间的固定间隔
+
+    /// <summary>当前侧栏几何(各部件宽度/偏移/命中区间,见 <see cref="GutterLayout" />)。按当前单元格宽与开关计算。</summary>
+    private GutterLayout Gutter => new(_cellWidth, _showLineTimestamp, _showLineNumber, _showFoldMarker, _gutterBlank);
 
     /// <summary>任一侧栏部件开启即绘制侧栏。</summary>
-    private bool GutterEnabled => _showLineTimestamp || _showLineNumber || _showFoldMarker || _gutterBlank;
-
-    // 各部件像素宽度(按左→右顺序:时间 → 行号 → 折叠列 → 空白)。折叠列/空白用固定像素,其余按字符宽。
-    private double GutterTimeWidth => _showLineTimestamp ? 11 * _cellWidth : 0;
-    private double GutterNumberPixels => _showLineNumber ? (GutterNumberWidth + 1) * _cellWidth : 0;
-    private double GutterFoldWidth => _showFoldMarker ? Math.Ceiling(_cellWidth * 1.6) : 0;
-    private double GutterBlankWidth => _gutterBlank ? GutterBlankPixels : 0;
-
-    /// <summary>折叠列左边缘的 x(控件坐标)。</summary>
-    private double GutterFoldLeft => GutterTimeWidth + GutterNumberPixels;
+    private bool GutterEnabled => Gutter.Enabled;
 
     /// <summary>侧栏总像素宽度(全部部件关时为 0)。</summary>
-    private double GutterWidth() => GutterTimeWidth + GutterNumberPixels + GutterFoldWidth + GutterBlankWidth;
+    private double GutterWidth() => Gutter.TotalWidth;
+
+    // ---- 测试专用只读探针(headless UI 测试用,见 GutterFoldUiTests)----------
+    internal int FoldCountForTest => _foldModel.Count;
+    internal double CellWidthForTest => _cellWidth;
+    internal double CellHeightForTest => _cellHeight;
+    internal GutterLayout GutterForTest => Gutter;
 
     private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows)
     {
@@ -980,7 +975,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Rgba dim = Blend(palette.DefaultForeground, palette.DefaultBackground, 0.45);
         ImmutableSolidColorBrush dimBrush = BrushFor(dim);
         var typeface = new Typeface(FontFamily);
-        double numberLeft = GutterTimeWidth;
+        double numberLeft = Gutter.NumberLeft;
         int lastContentRow = -1; // 最后一行有内容的屏幕行:分隔线/折叠线只画到这里,空屏不画侧栏。
         for (int screenRow = 0; screenRow < rows; screenRow++)
         {
@@ -1006,7 +1001,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             }
             if (_showLineNumber)
             {
-                string number = (absoluteRow + 1).ToString(CultureInfo.InvariantCulture).PadLeft(GutterNumberWidth) + " ";
+                string number = (absoluteRow + 1).ToString(CultureInfo.InvariantCulture).PadLeft(GutterLayout.NumberDigits) + " ";
                 context.DrawText(new(number, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, dimBrush), new Point(numberLeft, y));
             }
         }
@@ -1015,13 +1010,11 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             return; // 空屏:不画分隔线/折叠列,侧栏完全隐形。
         }
         double contentBottom = (lastContentRow + 1) * _cellHeight;
+        // 唯一的竖线由折叠列绘制(用户要求:去掉原来的分隔竖线,只保留折叠标记这一条)。
         if (_showFoldMarker)
         {
             RenderFoldColumn(context, screen, palette, rows, dim, contentBottom);
         }
-        // 侧栏与正文之间一条细分隔线,只画到内容底部。
-        double sepX = GutterWidth() - GutterBlankWidth - 0.5;
-        context.DrawLine(new Pen(BrushFor(Blend(dim, palette.DefaultBackground, 0.3)), 0.5), new Point(sepX, 0), new Point(sepX, contentBottom));
     }
 
     /// <summary>
@@ -1029,12 +1022,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// </summary>
     private void RenderFoldColumn(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows, Rgba dim, double contentBottom)
     {
-        double cx = GutterFoldLeft + GutterFoldWidth / 2;
+        GutterLayout g = Gutter;
+        double cx = g.FoldLeft + g.FoldWidth / 2;
         context.DrawLine(new Pen(BrushFor(Blend(dim, palette.DefaultBackground, 0.4)), 1), new Point(cx, 0), new Point(cx, contentBottom));
-        if (_folds.Count == 0)
-        {
-            return;
-        }
         var typeface = new Typeface(FontFamily);
         ImmutableSolidColorBrush glyphBrush = BrushFor(dim);
         for (int screenRow = 0; screenRow < rows; screenRow++)
@@ -1044,26 +1034,25 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 continue;
             }
-            if (FoldAnchorAt(absoluteRow, screen) is not null)
+            // 折叠头显示 ▸(点它展开);鼠标悬停的普通行显示 ▾(点它把上方内容折叠到这里)。
+            string? glyph = _foldModel.IsAnchor(screen, absoluteRow) ? "▸"
+                : absoluteRow == _foldHoverAbs ? "▾"
+                : null;
+            if (glyph is not null)
             {
-                context.DrawText(new("▸", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, glyphBrush),
-                    new Point(GutterFoldLeft, screenRow * _cellHeight + _glyphYOffset));
+                context.DrawText(new(glyph, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, glyphBrush),
+                    new Point(g.FoldLeft, screenRow * _cellHeight + _glyphYOffset));
             }
         }
     }
 
     // ---- Folding(折叠区域)-------------------------------------------------
-    // 折叠区域按「行对象引用」锚定:行在滚动时按引用迁入 scrollback,引用稳定;列宽 reflow 会重建行对象,
-    // 届时折叠失效,由 ClearFolds() 在 resize 时清空。默认无折叠(_folds 空),渲染/滚动走原快路径,零影响。
+    // 折叠逻辑抽到 UI 无关的 GutterFoldModel(可单测,见 GutterFoldTests);默认无折叠时渲染/滚动
+    // 走连续快路径,零影响。列宽 reflow 会重建行对象使引用失效,由 ClearFolds() 在 resize 时清空。
 
-    private sealed class FoldRegion
-    {
-        public required TerminalRow AnchorRow; // 折叠后仍显示的占位行(区域首行,显示 ▸ 展开)
-        public required TerminalRow[] Rows; // 区域内全部行(含 AnchorRow),按缓冲区顺序
-    }
-
-    private readonly List<FoldRegion> _folds = [];
+    private readonly GutterFoldModel _foldModel = new();
     private int[] _screenToAbs = []; // 本帧 screenRow → 绝对缓冲行(-1=空),侧栏/正文/光标/命中测试共用
+    private int _foldHoverAbs = -1; // 折叠列上鼠标悬停的绝对行(显示 ▾ 折叠提示),-1=无
 
     /// <summary>构建本帧屏幕行映射;无折叠走连续快路径,有折叠跳过隐藏行。同时把 _scrollOffset 夹到可见范围。</summary>
     private void BuildScreenRowMap(TerminalScreen screen, int rows)
@@ -1072,137 +1061,21 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             _screenToAbs = new int[rows];
         }
-        List<int>? visible = BuildVisibleRowsOrNull(screen);
-        int total = visible?.Count ?? screen.TotalRows;
-        int maxOffset = Math.Max(0, total - rows);
-        if (_scrollOffset > maxOffset)
-        {
-            _scrollOffset = maxOffset; // 折叠缩短了可滚动范围
-        }
-        int top = Math.Max(0, total - rows - _scrollOffset);
-        for (int sr = 0; sr < rows; sr++)
-        {
-            int vi = top + sr;
-            _screenToAbs[sr] = vi < total ? visible?[vi] ?? vi : -1;
-        }
-    }
-
-    /// <summary>本帧可见的绝对行序列(隐藏被折叠的非锚点行);无折叠返回 null 表示走连续快路径。</summary>
-    private List<int>? BuildVisibleRowsOrNull(TerminalScreen screen)
-    {
-        if (_folds.Count == 0)
-        {
-            return null;
-        }
-        PruneStaleFolds(screen);
-        if (_folds.Count == 0)
-        {
-            return null;
-        }
-        var hidden = new HashSet<TerminalRow>();
-        foreach (FoldRegion f in _folds)
-        {
-            foreach (TerminalRow r in f.Rows)
-            {
-                if (!ReferenceEquals(r, f.AnchorRow))
-                {
-                    hidden.Add(r);
-                }
-            }
-        }
-        var vis = new List<int>(screen.TotalRows);
-        for (int abs = 0; abs < screen.TotalRows; abs++)
-        {
-            if (!hidden.Contains(screen.ViewLine(abs)))
-            {
-                vis.Add(abs);
-            }
-        }
-        return vis;
-    }
-
-    /// <summary>折叠锚点行若已被 scrollback 淘汰(不在当前缓冲区)则折叠失效,清除之。</summary>
-    private void PruneStaleFolds(TerminalScreen screen)
-    {
-        var present = new HashSet<TerminalRow>();
-        for (int abs = 0; abs < screen.TotalRows; abs++)
-        {
-            present.Add(screen.ViewLine(abs));
-        }
-        _folds.RemoveAll(f => !present.Contains(f.AnchorRow));
+        List<int>? visible = _foldModel.VisibleRowsOrNull(screen);
+        GutterFoldModel.FillScreenRowMap(_screenToAbs, visible, screen.TotalRows, rows, ref _scrollOffset);
     }
 
     /// <summary>清空所有折叠(列宽 reflow 会重建行对象使引用失效,resize 时调用)。</summary>
-    private void ClearFolds()
-    {
-        if (_folds.Count > 0)
-        {
-            _folds.Clear();
-        }
-    }
+    private void ClearFolds() => _foldModel.Clear();
 
-    /// <summary>
-    /// 折叠交互:点击折叠列某屏幕行 —— 若该行是折叠锚点则展开;否则把「该行之前、上一折叠边界之后」的
-    /// 内容折叠成一个新区域(区域首行作锚点保留可见,显示 ▸)。返回是否发生了折叠状态变化。
-    /// </summary>
-    private bool ToggleFoldAt(int screenRow)
+    /// <summary>折叠交互:点击折叠列某屏幕行 —— 折叠头则展开,否则把上方内容折叠到该行(见 <see cref="GutterFoldModel" />)。</summary>
+    private void ToggleFoldAt(int screenRow)
     {
-        TerminalScreen screen = Emulator.Screen;
         int abs = AbsoluteForScreenRow(screenRow);
-        if (abs < 0)
+        if (abs >= 0 && _foldModel.Toggle(Emulator.Screen, abs))
         {
-            return false;
-        }
-        if (FoldAnchorAt(abs, screen) is { } existing)
-        {
-            _folds.Remove(existing);
             AfterFoldChange();
-            return true;
         }
-        int startAbs = NearestFoldBoundaryAbove(abs, screen);
-        if (abs - 1 < startAbs)
-        {
-            return false; // 该行之前没有可折叠内容
-        }
-        var region = new TerminalRow[abs - startAbs];
-        for (int i = 0; i < region.Length; i++)
-        {
-            region[i] = screen.ViewLine(startAbs + i);
-        }
-        _folds.Add(new FoldRegion { AnchorRow = region[0], Rows = region });
-        AfterFoldChange();
-        return true;
-    }
-
-    /// <summary>解析既有折叠区域,返回 <paramref name="abs" /> 之上最近折叠边界的下一行(无则 0)。</summary>
-    private int NearestFoldBoundaryAbove(int abs, TerminalScreen screen)
-    {
-        if (_folds.Count == 0)
-        {
-            return 0;
-        }
-        var absOf = new Dictionary<TerminalRow, int>();
-        for (int a = 0; a < screen.TotalRows; a++)
-        {
-            absOf[screen.ViewLine(a)] = a;
-        }
-        int boundary = 0;
-        foreach (FoldRegion f in _folds)
-        {
-            int last = -1;
-            foreach (TerminalRow r in f.Rows)
-            {
-                if (absOf.TryGetValue(r, out int a))
-                {
-                    last = Math.Max(last, a);
-                }
-            }
-            if (last >= 0 && last < abs)
-            {
-                boundary = Math.Max(boundary, last + 1);
-            }
-        }
-        return boundary;
     }
 
     private void AfterFoldChange()
@@ -1212,7 +1085,10 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     }
 
     /// <summary>侧栏右键菜单:四个部件(行号/时间戳/折叠标记/空白)的可勾选开关(勾号前缀表示已开)。</summary>
-    private void ShowGutterContextMenu()
+    private void ShowGutterContextMenu() => BuildGutterContextMenu().Open(this);
+
+    /// <summary>构建侧栏右键菜单(不弹出)。internal 供 headless 测试直接检视内容与开关接线,避免打开弹层。</summary>
+    internal ContextMenu BuildGutterContextMenu()
     {
         GutterMenuLabels labels = GutterMenu;
         var menu = new ContextMenu();
@@ -1220,7 +1096,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         AddGutterMenuItem(menu, labels.Timestamp, _showLineTimestamp, v => ShowLineTimestamp = v);
         AddGutterMenuItem(menu, labels.FoldMarker, _showFoldMarker, v => ShowFoldMarker = v);
         AddGutterMenuItem(menu, labels.Blank, _gutterBlank, v => GutterBlank = v);
-        menu.Open(this);
+        return menu;
     }
 
     private void AddGutterMenuItem(ContextMenu menu, string label, bool on, Action<bool> set)
@@ -1236,24 +1112,6 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     /// <summary>侧栏右键菜单四个部件的本地化标签。</summary>
     public sealed record GutterMenuLabels(string LineNumber, string Timestamp, string FoldMarker, string Blank);
-
-    /// <summary>若绝对行 <paramref name="abs" /> 是某折叠区域的锚点行,返回该区域,否则 null。</summary>
-    private FoldRegion? FoldAnchorAt(int abs, TerminalScreen screen)
-    {
-        if (_folds.Count == 0)
-        {
-            return null;
-        }
-        TerminalRow row = screen.ViewLine(abs);
-        foreach (FoldRegion f in _folds)
-        {
-            if (ReferenceEquals(f.AnchorRow, row))
-            {
-                return f;
-            }
-        }
-        return null;
-    }
 
     /// <summary>本帧「绝对行 → 屏幕行」反查(命中测试/光标定位用),未在可见窗口内返回 -1。</summary>
     private int ScreenRowForAbsolute(int abs)
@@ -1809,7 +1667,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         PointerPointProperties props = e.GetCurrentPoint(this).Properties;
 
         // 侧栏(时间/行号/折叠)区域的交互:右键弹设置菜单;折叠列左键折叠/展开;其余左键吞掉不选文本。
-        if (GutterEnabled && point.X < GutterWidth())
+        GutterLayout gutter = Gutter;
+        if (gutter.ContainsX(point.X))
         {
             if (props.IsRightButtonPressed)
             {
@@ -1817,8 +1676,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 e.Handled = true;
                 return;
             }
-            if (props.IsLeftButtonPressed && _showFoldMarker &&
-                point.X >= GutterFoldLeft && point.X < GutterFoldLeft + GutterFoldWidth)
+            if (props.IsLeftButtonPressed && gutter.IsFoldColumnHit(point.X))
             {
                 ToggleFoldAt((int)(point.Y / _cellHeight));
                 e.Handled = true;
@@ -1947,6 +1805,20 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     {
         base.OnPointerMoved(e);
 
+        // 折叠列悬停提示:指针在折叠列上时记住其绝对行(用于画 ▾ 折叠手柄),移出则清除。
+        if (_showFoldMarker && !_selecting)
+        {
+            Point gp = e.GetPosition(this);
+            int hover = Gutter.IsFoldColumnHit(gp.X)
+                ? AbsoluteForScreenRow((int)(gp.Y / _cellHeight))
+                : -1;
+            if (hover != _foldHoverAbs)
+            {
+                _foldHoverAbs = hover;
+                InvalidateVisual();
+            }
+        }
+
         // Report motion to the app in button-event (?1002, only while a button is down) and
         // any-event (?1003, always) modes, but only when a cell boundary is crossed.
         MouseTracking tracking = Emulator.Modes.Mouse;
@@ -1974,6 +1846,16 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 _selectionCaret = PointToCell(e.GetPosition(this));
                 InvalidateVisual();
                 break;
+        }
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+        if (_foldHoverAbs != -1)
+        {
+            _foldHoverAbs = -1;
+            InvalidateVisual();
         }
     }
 

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -93,6 +93,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private int _scrollOffset; // lines scrolled up from the bottom (0 = live)
     private bool _showLineTimestamp; // 左侧栏:显示收行时间(见 ShowLineTimestamp)
     private bool _showLineNumber; // 左侧栏:显示缓冲区行号(见 ShowLineNumber)
+    private bool _showFoldMarker; // 左侧栏:显示折叠标记列(见 ShowFoldMarker)
+    private bool _gutterBlank; // 左侧栏:侧栏与正文间插入 ~5px 空白(见 GutterBlank)
 
     /// <summary>Search spans per absolute buffer row; the current hit is tinted differently.</summary>
     private Dictionary<int, List<(int Start, int End, bool Current)>>? _searchHighlights;
@@ -221,39 +223,56 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     public string BellMode { get; set; } = "system";
 
     /// <summary>
-    /// 左侧栏显示每行的收行时间 <c>[HH:mm:ss]</c>(设置 → 终端)。与 <see cref="ShowLineNumber" />
-    /// 相互独立:可只开时间、只开行号或都开。任一开启都会占用左侧宽度(减少可用列数,PTY 随之改列宽)。
+    /// 左侧栏显示每行的收行时间 <c>[HH:mm:ss]</c>(设置 → 终端 / 侧栏右键)。与 <see cref="ShowLineNumber" />
+    /// 等相互独立。任一侧栏部件开启都会占用左侧宽度(减少可用列数,PTY 随之改列宽)。
     /// </summary>
     public bool ShowLineTimestamp
     {
         get => _showLineTimestamp;
-        set
-        {
-            if (_showLineTimestamp == value)
-            {
-                return;
-            }
-            _showLineTimestamp = value;
-            RelayoutFromBounds(); // 侧栏宽度变化 → 立即重算列数并通知 PTY。
-            InvalidateVisual();
-        }
+        set => SetGutterOption(ref _showLineTimestamp, value);
     }
 
-    /// <summary>左侧栏显示每行的缓冲区行号(设置 → 终端)。与 <see cref="ShowLineTimestamp" /> 相互独立。</summary>
+    /// <summary>左侧栏显示每行的缓冲区行号。与其他侧栏部件相互独立。</summary>
     public bool ShowLineNumber
     {
         get => _showLineNumber;
-        set
-        {
-            if (_showLineNumber == value)
-            {
-                return;
-            }
-            _showLineNumber = value;
-            RelayoutFromBounds();
-            InvalidateVisual();
-        }
+        set => SetGutterOption(ref _showLineNumber, value);
     }
+
+    /// <summary>左侧栏显示折叠标记列:可折叠标记之前的历史内容(WindTerm 式)。</summary>
+    public bool ShowFoldMarker
+    {
+        get => _showFoldMarker;
+        set => SetGutterOption(ref _showFoldMarker, value);
+    }
+
+    /// <summary>在侧栏与命令输出之间插入约 5px 的空白间隔。</summary>
+    public bool GutterBlank
+    {
+        get => _gutterBlank;
+        set => SetGutterOption(ref _gutterBlank, value);
+    }
+
+    /// <summary>
+    /// 侧栏部件开关的公共写入:变化时重排布局(侧栏宽度→可用列数→PTY)并重绘。
+    /// 不在此上报持久化——由设置应用与右键菜单区分来源,菜单侧显式触发,避免「应用设置→上报→再存」死循环。
+    /// </summary>
+    private void SetGutterOption(ref bool field, bool value)
+    {
+        if (field == value)
+        {
+            return;
+        }
+        field = value;
+        RelayoutFromBounds();
+        InvalidateVisual();
+    }
+
+    /// <summary>侧栏右键菜单改动部件开关后上报(时间戳, 行号, 折叠标记, 空白),供上层持久化。</summary>
+    public event Action<bool, bool, bool, bool>? GutterOptionsChanged;
+
+    /// <summary>侧栏右键菜单的本地化标签(行号 / 时间戳 / 折叠标记 / 空白),由上层按当前语言注入。</summary>
+    public GutterMenuLabels GutterMenu { get; set; } = new("行号", "时间戳", "折叠标记", "空白");
 
     /// <summary>
     /// Enables the OS input method (Chinese/Japanese/Korean composition). Off = the
@@ -340,6 +359,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Emulator.Resize(cols, rows);
         _scrollOffset = 0;
         _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
+        ClearFolds(); // reflow 会重建行对象,折叠引用失效。
         // Row indexes in the selection are absolute and shift on resize; drop it rather than
         // let a stale range mark (or copy) the wrong text.
         ClearSelection();
@@ -620,9 +640,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private Rect GetImeCursorRect()
     {
         TerminalScreen screen = Emulator.Screen;
-        int topAbsolute = screen.TotalRows - screen.Rows - _scrollOffset;
         int cursorAbsolute = screen.TotalRows - screen.Rows + screen.CursorY;
-        int screenRow = cursorAbsolute - topAbsolute;
+        int screenRow = ScreenRowForAbsolute(cursorAbsolute);
+        if (screenRow < 0)
+        {
+            screenRow = Math.Max(0, screen.Rows - 1 - _scrollOffset);
+        }
         return new(screen.CursorX * _cellWidth + GutterWidth(), screenRow * _cellHeight, _cellWidth, _cellHeight);
     }
 
@@ -871,6 +894,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Emulator.Resize(cols, rows);
         _scrollOffset = Math.Clamp(_scrollOffset, 0, Emulator.Screen.ScrollbackCount);
         _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
+        ClearFolds(); // reflow 会重建行对象,折叠引用失效。
         // Reflow shifts absolute rows; a stale selection would mark (and copy) the wrong text.
         ClearSelection();
         InvalidateVisual();
@@ -887,23 +911,26 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         context.FillRectangle(BrushFor(palette.DefaultBackground), new(Bounds.Size));
         int rows = screen.Rows;
         int cols = screen.Columns;
-        int topAbsolute = Math.Max(0, screen.TotalRows - rows - _scrollOffset);
+
+        // 计算本帧「屏幕行 → 绝对缓冲行」映射(_screenToAbs):无折叠时即连续 topAbsolute+sr(与原行为一致),
+        // 有折叠时跳过被隐藏的行。侧栏、正文、光标、命中测试全部复用该映射,确保三者对齐。
+        BuildScreenRowMap(screen, rows);
         ((int Row, int Col) Start, (int Row, int Col) End)? sel = NormalizedSelection();
 
         // 行号/时间侧栏在正文左侧:先画侧栏,再把正文(含光标、选区)整体右移一个侧栏宽度绘制,
         // 这样所有 col*_cellWidth 的坐标计算保持不变,只在命中测试处减去侧栏宽度即可。
         if (GutterEnabled)
         {
-            RenderGutter(context, screen, palette, topAbsolute, rows);
+            RenderGutter(context, screen, palette, rows);
         }
         using (context.PushTransform(Matrix.CreateTranslation(GutterWidth(), 0)))
         {
             for (int screenRow = 0; screenRow < rows; screenRow++)
             {
-                int absoluteRow = topAbsolute + screenRow;
-                if (absoluteRow >= screen.TotalRows)
+                int absoluteRow = _screenToAbs[screenRow];
+                if (absoluteRow < 0)
                 {
-                    break;
+                    continue;
                 }
                 TerminalRow line = screen.ViewLine(absoluteRow);
                 double y = screenRow * _cellHeight;
@@ -911,7 +938,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             }
             if (_scrollOffset == 0)
             {
-                RenderCursor(context, screen, palette, topAbsolute);
+                RenderCursor(context, screen, palette);
             }
         }
 
@@ -922,59 +949,328 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
     }
 
-    // ---- Line gutter(时间/行号侧栏) ---------------------------------------
+    // ---- Line gutter(时间/行号/折叠侧栏,WindTerm 式) ---------------------
 
     // 数字列固定 5 位(右对齐):默认 1 万行 scrollback 的最大行号约 5 位。取固定宽度而非按当前行数
     // 动态计算,是为了侧栏宽度全程恒定 —— 既不在行数跨越 10/100/1000 时抖动,也不在主/备用屏(vim、
     // htop:scrollback=0)切换时变宽,从而不会无谓地重排 PTY 列宽。
     private const int GutterNumberWidth = 5;
     private const string GutterTimeFormat = "HH:mm:ss";
+    private const double GutterBlankPixels = 5.0; // “空白”部件:侧栏与正文间的固定间隔
 
-    /// <summary>时间/行号任一开启即绘制侧栏。</summary>
-    private bool GutterEnabled => _showLineTimestamp || _showLineNumber;
+    /// <summary>任一侧栏部件开启即绘制侧栏。</summary>
+    private bool GutterEnabled => _showLineTimestamp || _showLineNumber || _showFoldMarker || _gutterBlank;
 
-    // 字符数按启用的部分累加:时间段 "[HH:mm:ss] "(11)、行号段 "NNNNN "(6);两者拼接即
-    // "[HH:mm:ss] NNNNN "。任一关闭则该段不占宽度。
-    private int GutterChars() => (_showLineTimestamp ? 11 : 0) + (_showLineNumber ? GutterNumberWidth + 1 : 0);
+    // 各部件像素宽度(按左→右顺序:时间 → 行号 → 折叠列 → 空白)。折叠列/空白用固定像素,其余按字符宽。
+    private double GutterTimeWidth => _showLineTimestamp ? 11 * _cellWidth : 0;
+    private double GutterNumberPixels => _showLineNumber ? (GutterNumberWidth + 1) * _cellWidth : 0;
+    private double GutterFoldWidth => _showFoldMarker ? Math.Ceiling(_cellWidth * 1.6) : 0;
+    private double GutterBlankWidth => _gutterBlank ? GutterBlankPixels : 0;
 
-    /// <summary>侧栏像素宽度(时间/行号都关时为 0)。</summary>
-    private double GutterWidth() => GutterChars() * _cellWidth;
+    /// <summary>折叠列左边缘的 x(控件坐标)。</summary>
+    private double GutterFoldLeft => GutterTimeWidth + GutterNumberPixels;
 
-    private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int topAbsolute, int rows)
+    /// <summary>侧栏总像素宽度(全部部件关时为 0)。</summary>
+    private double GutterWidth() => GutterTimeWidth + GutterNumberPixels + GutterFoldWidth + GutterBlankWidth;
+
+    private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows)
     {
-        double gutter = GutterWidth();
-        // 侧栏底色:在默认底色上叠一层极淡前景,与正文区分;文本用前景/底色混出的暗色(不依赖具体主题)。
-        context.FillRectangle(BrushFor(Blend(palette.DefaultBackground, palette.DefaultForeground, 0.05)), new Rect(0, 0, gutter, Bounds.Height));
+        // 侧栏底色刻意保持与终端背景一致(不再叠色):正文区域整体右移,侧栏落在开头那次全局底色填充上,
+        // 因此无需单独填底 —— 空白处与终端浑然一体(WindTerm 观感),仅靠暗色文本/分隔线区分。
         Rgba dim = Blend(palette.DefaultForeground, palette.DefaultBackground, 0.45);
         ImmutableSolidColorBrush dimBrush = BrushFor(dim);
         var typeface = new Typeface(FontFamily);
+        double numberLeft = GutterTimeWidth;
+        int lastContentRow = -1; // 最后一行有内容的屏幕行:分隔线/折叠线只画到这里,空屏不画侧栏。
         for (int screenRow = 0; screenRow < rows; screenRow++)
         {
-            int absoluteRow = topAbsolute + screenRow;
-            if (absoluteRow >= screen.TotalRows)
+            int absoluteRow = _screenToAbs[screenRow];
+            if (absoluteRow < 0)
             {
-                break;
+                continue;
             }
             TerminalRow line = screen.ViewLine(absoluteRow);
-            var sb = new StringBuilder(GutterChars());
-            if (_showLineTimestamp)
+            // 从未写入内容的空行(刚开终端时的整屏空行、输出未满屏时下方的空行)不显示行号/时间,
+            // 避免像截图那样凭空多出几十行编号。
+            bool hasContent = line.Timestamp is not null || line.LastNonBlank() >= 0;
+            if (!hasContent)
             {
-                // 未写入过内容的空行不显示时间(留空占位以保持后续行号对齐)。
-                sb.Append(line.Timestamp is { } ts
-                    ? "[" + ts.ToString(GutterTimeFormat, CultureInfo.InvariantCulture) + "]"
-                    : new string(' ', 10)).Append(' ');
+                continue;
+            }
+            lastContentRow = screenRow;
+            double y = screenRow * _cellHeight + _glyphYOffset;
+            if (_showLineTimestamp && line.Timestamp is { } ts)
+            {
+                string stamp = "[" + ts.ToString(GutterTimeFormat, CultureInfo.InvariantCulture) + "] ";
+                context.DrawText(new(stamp, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, dimBrush), new Point(0, y));
             }
             if (_showLineNumber)
             {
-                sb.Append((absoluteRow + 1).ToString(CultureInfo.InvariantCulture).PadLeft(GutterNumberWidth)).Append(' ');
+                string number = (absoluteRow + 1).ToString(CultureInfo.InvariantCulture).PadLeft(GutterNumberWidth) + " ";
+                context.DrawText(new(number, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, dimBrush), new Point(numberLeft, y));
             }
-            var ft = new FormattedText(sb.ToString(), CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight, typeface, FontSize, dimBrush);
-            context.DrawText(ft, new Point(0, screenRow * _cellHeight + _glyphYOffset));
         }
-        // 侧栏与正文之间一条细分隔线。
-        context.DrawLine(new Pen(dimBrush, 0.5), new Point(gutter - 0.5, 0), new Point(gutter - 0.5, rows * _cellHeight));
+        if (lastContentRow < 0)
+        {
+            return; // 空屏:不画分隔线/折叠列,侧栏完全隐形。
+        }
+        double contentBottom = (lastContentRow + 1) * _cellHeight;
+        if (_showFoldMarker)
+        {
+            RenderFoldColumn(context, screen, palette, rows, dim, contentBottom);
+        }
+        // 侧栏与正文之间一条细分隔线,只画到内容底部。
+        double sepX = GutterWidth() - GutterBlankWidth - 0.5;
+        context.DrawLine(new Pen(BrushFor(Blend(dim, palette.DefaultBackground, 0.3)), 0.5), new Point(sepX, 0), new Point(sepX, contentBottom));
     }
+
+    /// <summary>
+    /// 折叠列:一条竖直折叠导引线;折叠区域的锚点行画 ▸(展开)标记。折叠交互见 <see cref="OnFoldColumnClicked" />。
+    /// </summary>
+    private void RenderFoldColumn(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows, Rgba dim, double contentBottom)
+    {
+        double cx = GutterFoldLeft + GutterFoldWidth / 2;
+        context.DrawLine(new Pen(BrushFor(Blend(dim, palette.DefaultBackground, 0.4)), 1), new Point(cx, 0), new Point(cx, contentBottom));
+        if (_folds.Count == 0)
+        {
+            return;
+        }
+        var typeface = new Typeface(FontFamily);
+        ImmutableSolidColorBrush glyphBrush = BrushFor(dim);
+        for (int screenRow = 0; screenRow < rows; screenRow++)
+        {
+            int absoluteRow = _screenToAbs[screenRow];
+            if (absoluteRow < 0)
+            {
+                continue;
+            }
+            if (FoldAnchorAt(absoluteRow, screen) is not null)
+            {
+                context.DrawText(new("▸", CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, glyphBrush),
+                    new Point(GutterFoldLeft, screenRow * _cellHeight + _glyphYOffset));
+            }
+        }
+    }
+
+    // ---- Folding(折叠区域)-------------------------------------------------
+    // 折叠区域按「行对象引用」锚定:行在滚动时按引用迁入 scrollback,引用稳定;列宽 reflow 会重建行对象,
+    // 届时折叠失效,由 ClearFolds() 在 resize 时清空。默认无折叠(_folds 空),渲染/滚动走原快路径,零影响。
+
+    private sealed class FoldRegion
+    {
+        public required TerminalRow AnchorRow; // 折叠后仍显示的占位行(区域首行,显示 ▸ 展开)
+        public required TerminalRow[] Rows; // 区域内全部行(含 AnchorRow),按缓冲区顺序
+    }
+
+    private readonly List<FoldRegion> _folds = [];
+    private int[] _screenToAbs = []; // 本帧 screenRow → 绝对缓冲行(-1=空),侧栏/正文/光标/命中测试共用
+
+    /// <summary>构建本帧屏幕行映射;无折叠走连续快路径,有折叠跳过隐藏行。同时把 _scrollOffset 夹到可见范围。</summary>
+    private void BuildScreenRowMap(TerminalScreen screen, int rows)
+    {
+        if (_screenToAbs.Length != rows)
+        {
+            _screenToAbs = new int[rows];
+        }
+        List<int>? visible = BuildVisibleRowsOrNull(screen);
+        int total = visible?.Count ?? screen.TotalRows;
+        int maxOffset = Math.Max(0, total - rows);
+        if (_scrollOffset > maxOffset)
+        {
+            _scrollOffset = maxOffset; // 折叠缩短了可滚动范围
+        }
+        int top = Math.Max(0, total - rows - _scrollOffset);
+        for (int sr = 0; sr < rows; sr++)
+        {
+            int vi = top + sr;
+            _screenToAbs[sr] = vi < total ? visible?[vi] ?? vi : -1;
+        }
+    }
+
+    /// <summary>本帧可见的绝对行序列(隐藏被折叠的非锚点行);无折叠返回 null 表示走连续快路径。</summary>
+    private List<int>? BuildVisibleRowsOrNull(TerminalScreen screen)
+    {
+        if (_folds.Count == 0)
+        {
+            return null;
+        }
+        PruneStaleFolds(screen);
+        if (_folds.Count == 0)
+        {
+            return null;
+        }
+        var hidden = new HashSet<TerminalRow>();
+        foreach (FoldRegion f in _folds)
+        {
+            foreach (TerminalRow r in f.Rows)
+            {
+                if (!ReferenceEquals(r, f.AnchorRow))
+                {
+                    hidden.Add(r);
+                }
+            }
+        }
+        var vis = new List<int>(screen.TotalRows);
+        for (int abs = 0; abs < screen.TotalRows; abs++)
+        {
+            if (!hidden.Contains(screen.ViewLine(abs)))
+            {
+                vis.Add(abs);
+            }
+        }
+        return vis;
+    }
+
+    /// <summary>折叠锚点行若已被 scrollback 淘汰(不在当前缓冲区)则折叠失效,清除之。</summary>
+    private void PruneStaleFolds(TerminalScreen screen)
+    {
+        var present = new HashSet<TerminalRow>();
+        for (int abs = 0; abs < screen.TotalRows; abs++)
+        {
+            present.Add(screen.ViewLine(abs));
+        }
+        _folds.RemoveAll(f => !present.Contains(f.AnchorRow));
+    }
+
+    /// <summary>清空所有折叠(列宽 reflow 会重建行对象使引用失效,resize 时调用)。</summary>
+    private void ClearFolds()
+    {
+        if (_folds.Count > 0)
+        {
+            _folds.Clear();
+        }
+    }
+
+    /// <summary>
+    /// 折叠交互:点击折叠列某屏幕行 —— 若该行是折叠锚点则展开;否则把「该行之前、上一折叠边界之后」的
+    /// 内容折叠成一个新区域(区域首行作锚点保留可见,显示 ▸)。返回是否发生了折叠状态变化。
+    /// </summary>
+    private bool ToggleFoldAt(int screenRow)
+    {
+        TerminalScreen screen = Emulator.Screen;
+        int abs = AbsoluteForScreenRow(screenRow);
+        if (abs < 0)
+        {
+            return false;
+        }
+        if (FoldAnchorAt(abs, screen) is { } existing)
+        {
+            _folds.Remove(existing);
+            AfterFoldChange();
+            return true;
+        }
+        int startAbs = NearestFoldBoundaryAbove(abs, screen);
+        if (abs - 1 < startAbs)
+        {
+            return false; // 该行之前没有可折叠内容
+        }
+        var region = new TerminalRow[abs - startAbs];
+        for (int i = 0; i < region.Length; i++)
+        {
+            region[i] = screen.ViewLine(startAbs + i);
+        }
+        _folds.Add(new FoldRegion { AnchorRow = region[0], Rows = region });
+        AfterFoldChange();
+        return true;
+    }
+
+    /// <summary>解析既有折叠区域,返回 <paramref name="abs" /> 之上最近折叠边界的下一行(无则 0)。</summary>
+    private int NearestFoldBoundaryAbove(int abs, TerminalScreen screen)
+    {
+        if (_folds.Count == 0)
+        {
+            return 0;
+        }
+        var absOf = new Dictionary<TerminalRow, int>();
+        for (int a = 0; a < screen.TotalRows; a++)
+        {
+            absOf[screen.ViewLine(a)] = a;
+        }
+        int boundary = 0;
+        foreach (FoldRegion f in _folds)
+        {
+            int last = -1;
+            foreach (TerminalRow r in f.Rows)
+            {
+                if (absOf.TryGetValue(r, out int a))
+                {
+                    last = Math.Max(last, a);
+                }
+            }
+            if (last >= 0 && last < abs)
+            {
+                boundary = Math.Max(boundary, last + 1);
+            }
+        }
+        return boundary;
+    }
+
+    private void AfterFoldChange()
+    {
+        InvalidateVisual();
+        ScrollChanged?.Invoke();
+    }
+
+    /// <summary>侧栏右键菜单:四个部件(行号/时间戳/折叠标记/空白)的可勾选开关(勾号前缀表示已开)。</summary>
+    private void ShowGutterContextMenu()
+    {
+        GutterMenuLabels labels = GutterMenu;
+        var menu = new ContextMenu();
+        AddGutterMenuItem(menu, labels.LineNumber, _showLineNumber, v => ShowLineNumber = v);
+        AddGutterMenuItem(menu, labels.Timestamp, _showLineTimestamp, v => ShowLineTimestamp = v);
+        AddGutterMenuItem(menu, labels.FoldMarker, _showFoldMarker, v => ShowFoldMarker = v);
+        AddGutterMenuItem(menu, labels.Blank, _gutterBlank, v => GutterBlank = v);
+        menu.Open(this);
+    }
+
+    private void AddGutterMenuItem(ContextMenu menu, string label, bool on, Action<bool> set)
+    {
+        var item = new MenuItem { Header = (on ? "✔  " : "      ") + label };
+        item.Click += (_, _) =>
+        {
+            set(!on);
+            GutterOptionsChanged?.Invoke(_showLineTimestamp, _showLineNumber, _showFoldMarker, _gutterBlank);
+        };
+        menu.Items.Add(item);
+    }
+
+    /// <summary>侧栏右键菜单四个部件的本地化标签。</summary>
+    public sealed record GutterMenuLabels(string LineNumber, string Timestamp, string FoldMarker, string Blank);
+
+    /// <summary>若绝对行 <paramref name="abs" /> 是某折叠区域的锚点行,返回该区域,否则 null。</summary>
+    private FoldRegion? FoldAnchorAt(int abs, TerminalScreen screen)
+    {
+        if (_folds.Count == 0)
+        {
+            return null;
+        }
+        TerminalRow row = screen.ViewLine(abs);
+        foreach (FoldRegion f in _folds)
+        {
+            if (ReferenceEquals(f.AnchorRow, row))
+            {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>本帧「绝对行 → 屏幕行」反查(命中测试/光标定位用),未在可见窗口内返回 -1。</summary>
+    private int ScreenRowForAbsolute(int abs)
+    {
+        for (int sr = 0; sr < _screenToAbs.Length; sr++)
+        {
+            if (_screenToAbs[sr] == abs)
+            {
+                return sr;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>本帧屏幕行 <paramref name="screenRow" /> 对应的绝对缓冲行(越界/空行返回 -1)。</summary>
+    private int AbsoluteForScreenRow(int screenRow) =>
+        screenRow >= 0 && screenRow < _screenToAbs.Length ? _screenToAbs[screenRow] : -1;
 
     /// <summary>按比例 <paramref name="t" /> 在两色间线性插值(0=a,1=b),用于混出侧栏暗色。</summary>
     private static Rgba Blend(Rgba a, Rgba b, double t)
@@ -1166,15 +1462,15 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             _ => palette.DefaultForeground
         };
 
-    private void RenderCursor(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int topAbsolute)
+    private void RenderCursor(DrawingContext context, TerminalScreen screen, TerminalPalette palette)
     {
         if (!Emulator.Modes.CursorVisible)
         {
             return;
         }
         int cursorAbsolute = screen.TotalRows - screen.Rows + screen.CursorY;
-        int screenRow = cursorAbsolute - topAbsolute;
-        if (screenRow < 0 || screenRow >= screen.Rows)
+        int screenRow = ScreenRowForAbsolute(cursorAbsolute);
+        if (screenRow < 0)
         {
             return;
         }
@@ -1373,12 +1669,18 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     private (int Row, int Col) PointToCell(Point p)
     {
-        int screenRow = (int)(p.Y / _cellHeight);
         int col = (int)((p.X - GutterWidth()) / _cellWidth);
-        int topAbsolute = Math.Max(0, Emulator.Screen.TotalRows - Emulator.Rows - _scrollOffset);
         // Clamp the row: while the pointer is captured a drag can leave the control (negative
         // p.Y), and a negative absolute row used to crash selection copy (#用户反馈).
-        int row = Math.Clamp(topAbsolute + screenRow, 0, Math.Max(0, Emulator.Screen.TotalRows - 1));
+        // 通过本帧屏幕行映射解析绝对行,折叠时命中被折叠后实际可见的那一行。
+        int maxRow = Math.Max(0, _screenToAbs.Length - 1);
+        int screenRow = Math.Clamp((int)(p.Y / _cellHeight), 0, maxRow);
+        int row = AbsoluteForScreenRow(screenRow);
+        if (row < 0)
+        {
+            // 点在内容下方的空白/折叠占位处:退回缓冲区末行。
+            row = Math.Max(0, Emulator.Screen.TotalRows - 1);
+        }
         return (row, Math.Clamp(col, 0, Emulator.Columns));
     }
 
@@ -1505,6 +1807,29 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Focus();
         Point point = e.GetPosition(this);
         PointerPointProperties props = e.GetCurrentPoint(this).Properties;
+
+        // 侧栏(时间/行号/折叠)区域的交互:右键弹设置菜单;折叠列左键折叠/展开;其余左键吞掉不选文本。
+        if (GutterEnabled && point.X < GutterWidth())
+        {
+            if (props.IsRightButtonPressed)
+            {
+                ShowGutterContextMenu();
+                e.Handled = true;
+                return;
+            }
+            if (props.IsLeftButtonPressed && _showFoldMarker &&
+                point.X >= GutterFoldLeft && point.X < GutterFoldLeft + GutterFoldWidth)
+            {
+                ToggleFoldAt((int)(point.Y / _cellHeight));
+                e.Handled = true;
+                return;
+            }
+            if (props.IsLeftButtonPressed)
+            {
+                e.Handled = true;
+                return;
+            }
+        }
 
         // Ctrl+click on a detected URL opens it in the default browser (#9).
         if (props.IsLeftButtonPressed && e.KeyModifiers.HasFlag(KeyModifiers.Control))

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -371,6 +371,8 @@ public class MainWindowViewModel : ReactiveObject
         Commands.Register(new("edit.clear", Strings.Get("Cmd_ClearScreen"), Strings.Get("CmdCat_Edit"),
             () => ActiveTerminalTab?.TerminalEmulator.WriteInput([0x0C]),
             () => ActiveTerminalTab?.ConnectionStatus == SessionStatus.Connected));
+        Commands.Register(new("terminal.linegutter", Strings.Get("Cmd_ToggleLineGutter"), Strings.Get("CmdCat_Edit"),
+            ToggleLineGutter, Shortcut: "Ctrl+Shift+L"));
         Commands.Register(new("app.settings", Strings.Get("Cmd_OpenSettings"), Strings.Get("CmdCat_Edit"),
             () => OpenSettingsCommand.Execute().Subscribe(), Shortcut: "Ctrl+,", Icon: "Icon.settings"));
         Commands.Register(new("app.palette", Strings.Get("Cmd_CommandPalette"), Strings.Get("CmdCat_Search"),
@@ -1641,6 +1643,8 @@ public class MainWindowViewModel : ReactiveObject
         control.CursorBlink = behavior.CursorBlink;
         control.BellMode = behavior.BellMode;
         control.ScrollOnOutput = behavior.ScrollOnOutput;
+        control.ShowLineTimestamp = behavior.ShowLineTimestamp;
+        control.ShowLineNumber = behavior.ShowLineNumber;
         control.ScrollOnKeystroke = behavior.ScrollOnKeystroke;
         control.CopyOnSelect = behavior.CopyOnSelect;
         control.RightClickPaste = behavior.RightClickPaste;
@@ -1704,6 +1708,34 @@ public class MainWindowViewModel : ReactiveObject
             catch
             {
                 // 写回失败只影响下次启动的初始值,不打断当前浏览。
+            }
+        });
+    }
+
+    /// <summary>
+    /// 一键切换整条侧栏(Ctrl+Shift+L / 命令面板):任一(时间/行号)开着就全部关掉,都关着则全部打开。
+    /// 只想单独显示时间或行号的用户走设置页两个独立开关。写回持久化设置即可 ——
+    /// SaveSettingsAsync 会触发 SettingsSaved → OnSettingsSaved,自动应用到所有已打开的终端标签。
+    /// </summary>
+    private void ToggleLineGutter()
+    {
+        if (_settingsService is null)
+        {
+            return;
+        }
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                AppSettings settings = await _settingsService.GetSettingsAsync().ConfigureAwait(false);
+                bool anyOn = settings.TerminalBehavior.ShowLineTimestamp || settings.TerminalBehavior.ShowLineNumber;
+                settings.TerminalBehavior.ShowLineTimestamp = !anyOn;
+                settings.TerminalBehavior.ShowLineNumber = !anyOn;
+                await _settingsService.SaveSettingsAsync(settings).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 切换失败只影响本次操作,不打断当前会话。
             }
         });
     }

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1611,8 +1611,42 @@ public class MainWindowViewModel : ReactiveObject
         if (emulator is VelaTerminalControl control)
         {
             control.TerminalType = terminalType;
+            // 侧栏右键菜单改动 → 持久化(-= 再 += 保证单次订阅,即使本方法重入)。
+            control.GutterOptionsChanged -= OnGutterOptionsChanged;
+            control.GutterOptionsChanged += OnGutterOptionsChanged;
         }
         ApplyLiveTerminalSettings(emulator, settings, forceUtf8);
+    }
+
+    /// <summary>侧栏右键菜单切换部件后写回设置;SaveSettingsAsync 会广播到所有已打开标签,保持一致。</summary>
+    private void OnGutterOptionsChanged(bool timestamp, bool number, bool fold, bool blank)
+    {
+        if (_settingsService is null)
+        {
+            return;
+        }
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                AppSettings settings = await _settingsService.GetSettingsAsync().ConfigureAwait(false);
+                TerminalBehaviorOptions b = settings.TerminalBehavior;
+                if (b.ShowLineTimestamp == timestamp && b.ShowLineNumber == number &&
+                    b.ShowFoldMarker == fold && b.GutterBlank == blank)
+                {
+                    return;
+                }
+                b.ShowLineTimestamp = timestamp;
+                b.ShowLineNumber = number;
+                b.ShowFoldMarker = fold;
+                b.GutterBlank = blank;
+                await _settingsService.SaveSettingsAsync(settings).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 写回失败只影响下次启动的初始值,不打断当前会话。
+            }
+        });
     }
 
     /// <summary>
@@ -1645,6 +1679,10 @@ public class MainWindowViewModel : ReactiveObject
         control.ScrollOnOutput = behavior.ScrollOnOutput;
         control.ShowLineTimestamp = behavior.ShowLineTimestamp;
         control.ShowLineNumber = behavior.ShowLineNumber;
+        control.ShowFoldMarker = behavior.ShowFoldMarker;
+        control.GutterBlank = behavior.GutterBlank;
+        control.GutterMenu = new(Strings.Get("Gutter_LineNumber"), Strings.Get("Gutter_Timestamp"),
+            Strings.Get("Gutter_FoldMarker"), Strings.Get("Gutter_Blank"));
         control.ScrollOnKeystroke = behavior.ScrollOnKeystroke;
         control.CopyOnSelect = behavior.CopyOnSelect;
         control.RightClickPaste = behavior.RightClickPaste;

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -34,6 +34,7 @@
     <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding RunCommand}" CommandParameter="session.clone" />
     <KeyBinding Gesture="Ctrl+Shift+T" Command="{Binding RunCommand}" CommandParameter="tools.tunnel" />
     <KeyBinding Gesture="Ctrl+Shift+F" Command="{Binding RunCommand}" CommandParameter="tools.files" />
+    <KeyBinding Gesture="Ctrl+Shift+L" Command="{Binding RunCommand}" CommandParameter="terminal.linegutter" />
   </Window.KeyBindings>
 
   <!-- 无边框窗体:与本应用全部对话框同款的 WindowDecorations="None" 全自绘模式

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -31,6 +31,20 @@
       </StackPanel>
       <NumericUpDown Grid.Column="1" Width="80" Value="{Binding TerminalBehavior.LineHeight}" Minimum="0.8" Maximum="2.0" Increment="0.1" FormatString="0.0" VerticalAlignment="Center" />
     </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_ShowLineTimestamp}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_ShowLineTimestampDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.ShowLineTimestamp}" VerticalAlignment="Center" />
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_ShowLineNumber}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_ShowLineNumberDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.ShowLineNumber}" VerticalAlignment="Center" />
+    </Grid>
     <Border Classes="sep" />
 
     <!-- 终端类型与编码(既有能力) -->

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -45,6 +45,20 @@
       </StackPanel>
       <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.ShowLineNumber}" VerticalAlignment="Center" />
     </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_ShowFoldMarker}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_ShowFoldMarkerDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.ShowFoldMarker}" VerticalAlignment="Center" />
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_GutterBlank}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_GutterBlankDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.GutterBlank}" VerticalAlignment="Center" />
+    </Grid>
     <Border Classes="sep" />
 
     <!-- 终端类型与编码(既有能力) -->

--- a/tests/VelaShell.Controls.Tests/VelaShell.Controls.Tests.csproj
+++ b/tests/VelaShell.Controls.Tests/VelaShell.Controls.Tests.csproj
@@ -13,8 +13,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VelaShell.Core.Tests/VelaShell.Core.Tests.csproj
+++ b/tests/VelaShell.Core.Tests/VelaShell.Core.Tests.csproj
@@ -13,9 +13,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VelaShell.Infrastructure.Tests/VelaShell.Infrastructure.Tests.csproj
+++ b/tests/VelaShell.Infrastructure.Tests/VelaShell.Infrastructure.Tests.csproj
@@ -13,9 +13,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VelaShell.Presentation.Tests/VelaShell.Presentation.Tests.csproj
+++ b/tests/VelaShell.Presentation.Tests/VelaShell.Presentation.Tests.csproj
@@ -13,9 +13,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VelaShell.Terminal.Tests/GutterFoldTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldTests.cs
@@ -1,0 +1,252 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 侧栏折叠模型的行为验证(WindTerm 式历史折叠):折叠隐藏正确的行、点折叠头展开、多段折叠、
+/// 折叠随行对象滚入 scrollback 保留、折叠头被淘汰后自动清除。GutterFoldModel 与控件解耦,可无头验证。
+/// </summary>
+[TestClass]
+[TestCategory("GutterFold")]
+public class GutterFoldTests
+{
+    private static TerminalScreen ScreenWithLines(int screenRows, int count, int maxScrollback = 0)
+    {
+        var e = new TerminalEmulator(40, screenRows, TerminalType.XtermColor256);
+        if (maxScrollback > 0)
+        {
+            e.Screen.MaxScrollback = maxScrollback;
+        }
+        var sb = new StringBuilder();
+        for (int i = 0; i < count; i++)
+        {
+            sb.Append('L').Append(i);
+            if (i < count - 1)
+            {
+                sb.Append("\r\n");
+            }
+        }
+        e.Feed(Encoding.UTF8.GetBytes(sb.ToString()));
+        return e.Screen;
+    }
+
+    private static int FindAbs(TerminalScreen screen, string text)
+    {
+        for (int a = 0; a < screen.TotalRows; a++)
+        {
+            if (screen.ViewLine(a).GetText() == text)
+            {
+                return a;
+            }
+        }
+        return -1;
+    }
+
+    [TestMethod]
+    public void NoFolds_VisibleRowsIsIdentity()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6);
+        var model = new GutterFoldModel();
+        Assert.IsFalse(model.HasFolds);
+        Assert.IsNull(model.VisibleRowsOrNull(screen), "无折叠应返回 null(走连续快路径)。");
+    }
+
+    [TestMethod]
+    public void Fold_HidesRowsAboveAnchor_AnchorStaysVisible()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6); // L0..L5 在 abs 0..5
+        var model = new GutterFoldModel();
+
+        Assert.IsTrue(model.Toggle(screen, 3), "点第 3 行应折叠 L0..L2。");
+        Assert.IsTrue(model.HasFolds);
+        Assert.IsTrue(model.IsAnchor(screen, 3), "被点击行 L3 应成为折叠头。");
+        Assert.IsFalse(model.IsAnchor(screen, 4));
+
+        List<int>? vis = model.VisibleRowsOrNull(screen);
+        Assert.IsNotNull(vis);
+        CollectionAssert.DoesNotContain(vis, 0);
+        CollectionAssert.DoesNotContain(vis, 1);
+        CollectionAssert.DoesNotContain(vis, 2);
+        CollectionAssert.Contains(vis, 3); // 折叠头可见
+        CollectionAssert.Contains(vis, 4);
+        CollectionAssert.Contains(vis, 5);
+    }
+
+    [TestMethod]
+    public void Toggle_OnAnchor_Expands()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6);
+        var model = new GutterFoldModel();
+        model.Toggle(screen, 3);
+        Assert.IsTrue(model.HasFolds);
+
+        Assert.IsTrue(model.Toggle(screen, 3), "再点折叠头应展开。");
+        Assert.IsFalse(model.HasFolds);
+        Assert.IsNull(model.VisibleRowsOrNull(screen));
+    }
+
+    [TestMethod]
+    public void Fold_AtTopRow_NothingBefore_NoOp()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6);
+        var model = new GutterFoldModel();
+        Assert.IsFalse(model.Toggle(screen, 0), "第 0 行之前无内容,不应折叠。");
+        Assert.IsFalse(model.HasFolds);
+    }
+
+    [TestMethod]
+    public void Fold_OutOfRange_NoOp()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6);
+        var model = new GutterFoldModel();
+        Assert.IsFalse(model.Toggle(screen, -1));
+        Assert.IsFalse(model.Toggle(screen, screen.TotalRows));
+        Assert.IsFalse(model.HasFolds);
+    }
+
+    [TestMethod]
+    public void Fold_MultipleRegions_EachHidesItsBlock()
+    {
+        TerminalScreen screen = ScreenWithLines(10, 8); // L0..L7
+        var model = new GutterFoldModel();
+        Assert.IsTrue(model.Toggle(screen, 3)); // 区域1:隐藏 L0..L2,头 L3
+        Assert.IsTrue(model.Toggle(screen, 6)); // 区域2:隐藏 L4..L5,头 L6(边界在头1 L3 之后)
+        Assert.AreEqual(2, model.Count);
+
+        List<int>? vis = model.VisibleRowsOrNull(screen);
+        Assert.IsNotNull(vis);
+        foreach (int hidden in new[] { 0, 1, 2, 4, 5 })
+        {
+            CollectionAssert.DoesNotContain(vis, hidden);
+        }
+        foreach (int shown in new[] { 3, 6, 7 })
+        {
+            CollectionAssert.Contains(vis, shown);
+        }
+        Assert.IsTrue(model.IsAnchor(screen, 3));
+        Assert.IsTrue(model.IsAnchor(screen, 6));
+    }
+
+    [TestMethod]
+    public void Clear_RemovesAllFolds()
+    {
+        TerminalScreen screen = ScreenWithLines(8, 6);
+        var model = new GutterFoldModel();
+        model.Toggle(screen, 3);
+        model.Clear();
+        Assert.IsFalse(model.HasFolds);
+        Assert.IsNull(model.VisibleRowsOrNull(screen));
+    }
+
+    [TestMethod]
+    public void Fold_PersistsAcrossScroll_ByRowReference()
+    {
+        // 折叠后继续输出使行滚入 scrollback(行对象按引用迁移),折叠应随内容保留。
+        var e = new TerminalEmulator(40, 4, TerminalType.XtermColor256);
+        e.Screen.MaxScrollback = 100;
+        e.Feed(Encoding.UTF8.GetBytes("L0\r\nL1\r\nL2\r\nL3"));
+        var model = new GutterFoldModel();
+        Assert.IsTrue(model.Toggle(e.Screen, FindAbs(e.Screen, "L2"))); // 折叠 L0..L1,头 L2
+
+        e.Feed(Encoding.UTF8.GetBytes("\r\nL4\r\nL5\r\nL6")); // 顶几行进 scrollback
+
+        int absL2 = FindAbs(e.Screen, "L2");
+        Assert.IsTrue(absL2 >= 0, "L2 应仍在缓冲区(scrollback)。");
+        Assert.IsTrue(model.IsAnchor(e.Screen, absL2), "滚动后折叠头应随行对象保留。");
+        List<int>? vis = model.VisibleRowsOrNull(e.Screen);
+        Assert.IsNotNull(vis);
+        CollectionAssert.DoesNotContain(vis, FindAbs(e.Screen, "L0"));
+        CollectionAssert.DoesNotContain(vis, FindAbs(e.Screen, "L1"));
+        CollectionAssert.Contains(vis, absL2);
+    }
+
+    [TestMethod]
+    public void FillScreenRowMap_NoFolds_IsIdentityAndClampsOffset()
+    {
+        var map = new int[4];
+        int offset = 0;
+        // total=10, screen=4, offset=0 → 底部 4 行 abs 6..9。
+        GutterFoldModel.FillScreenRowMap(map, null, totalRows: 10, screenRows: 4, ref offset);
+        CollectionAssert.AreEqual(new[] { 6, 7, 8, 9 }, map);
+
+        // offset 超范围应夹到 (total-screen)=6。
+        offset = 999;
+        GutterFoldModel.FillScreenRowMap(map, null, 10, 4, ref offset);
+        Assert.AreEqual(6, offset);
+        CollectionAssert.AreEqual(new[] { 0, 1, 2, 3 }, map);
+    }
+
+    [TestMethod]
+    public void FillScreenRowMap_WithFolds_UsesVisibleSequence()
+    {
+        var map = new int[4];
+        int offset = 0;
+        // 折叠后可见序列(隐藏了 1,2):[0,3,4,5]。屏幕 4 行 → 全部显示。
+        var visible = new List<int> { 0, 3, 4, 5 };
+        GutterFoldModel.FillScreenRowMap(map, visible, totalRows: 6, screenRows: 4, ref offset);
+        CollectionAssert.AreEqual(new[] { 0, 3, 4, 5 }, map);
+    }
+
+    [TestMethod]
+    public void ClickInFoldColumn_FoldsThatRow_ThenExpands_EndToEnd()
+    {
+        // 复刻控件点击链路:GutterLayout 命中折叠列 → y→屏幕行 → FillScreenRowMap→绝对行 → model.Toggle。
+        const double cellW = 8, cellH = 16;
+        TerminalScreen screen = ScreenWithLines(8, 6); // L0..L5 在 abs 0..5,屏幕行 0..5
+        var model = new GutterFoldModel();
+        var layout = new GutterLayout(cellW, showTimestamp: false, showNumber: false, showFold: true, blank: false);
+
+        // 用户点击折叠列的第 3 屏幕行。
+        double clickX = layout.FoldLeft + 2;
+        double clickY = 3 * cellH + 4;
+        Assert.IsTrue(layout.ContainsX(clickX));
+        Assert.IsTrue(layout.IsFoldColumnHit(clickX));
+        int screenRow = (int)(clickY / cellH);
+        Assert.AreEqual(3, screenRow);
+
+        var map = new int[screen.Rows];
+        int offset = 0;
+        GutterFoldModel.FillScreenRowMap(map, model.VisibleRowsOrNull(screen), screen.TotalRows, screen.Rows, ref offset);
+        int abs = map[screenRow];
+        Assert.AreEqual(3, abs, "第 3 屏幕行应映射到绝对行 3(L3)。");
+
+        Assert.IsTrue(model.Toggle(screen, abs), "点击应触发折叠。");
+        Assert.IsTrue(model.IsAnchor(screen, 3));
+        List<int>? vis = model.VisibleRowsOrNull(screen);
+        Assert.IsNotNull(vis);
+        foreach (int hidden in new[] { 0, 1, 2 })
+        {
+            CollectionAssert.DoesNotContain(vis, hidden);
+        }
+        CollectionAssert.Contains(vis, 3);
+
+        // 折叠头 L3 现在在屏幕行 0;再点它 → 展开。
+        offset = 0;
+        GutterFoldModel.FillScreenRowMap(map, model.VisibleRowsOrNull(screen), screen.TotalRows, screen.Rows, ref offset);
+        int anchorScreenRow = Array.IndexOf(map, 3);
+        Assert.AreEqual(0, anchorScreenRow, "折叠后 L3 应位于屏幕顶行。");
+        Assert.IsTrue(model.Toggle(screen, map[anchorScreenRow]));
+        Assert.IsFalse(model.HasFolds, "再点折叠头应展开。");
+    }
+
+    [TestMethod]
+    public void Fold_PrunedWhenAnchorEvicted()
+    {
+        var e = new TerminalEmulator(40, 3, TerminalType.XtermColor256);
+        e.Screen.MaxScrollback = 2;
+        e.Feed(Encoding.UTF8.GetBytes("L0\r\nL1\r\nL2"));
+        var model = new GutterFoldModel();
+        Assert.IsTrue(model.Toggle(e.Screen, FindAbs(e.Screen, "L2"))); // 头 L2
+        Assert.IsTrue(model.HasFolds);
+
+        for (int i = 3; i < 30; i++) // 大量输出把 L2 挤出 2 行的 scrollback
+        {
+            e.Feed(Encoding.UTF8.GetBytes("\r\nL" + i));
+        }
+        Assert.IsTrue(FindAbs(e.Screen, "L2") < 0, "L2 应已被淘汰出缓冲区。");
+        model.PruneStale(e.Screen);
+        Assert.IsFalse(model.HasFolds, "折叠头被淘汰后折叠应自动清除。");
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using System.Threading;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// Headless UI 端到端:用 Avalonia headless 平台实例化真实的 <see cref="VelaTerminalControl" />,
+/// 渲染后派发真实鼠标事件,验证「在折叠列点击 → 真的折叠 / 再点展开」。这一层覆盖单元测试够不到的
+/// Avalonia 事件投递 + 渲染 + 命中链路。
+/// </summary>
+[TestClass]
+[TestCategory("GutterFoldUi")]
+public class GutterFoldUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [TestMethod]
+    public void RealPointerClick_InFoldColumn_FoldsAndExpands()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ShowFoldMarker = true };
+            control.Feed(Encoding.UTF8.GetBytes("L0\r\nL1\r\nL2\r\nL3\r\nL4\r\nL5"));
+
+            var window = new Window { Width = 480, Height = 320, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame(); // 强制一帧渲染 → 填充屏幕行映射
+
+            Assert.IsTrue(control.CellHeightForTest > 0, "渲染后应有有效的单元格高度。");
+            Assert.AreEqual(0, control.FoldCountForTest);
+
+            // 只开折叠标记时折叠列从 x=0 开始;点击第 3 屏幕行(L0..L5 占屏幕行 0..5)。
+            GutterLayout gutter = control.GutterForTest;
+            var point = new Point(gutter.FoldLeft + 2, 3 * control.CellHeightForTest + 2);
+            Assert.IsTrue(gutter.IsFoldColumnHit(point.X));
+
+            window.MouseDown(point, MouseButton.Left);
+            window.MouseUp(point, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreEqual(1, control.FoldCountForTest, "在折叠列点击应产生一个折叠区域。");
+
+            // 折叠后 L3 成为折叠头,位于屏幕顶行;点它展开。
+            window.CaptureRenderedFrame();
+            var expandPoint = new Point(gutter.FoldLeft + 2, 0 * control.CellHeightForTest + 2);
+            window.MouseDown(expandPoint, MouseButton.Left);
+            window.MouseUp(expandPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreEqual(0, control.FoldCountForTest, "点击折叠头应展开(折叠数归零)。");
+        });
+    }
+
+    [TestMethod]
+    public void GutterContextMenu_HasFourToggles_ReflectsState_AndItemTogglesOption()
+    {
+        // 直接构建菜单(不弹出弹层,避免 headless 下 popup 阻塞),验证内容 + 菜单项→属性开关的接线。
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ShowLineNumber = true };
+            ContextMenu menu = control.BuildGutterContextMenu();
+            Assert.AreEqual(4, menu.Items.Count, "菜单应含 4 个部件开关(行号/时间戳/折叠标记/空白)。");
+
+            var lineNumberItem = (MenuItem)menu.Items[0]!;
+            var timestampItem = (MenuItem)menu.Items[1]!;
+            StringAssert.StartsWith((string)lineNumberItem.Header!, "✔", "行号已开,菜单项应带勾号。");
+            StringAssert.StartsWith((string)timestampItem.Header!, " ", "时间戳未开,菜单项应无勾号(空格前缀)。");
+
+            // 触发「行号」项 → 关闭行号,证明菜单项确实驱动属性开关。
+            lineNumberItem.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+            Assert.IsFalse(control.ShowLineNumber, "点击「行号」菜单项应关闭行号。");
+        });
+    }
+
+    [TestMethod]
+    public void RealPointerClick_OutsideFoldColumn_DoesNotFold()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ShowFoldMarker = true };
+            control.Feed(Encoding.UTF8.GetBytes("L0\r\nL1\r\nL2\r\nL3"));
+            var window = new Window { Width = 480, Height = 320, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            GutterLayout gutter = control.GutterForTest;
+            // 点正文区域(侧栏右侧),不应折叠。
+            var point = new Point(gutter.TotalWidth + 40, 2 * control.CellHeightForTest + 2);
+            window.MouseDown(point, MouseButton.Left);
+            window.MouseUp(point, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreEqual(0, control.FoldCountForTest, "正文区域点击不应折叠。");
+        });
+    }
+}
+
+/// <summary>headless 测试用的最小 Avalonia 应用。</summary>
+public class HeadlessTestApp : Application
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<HeadlessTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/VelaShell.Terminal.Tests/GutterLayoutTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterLayoutTests.cs
@@ -1,0 +1,63 @@
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>侧栏几何与折叠列命中判定:决定「鼠标点在哪算点到折叠列」,是折叠交互的坐标基础。</summary>
+[TestClass]
+[TestCategory("GutterLayout")]
+public class GutterLayoutTests
+{
+    private const double CellW = 8;
+
+    [TestMethod]
+    public void AllOff_IsDisabled_ZeroWidth()
+    {
+        var g = new GutterLayout(CellW, false, false, false, false);
+        Assert.IsFalse(g.Enabled);
+        Assert.AreEqual(0, g.TotalWidth);
+        Assert.IsFalse(g.ContainsX(0));
+        Assert.IsFalse(g.IsFoldColumnHit(0));
+    }
+
+    [TestMethod]
+    public void Widths_AddUp_LeftToRight()
+    {
+        var g = new GutterLayout(CellW, showTimestamp: true, showNumber: true, showFold: true, blank: true);
+        Assert.AreEqual(11 * CellW, g.TimeWidth);
+        Assert.AreEqual((GutterLayout.NumberDigits + 1) * CellW, g.NumberWidth);
+        Assert.AreEqual(Math.Ceiling(CellW * 1.6), g.FoldWidth);
+        Assert.AreEqual(GutterLayout.BlankPixels, g.BlankWidth);
+        Assert.AreEqual(g.TimeWidth, g.NumberLeft);
+        Assert.AreEqual(g.TimeWidth + g.NumberWidth, g.FoldLeft);
+        Assert.AreEqual(g.TimeWidth + g.NumberWidth + g.FoldWidth + g.BlankWidth, g.TotalWidth);
+    }
+
+    [TestMethod]
+    public void FoldColumnHit_OnlyWithinFoldPlusBlank()
+    {
+        // 时间+行号+折叠+空白都开:折叠列在时间/行号之后。
+        var g = new GutterLayout(CellW, true, true, true, true);
+        Assert.IsFalse(g.IsFoldColumnHit(g.FoldLeft - 1), "折叠列左边缘之前不算命中。");
+        Assert.IsTrue(g.IsFoldColumnHit(g.FoldLeft), "折叠列左边缘算命中。");
+        Assert.IsTrue(g.IsFoldColumnHit(g.FoldLeft + g.FoldWidth), "折叠列右侧空白区仍算命中(便于点击)。");
+        Assert.IsFalse(g.IsFoldColumnHit(g.TotalWidth), "侧栏右边缘之外不算命中。");
+    }
+
+    [TestMethod]
+    public void FoldOff_NeverFoldHit()
+    {
+        var g = new GutterLayout(CellW, showTimestamp: true, showNumber: true, showFold: false, blank: true);
+        Assert.AreEqual(0, g.FoldWidth);
+        Assert.IsFalse(g.IsFoldColumnHit(g.FoldLeft));
+        Assert.IsFalse(g.IsFoldColumnHit(g.TotalWidth - 1));
+    }
+
+    [TestMethod]
+    public void FoldOnly_FoldColumnStartsAtZero()
+    {
+        var g = new GutterLayout(CellW, showTimestamp: false, showNumber: false, showFold: true, blank: false);
+        Assert.AreEqual(0, g.FoldLeft);
+        Assert.IsTrue(g.IsFoldColumnHit(0));
+        Assert.IsTrue(g.IsFoldColumnHit(g.FoldWidth - 1));
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
@@ -83,6 +83,21 @@ public class LineTimestampTests
     }
 
     [TestMethod]
+    public void BlankLineWithinOutput_GetsTimestamp_TrailingRowsDoNot()
+    {
+        // 侧栏行号可见性依赖时间戳:输出中间的空行(光标经过)应有时间戳→显示行号;
+        // 光标从未到过的屏幕底部空行不应有时间戳→不显示行号(避免空屏凭空冒出几十行编号)。
+        TerminalEmulator e = New(20, 8);
+        Feed(e, "L0\r\n\r\nL2"); // L0、空行、L2
+
+        Assert.IsNotNull(e.Screen.ActiveLine(0).Timestamp, "内容行应有时间戳。");
+        Assert.IsNotNull(e.Screen.ActiveLine(1).Timestamp, "输出中间的空行也应有时间戳(光标经过)。");
+        Assert.IsNotNull(e.Screen.ActiveLine(2).Timestamp);
+        Assert.IsNull(e.Screen.ActiveLine(4).Timestamp, "光标从未到过的底部空行不应有时间戳。");
+        Assert.IsNull(e.Screen.ActiveLine(7).Timestamp);
+    }
+
+    [TestMethod]
     public void ErasingRow_ClearsTimestamp()
     {
         TerminalEmulator e = New();

--- a/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
@@ -55,6 +55,34 @@ public class LineTimestampTests
     }
 
     [TestMethod]
+    public void Timestamp_SurvivesColumnReflow()
+    {
+        // 开关侧栏会改变可用列宽 → 触发主屏 reflow(重建行对象)。时间戳必须穿过 reflow,
+        // 否则切换侧栏后历史行的时间/行号信息全部丢失(用户反馈的核心 bug)。
+        TerminalEmulator e = New(40, 4);
+        e.Screen.MaxScrollback = 1000;
+        Feed(e, "alpha\r\nbeta\r\ngamma");
+        DateTime? alphaTs = e.Screen.ViewLine(0).Timestamp;
+        Assert.IsNotNull(alphaTs);
+
+        // 模拟开启侧栏:列宽变窄触发 reflow。
+        e.Resize(30, 4);
+
+        // 内容与时间戳都应保留。
+        bool found = false;
+        for (int r = 0; r < e.Screen.TotalRows; r++)
+        {
+            TerminalRow row = e.Screen.ViewLine(r);
+            if (row.GetText() == "alpha")
+            {
+                Assert.AreEqual(alphaTs, row.Timestamp, "reflow 后行时间戳应保持不变。");
+                found = true;
+            }
+        }
+        Assert.IsTrue(found, "reflow 后仍应能找到原始行 alpha。");
+    }
+
+    [TestMethod]
     public void ErasingRow_ClearsTimestamp()
     {
         TerminalEmulator e = New();

--- a/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 行时间戳(时间/行号侧栏的数据基础):写入的行盖上「本次 Feed 到达时刻」,该时间戳随行对象在
+/// 滚动时迁入 scrollback 而保留;从未写入内容的空行时间戳为 null(侧栏据此不显示时间)。
+/// </summary>
+[TestClass]
+[TestCategory("LineTimestamp")]
+public class LineTimestampTests
+{
+    private static TerminalEmulator New(int cols = 20, int rows = 4) => new(cols, rows);
+
+    private static void Feed(TerminalEmulator e, string s) => e.Feed(Encoding.UTF8.GetBytes(s));
+
+    [TestMethod]
+    public void WrittenRow_GetsTimestamp()
+    {
+        TerminalEmulator e = New();
+        DateTime before = DateTime.Now;
+        Feed(e, "hello");
+        DateTime after = DateTime.Now;
+
+        DateTime? ts = e.Screen.ActiveLine(0).Timestamp;
+        Assert.IsNotNull(ts, "写入内容的行应被盖上时间戳。");
+        Assert.IsTrue(ts >= before && ts <= after, "时间戳应落在该次写入的时刻区间内。");
+    }
+
+    [TestMethod]
+    public void UntouchedRow_HasNoTimestamp()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "only first row");
+        Assert.IsNull(e.Screen.ActiveLine(1).Timestamp, "从未写入内容的空行不应有时间戳。");
+    }
+
+    [TestMethod]
+    public void Timestamp_TravelsIntoScrollback()
+    {
+        TerminalEmulator e = New(20, 2); // 仅 2 行,便于把第一行挤入 scrollback
+        Feed(e, "first");
+        DateTime? original = e.Screen.ActiveLine(0).Timestamp;
+        Assert.IsNotNull(original);
+
+        // 换足够多行把 "first" 顶出屏幕、进入 scrollback。
+        Feed(e, "\r\nsecond\r\nthird\r\nfourth");
+        Assert.IsTrue(e.Screen.ScrollbackCount > 0, "应已有行滚入 scrollback。");
+
+        // 绝对行 0 是最早的历史行(= "first"),其时间戳应与写入时一致(行对象按引用迁移)。
+        TerminalRow oldest = e.Screen.ViewLine(0);
+        Assert.AreEqual("first", oldest.GetText());
+        Assert.AreEqual(original, oldest.Timestamp, "滚入 scrollback 后时间戳应保持不变。");
+    }
+
+    [TestMethod]
+    public void ErasingRow_ClearsTimestamp()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "content");
+        Assert.IsNotNull(e.Screen.ActiveLine(0).Timestamp);
+
+        // 整行擦除(EL 模式 2)后该行视为空行,时间戳应作废。
+        Feed(e, "\r\x1b[2K");
+        Assert.IsNull(e.Screen.ActiveLine(0).Timestamp, "整行擦除后时间戳应清空。");
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
+++ b/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
@@ -13,9 +13,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
+++ b/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" Version="12.1.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/VelaShell.Tests/VelaShell.Tests.csproj
+++ b/tests/VelaShell.Tests/VelaShell.Tests.csproj
@@ -13,10 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="6.1.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="ReactiveUI.Testing" Version="23.2.28" />
   </ItemGroup>
 


### PR DESCRIPTION
新增终端侧栏，支持显示收行时间和行号，二者可独立控制。实现了侧栏渲染、宽度自适应、命中测试修正等逻辑。设置页增加对应开关，Ctrl+Shift+L 一键切换。行时间戳随内容写入、滚动、擦除动态维护。补充多语言资源及相关单元测试，升级测试依赖。