### PR TITLE
支持 Linux 平台自动检测及 Wayland 启用

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,15 @@
   <PropertyGroup>
 	<TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
+
+  <!-- 定义 Linux -->
+  <PropertyGroup>
+  	<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsLinux)' == 'true'">
+  	<DefineConstants>$(DefineConstants);LINUX</DefineConstants>
+  </PropertyGroup>
 	
   <PropertyGroup>
     <!-- 全仓统一版本:Version 派生 AssemblyInformationalVersion(含预发布后缀,

--- a/src/VelaShell/Program.cs
+++ b/src/VelaShell/Program.cs
@@ -135,7 +135,9 @@ internal static partial class Program
     private static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<App>()
                   .UsePlatformDetect()
+#if LINUX
                   .UseWayland()
+#endif
                   .WithInterFont()
                   .LogToTrace()
                   .UseReactiveUI(_ => { });


### PR DESCRIPTION
在 Directory.Build.props 中增加 Linux 检测与 LINUX 常量定义；在 Program.cs 中，Linux 下自动启用 Avalonia 的 Wayland 支持。