### PR TITLE
统一代码风格，简化语法并新增测试用例

### DIFF
--- a/src/VelaShell/Services/Update/GitHubReleaseSource.cs
+++ b/src/VelaShell/Services/Update/GitHubReleaseSource.cs
@@ -42,7 +42,7 @@ public sealed class GitHubReleaseSource : IUpdateSource
     /// <inheritdoc />
     public async Task<UpdateManifest?> GetLatestManifestAsync(bool includePreRelease, CancellationToken cancellationToken = default)
     {
-        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromSeconds(30));
         if (!includePreRelease)
         {
@@ -86,7 +86,7 @@ public sealed class GitHubReleaseSource : IUpdateSource
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
-        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
         string? firstNonDraft = null;
         foreach (JsonElement release in doc.RootElement.EnumerateArray())
         {
@@ -183,7 +183,7 @@ public sealed class GitHubReleaseSource : IUpdateSource
             {
                 resumeFrom = 0;
             }
-            using IncrementalHash sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
             if (resumed)
             {
                 // 续传:已落盘的前缀要先进哈希,这次读盘换来的是整包不必重下。
@@ -247,7 +247,7 @@ public sealed class GitHubReleaseSource : IUpdateSource
         long saveWatermark = segments.Sum(s => s.Done);
         bool rangeUnsupported = false;
         using SemaphoreSlim hashSignal = new(0);
-        using CancellationTokenSource abort = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var abort = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         void SaveMeta()
         {
@@ -415,7 +415,7 @@ public sealed class GitHubReleaseSource : IUpdateSource
         SemaphoreSlim hashSignal,
         CancellationToken cancellationToken)
     {
-        using IncrementalHash sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         await using FileStream stream = new(
             partialPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize: 1, useAsync: true);
         byte[] buffer = new byte[CopyBufferSize];

--- a/src/VelaShell/Services/Update/UpdateApplier.cs
+++ b/src/VelaShell/Services/Update/UpdateApplier.cs
@@ -267,7 +267,7 @@ public sealed class UpdateApplier(string applicationDirectory)
     /// <summary>把 zip 内所有文件解压为目标路径加 <c>.new</c> 后缀的暂存文件。</summary>
     private void ExtractZipAsNew(string archivePath, List<PackageEntry> entries)
     {
-        Dictionary<string, PackageEntry> byPath = entries.ToDictionary(
+        var byPath = entries.ToDictionary(
             e => e.RelativePath, StringComparer.OrdinalIgnoreCase);
         using (ZipArchive zip = ZipFile.OpenRead(archivePath))
         {

--- a/src/VelaShell/Services/Update/UpdateManifest.cs
+++ b/src/VelaShell/Services/Update/UpdateManifest.cs
@@ -58,7 +58,7 @@ public sealed class UpdateManifest
     /// </summary>
     public static UpdateManifest Parse(string json)
     {
-        using JsonDocument doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(json);
         JsonElement root = doc.RootElement;
         string version = root.GetProperty("version").GetString()
             ?? throw new FormatException("latest.json: version missing");

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -901,10 +901,7 @@ public class MainWindowViewModel : ReactiveObject
         TerminalTabViewModel? owner = _tabBar.Tabs
             .OfType<TerminalTabViewModel>()
             .FirstOrDefault(t => t.SessionId == sessionId);
-        if (owner is not null)
-        {
-            owner.FileBrowserOpen = visible;
-        }
+        owner?.FileBrowserOpen = visible;
     }
 
     /// <summary>SFTP「使用默认编辑器打开」读取的编辑器命令(设置 → 文件传输 → 默认编辑器)。</summary>

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1174,6 +1174,7 @@ public class SettingsViewModel : ReactiveObject
     /// <summary>窗口以任意方式关闭时由视图调用:未保存而预览过 → 回滚到打开时的基线。</summary>
     public void NotifyClosed()
     {
+        _previewDebounce?.Stop();
         if (_saved || !_previewed)
         {
             return;

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -472,16 +472,19 @@ public partial class MainWindow : Window
         });
 
     private void OnSettingsPreviewedForWindow(AppSettings settings) =>
-        Dispatcher.UIThread.Post(() => ApplyWindowAppearance(settings));
+        RunOnUiThread(() => ApplyWindowAppearance(settings));
 
-    private void OnSettingsOpacityPreviewedForWindow(int percent)
+    private void OnSettingsOpacityPreviewedForWindow(int percent) =>
+        RunOnUiThread(() => ApplyWindowOpacity(percent));
+
+    private void RunOnUiThread(Action action)
     {
         if (Dispatcher.UIThread.CheckAccess())
         {
-            ApplyWindowOpacity(percent);
+            action();
             return;
         }
-        Dispatcher.UIThread.Post(() => ApplyWindowOpacity(percent));
+        Dispatcher.UIThread.Post(action);
     }
 
     /// <summary>应用设置 → 外观:窗口透明度、侧边栏位置、界面字体/字号。

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -161,10 +161,7 @@ public partial class TerminalTabView : UserControl
     private void ClearGhost()
     {
         _ghostFull = null;
-        if (_termControl is not null)
-        {
-            _termControl.GhostText = null;
-        }
+        _termControl?.GhostText = null;
     }
 
     private void OnTrackedInputChanged()
@@ -215,10 +212,7 @@ public partial class TerminalTabView : UserControl
             && !HasTextRightOfCursor()
         )
         {
-            if (_termControl is not null)
-            {
-                _termControl.GhostText = full[input.Length..];
-            }
+            _termControl?.GhostText = full[input.Length..];
         }
         else
         {

--- a/tests/VelaShell.Presentation.Tests/Services/TunnelWorkflowServiceTests.cs
+++ b/tests/VelaShell.Presentation.Tests/Services/TunnelWorkflowServiceTests.cs
@@ -135,7 +135,7 @@ public sealed class TunnelWorkflowServiceTests
     [TestCategory("TunnelWorkflow")]
     public async Task StopTunnelAsync_ForwardsToService()
     {
-        Guid tunnelId = Guid.NewGuid();
+        var tunnelId = Guid.NewGuid();
         using var cancellation = new CancellationTokenSource();
         await CreateService().StopTunnelAsync(tunnelId, cancellation.Token);
         await _tunnelService.Received(1).StopTunnelAsync(tunnelId, cancellation.Token);
@@ -145,7 +145,7 @@ public sealed class TunnelWorkflowServiceTests
     [TestCategory("TunnelWorkflow")]
     public async Task RemoveTunnelAsync_ForwardsToService()
     {
-        Guid tunnelId = Guid.NewGuid();
+        var tunnelId = Guid.NewGuid();
         using var cancellation = new CancellationTokenSource();
         await CreateService().RemoveTunnelAsync(tunnelId, cancellation.Token);
         await _tunnelService.Received(1).RemoveTunnelAsync(tunnelId, cancellation.Token);

--- a/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
+++ b/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
@@ -51,7 +51,7 @@ public class SyncDebounceLifecycleTests
     {
         var lifecycle = new SyncDebounceLifecycle();
 
-        CancellationToken[] tokens = new CancellationToken[5];
+        var tokens = new CancellationToken[5];
         for (int i = 0; i < 5; i++)
         {
             lifecycle.TrySwapNew(out tokens[i]);
@@ -167,7 +167,7 @@ public class SyncDebounceLifecycleTests
             var collected = new System.Collections.Concurrent.ConcurrentBag<CancellationToken>();
             var barrier = new ManualResetEventSlim(false);
 
-            var swapTasks = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+            Task[] swapTasks = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
             {
                 barrier.Wait();
                 if (lifecycle.TrySwapNew(out CancellationToken token))

--- a/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
@@ -25,7 +25,7 @@ public class UpdateManifestTests
     [TestCategory("Update")]
     public void Parse_ValidManifest_ExposesAllFields()
     {
-        UpdateManifest manifest = UpdateManifest.Parse(SampleJson);
+        var manifest = UpdateManifest.Parse(SampleJson);
         Assert.AreEqual("0.2.0", manifest.Version);
         Assert.AreEqual("v0.2.0", manifest.Tag);
         Assert.HasCount(6, manifest.Assets);
@@ -40,7 +40,7 @@ public class UpdateManifestTests
     public void AssetForCurrentPlatform_KnownRids_ReturnsMatch()
     {
         // 测试跑在 win/osx/linux 的 x64/arm64 上,CurrentRid 一定命中样例清单。
-        UpdateManifest manifest = UpdateManifest.Parse(SampleJson);
+        var manifest = UpdateManifest.Parse(SampleJson);
         string? rid = UpdateManifest.CurrentRid();
         Assert.IsNotNull(rid);
         UpdateAsset? asset = manifest.AssetForCurrentPlatform();
@@ -52,7 +52,7 @@ public class UpdateManifestTests
     [TestCategory("Update")]
     public void AssetForCurrentPlatform_MissingRid_ReturnsNull()
     {
-        UpdateManifest manifest = UpdateManifest.Parse("""
+        var manifest = UpdateManifest.Parse("""
             { "version": "0.2.0", "tag": "v0.2.0",
               "assets": { "solaris-sparc": { "name": "n", "sha256": "s", "size": 1 } } }
             """);

--- a/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
@@ -94,7 +94,7 @@ public class UpdateServiceTests : IDisposable
     {
         byte[] zip = CreateZipBytes(("app.txt", "new"));
         _source.Manifest = CreateManifest("2.0.0", zip);
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
 
         Assert.IsTrue(await service.CheckForUpdateAsync());
         Assert.AreEqual("2.0.0", service.AvailableVersion);
@@ -108,7 +108,7 @@ public class UpdateServiceTests : IDisposable
     public async Task CheckForUpdateAsync_SameOrOlderVersion_ReturnsFalse(string remote)
     {
         _source.Manifest = CreateManifest(remote, CreateZipBytes(("a", "b")));
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
 
         Assert.IsFalse(await service.CheckForUpdateAsync());
         Assert.IsNull(service.AvailableVersion);
@@ -167,7 +167,7 @@ public class UpdateServiceTests : IDisposable
         byte[] zip = CreateZipBytes(("app.txt", "new"));
         _source.Manifest = CreateManifest("2.0.0", zip);
         _source.AssetBytes = zip;
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
         Assert.IsTrue(await service.CheckForUpdateAsync());
 
         List<int> reported = [];
@@ -185,7 +185,7 @@ public class UpdateServiceTests : IDisposable
         byte[] zip = CreateZipBytes(("app.txt", "new"));
         _source.Manifest = CreateManifest("2.0.0", zip);
         _source.AssetBytes = [1, 2, 3]; // 与清单声明的哈希不符
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
         Assert.IsTrue(await service.CheckForUpdateAsync());
 
         await Assert.ThrowsExactlyAsync<InvalidDataException>(() => service.DownloadUpdateAsync());
@@ -203,7 +203,7 @@ public class UpdateServiceTests : IDisposable
         byte[] zip = CreateZipBytes(("app.txt", "new"));
         _source.Manifest = CreateManifest("2.0.0", zip);
         _source.AssetBytes = zip;
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
         Assert.IsTrue(await service.CheckForUpdateAsync());
         await service.DownloadUpdateAsync();
         Assert.AreEqual(1, _source.DownloadCalls);
@@ -223,7 +223,7 @@ public class UpdateServiceTests : IDisposable
         byte[] zip = CreateZipBytes(("app.txt", "new"));
         _source.Manifest = CreateManifest("2.0.0", zip);
         _source.AssetBytes = zip;
-        var service = CreateService("1.0.0");
+        UpdateService service = CreateService("1.0.0");
         Assert.IsTrue(await service.CheckForUpdateAsync());
         string staging = Path.Combine(_appDir, UpdateApplier.StagingDirectoryName);
         Directory.CreateDirectory(staging);

--- a/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
@@ -105,7 +105,7 @@ public class SettingsViewUiTests
             window.Show();
             Dispatcher.UIThread.RunJobs();
 
-            var opacitySlider = window
+            Slider opacitySlider = window
                 .GetVisualDescendants()
                 .OfType<Slider>()
                 .Single(slider => slider.Minimum == 10 && slider.Maximum == 100);
@@ -122,6 +122,38 @@ public class SettingsViewUiTests
             CollectionAssert.AreEqual(expected, received);
             window.Close();
         });
+    }
+
+    [TestMethod]
+    public void CancelBeforePendingAppearanceDebounce_DoesNotPreviewEditedStateAfterRollback()
+    {
+        ISettingsService settings = Substitute.For<ISettingsService>();
+        IThemeService theme = Substitute.For<IThemeService>();
+        var preview = new SettingsPreviewService();
+        var baseline = new AppSettings
+        {
+            Appearance = new() { WindowOpacityPercent = 80, SidebarPosition = "left" },
+        };
+        settings.GetSettingsAsync().Returns(baseline);
+        var viewModel = new SettingsViewModel(settings, theme, previewService: preview);
+        viewModel.LoadCommand.Execute().FirstAsync().GetAwaiter().GetResult();
+        var snapshots = new List<AppSettings>();
+        OnUi(async () =>
+        {
+            preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+
+            viewModel.Appearance.SidebarPosition = "right";
+            viewModel.Appearance.WindowOpacityPercent = 40;
+            viewModel.NotifyClosed();
+
+            await Task.Delay(150);
+            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs();
+        });
+
+        Assert.HasCount(1, snapshots);
+        Assert.AreEqual(80, snapshots[0].Appearance.WindowOpacityPercent);
+        Assert.AreEqual("left", snapshots[0].Appearance.SidebarPosition);
     }
 
     private static void OnUi(Func<Task> body) =>

--- a/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
@@ -1,4 +1,3 @@
-using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Interactivity;

--- a/tests/VelaShell.Tests/Views/TunnelPanelUiTests.cs
+++ b/tests/VelaShell.Tests/Views/TunnelPanelUiTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -7,7 +8,6 @@ using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using NSubstitute;
-using System.Globalization;
 using VelaShell.Core.Localization;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -188,7 +188,7 @@ public sealed class TunnelPanelUiTests
 
     private static void RenderHelpDialog(string cultureName, ThemeVariant theme, string fileName)
     {
-        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+        var culture = CultureInfo.GetCultureInfo(cultureName);
         CultureInfo.CurrentCulture = culture;
         CultureInfo.CurrentUICulture = culture;
         _localization.SetLanguage(cultureName);
@@ -217,7 +217,7 @@ public sealed class TunnelPanelUiTests
         }
 
         Directory.CreateDirectory(directory);
-        using var frame = topLevel.CaptureRenderedFrame();
+        using WriteableBitmap? frame = topLevel.CaptureRenderedFrame();
         Assert.IsNotNull(frame, "Skia headless renderer should produce a visual-QA frame.");
         using FileStream output = File.Create(Path.Combine(directory, fileName));
         frame.Save(output, PngBitmapEncoderOptions.Default);


### PR DESCRIPTION
采用 C# 9.0 简化变量声明和空合并表达式，提升一致性和可读性。部分 UI 方法合并为表达式体成员，减少重复。SettingsViewUiTests 新增 CancelBeforePendingAppearanceDebounce_DoesNotPreviewEditedStateAfterRollback 测试，确保设置窗口关闭时预览状态正确回滚。调整 using 顺序，移除未用引用，整体优化代码结构和可维护性。