### PR TITLE
支持文件传输面板拖拽与位置持久化

### DIFF
--- a/src/VelaShell/ViewModels/FileTransferViewModel.cs
+++ b/src/VelaShell/ViewModels/FileTransferViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Reactive;
 using Avalonia.Threading;
 using ReactiveUI;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;
@@ -15,8 +16,17 @@ namespace VelaShell.ViewModels;
 /// </summary>
 public class FileTransferViewModel : ReactiveObject
 {
+    /// <summary>面板位置的存储位置(IAppDataStore 的用途之一即 UI 配置)。</summary>
+    private const string LayoutCollection = "ui-layout";
+
+    private const string PanelPositionId = "transfer-panel";
+
     // 可空:无参构造的宿主(单元测试/无 SFTP 服务的场景)不提供传输管理器。
     private readonly ITransferManager? _transferManager;
+
+    // 可空:同上,无存储时面板位置只在本次运行内保持。
+    private readonly IAppDataStore? _dataStore;
+
     private IDisposable? _autoHide;
 
     // 当前批次(一个文件夹/多文件的下载或上传):尚未完成的文件数,
@@ -34,10 +44,13 @@ public class FileTransferViewModel : ReactiveObject
     /// <summary>
     /// 构造视图模型并初始化各命令;<paramref name="transferManager" /> 可为空
     /// (单元测试或无 SFTP 服务的宿主场景不提供传输管理器)。
+    /// <paramref name="dataStore" /> 为空时面板位置只在本次运行内保持,不跨重启。
     /// </summary>
-    public FileTransferViewModel(ITransferManager? transferManager)
+    public FileTransferViewModel(ITransferManager? transferManager, IAppDataStore? dataStore = null)
     {
         _transferManager = transferManager;
+        _dataStore = dataStore;
+        RestorePanelPosition();
         Transfers = [];
         Transfers.CollectionChanged += OnTransfersChanged;
         CancelTransferCommand = ReactiveCommand.Create<Guid>(CancelTransfer);
@@ -295,6 +308,79 @@ public class FileTransferViewModel : ReactiveObject
         }
     }
 
+    // ---- 面板拖拽位置 ----
+    //
+    // 存的是相对默认锚点(右上角)的偏移,而不是绝对坐标:这样窗口缩放/最大化后面板
+    // 仍然贴着右上角的相对位置,不会因为窗口变小而跑到可视区之外。
+    // 越界夹紧由视图负责(只有它知道父容器和自身的实际尺寸)。
+
+    /// <summary>面板相对默认锚点的水平偏移(像素,向左为负)。</summary>
+    public double PanelOffsetX
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>面板相对默认锚点的垂直偏移(像素,向上为负)。</summary>
+    public double PanelOffsetY
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>拖拽结束时由视图调用:把当前位置落盘,供下次打开恢复。失败不影响使用。</summary>
+    public void PersistPanelPosition()
+    {
+        if (_dataStore is null)
+        {
+            return;
+        }
+        var position = new TransferPanelPosition { OffsetX = PanelOffsetX, OffsetY = PanelOffsetY };
+        _ = SaveAsync();
+
+        async Task SaveAsync()
+        {
+            try
+            {
+                await _dataStore.UpsertAsync(LayoutCollection, PanelPositionId, position).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 位置记不住不该影响传输本身;下次拖动会再试一次。
+            }
+        }
+    }
+
+    /// <summary>启动时异步取回上次的位置。取不到就保持默认锚点。</summary>
+    private void RestorePanelPosition()
+    {
+        if (_dataStore is null)
+        {
+            return;
+        }
+        _ = LoadAsync();
+
+        async Task LoadAsync()
+        {
+            try
+            {
+                TransferPanelPosition? saved = await _dataStore
+                                                     .GetAsync<TransferPanelPosition>(LayoutCollection, PanelPositionId)
+                                                     .ConfigureAwait(true);
+                if (saved is null)
+                {
+                    return;
+                }
+                PanelOffsetX = saved.OffsetX;
+                PanelOffsetY = saved.OffsetY;
+            }
+            catch
+            {
+                // 读不出来就用默认位置,不打扰用户。
+            }
+        }
+    }
+
     private void ScheduleAutoHide()
     {
         _autoHide = DispatcherTimer.RunOnce(() =>
@@ -349,4 +435,17 @@ public class FileTransferViewModel : ReactiveObject
             Transfers.Remove(item);
         }
     }
+}
+
+/// <summary>
+/// 传输面板拖拽位置的持久化载体(IAppDataStore 需要引用类型)。
+/// 存偏移而非绝对坐标,理由见 <see cref="FileTransferViewModel.PanelOffsetX" />。
+/// </summary>
+public sealed class TransferPanelPosition
+{
+    /// <summary>相对默认锚点的水平偏移(像素)。</summary>
+    public double OffsetX { get; set; }
+
+    /// <summary>相对默认锚点的垂直偏移(像素)。</summary>
+    public double OffsetY { get; set; }
 }

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -189,7 +189,7 @@ public class MainWindowViewModel : ReactiveObject
         _tabBar.Tabs.CollectionChanged += OnTabsCollectionChanged;
         _statusBar = new();
         _fileBrowser = new(null, Guid.Empty);
-        _fileTransfer = new(transferManager);
+        _fileTransfer = new(transferManager, appDataStore);
         _tabBar
             .WhenAnyValue(tabBar => tabBar.ActiveTab)
             .Subscribe(activeTab =>

--- a/src/VelaShell/Views/FileTransferView.axaml
+++ b/src/VelaShell/Views/FileTransferView.axaml
@@ -9,6 +9,14 @@
              x:Class="VelaShell.Views.FileTransferView"
              x:DataType="vm:FileTransferViewModel">
 
+  <!-- 拖拽位移加在 UserControl 自身而不是内层 Border:UserControl 的布局尺寸是裹住面板的,
+       把内层移出去会有裁剪与命中测试风险;而 UserControl 的父级是整行 Grid,空间足够。
+       位移相对默认锚点(右上角)而非绝对坐标,窗口缩放后面板仍贴着相对位置。
+       越界夹紧在 code-behind(只有它知道父容器与自身的实际尺寸)。 -->
+  <UserControl.RenderTransform>
+    <TranslateTransform X="{Binding PanelOffsetX}" Y="{Binding PanelOffsetY}" />
+  </UserControl.RenderTransform>
+
   <!-- 浮动传输提示(设计帧 9Ralg):宽 280px,bg-surface,圆角 6,
        1px border-secondary,阴影 blur16 y+4。仅在有传输时存在;
        全部完成后约 3s 自动淡出;x 收起而不取消(规范 §9)。 -->
@@ -23,8 +31,11 @@
     <StackPanel>
 
       <!-- 表头(32px,拖拽手柄):arrow-up-down 强调色 + 传输 + 数量徽标 | x -->
-      <Border Height="32"
+      <Border Name="DragHandle"
+              Height="32"
               Padding="12,0"
+              Cursor="SizeAll"
+              Background="Transparent"
               BorderBrush="{DynamicResource VelaBorderPrimary}"
               BorderThickness="0,0,0,1">
         <Grid ColumnDefinitions="Auto,*,Auto">

--- a/src/VelaShell/Views/FileTransferView.axaml.cs
+++ b/src/VelaShell/Views/FileTransferView.axaml.cs
@@ -1,12 +1,25 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
 using VelaShell.ViewModels;
 
 namespace VelaShell.Views;
 
-/// <summary>文件传输视图,展示传输进度与结果提示。</summary>
+/// <summary>文件传输视图,展示传输进度与结果提示;表头可拖动,位置跨会话保留。</summary>
 public partial class FileTransferView : UserControl
 {
-    /// <summary>初始化视图,并把指针悬停接线到暂停提示自动隐藏。</summary>
+    /// <summary>按下拖拽手柄时的指针位置(父容器坐标),用于计算位移增量。</summary>
+    private Point _dragOrigin;
+
+    /// <summary>按下那一刻的面板偏移,拖拽期间按增量叠加。</summary>
+    private double _dragStartOffsetX;
+
+    private double _dragStartOffsetY;
+
+    private bool _isDragging;
+
+    /// <summary>初始化视图,接线指针悬停(暂停自动隐藏)与表头拖拽。</summary>
     public FileTransferView()
     {
         InitializeComponent();
@@ -15,5 +28,105 @@ public partial class FileTransferView : UserControl
         // 3 秒倒计时恢复(§9)。
         PointerEntered += (_, _) => (DataContext as FileTransferViewModel)?.SetPointerOver(true);
         PointerExited += (_, _) => (DataContext as FileTransferViewModel)?.SetPointerOver(false);
+
+        if (this.FindControl<Border>("DragHandle") is { } handle)
+        {
+            handle.PointerPressed += OnDragHandlePressed;
+            handle.PointerMoved += OnDragHandleMoved;
+            handle.PointerReleased += OnDragHandleReleased;
+        }
+
+        // 窗口缩放/最大化后,原先合法的位置可能已经越界 —— 重新夹回可视区,
+        // 否则面板会停在看不见也够不着的地方。
+        LayoutUpdated += (_, _) =>
+        {
+            if (!_isDragging)
+            {
+                ClampOffsetIntoView();
+            }
+        };
     }
+
+    private void OnDragHandlePressed(object? sender, PointerPressedEventArgs e)
+    {
+        // 表头里还有"取消"和"关闭"按钮。Avalonia 里 Button 会把 PointerPressed 标记为已处理,
+        // 默认订阅收不到 —— 但不要依赖这个隐式行为:按在按钮上就明确不起拖拽。
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(true) is not null)
+        {
+            return;
+        }
+        if (DataContext is not FileTransferViewModel vm
+            || GetDragSpace() is not { } space
+            || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        _isDragging = true;
+        _dragOrigin = e.GetPosition(space);
+        _dragStartOffsetX = vm.PanelOffsetX;
+        _dragStartOffsetY = vm.PanelOffsetY;
+        e.Pointer.Capture((IInputElement?)sender);
+        e.Handled = true;
+    }
+
+    private void OnDragHandleMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_isDragging || DataContext is not FileTransferViewModel vm || GetDragSpace() is not { } space)
+        {
+            return;
+        }
+        Point current = e.GetPosition(space);
+        ApplyOffset(vm,
+            _dragStartOffsetX + (current.X - _dragOrigin.X),
+            _dragStartOffsetY + (current.Y - _dragOrigin.Y));
+        e.Handled = true;
+    }
+
+    private void OnDragHandleReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            return;
+        }
+        _isDragging = false;
+        e.Pointer.Capture(null);
+
+        // 只在松手时落盘,而不是每次移动都写 —— 拖一次会产生上百个移动事件。
+        (DataContext as FileTransferViewModel)?.PersistPanelPosition();
+        e.Handled = true;
+    }
+
+    /// <summary>拖拽的参考坐标系:面板所在的父容器。</summary>
+    private Visual? GetDragSpace() => this.GetVisualParent();
+
+    /// <summary>把恢复出来的/当前的偏移夹回可视区(窗口尺寸变化后尤其必要)。</summary>
+    private void ClampOffsetIntoView()
+    {
+        if (DataContext is FileTransferViewModel vm)
+        {
+            ApplyOffset(vm, vm.PanelOffsetX, vm.PanelOffsetY);
+        }
+    }
+
+    /// <summary>
+    /// 夹紧并写入偏移,保证面板整体留在父容器内。
+    /// <para>
+    /// <see cref="Visual.Bounds" /> 不含渲染变换,因此它就是"偏移为 0 时的锚定位置",
+    /// 由此推出合法偏移区间 —— 无需把 XAML 里的对齐方式和边距硬编码进来。
+    /// </para>
+    /// </summary>
+    private void ApplyOffset(FileTransferViewModel vm, double offsetX, double offsetY)
+    {
+        if (GetDragSpace() is not { } space || Bounds.Width <= 0 || space.Bounds.Width <= 0)
+        {
+            return;
+        }
+        Rect anchored = Bounds;
+        vm.PanelOffsetX = Clamp(offsetX, -anchored.X, space.Bounds.Width - anchored.Width - anchored.X);
+        vm.PanelOffsetY = Clamp(offsetY, -anchored.Y, space.Bounds.Height - anchored.Height - anchored.Y);
+    }
+
+    /// <summary>面板比容器还大时下限会超过上限,此时贴左上角而不是抛异常。</summary>
+    private static double Clamp(double value, double min, double max) =>
+        max < min ? min : Math.Clamp(value, min, max);
 }

--- a/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
@@ -1,4 +1,5 @@
 using NSubstitute;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
 using VelaShell.ViewModels;
@@ -320,5 +321,71 @@ public class FileTransferViewModelTests
         Assert.HasCount(2, _vm.Transfers);
         Assert.AreEqual("beta.tar.gz", _vm.Transfers[0].FileName);
         Assert.AreEqual("alpha.zip", _vm.Transfers[1].FileName);
+    }
+
+    // ---- 面板拖拽位置 ----
+
+    /// <summary>拖拽结束后位置要落盘,否则下次打开又回到默认锚点。</summary>
+    [TestMethod]
+    public void PersistPanelPosition_WritesCurrentOffsetToStore()
+    {
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        var vm = new FileTransferViewModel(_transferManager, store)
+        {
+            PanelOffsetX = -320,
+            PanelOffsetY = 180,
+        };
+
+        vm.PersistPanelPosition();
+
+        store.Received(1).UpsertAsync(
+            "ui-layout",
+            "transfer-panel",
+            Arg.Is<TransferPanelPosition>(p => p.OffsetX == -320 && p.OffsetY == 180),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>构造时从存储恢复上次的位置 —— 这就是"再次打开回到原有位置"。</summary>
+    [TestMethod]
+    public async Task Construction_RestoresPersistedPanelPosition()
+    {
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        store.GetAsync<TransferPanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
+             .Returns(new TransferPanelPosition { OffsetX = -240, OffsetY = 96 });
+
+        var vm = new FileTransferViewModel(_transferManager, store);
+
+        // 恢复是异步的,给它一次调度机会。
+        await Task.Yield();
+        await Task.Delay(50);
+
+        Assert.AreEqual(-240, vm.PanelOffsetX);
+        Assert.AreEqual(96, vm.PanelOffsetY);
+    }
+
+    /// <summary>没有存储(单元测试/精简宿主)时不该炸,位置退回默认锚点。</summary>
+    [TestMethod]
+    public void WithoutStore_PanelPositionDefaultsToAnchorAndPersistIsHarmless()
+    {
+        var vm = new FileTransferViewModel(_transferManager);
+
+        Assert.AreEqual(0, vm.PanelOffsetX);
+        Assert.AreEqual(0, vm.PanelOffsetY);
+        vm.PersistPanelPosition();
+    }
+
+    /// <summary>存储读取失败不能把界面带崩 —— 位置记不住是小事,启动不了是大事。</summary>
+    [TestMethod]
+    public async Task Construction_WhenStoreThrows_FallsBackToDefaultPosition()
+    {
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        store.GetAsync<TransferPanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
+             .Returns<TransferPanelPosition?>(_ => throw new InvalidOperationException("store offline"));
+
+        var vm = new FileTransferViewModel(_transferManager, store);
+        await Task.Delay(50);
+
+        Assert.AreEqual(0, vm.PanelOffsetX);
+        Assert.AreEqual(0, vm.PanelOffsetY);
     }
 }


### PR DESCRIPTION
实现 FileTransferView 拖拽移动及位置记忆，新增 PanelOffsetX/Y 属性和位置存储/恢复逻辑，窗口尺寸变化时自动夹紧面板。引入 TransferPanelPosition 类，完善单元测试覆盖持久化、恢复及异常场景，提升用户体验和健壮性。