### PR TITLE
chore: 侧栏菜单勾选项和SFTP勾选视觉效果优化.

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -1103,7 +1103,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         ScrollChanged?.Invoke();
     }
 
-    /// <summary>侧栏右键菜单:四个部件(行号/时间戳/折叠标记/空白)的可勾选开关(勾号前缀表示已开)。</summary>
+    /// <summary>侧栏右键菜单:四个部件(行号/时间戳/折叠标记/空白)的可勾选开关。</summary>
     private void ShowGutterContextMenu() => BuildGutterContextMenu().Open(this);
 
     /// <summary>构建侧栏右键菜单(不弹出)。internal 供 headless 测试直接检视内容与开关接线,避免打开弹层。</summary>
@@ -1118,12 +1118,25 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         return menu;
     }
 
+    /// <summary>
+    /// 用 <see cref="MenuItemToggleType.CheckBox" /> 而非在 Header 里拼勾号字符:勾号交给模板
+    /// 固定宽度的勾选列渲染,开关时文字不再左右跳,且勾号是矢量图形、跟随主题前景色 —— 拼字符
+    /// 时 JB Mono 没有 U+2714,回退字体的字宽与颜色都不受控。与文件浏览器的列开关菜单同款。
+    /// </summary>
     private void AddGutterMenuItem(ContextMenu menu, string label, bool on, Action<bool> set)
     {
-        var item = new MenuItem { Header = (on ? "✔  " : "      ") + label };
+        var item = new MenuItem
+        {
+            Header = label,
+            ToggleType = MenuItemToggleType.CheckBox,
+            IsChecked = on,
+            // 四个部件可一次性调完,不必每改一个都重新右键。
+            StaysOpenOnClick = true
+        };
+        // 读 item.IsChecked(点击时已由模板翻转)而非取反捕获的 on:菜单不关,同一项可被连点多次。
         item.Click += (_, _) =>
         {
-            set(!on);
+            set(item.IsChecked);
             GutterOptionsChanged?.Invoke(ShowLineTimestamp, ShowLineNumber, ShowFoldMarker, GutterBlank);
         };
         menu.Items.Add(item);

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:dockc="using:VelaShell.Docking.Controls">
+        xmlns:dockc="using:VelaShell.Docking.Controls"
+        xmlns:shapes="using:Avalonia.Controls.Shapes">
 
     <!-- 终端工作区(自研 VelaDock)底色 + 全局通用样式。标签本身的视觉
          (36px 条 / 32px 标签 / 状态点 / accent 顶线 / 关闭钮)内联在
@@ -80,6 +81,26 @@
         <Setter Property="Opacity" Value="0.6" />
     </Style>
 
+    <!-- 勾选项的勾号:与箭头同病同治 —— Fluent 也按 14 号字把它定死在 16x13,配 11 号字
+         (文字实高 12)偏大。0.8 → 渲染约 12.8x10.4,高度与缩放后的箭头齐平。
+         缩放挂在 ToggleIconPresenter 上:勾号本身是模板里的匿名 Path,选择器点不到它;
+         而 presenter 的 Width/Height 又是模板局部值、改不动,只有 RenderTransform 可用。
+         布局槽仍是 16x16,勾号原位缩小,文字不位移。图标列(PART_IconPresenter)不受影响。 -->
+    <Style Selector="ContextMenu MenuItem /template/ ContentControl#PART_ToggleIconPresenter">
+        <Setter Property="RenderTransform" Value="scale(0.65)" />
+    </Style>
+
+    <!-- 子菜单箭头:Fluent 按它默认的 14 号字把 8x16 写死在模板里,菜单压到 11 号后箭头
+         不跟着缩,16px 高的箭头配 11px 的字明显大一号。0.65 → 渲染约 10.4px,略低于字高。
+
+         两个坑(改之前先读 MenuChevronStyleTests):
+         · 只能缩放,不能设 Width/Height/Fill —— 那三个是模板里写死的局部值,样式覆盖不了,
+           设了不报错也不生效。布局槽仍是 8x16,箭头在原位缩小,不挤动行内其它元素。
+         · 类型必须写 shapes|Path:默认 xmlns 下裸写的 Path 匹配不到这个部件,同样静默失效。 -->
+    <Style Selector="ContextMenu MenuItem /template/ shapes|Path#PART_ChevronPath">
+        <Setter Property="RenderTransform" Value="scale(0.65)" />
+    </Style>
+
     <Style Selector="ContextMenu Separator">
         <Setter Property="Background" Value="{DynamicResource VelaBorderPrimary}" />
         <Setter Property="Height" Value="1" />
@@ -133,6 +154,14 @@
     <Style Selector="MenuFlyoutPresenter MenuItem.active-tab">
         <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
         <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+
+    <!-- 勾号与子菜单箭头:同 ContextMenu,见那边的说明。 -->
+    <Style Selector="MenuFlyoutPresenter MenuItem /template/ ContentControl#PART_ToggleIconPresenter">
+        <Setter Property="RenderTransform" Value="scale(0.65)" />
+    </Style>
+    <Style Selector="MenuFlyoutPresenter MenuItem /template/ shapes|Path#PART_ChevronPath">
+        <Setter Property="RenderTransform" Value="scale(0.65)" />
     </Style>
 
 </Styles>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -11,6 +11,8 @@
     <!-- 测试辅助 -->
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
+    <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="ReactiveUI.Testing" Version="23.2.28" />
   </ItemGroup>

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using VelaShell.Terminal.Rendering;
 
@@ -72,9 +73,8 @@ public class GutterFoldUiTests
     }
 
     [TestMethod]
-    public void GutterContextMenu_HasFourToggles_ReflectsState_AndItemTogglesOption()
+    public void GutterContextMenu_HasFourToggles_ReflectingCurrentState()
     {
-        // 直接构建菜单(不弹出弹层,避免 headless 下 popup 阻塞),验证内容 + 菜单项→属性开关的接线。
         OnUi(() =>
         {
             var control = new VelaTerminalControl { ShowLineNumber = true };
@@ -83,13 +83,98 @@ public class GutterFoldUiTests
 
             var lineNumberItem = (MenuItem)menu.Items[0]!;
             var timestampItem = (MenuItem)menu.Items[1]!;
-            StringAssert.StartsWith((string)lineNumberItem.Header!, "✔", "行号已开,菜单项应带勾号。");
-            StringAssert.StartsWith((string)timestampItem.Header!, " ", "时间戳未开,菜单项应无勾号(空格前缀)。");
+            Assert.IsTrue(lineNumberItem.IsChecked, "行号已开,菜单项应为勾选态。");
+            Assert.IsFalse(timestampItem.IsChecked, "时间戳未开,菜单项应为未勾选态。");
+        });
+    }
 
-            // 触发「行号」项 → 关闭行号,证明菜单项确实驱动属性开关。
-            lineNumberItem.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+    /// <summary>菜单项 → 属性开关的接线:走真实指针点击,不用合成事件(见 ClickMenuItem 的说明)。</summary>
+    [TestMethod]
+    public void GutterContextMenu_ClickingItem_TogglesOption()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, ContextMenu menu) = ShowGutterMenu(new() { ShowLineNumber = true });
+
+            ClickMenuItem((MenuItem)menu.Items[0]!);
+
             Assert.IsFalse(control.ShowLineNumber, "点击「行号」菜单项应关闭行号。");
         });
+    }
+
+    /// <summary>
+    /// 勾号必须由勾选列渲染,不能拼进 Header —— 拼字符会让文字随开关左右跳,且勾号颜色不跟随主题。
+    /// </summary>
+    [TestMethod]
+    public void GutterContextMenu_RendersCheckInToggleColumn_NotAsHeaderText()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ShowLineNumber = true };
+            ContextMenu menu = control.BuildGutterContextMenu();
+
+            foreach (object? raw in menu.Items)
+            {
+                var item = (MenuItem)raw!;
+                Assert.AreEqual(MenuItemToggleType.CheckBox, item.ToggleType, "菜单项应是复选型。");
+
+                // Header 只放标签:开与关的 Header 必须完全一致,文字才不会随勾选状态位移。
+                var header = (string)item.Header!;
+                Assert.AreEqual(header.Trim(), header, "Header 不应含用于占位/勾号的空白前缀。");
+                Assert.IsFalse(header.Contains('✔'), "勾号应由勾选列渲染,不应拼进 Header。");
+            }
+        });
+    }
+
+    /// <summary>
+    /// 菜单点击后不关闭(StaysOpenOnClick),同一项可被连点;开关必须跟着来回翻,
+    /// 不能因为读了构建时捕获的旧状态而卡住。
+    /// </summary>
+    [TestMethod]
+    public void GutterContextMenu_ClickingSameItemTwice_TogglesOptionBackAndForth()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, ContextMenu menu) = ShowGutterMenu(new() { ShowLineNumber = true });
+            var item = (MenuItem)menu.Items[0]!;
+
+            ClickMenuItem(item);
+            Assert.IsFalse(control.ShowLineNumber, "第一次点击应关闭行号。");
+
+            ClickMenuItem(item);
+            Assert.IsTrue(control.ShowLineNumber, "菜单不关闭,再点同一项应重新打开行号。");
+        });
+    }
+
+    /// <summary>把终端挂进窗口并弹出侧栏右键菜单,返回控件与已打开的菜单(菜单项此时才有模板与命中区)。</summary>
+    private static (VelaTerminalControl Control, ContextMenu Menu) ShowGutterMenu(VelaTerminalControl control)
+    {
+        var window = new Window { Width = 480, Height = 320, Content = control };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        ContextMenu menu = control.BuildGutterContextMenu();
+        menu.Open(control);
+        Dispatcher.UIThread.RunJobs();
+        TopLevel.GetTopLevel((Control)menu.Items[0]!)?.UpdateLayout();
+        return (control, menu);
+    }
+
+    /// <summary>
+    /// 派发真实指针事件而非 RaiseEvent(ClickEvent):IsChecked 由 MenuItem 的输入链路在 Click 之前
+    /// 翻转,合成事件绕过这一步,会让「点击后读 IsChecked」的接线看起来是坏的(实际不是)。
+    /// </summary>
+    private static void ClickMenuItem(MenuItem item)
+    {
+        var popup = (Window?)TopLevel.GetTopLevel(item);
+        Assert.IsNotNull(popup, "菜单项应已在弹层里完成布局。");
+        Assert.IsGreaterThan(0, item.Bounds.Width, "菜单项应有可命中的区域。");
+
+        Point center = item.TranslatePoint(new(item.Bounds.Width / 2, item.Bounds.Height / 2), popup)!.Value;
+        popup.MouseDown(center, MouseButton.Left);
+        popup.MouseUp(center, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
     }
 
     [TestMethod]
@@ -119,6 +204,9 @@ public class GutterFoldUiTests
 /// <summary>headless 测试用的最小 Avalonia 应用。</summary>
 public class HeadlessTestApp : Application
 {
+    /// <summary>菜单的模板由主题提供:缺了它 MenuItem 无模板、无命中区,真实点击测不了。</summary>
+    public override void Initialize() => Styles.Add(new FluentTheme());
+
     public static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<HeadlessTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
 }

--- a/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
+++ b/tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/VelaShell.Tests/Views/FileBrowserColumnsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileBrowserColumnsUiTests.cs
@@ -33,11 +33,10 @@ public class FileBrowserColumnsUiTests
 
     private static HeadlessUnitTestSession _session = null!;
 
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App,否则谁先跑谁的样式说了算。
     [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(FileBrowserColumnsUiTests).Assembly);
 
     [TestMethod]
     public void AllColumnsVisible_HeaderLaysOutEveryColumnAtItsWidth()
@@ -163,22 +162,4 @@ public class FileBrowserColumnsUiTests
             body();
             return Task.CompletedTask;
         }, CancellationToken.None).GetAwaiter().GetResult();
-
-    /// <summary>
-    /// 最小可跑的 headless 宿主:只加载视图要用到的样式与资源字典(图标是
-    /// StaticResource,缺了会在加载 XAML 时直接抛),不碰真实 App 的 DI 容器与数据库。
-    /// </summary>
-    private class HeadlessTestApp : Application
-    {
-        public override void Initialize()
-        {
-            Styles.Add(new FluentTheme());
-            Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Generic.axaml"));
-            Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaTokens.axaml"));
-            Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaShellTokens.axaml"));
-            Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Icons.axaml"));
-        }
-
-        private static ResourceInclude LoadDictionary(string uri) => new(new Uri(uri)) { Source = new(uri) };
-    }
 }

--- a/tests/VelaShell.Tests/Views/MenuGlyphStyleTests.cs
+++ b/tests/VelaShell.Tests/Views/MenuGlyphStyleTests.cs
@@ -1,0 +1,194 @@
+using System.Threading;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Shapes = Avalonia.Controls.Shapes;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 右键菜单里两个字形 —— 勾号(PART_ToggleIconPresenter)与子菜单箭头(PART_ChevronPath)——
+/// 的尺寸校准。加载真实的 DockStyles,对着真实的 Fluent 模板验证。
+/// </summary>
+/// <remarks>
+/// 两者 Fluent 都按它默认的 14 号字定死了尺寸,而菜单用的是 11 号,不缩就比字大一号。
+/// 这里盯着 RenderTransform 而不是 Width/Height,是因为那些尺寸是模板标记里的局部值,
+/// 样式设不动 —— 设了既不报错也不生效。缩放是唯一能落地的路子,故本测试同时钉住
+/// 「别改回 Width/Height」。
+/// </remarks>
+[TestClass]
+[TestCategory("MenuGlyphStyle")]
+public class MenuGlyphStyleTests
+{
+    /// <summary>Fluent 模板里写死的字形尺寸(按它默认的 14 号字定的)。</summary>
+    private const double FluentChevronWidth = 8;
+    private const double FluentChevronHeight = 16;
+    private const double FluentToggleSlot = 16;
+
+    /// <summary>勾号图形本身的高度(16x13,窄于它 16x16 的布局槽)。</summary>
+    private const double FluentCheckGlyphHeight = 13;
+
+    /// <summary>菜单文字的实际行高(FontSize 11)。字形不该比它更高。</summary>
+    private const double MenuTextHeight = 12;
+
+    /// <summary>DockStyles 给右键菜单钉死的字号。上面两个缩放比例就是按它算出来的。</summary>
+    private const double MenuFontSize = 11;
+
+    private static HeadlessUnitTestSession _session = null!;
+
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App,否则谁先跑谁的样式说了算。
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(MenuGlyphStyleTests).Assembly);
+
+    [TestMethod]
+    public void SubmenuChevron_IsScaledDown_ToMatchTheMenuFontSize()
+    {
+        OnUi(() =>
+        {
+            Shapes.Path chevron = OpenMenu().Chevron;
+
+            Assert.IsNotNull(chevron.RenderTransform, "子菜单箭头应被缩放:Fluent 的 8x16 是按 14 号字定的,菜单用的是 11 号。");
+
+            double scale = UniformScaleOf(chevron.RenderTransform, "箭头");
+            double rendered = FluentChevronHeight * scale;
+            Assert.IsLessThanOrEqualTo(MenuTextHeight, rendered, "箭头渲染高度不应超过菜单文字的行高。");
+            Assert.IsGreaterThanOrEqualTo(9.0, rendered, "也不该缩到看不清。");
+        });
+    }
+
+    [TestMethod]
+    public void CheckGlyph_IsScaledDown_ToMatchTheMenuFontSize()
+    {
+        OnUi(() =>
+        {
+            ContentControl toggle = OpenMenu().ToggleIcon;
+
+            Assert.IsNotNull(toggle.RenderTransform, "勾号应被缩放:Fluent 的 16x13 同样是按 14 号字定的。");
+
+            double scale = UniformScaleOf(toggle.RenderTransform, "勾号");
+            double rendered = FluentCheckGlyphHeight * scale;
+            Assert.IsLessThanOrEqualTo(MenuTextHeight, rendered, "勾号渲染高度不应超过菜单文字的行高。");
+            Assert.IsGreaterThanOrEqualTo(9.0, rendered, "也不该缩到看不清。");
+        });
+    }
+
+    /// <summary>两个字形缩放后观感应齐平,不能一个比另一个明显大。</summary>
+    [TestMethod]
+    public void CheckGlyphAndChevron_RenderAtAComparableHeight()
+    {
+        OnUi(() =>
+        {
+            (_, ContentControl toggle, Shapes.Path chevron) = OpenMenu();
+
+            double check = FluentCheckGlyphHeight * UniformScaleOf(toggle.RenderTransform, "勾号");
+            double arrow = FluentChevronHeight * UniformScaleOf(chevron.RenderTransform, "箭头");
+
+            Assert.IsLessThanOrEqualTo(1.5, Math.Abs(check - arrow), $"勾号({check:F1}px)与箭头({arrow:F1}px)的渲染高度应接近。");
+        });
+    }
+
+    /// <summary>
+    /// 布局槽仍由模板决定 —— 缩放只改观感,不动排布,所以文字不会随勾选状态或箭头位移。
+    /// </summary>
+    [TestMethod]
+    public void ScalingGlyphs_DoesNotDisturbTheMenuItemLayout()
+    {
+        OnUi(() =>
+        {
+            (_, ContentControl toggle, Shapes.Path chevron) = OpenMenu();
+
+            Assert.AreEqual(FluentToggleSlot, toggle.Bounds.Width, "勾选列宽度应仍由模板决定。");
+            Assert.AreEqual(FluentToggleSlot, toggle.Bounds.Height, "勾选列高度应仍由模板决定。");
+            Assert.AreEqual(FluentChevronWidth, chevron.Bounds.Width, "箭头布局槽宽度应仍由模板决定。");
+            Assert.AreEqual(FluentChevronHeight, chevron.Bounds.Height, "箭头布局槽高度应仍由模板决定。");
+        });
+    }
+
+    private static double UniformScaleOf(ITransform? transform, string what)
+    {
+        Assert.IsNotNull(transform, $"{what}应被缩放。");
+        Matrix m = transform.Value;
+        Assert.AreEqual(m.M11, m.M22, $"{what}应等比缩放,不该被压扁。");
+        Assert.IsLessThan(1.0, m.M11, $"{what}应是缩小。");
+        return m.M11;
+    }
+
+    /// <summary>
+    /// 字形缩放是按固定的 11 号菜单字号算死的,所以右键菜单必须不跟随「设置 → 外观 → 界面字号」——
+    /// 否则调大字号后字形会相对变小、调小后又相对变大,这两个比例就失准了。
+    /// 一旦哪天要让菜单跟随字号,缩放就得改成按字号推算,而不是常量。
+    /// </summary>
+    [TestMethod]
+    public void MenuFontSize_DoesNotFollowTheUiFontSizeSetting_SoTheGlyphScalesStayValid()
+    {
+        OnUi(() =>
+        {
+            IResourceDictionary res = Application.Current!.Resources;
+            try
+            {
+                // 模拟「设置 → 外观 → 界面字号 = 20」(见 MainWindow.ApplyWindowAppearance)。
+                res["VelaUiFontSize"] = 20.0;
+                res["ControlContentThemeFontSize"] = 20.0;
+                Dispatcher.UIThread.RunJobs();
+
+                // 对照:普通控件必须真的跟着变,否则下面那条断言是空的 —— 只能说明设置没生效。
+                var button = new Button { Content = "确定" };
+                var window = new Window { Width = 200, Height = 100, Content = button };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+                Assert.AreEqual(20.0, button.FontSize, "界面字号设置本应作用到普通控件上。");
+
+                Assert.AreEqual(MenuFontSize, OpenMenu().Check.FontSize,
+                                "右键菜单字号由 DockStyles 钉死,不应跟随界面字号 —— 字形缩放正是按它算的。");
+            }
+            finally
+            {
+                res.Remove("VelaUiFontSize");
+                res.Remove("ControlContentThemeFontSize");
+            }
+        });
+    }
+
+    /// <summary>弹出一个既有勾选项、又有子菜单项的右键菜单(与生产的菜单同形)。</summary>
+    private static (MenuItem Check, ContentControl ToggleIcon, Shapes.Path Chevron) OpenMenu()
+    {
+        var check = new MenuItem { Header = "时间戳", ToggleType = MenuItemToggleType.CheckBox, IsChecked = true };
+        var sub = new MenuItem { Header = "移动到分组" };
+        sub.Items.Add(new MenuItem { Header = "未分组" });
+
+        var menu = new ContextMenu();
+        menu.Items.Add(check);
+        menu.Items.Add(sub);
+
+        var host = new Border { Width = 200, Height = 100, ContextMenu = menu };
+        var window = new Window { Width = 400, Height = 300, Content = host };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        menu.Open(host);
+        Dispatcher.UIThread.RunJobs();
+        TopLevel.GetTopLevel(check)?.UpdateLayout();
+
+        ContentControl toggle = check.GetVisualDescendants().OfType<ContentControl>()
+                                     .Single(c => c.Name == "PART_ToggleIconPresenter");
+        Assert.IsTrue(toggle.IsVisible, "已勾选的项应显示勾号。");
+
+        Shapes.Path chevron = sub.GetVisualDescendants().OfType<Shapes.Path>().Single(p => p.Name == "PART_ChevronPath");
+        Assert.IsTrue(chevron.IsVisible, "有子菜单的项应显示箭头。");
+
+        return (check, toggle, chevron);
+    }
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+}

--- a/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
+++ b/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
@@ -1,0 +1,41 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using VelaShell.Tests.Views;
+
+[assembly: AvaloniaTestApplication(typeof(VelaHeadlessApp))]
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 本程序集所有 headless 视图测试共用的宿主,经 <see cref="AvaloniaTestApplicationAttribute" />
+/// 注册,各测试类用 <c>HeadlessUnitTestSession.GetOrStartForAssembly</c> 取同一个会话。
+/// </summary>
+/// <remarks>
+/// 必须共用:一个进程只允许一个 Avalonia Application。各测试类若各起各的 App,先跑的那个会赢,
+/// 其余测试就悄悄地对着别人的样式跑 —— 单独跑绿、全量跑红,且报错完全指不到症结。
+/// 因此这里按真实 App.axaml 的顺序加载完整样式栈,让测试看到的就是生产里的那套。
+/// </remarks>
+public class VelaHeadlessApp : Application
+{
+    public override void Initialize()
+    {
+        RequestedThemeVariant = ThemeVariant.Dark;
+        Styles.Add(new FluentTheme());
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Generic.axaml"));
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaTokens.axaml"));
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaShellTokens.axaml"));
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Icons.axaml"));
+        Styles.Add(LoadStyles("avares://VelaShell/Themes/DockStyles.axaml"));
+        Styles.Add(LoadStyles("avares://VelaShell/Themes/InputStyles.axaml"));
+    }
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<VelaHeadlessApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+
+    private static ResourceInclude LoadDictionary(string uri) => new(new Uri(uri)) { Source = new(uri) };
+
+    private static StyleInclude LoadStyles(string uri) => new(new Uri(uri)) { Source = new(uri) };
+}


### PR DESCRIPTION
重构侧栏右键菜单勾选项渲染，采用 MenuItemToggleType.CheckBox 和模板渲染勾选列，提升一致性和主题适配性。DockStyles.axaml 新增样式，缩放勾号与箭头图标，字号适配。VelaTerminalControl 支持新渲染方式和多次点击。GutterFoldUiTests 测试用例细化，真实指针事件模拟，验证勾选列和状态切换。新增 MenuGlyphStyleTests，专测菜单视觉细节。测试项目引入 Avalonia.Themes.Fluent，新增 VelaHeadlessApp 统一加载样式，测试类统一使用 HeadlessUnitTestSession，移除各自 Application 初始化，确保测试环境一致。