### PR TITLE
关于页依赖包版本自动同步与测试覆盖增强

### DIFF
--- a/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
@@ -80,7 +80,7 @@ public sealed class QuickCommandRunnerViewModel : ReactiveObject
     public void UpdateTargets(IEnumerable<(Guid Id, string DisplayName)> targets)
     {
         ArgumentNullException.ThrowIfNull(targets);
-        HashSet<Guid> selectedIds = Targets
+        var selectedIds = Targets
             .Where(target => target.IsSelected)
             .Select(target => target.Id)
             .ToHashSet();

--- a/src/VelaShell/Services/PackageVersions.cs
+++ b/src/VelaShell/Services/PackageVersions.cs
@@ -1,0 +1,44 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace VelaShell.Services;
+
+/// <summary>
+/// 关于页展示的依赖版本:取自编译期写入本程序集的元数据(由 VelaShell.csproj 的
+/// EmbedPackageVersions 目标从 Directory.Packages.props 的 PackageVersion 项生成)。
+/// </summary>
+/// <remarks>
+/// 之所以走编译期而不是运行时探测,两条路都堵死了(详见 VelaShell.csproj 里那段注释):
+/// · 读 .deps.json:Release 是 PublishSingleFile,该文件被打进 exe 的 bundle,磁盘上没有。
+/// · 读程序集版本:与包版本不是一回事 —— 实测 SSH.NET 的程序集报 2025.1.0.1、
+///   ReactiveUI 报 23.0.0.0,而包版本分别是 2025.1.0 和 23.2.28。
+/// 按包名查还有个好处:不必引用类型。SSH.NET 被刻意隔离在 Infrastructure 层,
+/// 关于页不该为了取个版本号把它引进来。
+/// </remarks>
+internal static class PackageVersions
+{
+    /// <summary>元数据键前缀,与 csproj 里 EmbedPackageVersions 写入的一致。</summary>
+    private const string KeyPrefix = "PackageVersion:";
+
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> Cache =
+        new(() => Read(typeof(PackageVersions).Assembly));
+
+    /// <summary>取包版本;查不到返回 null,由调用方决定如何降级。</summary>
+    public static string? Of(string packageId) =>
+        Cache.Value.TryGetValue(packageId, out string? version) ? version : null;
+
+    /// <summary>读取程序集里的包版本元数据。internal 供测试对着真实构建产物验证。</summary>
+    internal static IReadOnlyDictionary<string, string> Read(Assembly assembly)
+    {
+        Dictionary<string, string> versions = [with(StringComparer.OrdinalIgnoreCase)];
+        foreach (AssemblyMetadataAttribute metadata in assembly.GetCustomAttributes<AssemblyMetadataAttribute>())
+        {
+            if (metadata.Key.StartsWith(KeyPrefix, StringComparison.Ordinal) &&
+                !string.IsNullOrEmpty(metadata.Value))
+            {
+                versions.TryAdd(metadata.Key[KeyPrefix.Length..], metadata.Value);
+            }
+        }
+        return versions.Count > 0 ? versions : ReadOnlyDictionary<string, string>.Empty;
+    }
+}

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -35,6 +35,28 @@
     <InternalsVisibleTo Include="VelaShell.Tests" />
   </ItemGroup>
 
+  <!--
+    关于页的依赖版本(见 Services/PackageVersions.cs):把 Directory.Packages.props 里 pin 的
+    包版本在编译期写进程序集元数据,免得手写版本号跟着漂(它已经漂过一次:关于页停在 12.0.5,
+    实际引用早已是 12.1.0)。
+
+    为什么不在运行时读 .deps.json:Release 是 PublishSingleFile(见上面的 PropertyGroup),
+    deps.json 被打进 exe 的 bundle,磁盘上不存在,读不到。
+    为什么不读程序集版本:那与包版本不是一回事 —— SSH.NET 程序集报 2025.1.0.1、
+    ReactiveUI 报 23.0.0.0,而包版本是 2025.1.0 / 23.2.28。
+
+    这里把 17 个包全写进去(每条几十字节),而不是只挑关于页当前用到的那两个:
+    否则关于页每加一个依赖都得回来改构建脚本,这种隐式耦合迟早被漏掉。
+  -->
+  <Target Name="EmbedPackageVersions" BeforeTargets="GetAssemblyAttributes">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'%(PackageVersion.Version)' != ''">
+        <_Parameter1>PackageVersion:%(PackageVersion.Identity)</_Parameter1>
+        <_Parameter2>%(PackageVersion.Version)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <ProjectReference Include="..\VelaShell.Core\VelaShell.Core.csproj" />
     <ProjectReference Include="..\VelaShell.Terminal\VelaShell.Terminal.csproj" />

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1275,7 +1275,7 @@ public class MainWindowViewModel : ReactiveObject
         System.Collections.Specialized.NotifyCollectionChangedEventArgs e
     )
     {
-        HashSet<TerminalTabViewModel> currentTabs = TabBar
+        var currentTabs = TabBar
             .Tabs.OfType<TerminalTabViewModel>()
             .ToHashSet();
         foreach (
@@ -1324,7 +1324,7 @@ public class MainWindowViewModel : ReactiveObject
         QuickCommandExecutionRequest request
     )
     {
-        HashSet<Guid> targetIds = request.TargetIds.ToHashSet();
+        var targetIds = request.TargetIds.ToHashSet();
         TerminalTabViewModel[] targets = TabBar
             .Tabs.OfType<TerminalTabViewModel>()
             .Where(tab => tab.IsConnected && targetIds.Contains(tab.Id))

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reflection;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 using ReactiveUI;
 using VelaShell.Core.Data;
 using VelaShell.Core.Localization;
@@ -405,15 +404,22 @@ public class SettingsViewModel : ReactiveObject
             ?? "0.0.0"
         );
 
-    /// <summary>关于页显示的 UI 框架版本。</summary>
-    public static string AboutFramework => "Avalonia UI 12.0.5";
+    /// <summary>关于页显示的 UI 框架版本(版本取自实际引用的 NuGet 包,见 <see cref="PackageVersions" />)。</summary>
+    public static string AboutFramework => Describe("Avalonia UI", "Avalonia");
 
     /// <summary>关于页显示的 .NET 运行时版本。</summary>
     public static string AboutRuntime =>
         $".NET {Environment.Version.Major}.{Environment.Version.Minor}";
 
-    /// <summary>关于页显示的 SSH 库版本。</summary>
-    public static string AboutSshLibrary => "SSH.NET 2025.1.0";
+    /// <summary>关于页显示的 SSH 库版本(版本取自实际引用的 NuGet 包,见 <see cref="PackageVersions" />)。</summary>
+    public static string AboutSshLibrary => Describe("SSH.NET", "SSH.NET");
+
+    /// <summary>
+    /// 拼 "名称 版本";版本读不到时只显示名称 —— 关于页少个版本号可以接受,
+    /// 显示一个可能已经过时的写死数字不行。
+    /// </summary>
+    private static string Describe(string displayName, string packageId) =>
+        PackageVersions.Of(packageId) is { } version ? $"{displayName} {version}" : displayName;
 
     /// <summary>关于页显示的操作系统版本与位数。</summary>
     public static string AboutOs =>

--- a/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
+++ b/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
@@ -226,7 +226,7 @@ public class LocalizationTests : IDisposable
     {
         var manager = new System.Resources.ResourceManager("VelaShell.Core.Resources.Strings", typeof(Strings).Assembly);
         System.Resources.ResourceSet neutral = manager.GetResourceSet(CultureInfo.InvariantCulture, true, false)!;
-        HashSet<string> baseline = neutral.Cast<System.Collections.DictionaryEntry>()
+        var baseline = neutral.Cast<System.Collections.DictionaryEntry>()
                                           .Select(entry => (string)entry.Key)
                                           .ToHashSet();
         Assert.IsNotEmpty(baseline);
@@ -234,11 +234,11 @@ public class LocalizationTests : IDisposable
         {
             System.Resources.ResourceSet? set = manager.GetResourceSet(new CultureInfo(culture), true, false);
             Assert.IsNotNull(set, $"{culture} 卫星资源缺失");
-            HashSet<string> keys = set.Cast<System.Collections.DictionaryEntry>()
+            var keys = set.Cast<System.Collections.DictionaryEntry>()
                                       .Select(entry => (string)entry.Key)
                                       .ToHashSet();
-            List<string> missing = baseline.Except(keys).Order().ToList();
-            List<string> extra = keys.Except(baseline).Order().ToList();
+            var missing = baseline.Except(keys).Order().ToList();
+            var extra = keys.Except(baseline).Order().ToList();
             Assert.IsEmpty(missing, $"{culture} 缺失 {missing.Count} 键: {string.Join(", ", missing.Take(20))}");
             Assert.IsEmpty(extra, $"{culture} 多余 {extra.Count} 键: {string.Join(", ", extra.Take(20))}");
         }

--- a/tests/VelaShell.Terminal.Tests/GutterFoldTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldTests.cs
@@ -165,7 +165,7 @@ public class GutterFoldTests
     [TestMethod]
     public void FillScreenRowMap_NoFolds_IsIdentityAndClampsOffset()
     {
-        var map = new int[4];
+        int[] map = new int[4];
         int offset = 0;
         // total=10, screen=4, offset=0 → 底部 4 行 abs 6..9。
         GutterFoldModel.FillScreenRowMap(map, null, totalRows: 10, screenRows: 4, ref offset);
@@ -181,7 +181,7 @@ public class GutterFoldTests
     [TestMethod]
     public void FillScreenRowMap_WithFolds_UsesVisibleSequence()
     {
-        var map = new int[4];
+        int[] map = new int[4];
         int offset = 0;
         // 折叠后可见序列(隐藏了 1,2):[0,3,4,5]。屏幕 4 行 → 全部显示。
         var visible = new List<int> { 0, 3, 4, 5 };
@@ -206,7 +206,7 @@ public class GutterFoldTests
         int screenRow = (int)(clickY / cellH);
         Assert.AreEqual(3, screenRow);
 
-        var map = new int[screen.Rows];
+        int[] map = new int[screen.Rows];
         int offset = 0;
         GutterFoldModel.FillScreenRowMap(map, model.VisibleRowsOrNull(screen), screen.TotalRows, screen.Rows, ref offset);
         int abs = map[screenRow];

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -119,7 +118,7 @@ public class GutterFoldUiTests
                 Assert.AreEqual(MenuItemToggleType.CheckBox, item.ToggleType, "菜单项应是复选型。");
 
                 // Header 只放标签:开与关的 Header 必须完全一致,文字才不会随勾选状态位移。
-                var header = (string)item.Header!;
+                string header = (string)item.Header!;
                 Assert.AreEqual(header.Trim(), header, "Header 不应含用于占位/勾号的空白前缀。");
                 Assert.IsFalse(header.Contains('✔'), "勾号应由勾选列渲染,不应拼进 Header。");
             }

--- a/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
+++ b/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
@@ -1,0 +1,86 @@
+using System.Text.RegularExpressions;
+using VelaShell.Services;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.Services;
+
+/// <summary>
+/// 关于页的依赖版本取自编译期写入的程序集元数据(VelaShell.csproj 的 EmbedPackageVersions
+/// 目标,数据源是 Directory.Packages.props)。
+/// </summary>
+/// <remarks>
+/// 这组测试主要防的是「构建脚本静默失效」:MSBuild 目标不生效不会报错,只会让元数据凭空消失,
+/// 关于页悄悄退化成没有版本号 —— 正是那种没人会注意到的坏法。所以断言对着真实构建产物跑。
+/// </remarks>
+[TestClass]
+[TestCategory("PackageVersions")]
+public class PackageVersionsTests
+{
+    /// <summary>构建目标确实把包版本写进了程序集(失效则此处为空)。</summary>
+    [TestMethod]
+    public void Read_FindsPackageVersions_EmbeddedAtBuildTime()
+    {
+        IReadOnlyDictionary<string, string> versions = PackageVersions.Read(typeof(PackageVersions).Assembly);
+
+        Assert.IsGreaterThan(0, versions.Count, "构建目标 EmbedPackageVersions 应把包版本写进程序集元数据。");
+    }
+
+    /// <summary>关于页当前展示的两个包必须查得到,否则界面会退化成只有名称。</summary>
+    [TestMethod]
+    [DataRow("Avalonia")]
+    [DataRow("SSH.NET")]
+    public void Of_ResolvesPackagesShownOnTheAboutPage(string packageId)
+    {
+        string? version = PackageVersions.Of(packageId);
+
+        Assert.IsNotNull(version, $"关于页要显示 {packageId} 的版本,应能查到。");
+        Assert.MatchesRegex(new Regex(@"^\d+\.\d+"), version, "版本应形如 12.1.0。");
+    }
+
+    /// <summary>SSH.NET 被隔离在 Infrastructure 层,按包名查得到才说明没走类型引用那条路。</summary>
+    [TestMethod]
+    public void Of_ResolvesPackages_NotReferencedByThisAssembly()
+    {
+        Assert.IsNotNull(PackageVersions.Of("SSH.NET"),
+                         "SSH.NET 不被 VelaShell 直接引用,版本仍应可查(不必为取版本破坏分层)。");
+    }
+
+    [TestMethod]
+    public void Of_UnknownPackage_ReturnsNull()
+    {
+        Assert.IsNull(PackageVersions.Of("No.Such.Package"));
+    }
+
+    /// <summary>没有任何包版本元数据的程序集:返回空表而不是抛。</summary>
+    [TestMethod]
+    public void Read_AssemblyWithoutMetadata_ReturnsEmpty()
+    {
+        Assert.AreEqual(0, PackageVersions.Read(typeof(object).Assembly).Count);
+    }
+
+    /// <summary>
+    /// 关于页真正显示出来的文本 —— 这才是用户看到的东西,也是原先写死、并且已经漂移过的地方
+    /// (曾停留在 "Avalonia UI 12.0.5",而实际引用早已是 12.1.0)。
+    /// </summary>
+    [TestMethod]
+    public void AboutFramework_ShowsTheReferencedAvaloniaVersion()
+    {
+        Assert.AreEqual($"Avalonia UI {PackageVersions.Of("Avalonia")}", SettingsViewModel.AboutFramework);
+    }
+
+    [TestMethod]
+    public void AboutSshLibrary_ShowsTheReferencedSshNetVersion()
+    {
+        Assert.AreEqual($"SSH.NET {PackageVersions.Of("SSH.NET")}", SettingsViewModel.AboutSshLibrary);
+    }
+
+    /// <summary>关于页不该再出现写死的版本号 —— 这条盯的就是当初那个漂移。</summary>
+    [TestMethod]
+    public void AboutStrings_ContainNoHardcodedVersion()
+    {
+        foreach (string text in new[] { SettingsViewModel.AboutFramework, SettingsViewModel.AboutSshLibrary })
+        {
+            Assert.IsFalse(text.Contains("12.0.5", StringComparison.Ordinal), $"'{text}' 疑似残留写死的版本号。");
+        }
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -6,7 +6,6 @@ using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
 using VelaShell.Presentation.Commands;
 using VelaShell.Presentation.ViewModels;
-using VelaShell.Services;
 using VelaShell.Terminal;
 using VelaShell.ViewModels;
 

--- a/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
@@ -106,7 +106,7 @@ public class QuickCommandsViewModelTests : IDisposable
     public void Runner_NoExplicitSelection_UsesCurrentTerminal()
     {
         var runner = new QuickCommandRunnerViewModel(_vm);
-        Guid currentId = Guid.NewGuid();
+        var currentId = Guid.NewGuid();
         runner.UpdateTargets([(currentId, "current")]);
         runner.SetCurrentTarget(currentId);
         QuickCommandExecutionRequest? request = null;
@@ -124,9 +124,9 @@ public class QuickCommandsViewModelTests : IDisposable
     public void Runner_ExplicitSelection_BroadcastsOnlySelectedTerminals()
     {
         var runner = new QuickCommandRunnerViewModel(_vm);
-        Guid firstId = Guid.NewGuid();
-        Guid secondId = Guid.NewGuid();
-        Guid currentId = Guid.NewGuid();
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var currentId = Guid.NewGuid();
         runner.UpdateTargets([(firstId, "first"), (secondId, "second"), (currentId, "current")]);
         runner.SetCurrentTarget(currentId);
         runner.Targets[0].IsSelected = true;
@@ -145,8 +145,8 @@ public class QuickCommandsViewModelTests : IDisposable
     public void Runner_RemovedSelectedTarget_FallsBackToCurrentTerminal()
     {
         var runner = new QuickCommandRunnerViewModel(_vm);
-        Guid removedId = Guid.NewGuid();
-        Guid currentId = Guid.NewGuid();
+        var removedId = Guid.NewGuid();
+        var currentId = Guid.NewGuid();
         runner.UpdateTargets([(removedId, "removed"), (currentId, "current")]);
         runner.Targets[0].IsSelected = true;
         runner.SetCurrentTarget(currentId);

--- a/tests/VelaShell.Tests/Views/FileBrowserColumnsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileBrowserColumnsUiTests.cs
@@ -1,9 +1,5 @@
-using System.Threading;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
-using Avalonia.Markup.Xaml.Styling;
-using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using NSubstitute;

--- a/tests/VelaShell.Tests/Views/MenuGlyphStyleTests.cs
+++ b/tests/VelaShell.Tests/Views/MenuGlyphStyleTests.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;

--- a/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;

--- a/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;


### PR DESCRIPTION
实现依赖包版本自动同步，消除手写版本号漂移：新增 PackageVersions.cs 通过程序集元数据动态获取 NuGet 包版本，SettingsViewModel 关于页相关属性改为实时读取。引入 PackageVersionsTests.cs 单元测试，覆盖元数据写入、读取及降级场景，提升构建健壮性。VelaShell.csproj 集成 EmbedPackageVersions 目标，解决单文件发布后无法读取 .deps.json 问题。其余为变量声明风格统一与无用 using 移除等代码优化。