### PR TITLE
快捷命令“运行”逻辑调整为“发送”,UI视觉效果调整.

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1134,7 +1134,6 @@
   <data name="QuickCmd_CurrentTerminal" xml:space="preserve"><value>現在の端末</value></data>
   <data name="QuickCmd_SelectedTerminals" xml:space="preserve"><value>台の端末を選択中</value></data>
   <data name="QuickCmd_Search" xml:space="preserve"><value>スニペットを検索</value></data>
-  <data name="QuickCmd_Run" xml:space="preserve"><value>実行</value></data>
   <data name="QuickCmd_Ungrouped" xml:space="preserve"><value>未分類</value></data>
   <data name="QuickCmd_GroupPlaceholder" xml:space="preserve"><value>グループ名</value></data>
   <data name="QuickCmd_EditSnippet" xml:space="preserve"><value>スニペットを編集</value></data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1134,7 +1134,6 @@
   <data name="QuickCmd_CurrentTerminal" xml:space="preserve"><value>현재 터미널</value></data>
   <data name="QuickCmd_SelectedTerminals" xml:space="preserve"><value>개 터미널 선택됨</value></data>
   <data name="QuickCmd_Search" xml:space="preserve"><value>스니펫 검색</value></data>
-  <data name="QuickCmd_Run" xml:space="preserve"><value>실행</value></data>
   <data name="QuickCmd_Ungrouped" xml:space="preserve"><value>그룹 없음</value></data>
   <data name="QuickCmd_GroupPlaceholder" xml:space="preserve"><value>그룹 이름</value></data>
   <data name="QuickCmd_EditSnippet" xml:space="preserve"><value>스니펫 편집</value></data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -124,7 +124,6 @@
   <data name="QuickCmd_CurrentTerminal" xml:space="preserve"><value>Current terminal</value></data>
   <data name="QuickCmd_SelectedTerminals" xml:space="preserve"><value>terminals selected</value></data>
   <data name="QuickCmd_Search" xml:space="preserve"><value>Search snippets</value></data>
-  <data name="QuickCmd_Run" xml:space="preserve"><value>Run</value></data>
   <data name="QuickCmd_Ungrouped" xml:space="preserve"><value>Ungrouped</value></data>
   <data name="QuickCmd_GroupPlaceholder" xml:space="preserve"><value>Group name</value></data>
   <data name="QuickCmd_EditSnippet" xml:space="preserve"><value>Edit snippet</value></data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -223,7 +223,6 @@
   <data name="QuickCmd_CurrentTerminal" xml:space="preserve"><value>当前终端</value></data>
   <data name="QuickCmd_SelectedTerminals" xml:space="preserve"><value>个终端已选</value></data>
   <data name="QuickCmd_Search" xml:space="preserve"><value>搜索代码片段</value></data>
-  <data name="QuickCmd_Run" xml:space="preserve"><value>运行</value></data>
   <data name="QuickCmd_Ungrouped" xml:space="preserve"><value>未分组</value></data>
   <data name="QuickCmd_GroupPlaceholder" xml:space="preserve"><value>分组名称</value></data>
   <data name="QuickCmd_EditSnippet" xml:space="preserve"><value>编辑代码片段</value></data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1134,7 +1134,6 @@
   <data name="QuickCmd_CurrentTerminal" xml:space="preserve"><value>目前終端</value></data>
   <data name="QuickCmd_SelectedTerminals" xml:space="preserve"><value>個終端已選</value></data>
   <data name="QuickCmd_Search" xml:space="preserve"><value>搜尋程式碼片段</value></data>
-  <data name="QuickCmd_Run" xml:space="preserve"><value>執行</value></data>
   <data name="QuickCmd_Ungrouped" xml:space="preserve"><value>未分組</value></data>
   <data name="QuickCmd_GroupPlaceholder" xml:space="preserve"><value>分組名稱</value></data>
   <data name="QuickCmd_EditSnippet" xml:space="preserve"><value>編輯程式碼片段</value></data>

--- a/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
@@ -17,8 +17,8 @@ public sealed class QuickCommandRunnerViewModel : ReactiveObject
         Library = library ?? throw new ArgumentNullException(nameof(library));
         TargetSelector = targetSelector ?? new();
         TargetSelector.PropertyChanged += OnTargetSelectorPropertyChanged;
-        RunCommand = ReactiveCommand.Create<QuickCommandViewModel>(
-            Run,
+        SendCommand = ReactiveCommand.Create<QuickCommandViewModel>(
+            Send,
             this.WhenAnyValue(viewModel => viewModel.CanRun)
         );
     }
@@ -47,8 +47,8 @@ public sealed class QuickCommandRunnerViewModel : ReactiveObject
     /// <summary>当前是否可以执行快捷命令。</summary>
     public bool CanRun => TargetSelector.CanSend;
 
-    /// <summary>在解析出的目标终端上运行命令。</summary>
-    public ReactiveCommand<QuickCommandViewModel, Unit> RunCommand { get; }
+    /// <summary>把命令文本发送到解析出的目标终端(不附加回车,由用户补全后自行执行)。</summary>
+    public ReactiveCommand<QuickCommandViewModel, Unit> SendCommand { get; }
 
     /// <summary>选择全部目标终端。</summary>
     public ReactiveCommand<Unit, Unit> SelectAllCommand => TargetSelector.SelectAllCommand;
@@ -67,7 +67,7 @@ public sealed class QuickCommandRunnerViewModel : ReactiveObject
     /// <summary>更新活动终端回退目标。</summary>
     public void SetCurrentTarget(Guid? targetId) => TargetSelector.SetCurrentTarget(targetId);
 
-    private void Run(QuickCommandViewModel command)
+    private void Send(QuickCommandViewModel command)
     {
         IReadOnlyList<Guid> targetIds = TargetSelector.ResolveTargetIds();
         if (targetIds.Count == 0 || string.IsNullOrWhiteSpace(command.CommandText))

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1498,7 +1498,7 @@ public class MainWindowViewModel : ReactiveObject
         bool sent = false;
         foreach (TerminalTabViewModel target in targets)
         {
-            sent |= target.TryExecuteCommand(request.CommandText);
+            sent |= target.TrySendCommandText(request.CommandText);
         }
         if (sent)
         {

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -539,17 +539,17 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     }
 
     /// <summary>
-    /// 通过正常用户输入通道执行一条快捷命令。命令正文原样发送,仅移除已有的末尾
-    /// 换行并补一个回车,使其与用户键入后按 Enter 的行为一致。
+    /// 通过正常用户输入通道把快捷命令文本发送到终端。只发正文不附加回车——
+    /// 快捷命令可能是不完整的模板(如缺少参数),由用户在终端里补全后自行按 Enter 执行。
     /// </summary>
-    /// <returns>命令已发送时为 true;终端未连接或命令为空时为 false。</returns>
-    public bool TryExecuteCommand(string command)
+    /// <returns>文本已发送时为 true;终端未连接或命令为空时为 false。</returns>
+    public bool TrySendCommandText(string command)
     {
         if (!IsConnected || string.IsNullOrWhiteSpace(command))
         {
             return false;
         }
-        string payload = command.TrimEnd('\r', '\n') + "\r";
+        string payload = command.TrimEnd('\r', '\n');
 
         // 快捷命令可能同时下发给同频道的多个标签,若再经同步频道转发,频道内
         // 每个标签都会收到重复注入;WriteInput 同步触发 TypedInput,压制窗口有效。

--- a/src/VelaShell/Views/QuickCommandsView.axaml
+++ b/src/VelaShell/Views/QuickCommandsView.axaml
@@ -17,6 +17,61 @@
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="FontSize" Value="10" />
     </Style>
+
+    <!-- 分组头:压掉 Fluent ToggleButton 的强调色选中态,展开与否都保持侧栏的
+         "透明 + 悬停 VelaBgHover" 语言(与会话树分组行一致),展开状态只由箭头表达。 -->
+    <Style Selector="ToggleButton.group-header">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="7,5" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="ToggleButton.group-header /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+    </Style>
+
+    <!-- 命令条目:整行可点,点击即把命令文本发送到目标终端(不回车)。 -->
+    <Style Selector="Button.cmd-item">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="8,6" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Button.cmd-item /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="Button.cmd-item:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="Button.cmd-item:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+    </Style>
+    <!-- 悬停时右侧浮现"发送到终端"图标,提示点击行为。 -->
+    <Style Selector="Button.cmd-item pc|LucideIcon.send-hint">
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+    <Style Selector="Button.cmd-item:pointerover pc|LucideIcon.send-hint">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
     <Style Selector="Button.target-button">
       <Setter Property="Height" Value="26" />
       <Setter Property="Padding" Value="8,0" />
@@ -105,10 +160,8 @@
         <ItemsControl.ItemTemplate>
           <DataTemplate x:DataType="pvm:QuickCommandGroupViewModel">
             <StackPanel Margin="0,2">
-              <ToggleButton IsChecked="{Binding IsExpanded, Mode=TwoWay}"
-                            Background="Transparent" BorderThickness="0"
-                            Padding="7,5" HorizontalContentAlignment="Stretch"
-                            Cursor="Hand">
+              <ToggleButton Classes="group-header"
+                            IsChecked="{Binding IsExpanded, Mode=TwoWay}">
                 <Grid ColumnDefinitions="Auto,6,*,Auto">
                   <Panel Width="11" Height="11">
                     <pc:LucideIcon Width="11" Height="11"
@@ -124,21 +177,23 @@
                              Foreground="{DynamicResource VelaTextSecondary}"
                              FontSize="10" FontWeight="SemiBold"
                              TextTrimming="CharacterEllipsis" />
-                  <TextBlock Grid.Column="3" Text="{Binding FilteredCommands.Count}"
-                             Foreground="{DynamicResource VelaTextMuted}" FontSize="9" />
+                  <Border Grid.Column="3" Padding="5,1" CornerRadius="7"
+                          Background="{DynamicResource VelaBgInput}">
+                    <TextBlock Text="{Binding FilteredCommands.Count}"
+                               Foreground="{DynamicResource VelaTextMuted}" FontSize="9" />
+                  </Border>
                 </Grid>
               </ToggleButton>
               <ItemsControl ItemsSource="{Binding FilteredCommands}"
                             IsVisible="{Binding IsExpanded}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate x:DataType="pvm:QuickCommandViewModel">
-                    <Border Margin="4,1" Padding="8,6" CornerRadius="4"
-                            Background="Transparent">
-                      <Border.Styles>
-                        <Style Selector="Border:pointerover">
-                          <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
-                        </Style>
-                      </Border.Styles>
+                    <!-- 整行即按钮:点击把命令文本发送到目标终端(不附加回车),
+                         便于先补全参数再手动执行。 -->
+                    <Button Classes="cmd-item" Margin="4,1"
+                            Command="{Binding $parent[UserControl].((pvm:QuickCommandRunnerViewModel)DataContext).SendCommand}"
+                            CommandParameter="{Binding}"
+                            ToolTip.Tip="{Binding CommandText}">
                       <Grid ColumnDefinitions="*,8,Auto">
                         <StackPanel Spacing="2">
                           <TextBlock Text="{Binding Name}"
@@ -148,16 +203,15 @@
                           <TextBlock Text="{Binding CommandText}"
                                      Foreground="{DynamicResource VelaAccentText}"
                                      FontFamily="{DynamicResource VelaTerminalFont}"
-                                     FontSize="9" TextTrimming="CharacterEllipsis"
-                                     ToolTip.Tip="{Binding CommandText}" />
+                                     FontSize="9" TextTrimming="CharacterEllipsis" />
                         </StackPanel>
-                        <Button Grid.Column="2" Classes="quick-action"
-                                Content="{loc:Localize QuickCmd_Run}"
-                                Command="{Binding $parent[UserControl].((pvm:QuickCommandRunnerViewModel)DataContext).RunCommand}"
-                                CommandParameter="{Binding}"
-                                VerticalAlignment="Center" />
+                        <pc:LucideIcon Grid.Column="2" Classes="send-hint"
+                                       Width="12" Height="12"
+                                       Data="{StaticResource Icon.send}"
+                                       Foreground="{DynamicResource VelaAccent}"
+                                       VerticalAlignment="Center" />
                       </Grid>
-                    </Border>
+                    </Button>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>

--- a/src/VelaShell/Views/Settings/SnippetsPage.axaml
+++ b/src/VelaShell/Views/Settings/SnippetsPage.axaml
@@ -2,9 +2,62 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:VelaShell.ViewModels"
              xmlns:pvm="using:VelaShell.Presentation.ViewModels"
+             xmlns:pc="using:VelaShell.Controls.Controls"
              xmlns:loc="using:VelaShell.Localization"
              x:Class="VelaShell.Views.Settings.SnippetsPage"
              x:DataType="vm:SettingsViewModel">
+
+  <UserControl.Styles>
+    <!-- 分组头:与侧栏快捷命令面板同语言——压掉 Fluent ToggleButton 的强调色
+         选中态,展开状态只由箭头表达;底色沿用设置页表头的 VelaBgSidebar。 -->
+    <Style Selector="ToggleButton.group-header">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="12,8" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="ToggleButton.group-header /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+    </Style>
+
+    <!-- 行内操作:24×24 透明图标按钮(密钥管理页同款)。 -->
+    <Style Selector="Button.icon-btn">
+      <Setter Property="Width" Value="24" />
+      <Setter Property="Height" Value="24" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Button.icon-btn /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="Button.icon-btn:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+
+    <!-- 片段行:悬停高亮,与列表类页面的行反馈一致。 -->
+    <Style Selector="Border.snippet-row">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="Border.snippet-row:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+  </UserControl.Styles>
 
   <StackPanel Spacing="14">
     <StackPanel Spacing="2">
@@ -34,18 +87,32 @@
     <ItemsControl ItemsSource="{Binding Snippets.FilteredGroups}">
       <ItemsControl.ItemTemplate>
         <DataTemplate x:DataType="pvm:QuickCommandGroupViewModel">
-          <Border Margin="0,0,0,8" CornerRadius="6"
-                  BorderBrush="{DynamicResource VelaBorderSecondary}"
-                  BorderThickness="1">
+          <Border Classes="table" Margin="0,0,0,8">
             <StackPanel>
-              <ToggleButton IsChecked="{Binding IsExpanded, Mode=TwoWay}"
-                            Background="{DynamicResource VelaBgSurface}"
-                            BorderThickness="0" Padding="12,8"
-                            HorizontalContentAlignment="Stretch">
-                <Grid ColumnDefinitions="*,Auto">
-                  <TextBlock Text="{Binding Name}" FontSize="12" FontWeight="SemiBold" />
-                  <TextBlock Grid.Column="1" Text="{Binding FilteredCommands.Count}"
-                             Foreground="{DynamicResource VelaTextMuted}" FontSize="10" />
+              <ToggleButton Classes="group-header"
+                            IsChecked="{Binding IsExpanded, Mode=TwoWay}">
+                <Grid ColumnDefinitions="Auto,8,*,Auto">
+                  <Panel Width="11" Height="11" VerticalAlignment="Center">
+                    <pc:LucideIcon Width="11" Height="11"
+                                   Data="{StaticResource Icon.chevron-right}"
+                                   Foreground="{DynamicResource VelaTextTertiary}"
+                                   IsVisible="{Binding !IsExpanded}" />
+                    <pc:LucideIcon Width="11" Height="11"
+                                   Data="{StaticResource Icon.chevron-down}"
+                                   Foreground="{DynamicResource VelaTextTertiary}"
+                                   IsVisible="{Binding IsExpanded}" />
+                  </Panel>
+                  <TextBlock Grid.Column="2" Text="{Binding Name}"
+                             Foreground="{DynamicResource VelaTextSecondary}"
+                             FontSize="12" FontWeight="SemiBold"
+                             VerticalAlignment="Center"
+                             TextTrimming="CharacterEllipsis" />
+                  <Border Grid.Column="3" Padding="6,1" CornerRadius="8"
+                          Background="{DynamicResource VelaBgInput}"
+                          VerticalAlignment="Center">
+                    <TextBlock Text="{Binding FilteredCommands.Count}"
+                               Foreground="{DynamicResource VelaTextMuted}" FontSize="10" />
+                  </Border>
                 </Grid>
               </ToggleButton>
 
@@ -53,26 +120,38 @@
                             IsVisible="{Binding IsExpanded}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate x:DataType="pvm:QuickCommandViewModel">
-                    <Border Padding="12,8" BorderThickness="0,1,0,0"
-                            BorderBrush="{DynamicResource VelaBorderSecondary}">
-                      <Grid ColumnDefinitions="*,12,Auto,6,Auto">
+                    <Border Classes="snippet-row" Padding="12,8" BorderThickness="0,1,0,0"
+                            BorderBrush="{DynamicResource VelaBorderPrimary}">
+                      <Grid ColumnDefinitions="*,12,Auto,4,Auto">
                         <StackPanel Spacing="3">
-                          <TextBlock Text="{Binding Name}" FontSize="12" FontWeight="Medium" />
+                          <TextBlock Text="{Binding Name}"
+                                     Foreground="{DynamicResource VelaTextPrimary}"
+                                     FontSize="12" FontWeight="Medium" />
                           <TextBlock Text="{Binding CommandText}"
                                      Foreground="{DynamicResource VelaAccentText}"
                                      FontFamily="{DynamicResource VelaTerminalFont}"
                                      FontSize="10" TextWrapping="Wrap" />
                         </StackPanel>
-                        <Button Grid.Column="2" Height="24" Padding="8,0"
-                                Content="{loc:Localize Edit}"
+                        <Button Grid.Column="2" Classes="icon-btn"
+                                ToolTip.Tip="{loc:Localize Edit}"
                                 IsVisible="{Binding !IsBuiltIn}"
+                                VerticalAlignment="Center"
                                 Command="{Binding $parent[UserControl].((vm:SettingsViewModel)DataContext).Snippets.BeginEditCommand}"
-                                CommandParameter="{Binding}" />
-                        <Button Grid.Column="4" Height="24" Padding="8,0"
-                                Content="{loc:Localize Delete}"
+                                CommandParameter="{Binding}">
+                          <pc:LucideIcon Width="13" Height="13"
+                                         Data="{StaticResource Icon.pencil}"
+                                         Foreground="{DynamicResource VelaTextTertiary}" />
+                        </Button>
+                        <Button Grid.Column="4" Classes="icon-btn"
+                                ToolTip.Tip="{loc:Localize Delete}"
                                 IsVisible="{Binding !IsBuiltIn}"
+                                VerticalAlignment="Center"
                                 Command="{Binding $parent[UserControl].((vm:SettingsViewModel)DataContext).Snippets.DeleteCommandCommand}"
-                                CommandParameter="{Binding}" />
+                                CommandParameter="{Binding}">
+                          <pc:LucideIcon Width="13" Height="13"
+                                         Data="{StaticResource Icon.trash-2}"
+                                         Foreground="{DynamicResource VelaStatusError}" />
+                        </Button>
                       </Grid>
                     </Border>
                   </DataTemplate>
@@ -102,7 +181,7 @@
       <TextBox Text="{Binding $parent[UserControl].((vm:SettingsViewModel)DataContext).Snippets.NewDescription}"
                PlaceholderText="{loc:Localize Description}" />
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-        <Button Classes="dlg-secondary" Content="{loc:Localize Cancel}"
+        <Button Classes="dlg-outline" Content="{loc:Localize Cancel}"
                 Command="{Binding $parent[UserControl].((vm:SettingsViewModel)DataContext).Snippets.CancelEditCommand}" />
         <Button Classes="dlg-primary" Content="{loc:Localize Save}"
                 Command="{Binding $parent[UserControl].((vm:SettingsViewModel)DataContext).Snippets.SaveEditCommand}" />

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -130,7 +130,7 @@ public class MainWindowViewModelTests
         Assert.HasCount(1, runner.Targets);
         Assert.AreEqual(tab.Id, runner.Targets[0].Id);
         Assert.IsTrue(runner.CanRun);
-        runner.RunCommand.Execute(library.AllCommands[0]).Subscribe();
+        runner.SendCommand.Execute(library.AllCommands[0]).Subscribe();
         emulator.Received(1).WriteInput(Arg.Any<byte[]>());
 
         tab.ConnectionStatus = SessionStatus.Disconnected;
@@ -151,7 +151,7 @@ public class MainWindowViewModelTests
         bool focusRequested = false;
         vm.TerminalFocusRequested += (_, _) => focusRequested = true;
 
-        vm.Sidebar.QuickCommands!.RunCommand.Execute(library.AllCommands[0]).Subscribe();
+        vm.Sidebar.QuickCommands!.SendCommand.Execute(library.AllCommands[0]).Subscribe();
 
         Assert.IsTrue(focusRequested);
     }

--- a/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
@@ -114,7 +114,7 @@ public class QuickCommandsViewModelTests : IDisposable
         QuickCommandExecutionRequest? request = null;
         runner.ExecutionRequested += (_, e) => request = e;
         QuickCommandViewModel command = _vm.AllCommands.First(c => c.Name == SampleBuiltIn.Name);
-        runner.RunCommand.Execute(command).Subscribe();
+        runner.SendCommand.Execute(command).Subscribe();
 
         Assert.IsNotNull(request);
         Assert.AreEqual(SampleBuiltIn.CommandText, request.CommandText);
@@ -136,7 +136,7 @@ public class QuickCommandsViewModelTests : IDisposable
         QuickCommandExecutionRequest? request = null;
         runner.ExecutionRequested += (_, e) => request = e;
 
-        runner.RunCommand.Execute(_vm.AllCommands[0]).Subscribe();
+        runner.SendCommand.Execute(_vm.AllCommands[0]).Subscribe();
 
         Assert.IsNotNull(request);
         CollectionAssert.AreEquivalent(new[] { firstId, secondId }, request.TargetIds.ToArray());
@@ -159,7 +159,7 @@ public class QuickCommandsViewModelTests : IDisposable
         Assert.IsTrue(runner.CanRun);
         QuickCommandExecutionRequest? request = null;
         runner.ExecutionRequested += (_, e) => request = e;
-        runner.RunCommand.Execute(_vm.AllCommands[0]).Subscribe();
+        runner.SendCommand.Execute(_vm.AllCommands[0]).Subscribe();
         Assert.IsNotNull(request);
         CollectionAssert.AreEqual(new[] { currentId }, request.TargetIds.ToArray());
     }

--- a/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
@@ -51,27 +51,28 @@ public class TerminalTabViewModelTests
 
     [TestMethod]
     [TestCategory("TerminalTab")]
-    public void TryExecuteCommand_Connected_SendsBodyWithSingleCarriageReturn()
+    public void TrySendCommandText_Connected_SendsBodyWithoutTrailingNewline()
     {
         _vm.ConnectionStatus = SessionStatus.Connected;
 
-        bool sent = _vm.TryExecuteCommand(" echo hello\r\n");
+        bool sent = _vm.TrySendCommandText(" echo hello\r\n");
 
         Assert.IsTrue(sent);
+        // 只发正文不带回车:快捷命令可能是待补全的模板,由用户自行按 Enter 执行。
         _terminalEmulator
             .Received(1)
             .WriteInput(
                 Arg.Is<byte[]>(bytes =>
-                    bytes.SequenceEqual(System.Text.Encoding.UTF8.GetBytes(" echo hello\r"))
+                    bytes.SequenceEqual(System.Text.Encoding.UTF8.GetBytes(" echo hello"))
                 )
             );
     }
 
     [TestMethod]
     [TestCategory("TerminalTab")]
-    public void TryExecuteCommand_Disconnected_DoesNotSend()
+    public void TrySendCommandText_Disconnected_DoesNotSend()
     {
-        bool sent = _vm.TryExecuteCommand("uptime");
+        bool sent = _vm.TrySendCommandText("uptime");
 
         Assert.IsFalse(sent);
         _terminalEmulator.DidNotReceive().WriteInput(Arg.Any<byte[]>());


### PR DESCRIPTION
本次提交将快捷命令由“运行”改为“发送”，点击命令仅发送文本到终端，不再自动附加回车，便于用户补全参数后手动执行。主要变更包括：
- 移除所有语言资源文件中的“QuickCmd_Run”本地化字符串
- QuickCommandRunnerViewModel 中 RunCommand 替换为 SendCommand，方法实现和注释同步调整
- MainWindowViewModel、TerminalTabViewModel 相关方法由 TryExecuteCommand 改为 TrySendCommandText，逻辑仅发送正文
- QuickCommandsView.axaml UI 优化，命令条目改为整行 Button，悬停显示“发送”图标，分组头和命令数样式优化
- SnippetsPage.axaml 优化分组头、片段行及操作按钮样式，编辑/删除按钮改为图标
- 所有相关测试用例同步调整，校验只发送正文不带回车