### PR TITLE
完善终端行擦除后时间戳与侧栏显示逻辑

### DIFF
--- a/src/VelaShell.Terminal/Emulation/TerminalRow.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalRow.cs
@@ -43,12 +43,26 @@ public sealed class TerminalRow(int columns)
         Timestamp = null; // 整行清空(擦除/复用作滚动新行)→ 视为未写入,时间戳作废。
     }
 
-    /// <summary>Fills the cells in <paramref name="start" />..<paramref name="endExclusive" /> with the given cell, clamped to the row bounds.</summary>
+    /// <summary>
+    /// Fills the cells in <paramref name="start" />..<paramref name="endExclusive" /> with the given cell,
+    /// clamped to the row bounds. 若擦完整行已空,时间戳一并作废(与 <see cref="Fill" /> 同一不变量)。
+    /// </summary>
+    /// <remarks>
+    /// 这里必须与 <see cref="Fill" /> 守同一条「空行 = 未写入 = 无时间戳」的规矩:重绘型 shell
+    /// (PSReadLine 等)清行用的是 ESC[K(EL 0,擦到行尾)而非 ESC[2K,走的正是这里。少了这一步,
+    /// 行被擦空却留着时间戳,侧栏据 Timestamp 认定「有内容」→ 提示符下方的空行凭空显示时间,
+    /// 折叠导引线也跟着画过光标位置把光标盖住。
+    /// </remarks>
     public void FillRange(int start, int endExclusive, in TerminalCell cell)
     {
         for (int i = Math.Max(0, start); i < Math.Min(_cells.Length, endExclusive); i++)
         {
             _cells[i] = cell;
+        }
+        if (Timestamp is not null && LastNonBlank() < 0)
+        {
+            Wrapped = false;
+            Timestamp = null;
         }
     }
 

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -987,6 +987,21 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     internal double CellHeightForTest { get; private set; } = 16;
     internal GutterLayout GutterForTest => Gutter;
 
+    /// <summary>
+    /// 该行是否显示侧栏(行号/时间戳),并计入折叠导引线的下端。
+    /// </summary>
+    /// <remarks>
+    /// 两条规矩:
+    /// · 有真实内容的行一律显示 —— 满屏重绘型程序(vim 等)光标下方也有内容,不能按光标位置砍掉。
+    /// · 只有时间戳、没有内容的空行,仅在光标位置及之上显示。换行会给经过的行盖上时间戳(哪怕
+    ///   没写入任何字符,见 LineTimestampTests),重绘型 shell 又常把提示符下方来回涂改;若不设
+    ///   这道界,时间线会一直拖到提示符下方的空白区,折叠导引线随之画过光标把光标盖住
+    ///   (用户实测:PowerShell + oh-my-posh + PSReadLine 的历史列表撤销后)。
+    /// internal 供测试直接验证这条判定,不必去驱动整个渲染。
+    /// </remarks>
+    internal static bool ShowsGutterFor(TerminalRow line, int absoluteRow, int cursorAbsoluteRow) =>
+        line.LastNonBlank() >= 0 || (line.Timestamp is not null && absoluteRow <= cursorAbsoluteRow);
+
     private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows)
     {
         // 侧栏底色刻意保持与终端背景一致(不再叠色):正文区域整体右移,侧栏落在开头那次全局底色填充上,
@@ -996,6 +1011,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         var typeface = new Typeface(FontFamily);
         double numberLeft = Gutter.NumberLeft;
         int lastContentRow = -1; // 最后一行有内容的屏幕行:分隔线/折叠线只画到这里,空屏不画侧栏。
+        int cursorAbsoluteRow = screen.ScrollbackCount + screen.CursorY;
         for (int screenRow = 0; screenRow < rows; screenRow++)
         {
             int absoluteRow = _screenToAbs[screenRow];
@@ -1003,14 +1019,11 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 continue;
             }
-            TerminalRow line = screen.ViewLine(absoluteRow);
-            // 从未写入内容的空行(刚开终端时的整屏空行、输出未满屏时下方的空行)不显示行号/时间,
-            // 避免像截图那样凭空多出几十行编号。
-            bool hasContent = line.Timestamp is not null || line.LastNonBlank() >= 0;
-            if (!hasContent)
+            if (!ShowsGutterFor(screen.ViewLine(absoluteRow), absoluteRow, cursorAbsoluteRow))
             {
                 continue;
             }
+            TerminalRow line = screen.ViewLine(absoluteRow);
             lastContentRow = screenRow;
             double y = screenRow * CellHeightForTest + _glyphYOffset;
             if (ShowLineTimestamp && line.Timestamp is { } ts)

--- a/tests/VelaShell.Terminal.Tests/GutterVisibilityTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterVisibilityTests.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 侧栏(行号/时间戳/折叠导引线)的显示范围判定 —— <see cref="VelaTerminalControl.ShowsGutterFor" />。
+/// 时间线不得越过光标:换行会给经过的行盖时间戳(哪怕没写内容),重绘型 shell 又常在提示符下方
+/// 来回涂改,不设界的话时间线会拖到提示符下方,折叠导引线也会画过光标把光标盖住。
+/// </summary>
+[TestClass]
+[TestCategory("GutterVisibility")]
+public class GutterVisibilityTests
+{
+    private static TerminalRow RowWith(string text, DateTime? timestamp)
+    {
+        var row = new TerminalRow(20) { Timestamp = timestamp };
+        for (int i = 0; i < text.Length; i++)
+        {
+            row[i] = new TerminalCell { Rune = text[i] };
+        }
+        return row;
+    }
+
+    [TestMethod]
+    public void ContentRow_IsShown_EvenBelowTheCursor()
+    {
+        // 满屏重绘型程序(vim 等)光标下方也有内容,不能按光标位置砍掉。
+        TerminalRow row = RowWith("text", DateTime.Now);
+        Assert.IsTrue(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 9, cursorAbsoluteRow: 3));
+    }
+
+    [TestMethod]
+    public void ContentRow_WithoutTimestamp_IsStillShown()
+    {
+        TerminalRow row = RowWith("text", null);
+        Assert.IsTrue(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 1, cursorAbsoluteRow: 3));
+    }
+
+    /// <summary>输出中间、光标经过留下的空行:显示时间(时间线不该在中间断开)。</summary>
+    [TestMethod]
+    public void BlankRow_WithTimestamp_AboveCursor_IsShown()
+    {
+        TerminalRow row = RowWith("", DateTime.Now);
+        Assert.IsTrue(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 1, cursorAbsoluteRow: 3));
+    }
+
+    [TestMethod]
+    public void BlankRow_WithTimestamp_AtCursor_IsShown()
+    {
+        TerminalRow row = RowWith("", DateTime.Now);
+        Assert.IsTrue(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 3, cursorAbsoluteRow: 3));
+    }
+
+    /// <summary>提示符下方被涂改过、如今空白的行:不显示 —— 时间线到光标为止。</summary>
+    [TestMethod]
+    public void BlankRow_WithTimestamp_BelowCursor_IsHidden()
+    {
+        TerminalRow row = RowWith("", DateTime.Now);
+        Assert.IsFalse(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 4, cursorAbsoluteRow: 3));
+    }
+
+    [TestMethod]
+    public void BlankRow_WithoutTimestamp_IsHidden()
+    {
+        TerminalRow row = RowWith("", null);
+        Assert.IsFalse(VelaTerminalControl.ShowsGutterFor(row, absoluteRow: 1, cursorAbsoluteRow: 3));
+    }
+
+    /// <summary>
+    /// 端到端:PSReadLine 式的「提示符下方画列表 → 撤销 → 逐行 ESC[K 擦掉 → 光标回到提示符」,
+    /// 之后提示符下方不应还有任何行显示侧栏。
+    /// </summary>
+    [TestMethod]
+    public void AfterPredictionListIsErased_NoGutterBelowThePrompt()
+    {
+        var e = new TerminalEmulator(40, 8);
+        void Feed(string s) => e.Feed(Encoding.UTF8.GetBytes(s));
+
+        Feed("PS> c");
+        Feed("\r\n> history one");
+        Feed("\r\n> history two");
+
+        // 撤销:逐行擦掉列表并回到提示符行。
+        Feed("\r\x1b[K");
+        Feed("\x1b[A\r\x1b[K");
+        Feed("\x1b[A\r\x1b[KPS> ");
+
+        int cursorAbs = e.Screen.ScrollbackCount + e.Screen.CursorY;
+        Assert.AreEqual(0, e.Screen.CursorY, "光标应已回到提示符行。");
+
+        for (int row = cursorAbs + 1; row < e.Screen.TotalRows; row++)
+        {
+            Assert.IsFalse(VelaTerminalControl.ShowsGutterFor(e.Screen.ViewLine(row), row, cursorAbs),
+                           $"提示符下方第 {row} 行已空,不应再显示侧栏。");
+        }
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LineTimestampTests.cs
@@ -108,4 +108,59 @@ public class LineTimestampTests
         Feed(e, "\r\x1b[2K");
         Assert.IsNull(e.Screen.ActiveLine(0).Timestamp, "整行擦除后时间戳应清空。");
     }
+
+    /// <summary>
+    /// EL 模式 0(ESC[K,擦到行尾)是重绘型 shell 的主力擦除手段 —— PSReadLine 每重画一行都发它。
+    /// 它同样把行擦空,时间戳就同样该作废,否则侧栏会在空行上显示时间。
+    /// </summary>
+    [TestMethod]
+    public void ErasingToEndOfLine_ClearsTimestamp_WhenRowBecomesBlank()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "content");
+        Assert.IsNotNull(e.Screen.ActiveLine(0).Timestamp);
+
+        Feed(e, "\r\x1b[K");
+        Assert.IsNull(e.Screen.ActiveLine(0).Timestamp, "擦到行尾后整行已空,时间戳应清空。");
+    }
+
+    /// <summary>擦除只清掉一部分时,行还有内容,时间戳必须留着 —— 别矫枉过正。</summary>
+    [TestMethod]
+    public void ErasingToEndOfLine_KeepsTimestamp_WhenContentRemains()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "abcdef");
+        DateTime? ts = e.Screen.ActiveLine(0).Timestamp;
+
+        // 光标回到第 3 列再擦到行尾:留下 "abc"。
+        Feed(e, "\r\x1b[3C\x1b[K");
+        Assert.AreEqual("abc", e.Screen.ActiveLine(0).GetText(), "应只擦掉光标之后的部分。");
+        Assert.AreEqual(ts, e.Screen.ActiveLine(0).Timestamp, "行仍有内容,时间戳应保留。");
+    }
+
+    /// <summary>
+    /// 用户实测的场景:PowerShell + PSReadLine 在提示符下方画出历史/预测列表,撤销输入后又逐行
+    /// 用 ESC[K 擦掉。被擦掉的行必须不再有时间戳,否则侧栏的时间线会一直拖到提示符下方,
+    /// 折叠导引线也随之画过光标位置(光标被盖住)。
+    /// </summary>
+    [TestMethod]
+    public void PredictionRowsErasedWithEl0_LeaveNoTimestampBelowThePrompt()
+    {
+        TerminalEmulator e = New(40, 8);
+        Feed(e, "PS> c");                       // 提示符 + 输入(第 0 行)
+        Feed(e, "\r\n> history one");           // 下方列表
+        Feed(e, "\r\n> history two");
+
+        Assert.IsNotNull(e.Screen.ActiveLine(1).Timestamp, "列表行此时确有内容。");
+        Assert.IsNotNull(e.Screen.ActiveLine(2).Timestamp);
+
+        // 撤销输入:PSReadLine 逐行 ESC[K 擦掉列表,光标回到提示符行。
+        Feed(e, "\r\x1b[K");                    // 擦第 2 行
+        Feed(e, "\x1b[A\r\x1b[K");              // 上移,擦第 1 行
+        Feed(e, "\x1b[A\r\x1b[KPS> ");          // 上移,重画提示符行
+
+        Assert.IsNull(e.Screen.ActiveLine(1).Timestamp, "被擦空的列表行不应再有时间戳。");
+        Assert.IsNull(e.Screen.ActiveLine(2).Timestamp, "被擦空的列表行不应再有时间戳。");
+        Assert.IsNotNull(e.Screen.ActiveLine(0).Timestamp, "提示符行仍有内容,应保留时间戳。");
+    }
 }


### PR DESCRIPTION
本次更新优化了 ESC[K 等操作导致整行擦空时的时间戳清除机制，避免空行侧栏错误显示时间。`TerminalRow.FillRange` 增加整行擦空时清除时间戳的判断及注释，`VelaTerminalControl` 新增 `ShowsGutterFor` 静态方法，明确侧栏显示规则：有内容的行始终显示，只有时间戳的空行仅在光标及其上方显示，防止时间线和折叠线越界。同步调整渲染逻辑，补充多项单元测试与端到端测试，提升终端 UI 一致性与用户体验。