### PR TITLE
条件化处理 InternalsVisibleTo 友元程序集声明

### DIFF
--- a/src/VelaShell.Terminal/VelaShell.Terminal.csproj
+++ b/src/VelaShell.Terminal/VelaShell.Terminal.csproj
@@ -12,7 +12,10 @@
     <ProjectReference Include="..\VelaShell.Core\VelaShell.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- 强名签名(仅 Release,见 src/Directory.Build.props)时,签名程序集的 InternalsVisibleTo
+       必须带友元公钥;而测试程序集本地是非签名的,带公钥反而在 Debug 下失配。发布 CI 只 publish
+       应用、不跑测试,故签名构建(Release)时省略友元声明,仅在非签名构建(Debug / 本地测试)保留。 -->
+  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
     <InternalsVisibleTo Include="VelaShell.Terminal.Tests" />
   </ItemGroup>
 

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -29,7 +29,8 @@
     <PackageReference Include="Velopack" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- 见 VelaShell.Terminal.csproj 同处注释:签名构建(Release)省略友元声明,非签名构建保留。 -->
+  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
     <InternalsVisibleTo Include="VelaShell.Tests" />
   </ItemGroup>
 


### PR DESCRIPTION
对 VelaShell.Terminal.csproj 和 VelaShell.csproj 增加条件：仅在非签名构建（Debug/本地测试）时声明测试程序集为友元，签名构建（Release）时省略，避免公钥失配，提升测试与发布兼容性。