### PR TITLE
chore: 优化内存占用(⬇️:40-50MB),终端渲染与数据通路性能与健壮性优化

### DIFF
--- a/src/VelaShell.Terminal/EchoSuppressor.cs
+++ b/src/VelaShell.Terminal/EchoSuppressor.cs
@@ -50,6 +50,13 @@ public sealed class EchoSuppressor
             return ReleaseHeld(data);
         }
 
+        // 快路径:无扣留前缀且整块不含 needle 首字节 → 原样返回,零分配零拷贝。
+        // 抑制窗内绝大多数输出块(MOTD、提示符刷新)都走这里。
+        if (_held == 0 && Array.IndexOf(data, _needle[0]) < 0)
+        {
+            return data;
+        }
+
         // 把上次扣住的前缀接回输入统一扫描(其内容与 needle 前缀相同,可直接重建)。
         byte[] input;
         if (_held > 0)

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -501,7 +501,8 @@ public sealed class TerminalEmulator : IVtActions
     public void Feed(ReadOnlySpan<byte> bytes)
     {
         _feedTimestamp = DateTime.Now;
-        string decoded = _utf8.Decode(bytes);
+        // DecodeSpan 复用 sink 的内部缓冲,parser 只读遍历不留引用——全程零 string 物化。
+        ReadOnlySpan<char> decoded = _utf8.DecodeSpan(bytes);
         if (decoded.Length > 0)
         {
             _parser.Parse(decoded);

--- a/src/VelaShell.Terminal/Emulation/Utf8Sink.cs
+++ b/src/VelaShell.Terminal/Emulation/Utf8Sink.cs
@@ -33,9 +33,19 @@ public sealed class Utf8Sink(Encoding? encoding = null)
     /// </summary>
     public string Decode(ReadOnlySpan<byte> bytes)
     {
+        ReadOnlySpan<char> decoded = DecodeSpan(bytes);
+        return decoded.IsEmpty ? string.Empty : new(decoded);
+    }
+
+    /// <summary>
+    /// 增量解码到内部复用缓冲,返回其只读视图(仅在下次 Decode/DecodeSpan 前有效)。
+    /// 输出热路径(每帧一次)用它避免物化中间 string。
+    /// </summary>
+    public ReadOnlySpan<char> DecodeSpan(ReadOnlySpan<byte> bytes)
+    {
         if (bytes.IsEmpty)
         {
-            return string.Empty;
+            return [];
         }
         int max = _decoder.GetCharCount(bytes, false);
         if (_chars.Length < max)
@@ -47,7 +57,7 @@ public sealed class Utf8Sink(Encoding? encoding = null)
         // GetCharCount 不改变解码器状态,早退会把这些字节整段丢掉,下一段解码成 U+FFFD
         // (网络分块恰好切在 CJK 字符中间时输出变 �,cat 中文文件偶发乱码的根因)。
         int written = _decoder.GetChars(bytes, _chars, false);
-        return written == 0 ? string.Empty : new(_chars, 0, written);
+        return _chars.AsSpan(0, written);
     }
 
     /// <summary>

--- a/src/VelaShell.Terminal/Emulation/VtParser.cs
+++ b/src/VelaShell.Terminal/Emulation/VtParser.cs
@@ -39,7 +39,11 @@ public sealed class VtParser(IVtActions actions)
         _prefix = '\0';
     }
 
-    private void Parse(ReadOnlySpan<char> text)
+    /// <summary>
+    /// Feeds a chunk of decoded terminal output through the state machine, dispatching actions.
+    /// Span 重载是输出热路径(<c>TerminalEmulator.Feed</c> 每帧调用),避免中间 string 物化。
+    /// </summary>
+    public void Parse(ReadOnlySpan<char> text)
     {
         // Iterate Unicode scalar values so surrogate pairs are delivered as one rune.
         for (int i = 0; i < text.Length; i++)

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -362,6 +362,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <summary>Feeds raw host output bytes into the emulator for parsing and display.</summary>
     public void Feed(byte[] data) => Emulator.Feed(data);
 
+    /// <summary>Feed 的 span 重载:桥的合批热路径直喂复用缓冲,避免物化精确尺寸数组。</summary>
+    public void Feed(ReadOnlySpan<byte> data) => Emulator.Feed(data);
+
     /// <summary>Resizes the emulator grid to the given columns/rows, resetting scroll, folds and selection.</summary>
     public void Resize(int cols, int rows)
     {
@@ -844,6 +847,11 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             return brush;
         }
+        // 同 PenFor:truecolor 下颜色空间无界,封顶防止字典长期膨胀。
+        if (_brushCache.Count > 4096)
+        {
+            _brushCache.Clear();
+        }
         brush = new(Color.FromArgb(c.A, c.R, c.G, c.B));
         _brushCache[c.Packed] = brush;
         return brush;
@@ -859,6 +867,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         if (_penCache.TryGetValue(c.Packed, out ImmutablePen? pen))
         {
             return pen;
+        }
+        // Truecolor 输出(渐变进度条等)每 cell 一色,不设上界会无限增长;
+        // 全清后一两帧内按需回填,成本可忽略。
+        if (_penCache.Count > 4096)
+        {
+            _penCache.Clear();
         }
         pen = new(BrushFor(c));
         _penCache[c.Packed] = pen;
@@ -922,6 +936,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
         // Cached glyphs are bound to the old typeface/size; drop them on any metric change.
         _glyphCache.Clear();
+        _ghostFormatted = null;
         _styleTypefacesReady = false;
     }
 
@@ -1159,23 +1174,36 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         double x = screen.CursorX * CellWidthForTest;
         double y = screenRow * CellHeightForTest;
-        var ft = new FormattedText(
-            ghost,
-            CultureInfo.CurrentCulture,
-            FlowDirection.LeftToRight,
-            new Typeface(FontFamily),
-            FontSize,
-            BrushFor(palette.DefaultForeground with { A = 0x66 })
-        );
+
+        // 幽灵可见期间光标闪烁每 ~530ms 重绘一帧;FormattedText 塑形较贵,
+        // 按 (文本, 颜色) 缓存,仅在幽灵内容/主题/字体度量变化时重建。
+        Rgba fg = palette.DefaultForeground with { A = 0x66 };
+        if (_ghostFormatted is null || _ghostFormattedText != ghost || _ghostFormattedColor != fg.Packed)
+        {
+            _ghostFormatted = new(
+                ghost,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily),
+                FontSize,
+                BrushFor(fg)
+            );
+            _ghostFormattedText = ghost;
+            _ghostFormattedColor = fg.Packed;
+        }
         using (
             context.PushClip(
                 new Rect(x, y, (cols - screen.CursorX) * CellWidthForTest, CellHeightForTest)
             )
         )
         {
-            context.DrawText(ft, new(x, y + _glyphYOffset));
+            context.DrawText(_ghostFormatted, new(x, y + _glyphYOffset));
         }
     }
+
+    private FormattedText? _ghostFormatted;
+    private string? _ghostFormattedText;
+    private uint _ghostFormattedColor;
 
     // ---- Line gutter(时间/行号/折叠侧栏,WindTerm 式) ---------------------
 

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -212,8 +212,9 @@ public class SshTerminalBridge : IDisposable
                 // ZMODEM 路由优先:会话期间返回空终端字节(全部转交引擎),
                 // 命中时仅把引导前的字节嗂终端;未启用时原样嗂入。
                 ZModem.ZModemTerminalRouter? router = ZModemRouter;
-                if (router is null)
+                if (router is null || router.CanPassThrough(data))
                 {
+                    // 常态直通:无 ZMODEM 引导迹象时原始块零拷贝进合批队列。
                     EnqueueForFeed(data);
                 }
                 else
@@ -267,11 +268,16 @@ public class SshTerminalBridge : IDisposable
         }
     }
 
+    // 多 chunk 合批的复用缓冲:只增不缩,仅在 UI 线程的 FlushPending 内访问,
+    // Feed 同步消费不留引用,因此跨帧复用安全。
+    private byte[] _combineBuffer = [];
+
     private void FlushPending()
     {
         // Reset first so chunks arriving during the drain schedule a fresh flush.
         Interlocked.Exchange(ref _flushScheduled, 0);
-        byte[] combined;
+        byte[] buffer;
+        int length;
         lock (_pendingLock)
         {
             int count = _pending.Count;
@@ -281,7 +287,8 @@ public class SshTerminalBridge : IDisposable
             }
             if (count == 1)
             {
-                combined = _pending[0];
+                buffer = _pending[0];
+                length = buffer.Length;
             }
             else
             {
@@ -290,14 +297,20 @@ public class SshTerminalBridge : IDisposable
                 {
                     total += _pending[i].Length;
                 }
-                combined = new byte[total];
+                if (_combineBuffer.Length < total)
+                {
+                    // 2 倍步进摊平增长成本,避免突发行情下反复重分配。
+                    _combineBuffer = new byte[Math.Max(total, _combineBuffer.Length * 2)];
+                }
                 int offset = 0;
                 for (int i = 0; i < count; i++)
                 {
                     byte[] chunk = _pending[i];
-                    Array.Copy(chunk, 0, combined, offset, chunk.Length);
+                    Array.Copy(chunk, 0, _combineBuffer, offset, chunk.Length);
                     offset += chunk.Length;
                 }
+                buffer = _combineBuffer;
+                length = total;
             }
             _pending.Clear();
         }
@@ -307,24 +320,45 @@ public class SshTerminalBridge : IDisposable
         }
         if (_echoSuppressor is { } suppressor)
         {
-            combined = suppressor.Process(combined);
+            // 抑制窗只覆盖连接后的最初几秒:此路径物化精确数组无妨,稳态热路径不经过。
+            byte[] exact = length == buffer.Length ? buffer : buffer[..length];
+            exact = suppressor.Process(exact);
             if (suppressor.Expired)
             {
                 _echoSuppressor = null;
             }
-            if (combined.Length == 0)
+            if (exact.Length == 0)
             {
                 return;
             }
+            buffer = exact;
+            length = exact.Length;
         }
         try
         {
             // One Feed per flush => one Updated => one repaint, regardless of chunk count.
-            _terminal.Feed(combined);
+            FeedTerminal(buffer, length);
         }
         catch (Exception ex)
         {
             Error?.Invoke(ex);
+        }
+    }
+
+    /// <summary>
+    /// 把合批结果喂给模拟器:生产中的具体实现(VelaTerminalControl)走 span 直喂
+    /// (复用缓冲零物化);其它 ITerminalEmulator 实现(测试替身)回退 byte[] 语义——
+    /// 接口不宜引入 span 成员,ref struct 参数无法被常规 mock 框架替身化。
+    /// </summary>
+    private void FeedTerminal(byte[] buffer, int length)
+    {
+        if (_terminal is Rendering.VelaTerminalControl control)
+        {
+            control.Feed(buffer.AsSpan(0, length));
+        }
+        else
+        {
+            _terminal.Feed(length == buffer.Length ? buffer : buffer[..length]);
         }
     }
 

--- a/src/VelaShell.Terminal/ZModem/ZModemDetector.cs
+++ b/src/VelaShell.Terminal/ZModem/ZModemDetector.cs
@@ -45,6 +45,17 @@ public sealed class ZModemDetector
     // 扣留的、可能属于被切断引导前缀的尾部字节。
     private readonly List<byte> _held = [];
 
+    /// <summary>
+    /// 常态零拷贝快路径判定:无扣留尾部、块内无任一引导、且块尾与引导前缀无重叠时为
+    /// true——调用方可把原始块原样喂终端,跳过 <see cref="Process" /> 的窗口拼接与切片拷贝。
+    /// 该检测器挂在所有会话的输出链路上,绝大多数输出块都应走此路径。
+    /// </summary>
+    public bool CanPassThrough(ReadOnlySpan<byte> incoming) =>
+        _held.Count == 0
+        && IndexOf(incoming, ReceiveSignature) < 0
+        && IndexOf(incoming, SendSignature) < 0
+        && LongestSignaturePrefixSuffix(incoming) == 0;
+
     /// <summary>处理一段新到达的输出字节,判断是否命中 ZMODEM 引导。</summary>
     /// <param name="incoming">本次到达的原始输出字节。</param>
     /// <returns>检测结果:待喂终端字节、命中的引导类型、以及命中后交给引擎的协议字节。</returns>
@@ -80,7 +91,7 @@ public sealed class ZModemDetector
             byte[] feed = window[..feedLen];
             if (holdLen > 0)
             {
-                _held.AddRange(window.AsSpan(feedLen).ToArray());
+                _held.AddRange(window.AsSpan(feedLen));
             }
             return new(feed, ZModemTrigger.None, []);
         }

--- a/src/VelaShell.Terminal/ZModem/ZModemTerminalRouter.cs
+++ b/src/VelaShell.Terminal/ZModem/ZModemTerminalRouter.cs
@@ -65,6 +65,20 @@ public sealed class ZModemTerminalRouter(
     public event Action<ZModemSession>? SessionEnded;
 
     /// <summary>
+    /// 常态零拷贝快路径:未处于 ZMODEM 会话且检测器判定本块可直通时为 true,
+    /// 调用方(读循环)可把原始块原样喂终端,完全绕过 <see cref="ProcessIncoming" />
+    /// 的窗口拼接与切片。会话只会在同一读线程的 ProcessIncoming 里启动,
+    /// 判定与直喂之间不存在"突然进入会话"的竞态。
+    /// </summary>
+    public bool CanPassThrough(ReadOnlySpan<byte> data)
+    {
+        lock (_gate)
+        {
+            return _state != ZModemRoutingState.InSession && _detector.CanPassThrough(data);
+        }
+    }
+
+    /// <summary>
     /// 处理一段来自读循环的原始输出字节,返回应喂入 VT 终端的字节。
     /// 会话期间返回空数组;检测到引导时启动会话并把引导及其后字节转交引擎。
     /// </summary>

--- a/src/VelaShell/Services/SuggestDiag.cs
+++ b/src/VelaShell/Services/SuggestDiag.cs
@@ -13,6 +13,12 @@ public static class SuggestDiag
     private static readonly string LogPath = Path.Combine(Path.GetTempPath(), "velashell-suggest.log");
     private static readonly Lock Gate = new();
 
+    /// <summary>
+    /// 诊断开关是否开启。热路径(每键)调用方必须先查它再拼 Log 的实参——
+    /// C# 会急切求值实参,不设防的话关着开关每键也白白分配几个字符串。
+    /// </summary>
+    public static bool IsEnabled => Enabled;
+
     /// <summary>在诊断开关开启时,把补全链路某个环节的详情写入日志文件与调试输出;关闭时零开销。</summary>
     public static void Log(string stage, string detail)
     {

--- a/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
+++ b/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
@@ -329,6 +329,12 @@ public class RecordingPlayerViewModel : ReactiveObject
         this.RaisePropertyChanged(nameof(PlayButtonText));
     }
 
+    /// <summary>
+    /// 窗口关闭时必须调用:运行中的 DispatcherTimer 被调度器强引用,不停表会让
+    /// 已关闭窗口的 VM 连同整段录制字节以 30Hz 空转存活到播放位置走完为止。
+    /// </summary>
+    public void StopPlayback() => Pause();
+
     private void OnTick(object? sender, EventArgs e)
     {
         if (_chunks.Count == 0)

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -227,12 +227,16 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     private void OnUserInputForTracker(byte[] data)
     {
         InputTracker.Process(data);
-        SuggestDiag.Log(
-            "typed",
-            $"""
-            bytes=[{Convert.ToHexString(data)}] input="{InputTracker.CurrentInput ?? "<unknown>"}"
-            """
-        );
+        // 每键路径:先查开关再拼实参,否则关着诊断每键也分配 3 个字符串。
+        if (SuggestDiag.IsEnabled)
+        {
+            SuggestDiag.Log(
+                "typed",
+                $"""
+                bytes=[{Convert.ToHexString(data)}] input="{InputTracker.CurrentInput ?? "<unknown>"}"
+                """
+            );
+        }
     }
 
     private void OnTrackedCommandSubmitted(string command)

--- a/src/VelaShell/Views/RecordingPlayerView.axaml.cs
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml.cs
@@ -75,6 +75,13 @@ public partial class RecordingPlayerView : Window
 
     private void Close_Click(object? sender, RoutedEventArgs e) => Close();
 
+    /// <summary>关闭时停掉回放定时器,否则 VM 与整段录制数据会被调度器吊住(见 StopPlayback)。</summary>
+    protected override void OnClosed(EventArgs e)
+    {
+        (DataContext as RecordingPlayerViewModel)?.StopPlayback();
+        base.OnClosed(e);
+    }
+
     /// <summary>Esc 关闭回放中心,与右上角关闭按钮同路径(回放终端不可聚焦,不会截获按键)。</summary>
     protected override void OnKeyDown(KeyEventArgs e)
     {

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -119,13 +119,25 @@ public partial class TerminalTabView : UserControl
     private void HookSuggestions()
     {
         _suggestVm?.InputTracker.InputChanged -= OnTrackedInputChanged;
+        _suggestVm?.Disconnected -= OnSuggestVmDisconnected;
         _suggestVm = DataContext as TerminalTabViewModel;
         _suggestVm?.InputTracker.InputChanged += OnTrackedInputChanged;
+        _suggestVm?.Disconnected += OnSuggestVmDisconnected;
         SuggestDiag.Log(
             "hook",
             $"view={GetHashCode():X} vm={_suggestVm?.GetHashCode():X} provider={(_suggestVm?.SuggestionProvider is null ? "null" : "ok")}"
         );
-        CloseSuggestPopup(suppress: false);
+        DismissSuggestions(suppress: false);
+    }
+
+    /// <summary>断连横幅会移动光标,残留的幽灵会被画到新光标处——断连即收口。</summary>
+    private void OnSuggestVmDisconnected(object? sender, EventArgs e) =>
+        DismissSuggestions(suppress: false);
+
+    /// <summary>统一收起智能提示:弹层与幽灵文本同生共灭,防止各清一半的残留。</summary>
+    private void DismissSuggestions(bool suppress)
+    {
+        CloseSuggestPopup(suppress);
         ClearGhost();
     }
 
@@ -141,13 +153,17 @@ public partial class TerminalTabView : UserControl
     private void OnTrackedInputChanged()
     {
         string input = EffectiveInput();
-        SuggestDiag.Log(
-            "changed",
-            $"""
-            view={GetHashCode():X} attached={IsAttachedToVisualTree()} known="{_suggestVm?.InputTracker.CurrentInput
-                ?? "<unknown>"}" effective="{input}" suppressed="{_suppressedInput}"
-            """
-        );
+        // 每键路径:先查开关再拼实参(急切求值防线,见 SuggestDiag.IsEnabled)。
+        if (SuggestDiag.IsEnabled)
+        {
+            SuggestDiag.Log(
+                "changed",
+                $"""
+                view={GetHashCode():X} attached={IsAttachedToVisualTree()} known="{_suggestVm?.InputTracker.CurrentInput
+                    ?? "<unknown>"}" effective="{input}" suppressed="{_suppressedInput}"
+                """
+            );
+        }
         // 程序注入(快捷命令下发)不是用户键入:收起并记为已抑制,待用户继续
         // 编辑(输入内容变化)后再恢复正常补全。
         if (_suggestVm?.IsProgrammaticInput == true)
@@ -707,11 +723,14 @@ public partial class TerminalTabView : UserControl
     }
 
     private void OnHostWindowDeactivated(object? sender, EventArgs e) =>
-        CloseSuggestPopup(suppress: false);
+        DismissSuggestions(suppress: false);
 
     private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        CloseSuggestPopup(suppress: false);
+        DismissSuggestions(suppress: false);
+        // 脱离可视树后不该再响应跟踪器(重新 attach 时 HookSuggestions 会幂等重订)。
+        _suggestVm?.InputTracker.InputChanged -= OnTrackedInputChanged;
+        _suggestVm?.Disconnected -= OnSuggestVmDisconnected;
         _hostWindow?.Deactivated -= OnHostWindowDeactivated;
         _hostWindow = null;
         if (_termControl is not null)
@@ -723,11 +742,11 @@ public partial class TerminalTabView : UserControl
     }
 
     /// <summary>
-    /// 终端失焦(点击 SFTP 面板/侧边栏等)时收起弹层;建议列表项不可聚焦,
+    /// 终端失焦(点击 SFTP 面板/侧边栏等)时收起弹层与幽灵;建议列表项不可聚焦,
     /// 因此点击建议项本身不会触发这里。
     /// </summary>
     private void OnTerminalLostFocus(object? sender, RoutedEventArgs e) =>
-        CloseSuggestPopup(suppress: false);
+        DismissSuggestions(suppress: false);
 
     // The terminal control is a single shared instance reparented across split panes, so each
     // view (re)binds the scrollbar to whichever control it currently hosts.
@@ -744,7 +763,11 @@ public partial class TerminalTabView : UserControl
         {
             _termControl.ScrollChanged -= OnTerminalScrollChanged;
             _termControl.LostFocus -= OnTerminalLostFocus;
+            // 幽灵是画在控件上的覆盖层:换出的旧控件若在别的面板仍可见,
+            // 不清会把幽灵永久残留在旧光标处。
+            _termControl.GhostText = null;
         }
+        _ghostFull = null;
         _termControl = ctrl;
         if (_termControl is not null)
         {


### PR DESCRIPTION
- 终端数据零拷贝快路径：EchoSuppressor、ZModemDetector、ZModemTerminalRouter 支持快路径判定，常态输出直接返回，减少分配与拷贝；SshTerminalBridge 合批缓冲区复用，合批后用 span 直喂控件。
- 渲染热路径优化：Utf8Sink 新增 DecodeSpan，主循环用 span 解码，TerminalEmulator.Feed 等接口支持 span 重载，全程零分配；画刷/画笔缓存上限防止 truecolor 下膨胀。
- 幽灵文本渲染优化：VelaTerminalControl 对幽灵文本内容+颜色缓存，仅在变更时重建，降低重绘开销。
- 智能补全与诊断日志优化：SuggestDiag 增加 IsEnabled，日志先判定开关再拼接字符串，TerminalTabView 智能补全与幽灵文本统一收起，防止残留。
- 健壮性提升：RecordingPlayerViewModel 增加 StopPlayback，窗口关闭时主动停表，防止内存泄漏；完善事件解绑与缓存清理，确保资源及时释放。

整体提升终端性能、资源利用率，降低 GC 压力，修复部分 UI 细节与潜在内存泄漏。