### PR TITLE
终端设置新增“连接后自动打开 SFTP 文件浏览器”选项

### DIFF
--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -375,6 +375,17 @@ public class TerminalBehaviorOptions : ObservableOptions
         set => Set(ref field, value);
     } = 1.0;
 
+    /// <summary>
+    /// 连接远程会话后是否总是自动打开 SFTP 文件浏览器。关闭时跟随上次退出程序时
+    /// 面板的显示状态(<see cref="AppState.FileBrowserVisible" />):上次关着就不自动打开。
+    /// 面板不显示时不做任何 SFTP 拉取(文件列表、属主/属组等),首次展开才加载。
+    /// </summary>
+    public bool AutoOpenFileBrowser
+    {
+        get;
+        set => Set(ref field, value);
+    } = true;
+
     /// <summary>光标形状(如 bar / block / underline)。</summary>
     public string CursorStyle
     {

--- a/src/VelaShell.Core/Models/AppState.cs
+++ b/src/VelaShell.Core/Models/AppState.cs
@@ -26,6 +26,12 @@ public class AppState
 
     /// <summary>最近连接侧栏区域上次展开时的高度。</summary>
     public double SidebarRecentConnectionsHeight { get; set; } = 180;
+
+    /// <summary>
+    /// 上次退出时 SFTP 文件浏览器是否处于显示状态。仅当设置
+    /// 「连接后自动打开文件浏览器」关闭时生效:下次启动按此恢复面板的初始意图。
+    /// </summary>
+    public bool FileBrowserVisible { get; set; } = true;
 }
 
 /// <summary>窗口在屏幕上的位置坐标。</summary>

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1956,6 +1956,12 @@
   <data name="SetTerm_LineHeightDesc" xml:space="preserve">
     <value>// 行間の倍率(既定値 1.0)</value>
   </data>
+  <data name="SetTerm_AutoOpenSftp" xml:space="preserve">
+    <value>接続時にファイルブラウザーを自動的に開く</value>
+  </data>
+  <data name="SetTerm_AutoOpenSftpDesc" xml:space="preserve">
+    <value>オン:リモートセッションに接続するたびに SFTP ファイルブラウザーを自動的に開きます。オフ:前回終了時のパネル表示状態に従います。</value>
+  </data>
   <data name="SetTerm_OutputEncoding" xml:space="preserve">
     <value>出力エンコーディング</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1956,6 +1956,12 @@
   <data name="SetTerm_LineHeightDesc" xml:space="preserve">
     <value>// 줄 간격 배율, 기본값 1.0</value>
   </data>
+  <data name="SetTerm_AutoOpenSftp" xml:space="preserve">
+    <value>연결 시 파일 브라우저 자동 열기</value>
+  </data>
+  <data name="SetTerm_AutoOpenSftpDesc" xml:space="preserve">
+    <value>켜기: 원격 세션에 연결할 때마다 SFTP 파일 브라우저를 자동으로 엽니다. 끄기: 마지막 종료 시 패널 표시 상태를 따릅니다.</value>
+  </data>
   <data name="SetTerm_OutputEncoding" xml:space="preserve">
     <value>출력 인코딩</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2023,6 +2023,12 @@ Paste anyway?</value>
   <data name="SetTerm_LineHeightDesc" xml:space="preserve">
     <value>// Line spacing multiplier; 1.0 is default</value>
   </data>
+  <data name="SetTerm_AutoOpenSftp" xml:space="preserve">
+    <value>Auto-open file browser on connect</value>
+  </data>
+  <data name="SetTerm_AutoOpenSftpDesc" xml:space="preserve">
+    <value>On: the SFTP file browser opens every time a remote session connects. Off: it follows whether the panel was open when the app last exited.</value>
+  </data>
   <data name="SetTerm_OutputEncoding" xml:space="preserve">
     <value>Output encoding</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2114,6 +2114,12 @@
   <data name="SetTerm_LineHeightDesc" xml:space="preserve">
     <value>// 行间距倍数,1.0 为默认</value>
   </data>
+  <data name="SetTerm_AutoOpenSftp" xml:space="preserve">
+    <value>连接后自动打开文件浏览器</value>
+  </data>
+  <data name="SetTerm_AutoOpenSftpDesc" xml:space="preserve">
+    <value>开启:每次连接远程会话都会自动打开 SFTP 文件浏览器;关闭:跟随上次退出程序时面板的显示状态。</value>
+  </data>
   <data name="SetTerm_OutputEncoding" xml:space="preserve">
     <value>输出编码</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1956,6 +1956,12 @@
   <data name="SetTerm_LineHeightDesc" xml:space="preserve">
     <value>// 行距倍數,預設為 1.0</value>
   </data>
+  <data name="SetTerm_AutoOpenSftp" xml:space="preserve">
+    <value>連線後自動開啟檔案瀏覽器</value>
+  </data>
+  <data name="SetTerm_AutoOpenSftpDesc" xml:space="preserve">
+    <value>開啟:每次連線遠端工作階段都會自動開啟 SFTP 檔案瀏覽器;關閉:跟隨上次結束程式時面板的顯示狀態。</value>
+  </data>
   <data name="SetTerm_OutputEncoding" xml:space="preserve">
     <value>輸出編碼</value>
   </data>

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -104,7 +104,9 @@ public class MainWindowViewModel : ReactiveObject
     /// <summary>
     /// SFTP 面板的用户开关意图(全局,跨标签)。面板对象随标签切换/会话驱逐被整体
     /// 替换,可见性不能从上一个对象“抄”过来(本地终端占位是隐藏的,会把 false 传染
-    /// 给下一个远程标签);统一以本字段为准恢复。
+    /// 给下一个远程标签);统一以本字段为准恢复。启动时由 <see cref="InitializeAsync" />
+    /// 按设置初始化(总是打开 / 跟随上次退出状态),退出时经 <see cref="CaptureSidebarState" />
+    /// 持久化到 <see cref="AppState.FileBrowserVisible" />。
     /// </summary>
     private bool _fileBrowserOpenIntent = true;
     private Dictionary<Guid, string> _paletteGroupNames = [];
@@ -1303,8 +1305,16 @@ public class MainWindowViewModel : ReactiveObject
         if (_settingsService is not null)
         {
             _appState = await _settingsService.GetStateAsync();
+            AppSettings settings = await LoadSettingsSnapshotAsync();
+
+            // SFTP 面板的初始意图:「连接后自动打开文件浏览器」开启时无条件打开;
+            // 关闭时跟随上次退出的显示状态。必须先于 ApplySidebarState 赋值——
+            // 其内部的 CaptureSidebarState 会把当前意图回写进 _appState。
+            _fileBrowserOpenIntent =
+                settings.TerminalBehavior.AutoOpenFileBrowser || _appState.FileBrowserVisible;
+
             ApplySidebarState(_appState);
-            ApplyShellPreferences(await LoadSettingsSnapshotAsync());
+            ApplyShellPreferences(settings);
         }
         await Sidebar.RecentConnections.RefreshAsync();
         await RefreshSessionTreeAsync();
@@ -1378,6 +1388,9 @@ public class MainWindowViewModel : ReactiveObject
             Sidebar.RecentConnectionsHeight,
             180
         );
+        // 面板显示状态跟随用户意图落盘(窗口关闭时随本方法最终保存一次),
+        // 供「连接后自动打开文件浏览器」关闭时在下次启动恢复。
+        _appState.FileBrowserVisible = _fileBrowserOpenIntent;
     }
 
     private async Task SaveSidebarStateAfterDelayAsync(CancellationToken cancellationToken)

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -33,6 +33,13 @@
     </Grid>
     <Grid ColumnDefinitions="*,Auto">
       <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_AutoOpenSftp}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_AutoOpenSftpDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.AutoOpenFileBrowser}" VerticalAlignment="Center" />
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
         <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_ShowLineTimestamp}" />
         <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_ShowLineTimestampDesc}" />
       </StackPanel>

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -340,6 +340,92 @@ public class MainWindowViewModelTests
             );
     }
 
+    /// <summary>构造带设置/状态桩的 VM 并完成初始化,用于验证 SFTP 面板的启动意图。</summary>
+    private static async Task<MainWindowViewModel> CreateInitializedVmAsync(
+        bool autoOpenFileBrowser,
+        bool lastVisible,
+        ISettingsService? settingsServiceOut = null)
+    {
+        ISettingsService settingsService = settingsServiceOut ?? Substitute.For<ISettingsService>();
+        settingsService
+            .GetSettingsAsync()
+            .Returns(new AppSettings
+            {
+                TerminalBehavior = new() { AutoOpenFileBrowser = autoOpenFileBrowser }
+            });
+        settingsService.GetStateAsync().Returns(new AppState { FileBrowserVisible = lastVisible });
+        var vm = new MainWindowViewModel(
+            settingsService: settingsService,
+            sftpService: Substitute.For<ISftpService>()
+        );
+        await vm.InitializeAsync();
+        return vm;
+    }
+
+    private static TerminalTabViewModel CreateConnectedSshTab() =>
+        new(Substitute.For<ITerminalEmulator>())
+        {
+            Profile = new() { Name = "srv", Host = "srv.example" },
+            SessionId = Guid.NewGuid(),
+            ConnectionStatus = SessionStatus.Connected,
+        };
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task FileBrowser_AutoOpenSettingOn_OpensOnConnectDespiteLastClosedState()
+    {
+        MainWindowViewModel vm = await CreateInitializedVmAsync(
+            autoOpenFileBrowser: true, lastVisible: false);
+
+        vm.TabBar.AddTab(CreateConnectedSshTab());
+
+        Assert.IsTrue(vm.FileBrowser.IsVisible, "开关开启时,无论上次退出状态如何都自动打开。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task FileBrowser_AutoOpenSettingOff_FollowsLastClosedState()
+    {
+        MainWindowViewModel vm = await CreateInitializedVmAsync(
+            autoOpenFileBrowser: false, lastVisible: false);
+
+        vm.TabBar.AddTab(CreateConnectedSshTab());
+
+        Assert.IsFalse(vm.FileBrowser.IsVisible, "开关关闭且上次退出时面板关闭:不自动打开。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task FileBrowser_AutoOpenSettingOff_FollowsLastVisibleState()
+    {
+        MainWindowViewModel vm = await CreateInitializedVmAsync(
+            autoOpenFileBrowser: false, lastVisible: true);
+
+        vm.TabBar.AddTab(CreateConnectedSshTab());
+
+        Assert.IsTrue(vm.FileBrowser.IsVisible, "开关关闭但上次退出时面板可见:仍自动打开。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task FileBrowser_VisibilityIntent_IsPersistedOnExit()
+    {
+        ISettingsService settingsService = Substitute.For<ISettingsService>();
+        MainWindowViewModel vm = await CreateInitializedVmAsync(
+            autoOpenFileBrowser: true, lastVisible: true, settingsService);
+
+        vm.TabBar.AddTab(CreateConnectedSshTab());
+        Assert.IsTrue(vm.FileBrowser.IsVisible);
+        vm.ToggleFileBrowser();
+        Assert.IsFalse(vm.FileBrowser.IsVisible);
+
+        await vm.PersistSidebarStateAsync();
+
+        await settingsService
+            .Received()
+            .SaveStateAsync(Arg.Is<AppState>(state => !state.FileBrowserVisible));
+    }
+
     [TestMethod]
     [TestCategory("SessionTree")]
     public async Task ActiveTerminalTab_FollowsSavedProfileWhenSettingEnabled()


### PR DESCRIPTION
新增 AutoOpenFileBrowser 选项，支持连接后自动显示 SFTP 文件浏览器。关闭时，面板显示状态跟随上次退出（AppState.FileBrowserVisible），首次展开时才加载 SFTP 数据。MainWindowViewModel 初始化和关闭时处理面板显示意图及状态持久化。TerminalSettingsPage.axaml 增加 UI，补充多语言文案。新增 MainWindowViewModelTests 单元测试，覆盖选项和面板状态组合场景。