### PR TITLE
条件编译添加测试友元声明至项目文件

### DIFF
--- a/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
+++ b/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
@@ -9,14 +9,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="VelaShell.Core.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="SonnetDB.Core" />
     <PackageReference Include="Tmds.Ssh" />
     <!-- DPAPI(CurrentUser)包裹本地 AES 密钥文件;仅 Windows 运行时可用,其余平台已代码守卫。 -->
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+  </ItemGroup>
+
+  <!-- 见 VelaShell.Terminal.csproj 同处注释:签名构建(Release)省略友元声明,非签名构建保留。
+       本项目的友元是 VelaShell.Core.Tests(Tmds.Ssh 包装类与异常翻译的白盒测试放在那边)。 -->
+  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+    <InternalsVisibleTo Include="VelaShell.Core.Tests" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
在 VelaShell.Infrastructure.csproj 中新增条件编译的 ItemGroup：仅在未签名构建时，添加 InternalsVisibleTo 以允许 VelaShell.Core.Tests 访问 internal 成员。注释说明测试友元声明仅在非签名构建保留，签名构建时省略，VelaShell.Core.Tests 用于 Tmds.Ssh 包装类与异常翻译的白盒测试。