### PR TITLE
终端新增本地回显功能，支持多场景配置

### DIFF
--- a/VelaShell.slnx
+++ b/VelaShell.slnx
@@ -8,6 +8,8 @@
     <File Path="docs/design-specs.md" />
     <File Path="docs/dock-replacement-plan.md" />
     <File Path="docs/settings-audit.md" />
+    <File Path="docs/SFTP双栏与WinSCP差距分析.md" />
+    <File Path="docs/Telnet与串口可行性调研.md" />
     <File Path="docs/交互与界面规格.md" />
     <File Path="docs/架构设计.md" />
     <File Path="docs/隧道功能规划.md" />

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -387,6 +387,20 @@ public class TerminalBehaviorOptions : ObservableOptions
         set => Set(ref field, value);
     } = true;
 
+    /// <summary>
+    /// 本地回显:终端把键入的可见字符自己显示一份,不等对端回传。
+    /// <para>
+    /// 默认关闭。SSH 场景下远端 shell 自己会回显,开了会**每个字符显示两遍**;
+    /// 它是给对端不回显的链路用的(Telnet 半双工、串口设备)。
+    /// 主机若以 <c>CSI 12 l</c> 复位 SRM 显式要求终端回显,即便本项为关也会生效。
+    /// </para>
+    /// </summary>
+    public bool LocalEcho
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
     /// <summary>光标形状(如 bar / block / underline)。</summary>
     public string CursorStyle
     {

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1959,6 +1959,12 @@
   <data name="SetTerm_ImeSupport" xml:space="preserve">
     <value>IME サポート</value>
   </data>
+  <data name="SetTerm_LocalEcho" xml:space="preserve">
+    <value>ローカルエコー</value>
+  </data>
+  <data name="SetTerm_LocalEchoDesc" xml:space="preserve">
+    <value>入力した文字をホストからのエコーを待たずに端末側で表示します。相手がエコーしない接続(半二重 Telnet、シリアル機器)向けです。SSH ではオフのままにしてください —— リモートのシェルがエコーするため、有効にすると文字が二重に表示されます。</value>
+  </data>
   <data name="SetTerm_ImeSupportDesc" xml:space="preserve">
     <value>// 中国語・日本語などの IME のインライン入力を有効化</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1959,6 +1959,12 @@
   <data name="SetTerm_ImeSupport" xml:space="preserve">
     <value>IME 지원</value>
   </data>
+  <data name="SetTerm_LocalEcho" xml:space="preserve">
+    <value>로컬 에코</value>
+  </data>
+  <data name="SetTerm_LocalEchoDesc" xml:space="preserve">
+    <value>입력한 문자를 호스트의 에코를 기다리지 않고 터미널에서 직접 표시합니다. 상대가 에코하지 않는 연결(반이중 Telnet, 시리얼 장치)용입니다. SSH에서는 꺼 두십시오 —— 원격 셸이 에코하므로 켜면 모든 문자가 두 번 표시됩니다.</value>
+  </data>
   <data name="SetTerm_ImeSupportDesc" xml:space="preserve">
     <value>// 중국어/일본어 등 입력기의 인라인 입력 사용</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2026,6 +2026,12 @@ Paste anyway?</value>
   <data name="SetTerm_ImeSupport" xml:space="preserve">
     <value>IME support</value>
   </data>
+  <data name="SetTerm_LocalEcho" xml:space="preserve">
+    <value>Local echo</value>
+  </data>
+  <data name="SetTerm_LocalEchoDesc" xml:space="preserve">
+    <value>Show typed characters locally instead of waiting for the host to echo them. For links whose peer does not echo (half-duplex Telnet, serial devices). Leave off for SSH — the remote shell echoes, so enabling this shows every character twice.</value>
+  </data>
   <data name="SetTerm_ImeSupportDesc" xml:space="preserve">
     <value>// Enable inline input for Chinese, Japanese and other IMEs</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2117,6 +2117,12 @@
   <data name="SetTerm_ImeSupport" xml:space="preserve">
     <value>输入法支持 (IME)</value>
   </data>
+  <data name="SetTerm_LocalEcho" xml:space="preserve">
+    <value>本地回显</value>
+  </data>
+  <data name="SetTerm_LocalEchoDesc" xml:space="preserve">
+    <value>键入的字符由终端自己显示,不等对端回传。用于对端不回显的链路(Telnet 半双工、串口设备)。SSH 请保持关闭 —— 远端 shell 自己会回显,开启会导致每个字符显示两遍。</value>
+  </data>
   <data name="SetTerm_ImeSupportDesc" xml:space="preserve">
     <value>// 启用中文/日文等输入法的内联输入</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1959,6 +1959,12 @@
   <data name="SetTerm_ImeSupport" xml:space="preserve">
     <value>輸入法支援 (IME)</value>
   </data>
+  <data name="SetTerm_LocalEcho" xml:space="preserve">
+    <value>本機回應</value>
+  </data>
+  <data name="SetTerm_LocalEchoDesc" xml:space="preserve">
+    <value>鍵入的字元由終端機自行顯示,不等對端回傳。用於對端不回應的連線(Telnet 半雙工、序列埠裝置)。SSH 請保持關閉 —— 遠端 shell 自己會回應,開啟會導致每個字元顯示兩次。</value>
+  </data>
   <data name="SetTerm_ImeSupportDesc" xml:space="preserve">
     <value>// 啟用中文/日文等輸入法的內嵌輸入</value>
   </data>

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -740,6 +740,10 @@ public sealed class TerminalEmulator : IVtActions
                 case 4:
                     Modes.InsertMode = set;
                     break; // IRM
+                case 12:
+                    // SRM。语义是反的:置位(12h)= 本地回显关,复位(12l)= 本地回显开。
+                    Modes.SendReceive = set;
+                    break; // SRM
                 case 20:
                     Modes.NewLineMode = set;
                     break; // LNM

--- a/src/VelaShell.Terminal/Emulation/TerminalModes.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalModes.cs
@@ -36,6 +36,14 @@ public sealed class TerminalModes
     /// <summary>反显模式(DECSCNM ?5):整屏前景色与背景色反转。</summary>
     public bool ReverseVideo; // DECSCNM ?5
 
+    /// <summary>
+    /// 发送/接收模式(SRM 12):**置位(<c>CSI 12 h</c>,默认)表示本地回显关闭** ——
+    /// 终端只把键入发往主机,由主机回显。复位(<c>CSI 12 l</c>)则要求终端本地回显。
+    /// 注意语义是反的:<c>SendReceive == true</c> 意味着**不**本地回显。
+    /// 默认 true 与 SSH 场景一致(远端 shell 自己回显,本地再回显会出现双字符)。
+    /// </summary>
+    public bool SendReceive = true; // SRM (12)
+
     /// <summary>将所有模式恢复为终端复位后的默认状态。</summary>
     public void Reset()
     {
@@ -51,6 +59,7 @@ public sealed class TerminalModes
         MouseEncoding = MouseEncoding.Default;
         InsertMode = false;
         NewLineMode = false;
+        SendReceive = true;
     }
 }
 

--- a/src/VelaShell.Terminal/LocalEcho.cs
+++ b/src/VelaShell.Terminal/LocalEcho.cs
@@ -1,0 +1,102 @@
+namespace VelaShell.Terminal;
+
+/// <summary>
+/// 本地回显策略:把一段"即将发往主机的键入字节"翻译成"应当喂回终端显示的字节"。
+/// <para>
+/// 用于对端不回显的链路(Telnet 半双工、串口设备),或主机以 SRM 复位(<c>CSI 12 l</c>)
+/// 显式要求终端自行回显的场合。SSH 场景默认关闭 —— 远端 shell 自己回显,再本地回显会出现双字符。
+/// </para>
+/// <para>
+/// **不能直接把编码后的字节回显。** 方向键编码出来是 <c>ESC [ A</c>,喂回终端会被**执行**
+/// (光标真的移动),而不是显示出来。所以这里按内容筛选,只回显"打出来就该看见"的部分。
+/// </para>
+/// </summary>
+/// <remarks>
+/// 刻意做成纯函数、不依赖 Avalonia 也不依赖任何传输:可直接单测,且 SSH / ConPTY /
+/// 未来的串口·Telnet 通用。
+/// </remarks>
+public static class LocalEcho
+{
+    private const byte Escape = 0x1B;
+    private const byte Backspace = 0x08;
+    private const byte Delete = 0x7F;
+    private const byte CarriageReturn = 0x0D;
+    private const byte LineFeed = 0x0A;
+    private const byte Space = 0x20;
+
+    /// <summary>退格的可见擦除:退一格、盖掉、再退回来。</summary>
+    private static readonly byte[] EraseLast = [Backspace, Space, Backspace];
+
+    /// <summary>
+    /// 计算 <paramref name="input" /> 应当本地回显的字节。无可回显内容时返回空数组。
+    /// </summary>
+    /// <param name="input">即将发往主机的键入字节(已按终端编码)。</param>
+    /// <param name="newLineMode">
+    /// LNM(ANSI 模式 20)是否置位。置位时回车要回显 CR+LF,否则只回显 CR ——
+    /// 与终端处理主机输出时的换行语义保持一致,免得本地回显的行为和远端回显的不一样。
+    /// </param>
+    public static byte[] Compute(ReadOnlySpan<byte> input, bool newLineMode)
+    {
+        if (input.IsEmpty || input.IndexOf(Escape) >= 0)
+        {
+            // 含 ESC 的载荷整段不回显:方向键/功能键/括号粘贴包裹等,回显出去只会乱屏。
+            return [];
+        }
+
+        var output = new List<byte>(input.Length);
+        foreach (byte b in input)
+        {
+            switch (b)
+            {
+                case CarriageReturn:
+                    output.Add(CarriageReturn);
+                    if (newLineMode)
+                    {
+                        output.Add(LineFeed);
+                    }
+                    break;
+                case LineFeed:
+                    output.Add(LineFeed);
+                    break;
+                case Backspace:
+                case Delete:
+                    output.AddRange(EraseLast);
+                    break;
+                case Space:
+                    output.Add(Space);
+                    break;
+                default:
+                    // 其余控制字符(Ctrl+C=0x03、Tab=0x09 等)不回显:它们的屏幕效果该由
+                    // 主机决定(^C 提示、制表位展开),本地猜会和远端不一致。
+                    // ≥0x21 的一律回显 —— 含 UTF-8 多字节序列的所有后续字节(均 ≥0x80)。
+                    if (b > Space)
+                    {
+                        output.Add(b);
+                    }
+                    break;
+            }
+        }
+        return [.. output];
+    }
+
+    /// <summary>
+    /// 本地回显此刻是否生效。
+    /// </summary>
+    /// <param name="userEnabled">用户设置(设置 → 终端 → 本地回显)。</param>
+    /// <param name="sendReceiveMode">
+    /// SRM 当前值(<see cref="Emulation.TerminalModes.SendReceive" />)。语义是反的:
+    /// true(12h,默认)= 主机负责回显;false(12l)= 主机要求终端本地回显。
+    /// </param>
+    /// <param name="peerEchoes">
+    /// 对端是否自己回显键入(SSH 的远端 PTY、本地 ConPTY 的 shell 都会)。
+    /// 为 true 时**无视用户设置** —— 这类链路上开本地回显必然出现双字符,属于配置错误而非用户意图。
+    /// 判据刻意是"对端行为"而不是"连接类型":Terminal 层不认识 SSH/Telnet/串口,由宿主告知即可。
+    /// </param>
+    /// <remarks>
+    /// 主机显式复位 SRM(<c>CSI 12 l</c>)时仍然回显,即便 <paramref name="peerEchoes" /> 为 true——
+    /// 那是远端程序主动要求终端接管回显(它自己会相应停止回显),照做才是正确行为,
+    /// 无视它会导致用户打字完全看不见。
+    /// </remarks>
+    public static bool IsEnabled(bool userEnabled, bool sendReceiveMode, bool peerEchoes = false) =>
+        (userEnabled && !peerEchoes) || !sendReceiveMode;
+}

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -213,6 +213,21 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     public bool ScrollOnKeystroke { get; set; } = true;
 
     /// <summary>
+    /// 本地回显(设置 → 终端):对端不回显的链路(Telnet 半双工、串口设备)需要开启,
+    /// 否则打字看不见。默认关 —— SSH 下远端 shell 自己回显,再本地回显会出现双字符。
+    /// 主机以 <c>CSI 12 l</c> 复位 SRM 时即便本项为关也会生效(见 <see cref="LocalEcho.IsEnabled" />)。
+    /// </summary>
+    public bool LocalEchoEnabled { get; set; }
+
+    /// <summary>
+    /// 对端是否自己回显键入。SSH(远端 PTY)与本地终端(ConPTY 里的 shell)都会,故均置 true——
+    /// 此时 <see cref="LocalEchoEnabled" /> 被忽略,避免用户为串口开了开关后 SSH/本地标签全部双字符。
+    /// 将来的 Telnet 半双工 / 串口置 false,走正常逻辑。
+    /// 默认 true:新传输接入时若忘了设,宁可不回显(看得见但要按两下),也好过满屏重影。
+    /// </summary>
+    public bool PeerEchoesInput { get; set; } = true;
+
+    /// <summary>
     /// 新输出会把历史滚动视图拉回底部;关闭则保持
     /// 用户的历史视图固定不动(#15 行为)。
     /// </summary>
@@ -444,6 +459,27 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     {
         TypedInput?.Invoke(data);
         UserInput?.Invoke(data);
+        EchoLocally(data);
+    }
+
+    /// <summary>
+    /// 本地回显:对端不回显时(Telnet 半双工、串口设备,或主机以 <c>CSI 12 l</c> 复位 SRM),
+    /// 把键入的可见部分喂回终端自己显示。默认关闭 —— SSH 下远端 shell 自己回显,再回显会出双字符。
+    /// </summary>
+    /// <remarks>
+    /// 放在发送**之后**:回显只是显示层的补偿,不该影响或延后真正的发送。
+    /// </remarks>
+    private void EchoLocally(byte[] data)
+    {
+        if (!LocalEcho.IsEnabled(LocalEchoEnabled, Emulator.Modes.SendReceive, PeerEchoesInput))
+        {
+            return;
+        }
+        byte[] echo = LocalEcho.Compute(data, Emulator.Modes.NewLineMode);
+        if (echo.Length > 0)
+        {
+            Emulator.Feed(echo);
+        }
     }
 
     private void AfterProgrammaticInput()

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -2538,6 +2538,14 @@ public class MainWindowViewModel : ReactiveObject
         control.MultilinePasteConfirmation = MultilinePasteConfirmer;
         control.CtrlCCopiesWhenSelected = behavior.CtrlCCopiesWhenSelected;
         control.ImeEnabled = behavior.ImeSupport;
+        control.LocalEchoEnabled = behavior.LocalEcho;
+
+        // 现有两种传输的对端都自己回显:SSH 是远端 PTY,本地终端是 ConPTY 里的 shell。
+        // 因此这两类标签上强制忽略「本地回显」开关 —— 否则用户为串口设备打开它之后,
+        // 所有 SSH 与本地标签都会变成每个字符两遍。
+        // 将来接入 Telnet 半双工 / 串口时,在此按传输置 false,让它们走正常逻辑。
+        // (主机显式 CSI 12 l 要求终端回显时仍然生效,不受本项影响。)
+        control.PeerEchoesInput = true;
 
         // 用户自定义的终端配色(仅覆盖改过的颜色,其余跟随主题)。
         control.PaletteOverrides = TerminalAppearanceMapper.BuildPaletteOverrides(

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -211,6 +211,13 @@
     </Grid>
     <Grid ColumnDefinitions="*,Auto">
       <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_LocalEcho}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_LocalEchoDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.LocalEcho}" VerticalAlignment="Center" />
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
         <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_CtrlCCopy}" />
         <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_CtrlCCopyDesc}" />
       </StackPanel>

--- a/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
@@ -1,0 +1,158 @@
+using System.Text;
+using VelaShell.Terminal;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 本地回显策略。重点守两件事:
+/// ① 含 ESC 的载荷绝不回显 —— 方向键编码是 <c>ESC [ A</c>,喂回终端会被**执行**(光标真的动),
+///    而不是显示出来,这是这个功能最容易做错的地方;
+/// ② 开关语义 —— SRM 是反的(置位 = 不回显),写反了 SSH 下每个字符都会显示两遍。
+/// </summary>
+[TestClass]
+[TestCategory("LocalEcho")]
+public class LocalEchoTests
+{
+    private static string Echo(string input, bool newLineMode = false) =>
+        Encoding.ASCII.GetString(LocalEcho.Compute(Encoding.ASCII.GetBytes(input), newLineMode));
+
+    [TestMethod]
+    public void PrintableText_IsEchoedVerbatim()
+    {
+        Assert.AreEqual("ls -la", Echo("ls -la"));
+    }
+
+    [TestMethod]
+    public void Utf8MultiByte_SurvivesRoundTrip()
+    {
+        byte[] input = Encoding.UTF8.GetBytes("中文");
+        byte[] echo = LocalEcho.Compute(input, newLineMode: false);
+        Assert.AreEqual("中文", Encoding.UTF8.GetString(echo), "多字节字符的后续字节(≥0x80)不能被当成控制字符丢掉。");
+    }
+
+    /// <summary>这条是本类的核心:方向键回显出去会移动光标而不是显示字符。</summary>
+    [TestMethod]
+    public void EscapeSequences_AreNeverEchoed()
+    {
+        Assert.AreEqual("", Echo("\e[A"), "方向键序列不能回显 —— 回显即被执行。");
+        Assert.AreEqual("", Echo("\e[200~pasted\e[201~"), "括号粘贴的包裹序列同理。");
+    }
+
+    /// <summary>含 ESC 时整段丢弃,不做"挑出可打印部分"的小聪明 —— 那会把序列拆碎得更难看。</summary>
+    [TestMethod]
+    public void PayloadContainingEscape_IsDroppedEntirely()
+    {
+        Assert.AreEqual("", Echo("abc\e[Adef"));
+    }
+
+    [TestMethod]
+    public void Backspace_EchoesVisibleErase()
+    {
+        Assert.AreEqual("\b \b", Echo("\b"), "退格要真正擦掉:退一格、盖空格、再退回。");
+        Assert.AreEqual("\b \b", Echo("\u007F"), "DEL 与 BS 同样处理。");
+    }
+
+    [TestMethod]
+    public void CarriageReturn_FollowsNewLineMode()
+    {
+        Assert.AreEqual("\r", Echo("\r"), "LNM 关:只回显 CR。");
+        Assert.AreEqual("\r\n", Echo("\r", newLineMode: true), "LNM 开:CR 要带上 LF,与终端处理主机输出的语义一致。");
+    }
+
+    [TestMethod]
+    public void ControlCharacters_AreNotEchoed()
+    {
+        Assert.AreEqual("", Echo("\u0003"), "Ctrl+C 的屏幕效果(^C)该由主机决定。");
+        Assert.AreEqual("", Echo("\t"), "Tab 的制表位展开该由主机决定。");
+    }
+
+    [TestMethod]
+    public void EmptyInput_ProducesNothing()
+    {
+        Assert.AreEqual("", Echo(""));
+    }
+
+    // ---- 开关语义 ----------------------------------------------------
+
+    [TestMethod]
+    public void Disabled_WhenUserOffAndSrmSet()
+    {
+        // SRM 置位(默认)= 主机负责回显 → 不本地回显。SSH 的常态。
+        Assert.IsFalse(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: true));
+    }
+
+    [TestMethod]
+    public void Enabled_WhenUserTurnsItOn()
+    {
+        // Telnet/串口:主机不回显也不会发 SRM,只能靠用户设置。
+        Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: true, sendReceiveMode: true));
+    }
+
+    [TestMethod]
+    public void Enabled_WhenHostResetsSrm()
+    {
+        // CSI 12 l:主机显式要求终端自行回显。
+        Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: false));
+    }
+
+    // ---- 对端自己回显时强制关闭(SSH / 本地 ConPTY)------------------
+
+    /// <summary>
+    /// 这条是防"用户为串口打开开关后,SSH 与本地标签全部双字符"。
+    /// 判据是对端行为而非连接类型 —— 现有两种传输(SSH 远端 PTY、本地 ConPTY 的 shell)都自己回显。
+    /// </summary>
+    [TestMethod]
+    public void UserSetting_IsIgnored_WhenPeerEchoes()
+    {
+        Assert.IsFalse(
+            LocalEcho.IsEnabled(userEnabled: true, sendReceiveMode: true, peerEchoes: true),
+            "对端自己回显时必须忽略用户开关,否则每个字符会显示两遍。");
+    }
+
+    [TestMethod]
+    public void UserSetting_Applies_WhenPeerDoesNotEcho()
+    {
+        Assert.IsTrue(
+            LocalEcho.IsEnabled(userEnabled: true, sendReceiveMode: true, peerEchoes: false),
+            "Telnet 半双工 / 串口等不回显的链路上,用户开关照常生效。");
+    }
+
+    /// <summary>
+    /// 主机显式复位 SRM 时,即便对端平时自己回显也要照做 —— 远端程序主动要求终端接管回显
+    /// (它自己会相应停止),无视它会让用户打字完全看不见。
+    /// </summary>
+    [TestMethod]
+    public void ExplicitSrmReset_StillWins_OverPeerEchoes()
+    {
+        Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: false, peerEchoes: true));
+    }
+
+    // ---- SRM 在引擎里的解析 ------------------------------------------
+
+    [TestMethod]
+    public void Srm_DefaultsToHostEcho()
+    {
+        Assert.IsTrue(new TerminalModes().SendReceive, "默认必须是 12h(不本地回显),否则 SSH 会话会双字符。");
+    }
+
+    [TestMethod]
+    public void Srm_IsParsedFromAnsiMode12()
+    {
+        var emulator = new TerminalEmulator(20, 5);
+
+        emulator.Feed(Encoding.ASCII.GetBytes("\e[12l"));
+        Assert.IsFalse(emulator.Modes.SendReceive, "CSI 12 l 复位 SRM = 要求本地回显。");
+
+        emulator.Feed(Encoding.ASCII.GetBytes("\e[12h"));
+        Assert.IsTrue(emulator.Modes.SendReceive, "CSI 12 h 置位 SRM = 主机负责回显。");
+    }
+
+    [TestMethod]
+    public void Srm_IsRestoredByReset()
+    {
+        var modes = new TerminalModes { SendReceive = false };
+        modes.Reset();
+        Assert.IsTrue(modes.SendReceive, "复位后应回到默认的 12h。");
+    }
+}


### PR DESCRIPTION
本次提交实现了终端“本地回显”功能，适用于 Telnet 半双工、串口等对端不回显场景，避免用户输入不可见。主要变更包括：新增 LocalEcho 策略类及单元测试，确保仅回显可见字符并支持 UTF-8；AppSettings.cs 增加 LocalEcho 配置项并详细注释；VelaTerminalControl 支持本地回显属性和逻辑，防止 SSH 等场景下双字符；TerminalModes 支持 SRM 控制码，决定回显生效与否；MainWindowViewModel 绑定设置并根据传输类型自动调整；设置页面和多语言资源补充相关文案；文档目录补充调研分析文档。