### PR TITLE
窗口不透明度即时预览通道与性能优化

### DIFF
--- a/src/VelaShell.Core/Services/SettingsPreviewService.cs
+++ b/src/VelaShell.Core/Services/SettingsPreviewService.cs
@@ -14,6 +14,12 @@ public interface ISettingsPreviewService
 
     /// <summary>广播一份未持久化的设置快照以触发即时预览。</summary>
     void Preview(AppSettings settings);
+
+    /// <summary>窗口不透明度即时预览事件(已钳位到 10..100)。绕过 AppSettings 快照路径,在 UI 线程触发。</summary>
+    event Action<int>? WindowOpacityPreviewRequested;
+
+    /// <summary>广播窗口不透明度百分比(钳位到 10..100),不产生 AppSettings/JSON 开销。</summary>
+    void PreviewWindowOpacity(int percent);
 }
 
 /// <summary><see cref="ISettingsPreviewService" /> 的默认实现:将预览请求同步转发给订阅者。</summary>
@@ -27,5 +33,14 @@ public sealed class SettingsPreviewService : ISettingsPreviewService
     {
         ArgumentNullException.ThrowIfNull(settings);
         PreviewRequested?.Invoke(settings);
+    }
+
+    /// <inheritdoc />
+    public event Action<int>? WindowOpacityPreviewRequested;
+
+    /// <inheritdoc />
+    public void PreviewWindowOpacity(int percent)
+    {
+        WindowOpacityPreviewRequested?.Invoke(Math.Clamp(percent, 10, 100));
     }
 }

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1108,8 +1108,20 @@ public class SettingsViewModel : ReactiveObject
 
     private Avalonia.Threading.DispatcherTimer? _previewDebounce;
 
-    private void OnAppearanceItemChanged(object? sender, PropertyChangedEventArgs e) =>
+    private void OnAppearanceItemChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AppearanceOptions.WindowOpacityPercent))
+        {
+            if (_suppressPreview || _previewService is null)
+            {
+                return;
+            }
+            _previewed = true;
+            _previewService.PreviewWindowOpacity(Appearance.WindowOpacityPercent);
+            return;
+        }
         SchedulePreviewBroadcast();
+    }
 
     /// <summary>
     /// 合并外观单项修改的预览广播到 50ms 尾沿:拖动滑杆时 INPC 每次微调都来一发,

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -414,6 +414,9 @@ public partial class MainWindow : Window
             {
                 previewService.PreviewRequested += OnSettingsPreviewedForWindow;
                 Closed += (_, _) => previewService.PreviewRequested -= OnSettingsPreviewedForWindow;
+                previewService.WindowOpacityPreviewRequested += OnSettingsOpacityPreviewedForWindow;
+                Closed += (_, _) =>
+                    previewService.WindowOpacityPreviewRequested -= OnSettingsOpacityPreviewedForWindow;
             }
             try
             {
@@ -471,12 +474,22 @@ public partial class MainWindow : Window
     private void OnSettingsPreviewedForWindow(AppSettings settings) =>
         Dispatcher.UIThread.Post(() => ApplyWindowAppearance(settings));
 
+    private void OnSettingsOpacityPreviewedForWindow(int percent)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplyWindowOpacity(percent);
+            return;
+        }
+        Dispatcher.UIThread.Post(() => ApplyWindowOpacity(percent));
+    }
+
     /// <summary>应用设置 → 外观:窗口透明度、侧边栏位置、界面字体/字号。
     /// (菜单栏显隐设置已随文字菜单一并移除:自绘标题栏承载窗口控制按钮,必须常显。)</summary>
     private void ApplyWindowAppearance(AppSettings settings)
     {
         AppearanceOptions a = settings.Appearance;
-        Opacity = Math.Clamp(a.WindowOpacityPercent, 10, 100) / 100.0;
+        ApplyWindowOpacity(a.WindowOpacityPercent);
         ApplySidebarPosition(a.SidebarPosition == "right");
         if (Application.Current is not { } app)
         {
@@ -505,6 +518,9 @@ public partial class MainWindow : Window
         app.Resources["VelaUiFontSize"] = uiFontSize;
         app.Resources["ControlContentThemeFontSize"] = uiFontSize;
     }
+
+    private void ApplyWindowOpacity(int percent) =>
+        Opacity = Math.Clamp(percent, 10, 100) / 100.0;
 
     /// <summary>侧边栏位置(设置 → 外观):交换侧边栏与主区所在列,分隔条留在中间。</summary>
     private void ApplySidebarPosition(bool right)

--- a/tests/VelaShell.Core.Tests/Services/SettingsPreviewServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Services/SettingsPreviewServiceTests.cs
@@ -1,0 +1,140 @@
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+
+namespace VelaShell.Core.Tests.Services;
+
+[TestClass]
+public sealed class SettingsPreviewServiceTests
+{
+    private SettingsPreviewService _sut = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _sut = new SettingsPreviewService();
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_InvokeOnce_EmitsExactlyOneEvent()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(50);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(50, received[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_InvokeMultiple_EmitsInOrder()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(30);
+        _sut.PreviewWindowOpacity(60);
+        _sut.PreviewWindowOpacity(90);
+
+        Assert.AreSequenceEqual([30, 60, 90], received);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_BelowMin_ClampsTo10()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(0);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(10, received[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_AboveMax_ClampsTo100()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(150);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(100, received[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_Boundary10_PassesThrough()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(10);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(10, received[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_Boundary100_PassesThrough()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(100);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(100, received[0]);
+    }
+
+    [TestMethod]
+    public void OpacityChannel_And_SnapshotChannel_AreIndependent()
+    {
+        var opacityReceived = new List<int>();
+        var snapshotReceived = new List<AppSettings>();
+
+        _sut.WindowOpacityPreviewRequested += v => opacityReceived.Add(v);
+        _sut.PreviewRequested += s => snapshotReceived.Add(s);
+
+        var settings = new AppSettings();
+        _sut.Preview(settings);
+        _sut.PreviewWindowOpacity(42);
+
+        Assert.HasCount(1, snapshotReceived);
+        Assert.AreEqual(settings, snapshotReceived[0]);
+        Assert.HasCount(1, opacityReceived);
+        Assert.AreEqual(42, opacityReceived[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_NegativeValue_ClampsTo10()
+    {
+        var received = new List<int>();
+        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+
+        _sut.PreviewWindowOpacity(-5);
+
+        Assert.HasCount(1, received);
+        Assert.AreEqual(10, received[0]);
+    }
+
+    [TestMethod]
+    public void PreviewWindowOpacity_NoSubscribers_DoesNotThrow()
+    {
+        // No subscribers attached — should not throw.
+        _sut.PreviewWindowOpacity(50);
+    }
+
+    [TestMethod]
+    public void Preview_SnapshotStillWorks_Unchanged()
+    {
+        var snapshotReceived = new List<AppSettings>();
+        _sut.PreviewRequested += s => snapshotReceived.Add(s);
+
+        var settings = new AppSettings();
+        _sut.Preview(settings);
+
+        Assert.HasCount(1, snapshotReceived);
+        Assert.AreEqual(settings, snapshotReceived[0]);
+    }
+}

--- a/tests/VelaShell.Core.Tests/ZModem/LrzszInteropTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/LrzszInteropTests.cs
@@ -177,7 +177,7 @@ public class LrzszInteropTests
 
         Assert.AreEqual(ZModemTransferStatus.Failed, session.Status);
         // 每次超时都应补发一次 ZRINIT,最后再发取消序列。
-        Assert.IsTrue(duplex.WrittenBytes > 0, "超时后应向对端发过 ZRINIT / 取消序列");
+        Assert.IsGreaterThan(0, duplex.WrittenBytes, "超时后应向对端发过 ZRINIT / 取消序列");
     }
 
     /// <summary>
@@ -192,12 +192,12 @@ public class LrzszInteropTests
         ZModemOptions o = ZModemOptions.Default;
         // 握手最坏耗时 ≈ (1 次首读 + HandshakeRetries 次重试) × HandshakeTimeout。
         TimeSpan worstCase = o.HandshakeTimeout * (o.HandshakeRetries + 1);
-        Assert.IsTrue(
-            worstCase <= TimeSpan.FromSeconds(30),
+        Assert.IsLessThanOrEqualTo(
+            TimeSpan.FromSeconds(30), worstCase,
             $"默认握手预算最坏 {worstCase.TotalSeconds:F0}s,应为秒级(旧实现曾是 FrameTimeout×MaxRetries=300s)");
         // 握手预算必须显著短于数据阶段预算,否则等于没区分。
-        Assert.IsTrue(
-            o.HandshakeTimeout < o.FrameTimeout,
+        Assert.IsLessThan(
+            o.FrameTimeout, o.HandshakeTimeout,
             "握手超时应远短于数据阶段超时");
     }
 

--- a/tests/VelaShell.Core.Tests/ZModem/ReceiverTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ReceiverTests.cs
@@ -43,7 +43,7 @@ public class ReceiverTests
         await RunAsync([("empty.bin", [])], useCrc32: true, 1024, sink);
 
         Assert.IsTrue(sink.Completed.ContainsKey("empty.bin"));
-        Assert.AreEqual(0, sink.Completed["empty.bin"].Length);
+        Assert.IsEmpty(sink.Completed["empty.bin"]);
     }
 
     [TestMethod]
@@ -76,7 +76,7 @@ public class ReceiverTests
         var sink = new InMemoryFileSink();
         await RunAsync(files, useCrc32: true, 4, sink);
 
-        Assert.AreEqual(3, sink.Completed.Count);
+        Assert.HasCount(3, sink.Completed);
         CollectionAssert.AreEqual("first"u8.ToArray(), sink.Completed["a.txt"]);
         CollectionAssert.AreEqual("second file body"u8.ToArray(), sink.Completed["b.txt"]);
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x18, 0x11, 0x13, 0xFF, 0x7F }, sink.Completed["c.bin"]);

--- a/tests/VelaShell.Core.Tests/ZModem/SenderTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/SenderTests.cs
@@ -95,7 +95,7 @@ public class SenderTests
         (ZModemSession send, _, InMemoryFileSink sink) = await RoundTripAsync([("empty.txt", [])]);
 
         Assert.AreEqual(ZModemTransferStatus.Completed, send.Status);
-        Assert.AreEqual(0, sink.Completed["empty.txt"].Length);
+        Assert.IsEmpty(sink.Completed["empty.txt"]);
     }
 
     [TestMethod]
@@ -195,7 +195,7 @@ public class SenderTests
 
         Assert.AreEqual(ZModemTransferStatus.Cancelled, send.Result.Status);
         Assert.AreEqual(ZModemTransferStatus.Completed, receive.Result.Status, "接收方收到 ZFIN 应干净收束,而非挂起");
-        Assert.AreEqual(0, receiverSink.Completed.Count, "取消批次不应落地任何文件");
+        Assert.IsEmpty(receiverSink.Completed, "取消批次不应落地任何文件");
     }
 
     private static bool ContainsSequence(byte[] haystack, byte[] needle)

--- a/tests/VelaShell.Core.Tests/ZModem/SubpacketTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/SubpacketTests.cs
@@ -74,7 +74,7 @@ public class SubpacketTests
         byte[] wire = ZModemSubpacket.Write([], ZModemSubpacketEnd.EndNoAck, useCrc32: false);
         ZModemSubpacketResult result = await ReadOneAsync(wire, useCrc32: false, wire.Length);
         Assert.AreEqual(ZModemSubpacketStatus.Ok, result.Status);
-        Assert.AreEqual(0, result.Data.Length);
+        Assert.IsEmpty(result.Data);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/ZModemRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ZModemRouterTests.cs
@@ -37,7 +37,7 @@ public class ZModemRouterTests
 
         Assert.IsTrue(result.Detected);
         CollectionAssert.AreEqual(prefix, result.TerminalBytes);
-        Assert.AreEqual(Signature.Length + 2, result.ProtocolBytes.Length);
+        Assert.HasCount(Signature.Length + 2, result.ProtocolBytes);
         CollectionAssert.AreEqual(Signature, result.ProtocolBytes[..Signature.Length]);
     }
 
@@ -57,7 +57,7 @@ public class ZModemRouterTests
         ZModemDetectResult r2 = detector.Process(second);
 
         Assert.IsTrue(r2.Detected);
-        Assert.AreEqual(0, r2.TerminalBytes.Length);
+        Assert.IsEmpty(r2.TerminalBytes);
         CollectionAssert.AreEqual(Signature, r2.ProtocolBytes[..Signature.Length]);
     }
 
@@ -165,7 +165,7 @@ public class ZModemRouterTests
 
         ZModemRouteResult route2 = router.ProcessIncoming(stream);
         Assert.IsTrue(route2.SessionStarted);
-        Assert.AreEqual(0, route2.TerminalBytes.Length);
+        Assert.IsEmpty(route2.TerminalBytes);
 
         ZModemSession session = await completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.AreEqual(ZModemTransferStatus.Completed, session.Status);

--- a/tests/VelaShell.Tests/Services/FileZModemFileSourceTests.cs
+++ b/tests/VelaShell.Tests/Services/FileZModemFileSourceTests.cs
@@ -25,8 +25,8 @@ public class FileZModemFileSourceTests
         var source = new FileZModemFileSource(picker);
         IReadOnlyList<ZModemOutgoingFile> files = await source.GetFilesAsync(CancellationToken.None);
 
-        Assert.AreEqual(0, files.Count, "两次都取消应最终返回空清单(触发发送方优雅收尾)");
-        Assert.AreEqual(2, retryFlags.Count, "首次取消应重弹一次,共两次");
+        Assert.IsEmpty(files, "两次都取消应最终返回空清单(触发发送方优雅收尾)");
+        Assert.HasCount(2, retryFlags, "首次取消应重弹一次,共两次");
         Assert.IsFalse(retryFlags[0], "第一次弹窗不是重试");
         Assert.IsTrue(retryFlags[1], "第二次弹窗应标记为重试");
     }
@@ -50,7 +50,7 @@ public class FileZModemFileSourceTests
             IReadOnlyList<ZModemOutgoingFile> files = await source.GetFilesAsync(CancellationToken.None);
 
             Assert.AreEqual(2, callCount);
-            Assert.AreEqual(1, files.Count);
+            Assert.HasCount(1, files);
             Assert.AreEqual(Path.GetFileName(tmp), files[0].RemoteName, "远端文件名应为纯文件名");
             Assert.AreEqual(5, files[0].Size);
         }
@@ -79,7 +79,7 @@ public class FileZModemFileSourceTests
             IReadOnlyList<ZModemOutgoingFile> files = await source.GetFilesAsync(CancellationToken.None);
 
             Assert.AreEqual(1, callCount, "首次即选定不应重弹");
-            Assert.AreEqual(1, files.Count);
+            Assert.HasCount(1, files);
         }
         finally
         {

--- a/tests/VelaShell.Tests/Services/FolderZModemFileSinkTests.cs
+++ b/tests/VelaShell.Tests/Services/FolderZModemFileSinkTests.cs
@@ -38,7 +38,7 @@ public class FolderZModemFileSinkTests
             await sink.OnFileOfferedAsync(Meta("a.bin"), new ZModemTransferItem { FileName = "a.bin" }, CancellationToken.None);
 
         Assert.AreEqual(ZModemFileDisposition.Abort, disposition);
-        Assert.AreEqual(2, calls.Count, "首次取消应重弹一次,共两次");
+        Assert.HasCount(2, calls, "首次取消应重弹一次,共两次");
         Assert.IsFalse(calls[0].IsRetryAfterCancel, "第一次弹窗不是重试");
         Assert.IsTrue(calls[1].IsRetryAfterCancel, "第二次弹窗应标记为重试(标题提示再次取消即中止)");
     }

--- a/tests/VelaShell.Tests/Services/GitHubReleaseSourceTests.cs
+++ b/tests/VelaShell.Tests/Services/GitHubReleaseSourceTests.cs
@@ -179,7 +179,7 @@ public class GitHubReleaseSourceTests : IDisposable
         string? hash = await source.DownloadAssetAsync(
             CreateManifest("pkg.zip", payload.Length), Asset(payload.Length), destination);
 
-        Assert.AreEqual(3, ranges.Count, "24MB 应切成 3 段并发请求");
+        Assert.HasCount(3, ranges, "24MB 应切成 3 段并发请求");
         CollectionAssert.AreEquivalent(
             new long[] { 0, 8 * 1024 * 1024, 16 * 1024 * 1024 },
             ranges.Select(r => r.From).ToArray());
@@ -220,7 +220,7 @@ public class GitHubReleaseSourceTests : IDisposable
         string? hash = await source.DownloadAssetAsync(
             CreateManifest("pkg.zip", payload.Length), Asset(payload.Length), destination);
 
-        Assert.AreEqual(2, ranges.Count, "已完成的第一段不应重新请求");
+        Assert.HasCount(2, ranges, "已完成的第一段不应重新请求");
         CollectionAssert.AreEquivalent(
             new long[] { segmentLength, 2 * segmentLength },
             ranges.Select(r => r.From).ToArray());

--- a/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
+++ b/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
@@ -55,7 +55,7 @@ public class PackageVersionsTests
     [TestMethod]
     public void Read_AssemblyWithoutMetadata_ReturnsEmpty()
     {
-        Assert.AreEqual(0, PackageVersions.Read(typeof(object).Assembly).Count);
+        Assert.IsEmpty(PackageVersions.Read(typeof(object).Assembly));
     }
 
     /// <summary>

--- a/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
+++ b/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
@@ -16,7 +16,7 @@ public class SyncDebounceLifecycleTests
 
         Assert.IsTrue(ok1);
         Assert.IsTrue(ok2);
-        Assert.IsTrue(t1 != t2, "Consecutive tokens must differ");
+        Assert.AreNotEqual(t2, t1, "Consecutive tokens must differ");
     }
 
     [TestMethod]
@@ -148,7 +148,7 @@ public class SyncDebounceLifecycleTests
             }
         });
 
-        Assert.AreEqual(1, all.Count(token => !token.IsCancellationRequested));
+        Assert.ContainsSingle(token => !token.IsCancellationRequested, all);
 
         lifecycle.Shutdown();
 

--- a/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
@@ -28,7 +28,7 @@ public class UpdateManifestTests
         UpdateManifest manifest = UpdateManifest.Parse(SampleJson);
         Assert.AreEqual("0.2.0", manifest.Version);
         Assert.AreEqual("v0.2.0", manifest.Tag);
-        Assert.AreEqual(6, manifest.Assets.Count);
+        Assert.HasCount(6, manifest.Assets);
         UpdateAsset asset = manifest.Assets["win-x64"];
         Assert.AreEqual("VelaShell-0.2.0-win-x64.zip", asset.Name);
         Assert.AreEqual("aa11", asset.Sha256);

--- a/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
@@ -191,7 +191,7 @@ public class UpdateServiceTests : IDisposable
         await Assert.ThrowsExactlyAsync<InvalidDataException>(() => service.DownloadUpdateAsync());
 
         string staging = Path.Combine(_appDir, UpdateApplier.StagingDirectoryName);
-        Assert.AreEqual(0, Directory.GetFiles(staging).Length, "校验失败的下载必须删除");
+        Assert.IsEmpty(Directory.GetFiles(staging), "校验失败的下载必须删除");
         // 校验失败后不允许进入换版。
         Assert.ThrowsExactly<InvalidOperationException>(() => service.ApplyUpdateAndRestart());
     }

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -20,7 +20,50 @@ public class SettingsViewModelTests
         _themeService = Substitute.For<IThemeService>();
     }
 
-    private SettingsViewModel CreateVm() => new(_settingsService, _themeService);
+    private SettingsViewModel CreateVm(ISettingsPreviewService? previewService = null) =>
+        new(_settingsService, _themeService, previewService: previewService);
+
+    [TestMethod]
+    [TestCategory("Settings")]
+    public async Task AppearanceOpacityChange_PreviewsEveryValueImmediately_WithoutSnapshot()
+    {
+        ISettingsPreviewService preview = new SettingsPreviewService();
+        var opacityValues = new List<int>();
+        var snapshots = new List<AppSettings>();
+        preview.WindowOpacityPreviewRequested += value => opacityValues.Add(value);
+        preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+        _settingsService.GetSettingsAsync().Returns(new AppSettings());
+
+        SettingsViewModel vm = CreateVm(preview);
+        await vm.LoadCommand.Execute().FirstAsync();
+
+        foreach (int value in new[] { 20, 30, 40, 50 })
+        {
+            vm.Appearance.WindowOpacityPercent = value;
+        }
+
+        CollectionAssert.AreEqual(new[] { 20, 30, 40, 50 }, opacityValues);
+        Assert.IsEmpty(snapshots);
+    }
+
+    [TestMethod]
+    [TestCategory("Settings")]
+    public async Task OpacityOnlyPreview_NotifyClosed_BroadcastsOriginalBaseline()
+    {
+        ISettingsPreviewService preview = new SettingsPreviewService();
+        var snapshots = new List<AppSettings>();
+        preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+        var baseline = new AppSettings { Appearance = new() { WindowOpacityPercent = 80 } };
+        _settingsService.GetSettingsAsync().Returns(baseline);
+
+        SettingsViewModel vm = CreateVm(preview);
+        await vm.LoadCommand.Execute().FirstAsync();
+        vm.Appearance.WindowOpacityPercent = 40;
+        vm.NotifyClosed();
+
+        Assert.HasCount(1, snapshots);
+        Assert.AreEqual(80, snapshots[0].Appearance.WindowOpacityPercent);
+    }
 
     [TestMethod]
     [TestCategory("Settings")]

--- a/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
@@ -57,6 +57,73 @@ public class SettingsViewUiTests
         });
     }
 
+    [TestMethod]
+    public void NonOpacityAppearanceChange_RemainsTrailingSnapshotDebounced()
+    {
+        OnUi(async () =>
+        {
+            ISettingsService settings = Substitute.For<ISettingsService>();
+            IThemeService theme = Substitute.For<IThemeService>();
+            ISettingsPreviewService preview = new SettingsPreviewService();
+            var snapshots = new List<AppSettings>();
+            var opacityValues = new List<int>();
+            preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+            preview.WindowOpacityPreviewRequested += value => opacityValues.Add(value);
+            settings.GetSettingsAsync().Returns(new AppSettings());
+
+            var viewModel = new SettingsViewModel(settings, theme, previewService: preview);
+            await viewModel.LoadCommand.Execute().FirstAsync();
+            viewModel.Appearance.SidebarPosition = "right";
+
+            Assert.IsEmpty(snapshots);
+            Assert.IsEmpty(opacityValues);
+
+            await Task.Delay(75);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.HasCount(1, snapshots);
+            Assert.AreEqual("right", snapshots[0].Appearance.SidebarPosition);
+            Assert.IsEmpty(opacityValues);
+        });
+    }
+
+    [TestMethod]
+    public void AppearanceOpacitySlider_EmitsEveryValueImmediately()
+    {
+        OnUi(async () =>
+        {
+            ISettingsService settings = Substitute.For<ISettingsService>();
+            IThemeService theme = Substitute.For<IThemeService>();
+            var preview = new SettingsPreviewService();
+            settings.GetSettingsAsync().Returns(new AppSettings());
+
+            var viewModel = new SettingsViewModel(settings, theme, previewService: preview);
+            await viewModel.LoadCommand.Execute().FirstAsync();
+            viewModel.SelectedSectionIndex = 1;
+
+            var window = new SettingsView { DataContext = viewModel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var opacitySlider = window
+                .GetVisualDescendants()
+                .OfType<Slider>()
+                .Single(slider => slider.Minimum == 10 && slider.Maximum == 100);
+            var received = new List<int>();
+            preview.WindowOpacityPreviewRequested += value => received.Add(value);
+            int[] expected = [20, 30, 40, 50];
+
+            foreach (int value in expected)
+            {
+                opacitySlider.Value = value;
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            CollectionAssert.AreEqual(expected, received);
+            window.Close();
+        });
+    }
+
     private static void OnUi(Func<Task> body) =>
         _session.Dispatch(body, CancellationToken.None).GetAwaiter().GetResult();
 


### PR DESCRIPTION
为设置窗口增加窗口不透明度的即时预览通道，绕过 AppSettings 快照广播，提升滑块拖动时的 UI 响应速度，避免频繁 JSON 克隆带来的性能问题。 ISettingsPreviewService 新增 WindowOpacityPreviewRequested 事件和 PreviewWindowOpacity(int percent) 方法，已对 percent 参数做 10~100 钳位。 SettingsPreviewService 实现新接口并补充单元测试，覆盖边界值、钳位、无订阅者等场景。 SettingsViewModel 在 WindowOpacityPercent 变更时直接调用 PreviewWindowOpacity，其他外观项仍走原有合并路径。 MainWindow 订阅新预览事件并即时响应 UI。
新增多项单元测试，验证事件独立性、边界处理和 UI 交互。
部分测试断言改为更语义化的写法，提升可读性和一致性。