### PR TITLE
chore: 升级依赖包版本，提升兼容性与稳定性

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,16 +13,16 @@
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <!-- Microsoft.Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- 其它 -->
     <PackageVersion Include="ReactiveUI" Version="23.2.28" />
     <PackageVersion Include="Velopack" Version="1.2.0" />
     <PackageVersion Include="SonnetDB.Core" Version="3.0.1" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -2,14 +2,12 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- 测试框架 -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-
     <!-- 测试辅助 -->
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />


### PR DESCRIPTION
升级了部分依赖包的版本，包括：
- Microsoft.Extensions.DependencyInjection 及其 Abstractions、Microsoft.Extensions.Logging.Abstractions 从 10.0.9 升级到 10.0.10
- System.Security.Cryptography.ProtectedData 从 10.0.9 升级到 10.0.10
- Microsoft.SourceLink.GitHub 从 10.0.300 升级到 10.0.301
- Microsoft.NET.Test.Sdk 从 18.7.0 升级到 18.8.1

其它依赖项未做变动，仅为常规版本升级，提升兼容性并修复潜在问题。