### PR TITLE
升级 Microsoft.Reactive.Testing 至 7.0.0 并添加 global.json

### DIFF
--- a/VelaShell.slnx
+++ b/VelaShell.slnx
@@ -14,6 +14,7 @@
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="Directory.Build.props" />
+    <File Path="global.json" />
     <File Path="LICENSE" />
     <File Path="LICENSE-COMMERCIAL.md" />
     <File Path="plan.md" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0" />
     <PackageVersion Include="ReactiveUI.Testing" Version="23.2.28" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
在 VelaShell.slnx 中新增了 global.json 文件的引用。
将 Directory.Packages.props 中 Microsoft.Reactive.Testing 包版本从 6.1.0 升级到 7.0.0。