### PR TITLE
统一各窗口 Esc 键关闭行为，提升一致性体验

### DIFF
--- a/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
@@ -29,6 +29,25 @@ public partial class AuthenticationDialogView : Window
         viewModel.CancelCommand.Subscribe(Close);
     }
 
+    /// <summary>Esc 等价于点击取消:经 CancelCommand 走与取消按钮完全相同的关闭路径(结果为 null)。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            if (DataContext is AuthenticationDialogViewModel viewModel)
+            {
+                viewModel.CancelCommand.Execute().Subscribe();
+            }
+            else
+            {
+                Close();
+            }
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
     private void Header_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
@@ -37,6 +37,18 @@ public partial class ConnectionDiagnosticsView : Window
 
     private void Close_Click(object? sender, RoutedEventArgs e) => Close();
 
+    /// <summary>Esc 关闭诊断窗口,与右上角关闭按钮同路径。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
     /// <summary>导出诊断报告为文本文件(设计 RGXg1 exportDiag)。</summary>
     private async void ExportReport_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -29,6 +29,25 @@ public partial class ConnectionProfileView : Window
         await viewModel.LoadGroupsAsync();
     }
 
+    /// <summary>Esc 等价于点击取消:经 CancelCommand 走与取消按钮完全相同的关闭路径(不保存改动)。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            if (DataContext is ConnectionProfileViewModel viewModel)
+            {
+                viewModel.CancelCommand.Execute().Subscribe();
+            }
+            else
+            {
+                Close();
+            }
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
     /// <summary>无系统标题栏 —— 按住头部可拖动窗口。</summary>
     private void Header_PointerPressed(object? sender, PointerPressedEventArgs e)
     {

--- a/src/VelaShell/Views/HostKeyPromptView.axaml.cs
+++ b/src/VelaShell/Views/HostKeyPromptView.axaml.cs
@@ -33,6 +33,25 @@ public partial class HostKeyPromptView : Window
         }
     }
 
+    /// <summary>Esc 等价于点击拒绝:安全提示的取消必须落在保守分支(Reject),绝不隐式信任。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            if (_viewModel is { } viewModel)
+            {
+                viewModel.CancelCommand.Execute().Subscribe();
+            }
+            else
+            {
+                Close();
+            }
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
     private void Header_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)

--- a/src/VelaShell/Views/RecordingPlayerView.axaml.cs
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml.cs
@@ -75,6 +75,18 @@ public partial class RecordingPlayerView : Window
 
     private void Close_Click(object? sender, RoutedEventArgs e) => Close();
 
+    /// <summary>Esc 关闭回放中心,与右上角关闭按钮同路径(回放终端不可聚焦,不会截获按键)。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
     /// <summary>倍速按钮:按 VM 定义的档位循环(1x…16x)。</summary>
     private void CycleSpeed_Click(object? sender, RoutedEventArgs e) => _viewModel?.CycleSpeed();
 

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
@@ -132,13 +132,20 @@ public partial class RemoteFileEditorView : Window
     }
 
     /// <summary>
-    /// 处理键盘输入:Ctrl+S 触发保存并阻止事件继续冒泡。
+    /// 处理键盘输入:Ctrl+S 触发保存;Esc 关闭窗口(编辑器搜索面板等内层控件先消费
+    /// 各自的 Esc,冒泡到这里才关窗;未保存改动由 <see cref="OnClosing" /> 确认守卫兜底)。
     /// </summary>
     protected override void OnKeyDown(KeyEventArgs e)
     {
         if (e.Key == Key.S && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             _ = SaveAsync();
+            e.Handled = true;
+            return;
+        }
+        if (e.Key == Key.Escape)
+        {
+            Close();
             e.Handled = true;
             return;
         }


### PR DESCRIPTION
本次为 AuthenticationDialogView、ConnectionDiagnosticsView、ConnectionProfileView、HostKeyPromptView、RecordingPlayerView、RemoteFileEditorView 等窗口统一实现了 Esc 键关闭快捷操作：
- 认证、主机密钥提示、连接配置等窗口按 Esc 触发 CancelCommand，保证与取消按钮一致的关闭逻辑。
- 诊断、回放中心、远程文件编辑器等窗口按 Esc 直接关闭，等同于点击关闭按钮。
- RemoteFileEditorView 的 OnKeyDown 增加 Esc 处理，注释说明未被内层控件消费时关闭窗口，未保存改动仍由 OnClosing 兜底确认。 这些调整提升了用户体验，使 Esc 行为一致且更符合直觉。