### PR TITLE
fix: 修复SSH查表命令分隔标记被shell注释问题,导致 group 查询被 shell 注释吞掉

### DIFF
--- a/src/VelaShell.Core/Sftp/RemoteIdentityResolver.cs
+++ b/src/VelaShell.Core/Sftp/RemoteIdentityResolver.cs
@@ -32,6 +32,10 @@ internal sealed record RemoteIdentityMap(IReadOnlyDictionary<int, string> Users,
 internal sealed class RemoteIdentityResolver(ISshConnectionService connectionService)
 {
     /// <summary>passwd 段与 group 段的分隔标记(一次往返读回两张表)。</summary>
+    /// <remarks>
+    /// 在 <see cref="LookupCommand" /> 里必须带引号:'#' 开头的词会被 shell 当注释,
+    /// 吞掉标记连同其后的整条 group 查询。
+    /// </remarks>
     private const string SectionSeparator = "###VELA-GROUPS###";
 
     /// <summary>
@@ -41,7 +45,7 @@ internal sealed class RemoteIdentityResolver(ISshConnectionService connectionSer
     /// </summary>
     private const string LookupCommand =
         "{ getent passwd 2>/dev/null || cat /etc/passwd 2>/dev/null; }; " +
-        "echo " + SectionSeparator + "; " +
+        "echo '" + SectionSeparator + "'; " +
         "{ getent group 2>/dev/null || cat /etc/group 2>/dev/null; }";
 
     /// <summary>

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -548,6 +548,28 @@ public class SftpServiceTests
         await sshClient.Received(2).RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// 分隔标记以 '#' 开头,在命令里必须带引号:裸写时 shell 会把它当注释,连同其后的
+    /// group 查询一起吞掉,于是只有 passwd 段跑出来 —— 属主显示名称而属组回退数字。
+    /// 其余查表测试都直接喂假输出,测不到命令本身,故在此守住。
+    /// </summary>
+    [TestMethod]
+    public async Task ListDirectoryAsync_IdentityLookupCommand_QuotesSectionSeparator()
+    {
+        ISshClientWrapper sshClient = GivenIdentityLookupReturns(IdentityLookupOutput);
+        _sftpClient.ListDirectoryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult<IEnumerable<SftpEntry>>([]));
+
+        await _sftpService.ListDirectoryAsync(_sessionId, "/srv");
+
+        string command = (string)sshClient.ReceivedCalls()
+                                          .Single(c => c.GetMethodInfo().Name == nameof(ISshClientWrapper.RunCommandAsync))
+                                          .GetArguments()[0]!;
+        StringAssert.Contains(command, "echo '###VELA-GROUPS###'");
+        Assert.IsFalse(command.Contains("echo ###", StringComparison.Ordinal),
+                       "分隔标记未加引号,group 段会被 shell 当注释吞掉。");
+    }
+
     private ISshClientWrapper GivenIdentityLookupReturns(string output)
     {
         ISshClientWrapper sshClient = Substitute.For<ISshClientWrapper>();


### PR DESCRIPTION
修正 SectionSeparator 未加引号导致 group 查询被 shell 注释吞掉，确保属组名称正确显示。新增单元测试 ListDirectoryAsync_IdentityLookupCommand_QuotesSectionSeparator，验证分隔标记加引号逻辑，防止回归。