### PR TITLE
修复终端输入乱序，串行化写入保障顺序

### DIFF
--- a/docs/终端输入乱序问题分析与架构建议.md
+++ b/docs/终端输入乱序问题分析与架构建议.md
@@ -1,0 +1,95 @@
+# 终端输入乱序("字符跳动")问题分析与架构建议
+
+> 2026-07:用户报告打字时字母"跳来跳去",输入 `docker status` 上屏后字符被拆散。
+> 本文记录根因、修复、其他开源终端的对照做法,以及面向 AI 集成的架构评估。
+
+## 1. 现象与根因
+
+**现象**:快速打字(尤其网络有延迟的 SSH 会话)时,回显的字符顺序错乱、拆散,
+看起来像"光标跳来跳去"。智能提示弹层在场时更容易复现,因此最初被怀疑是提示功能引入的。
+
+**根因**:出站写没有串行化,底层通道又不允许并发写。
+
+- `SshTerminalBridge.OnUserInput` 对**每个按键**都是 `_ = WriteUserInputAsync(data)`
+  即发即忘,没有队列、没有锁。
+- Tmds.Ssh 的 `SshChannel.WriteAsync`(经 `RemoteProcess.WriteAsync`)**没有任何并发防护**
+  (已核对上游源码):两个写并发时各自读取发送窗口、独立切包,字节以任意交错顺序进入通道。
+- 时序:按键 A 的 `WriteAsync` 因发送窗口收紧/网络延迟在某个 await 处挂起 → 按键 B 的
+  `WriteAsync` 在 UI 线程同步启动并可能先行完成 → 远端收到 `B A` → 远端 shell 按收到顺序回显
+  → 屏幕上字符乱序。
+- ConPTY 本地终端同理:并发 `FileStream.WriteAsync` + `FlushAsync` 一样可交错。
+
+**为什么"不是最近才出现"**:旧 SSH.NET 的 `ShellStream` 内部带锁,掩盖了这条竞态;
+迁移到 Tmds.Ssh 后隐患暴露。触发概率与打字速度、网络 RTT 正相关,所以时隐时现。
+
+**为什么智能提示像凶手**:提示本身(`TerminalInputTracker` 旁路跟踪、弹层 UI)完全不写 PTY,
+不是根因。但"接受建议"一次性写入较大载荷(回删 + 补全文本),与随后的按键写并发的窗口更大,
+放大了乱序的可见度——所以它总在事故现场,但只是共犯嫌疑人。
+
+## 2. 修复(已落地)
+
+`SshTerminalBridge` 增加**单写者出站队列**:
+
+- 所有发往 PTY 的字节(击键 `OnUserInput` + 程序化注入 `SendRaw`)只做
+  `Channel<byte[]>.Writer.TryWrite` 入队(二者均在 UI 线程触发,入队即保序);
+- 唯一的 `WriteLoopAsync` 按 FIFO 逐段 `await WriteAsync`,一段未完成绝不开始下一段;
+- 上一段挂起期间攒下的后续段合并为一次写出(语义等价、少切 SSH 包);
+- `Dispose` 时封口队列,写循环排空后自行退出。
+
+回归测试:`TerminalBridgeTests.UserInput_RapidKeystrokes_NeverWriteConcurrently_AndPreserveByteOrder`
+——模拟写挂起 30ms 下连续击键 "docker status",断言任意时刻至多一个写在途且字节序完整。
+该测试在旧实现上必现失败(实测并发 13 路写),新实现通过。
+
+## 3. 其他开源终端的对照做法
+
+各主流终端都遵循同一条铁律:**PTY 的出站写只有一个写者,输入永远经队列串行刷出**。
+
+| 终端 | 做法 |
+| --- | --- |
+| Windows Terminal | 键入统一走 `TerminalInput` → 连接对象的单一 `WriteInput`,ConPTY 写句柄只被一个泵触碰 |
+| Alacritty | 键入事件投递到 PTY 事件循环线程的写缓冲,由该线程在可写时按序刷出(`polling` 单线程) |
+| iTerm2 | 每个会话一个写队列(`writeTask`),后台串行消费 |
+| xterm.js / VS Code | `Terminal.write`/`onData` 单通道,宿主侧 pty 服务对 stdin 写严格串行 |
+
+我们的读侧其实早已是这个形态(单读循环 + UI 合批泵),这次只是把写侧补齐成对称结构。
+
+## 4. 架构评估:要不要重构?
+
+**分层现状比"感觉上的混杂"要好**,不建议大爆炸式重构:
+
+- `VelaShell.Terminal` 不依赖任何 SSH 库(经 `IShellStreamWrapper` 抽象),SSH/ConPTY/
+  未来串口·Telnet 共用同一条桥;
+- VT 引擎(`TerminalEmulator`/`VtParser`)是纯逻辑、可单测;
+- ZMODEM 与传输解耦(`IByteDuplex`);
+- 输入跟踪(`TerminalInputTracker`)是旁路观察者,不干预数据流。
+
+"混杂感"主要来自两处,建议**渐进式**处理:
+
+1. `VelaTerminalControl` ~2500 行,渲染、键盘/IME、选区、搜索、折叠、滚动全在一个类。
+   后续可按部件拆(输入编码派发、选区/搜索、gutter/折叠各自成类,控件只做组合与绘制),
+   每次只搬一块、testable 后再搬下一块。
+2. 会话级"数据面"分散在 `TerminalTabViewModel` 里(桥、跟踪器、建议、ZModem 路由的装配)。
+   建议收拢成一个会话门面(见下)。
+
+## 5. 面向 AI 运维的集成点
+
+AI 需要的三件事,现有架构已各有九成:
+
+| AI 能力 | 现成机制 | 缺口 |
+| --- | --- | --- |
+| 读终端输出流 | `SshTerminalBridge.DataReceived`(原始字节,读线程) | 需一份解码后的文本流/环形缓冲 |
+| 读当前屏幕/回滚 | `TerminalScreen` + `ScrollbackBuffer` | 需线程安全的文本快照 API |
+| 向终端注入输入 | `SendRaw`(不扰动建议跟踪)/`WriteInput`(等同击键) | 无——本次修复后注入天然保序 |
+| 感知用户命令 | `TerminalInputTracker`(命令提交事件) | 无 |
+
+建议引入 `ITerminalSessionAutomation` 门面(挂在会话 VM 上,内部就是上表的转发):
+`GetScreenText()` / `GetScrollback(n)` / `IObservable<string> OutputText` / `SendText(string)` /
+`SendControl(byte)`。AI 层只依赖该接口,不触碰控件与桥的内部;审计/确认策略(哪些命令要
+用户点头)也收敛在门面一处。
+
+## 6. 已知边角(记录,暂不处理)
+
+- ZMODEM 会话期间,用户击键仍会入队写向流,理论上可能混进协议帧(修复前后行为一致,
+  仅取消序列有意义)。后续可在会话激活时于桥内丢弃非取消输入。
+- `EchoSuppressor` 只作用于连接初始化注入,与本问题无关。
+- 本地回显(LocalEcho)在 SSH/ConPTY 下被 `PeerEchoesInput` 强制关闭,不参与本事故。

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using Avalonia.Threading;
 using VelaShell.Core.Ssh;
 
@@ -11,6 +12,19 @@ public class SshTerminalBridge : IDisposable
 {
     private readonly CancellationTokenSource _cts;
     private readonly List<byte[]> _pending = [];
+
+    // 出站写队列:所有发往 PTY 的字节(击键 + SendRaw 注入)先入队,由唯一的写循环按序
+    // 逐段 await 后刷出。绝不能对底层流并发 WriteAsync —— Tmds.Ssh 的 SshChannel.WriteAsync
+    // 没有任何并发防护:两个写并发时会各自读发送窗口、交错切包,字节以乱序抵达远端;
+    // 远端 shell 按收到的顺序回显,屏幕上就是"打 docker status 出来字符拆散跳动"。
+    // 打字稍快 + 网络延迟让上一个写挂起 await,下一个按键就会插队,竞态必现。
+    // (旧 SSH.NET 的 ShellStream 内部有锁掩盖了这一点,迁移 Tmds.Ssh 后暴露。)
+    private readonly Channel<byte[]> _writeQueue = Channel.CreateUnbounded<byte[]>(new UnboundedChannelOptions
+    {
+        SingleReader = true
+    });
+
+    private readonly Task _writeTask;
 
     // 输出合批泵:读线程把原始分块入队,并只请求一次 UI 线程的合并刷新,
     // 而非每次读取都编组并喂入一次。在突发输出(apt/yum、cat、进度条)下,这把
@@ -33,6 +47,7 @@ public class SshTerminalBridge : IDisposable
         _shellStream = shellStream ?? throw new ArgumentNullException(nameof(shellStream));
         _cts = new();
         _terminal.UserInput += OnUserInput;
+        _writeTask = Task.Run(WriteLoopAsync);
     }
 
     /// <summary>停止读循环、退订输入事件并释放 Shell 流与取消源(可安全重复调用)。</summary>
@@ -45,6 +60,9 @@ public class SshTerminalBridge : IDisposable
         _disposed = true;
         _terminal.UserInput -= OnUserInput;
         ZModemRouter?.SessionEnded -= OnZModemSessionEnded;
+
+        // 封口写队列:写循环排空残余(_disposed 已置位,只弃不写)后自行退出。
+        _writeQueue.Writer.TryComplete();
 
         // 先释放流、后取消令牌:释放流会以"通道关闭"唤醒挂起的读取,包装层将其吞为 EOF,
         // 读循环无异常退出。若先 Cancel,取消会以 OperationCanceledException 打穿底层库的
@@ -66,6 +84,15 @@ public class SshTerminalBridge : IDisposable
         catch (AggregateException)
         {
             // 吞掉释放期间读任务抛出的异常
+        }
+        try
+        {
+            // 流已释放:挂起中的写以 ObjectDisposedException 醒来并被吞掉,循环随即因封口退出。
+            _writeTask.Wait(TimeSpan.FromSeconds(1));
+        }
+        catch (AggregateException)
+        {
+            // 吞掉释放期间写任务抛出的异常
         }
         _cts.Dispose();
         GC.SuppressFinalize(this);
@@ -159,7 +186,7 @@ public class SshTerminalBridge : IDisposable
         {
             return;
         }
-        _ = WriteUserInputAsync(data);
+        _writeQueue.Writer.TryWrite(data);
     }
 
     /// <summary>启动后台读循环;仅允许调用一次,重复调用会抛出异常。</summary>
@@ -366,24 +393,51 @@ public class SshTerminalBridge : IDisposable
             return;
         }
 
-        // 即发即忘并附带错误处理 —— 这是事件处理器,使用 async void 是可接受的
-        _ = WriteUserInputAsync(data);
+        // 只入队不直写:击键与 SendRaw 都在 UI 线程触发,TryWrite 保序;真正的发送
+        // 由唯一的写循环按序完成,杜绝对底层通道的并发 WriteAsync(见 _writeQueue 注释)。
+        _writeQueue.Writer.TryWrite(data);
     }
 
-    private async Task WriteUserInputAsync(byte[] data)
+    /// <summary>
+    /// 唯一的出站写者:按入队顺序逐段写入并等待完成,一段未落盘绝不开始下一段。
+    /// 上一段写入挂起期间(发送窗口收紧、网络延迟)攒下的后续段合并为一次写出——
+    /// 语义上等价于按序逐段发送,只是少切几个 SSH 包。
+    /// </summary>
+    private async Task WriteLoopAsync()
     {
-        try
+        while (await _writeQueue.Reader.WaitToReadAsync().ConfigureAwait(false))
         {
-            await _shellStream.WriteAsync(data, 0, data.Length, CancellationToken.None).ConfigureAwait(false);
-            _shellStream.Flush();
-        }
-        catch (ObjectDisposedException)
-        {
-            // 流已释放——拆除期间属正常情况
-        }
-        catch (Exception ex)
-        {
-            Error?.Invoke(ex);
+            while (_writeQueue.Reader.TryRead(out byte[]? payload))
+            {
+                if (_writeQueue.Reader.TryRead(out byte[]? next))
+                {
+                    var merged = new MemoryStream(payload.Length + next.Length + 64);
+                    merged.Write(payload);
+                    merged.Write(next);
+                    while (_writeQueue.Reader.TryRead(out byte[]? more))
+                    {
+                        merged.Write(more);
+                    }
+                    payload = merged.ToArray();
+                }
+                if (_disposed || !_shellStream.CanWrite)
+                {
+                    continue; // 拆除中:弃段快速排空,让循环尽快退出。
+                }
+                try
+                {
+                    await _shellStream.WriteAsync(payload, 0, payload.Length, CancellationToken.None).ConfigureAwait(false);
+                    _shellStream.Flush();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // 流已释放——拆除期间属正常情况
+                }
+                catch (Exception ex)
+                {
+                    Error?.Invoke(ex);
+                }
+            }
         }
     }
 }

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -274,6 +274,53 @@ public class TerminalBridgeTests
     }
 
     [TestMethod]
+    public void UserInput_RapidKeystrokes_NeverWriteConcurrently_AndPreserveByteOrder()
+    {
+        // 回归防护:Tmds.Ssh 的通道写没有并发防护,桥必须把击键写串行化。
+        // 旧实现对每个按键即发即忘地 WriteAsync,上一个写因网络延迟挂起时下一个按键
+        // 就并发插队 → 字节乱序抵达远端 → 回显出"字符拆散跳动"(docker status 事故)。
+        _shellStream.CanRead.Returns(false);
+        _shellStream.CanWrite.Returns(true);
+
+        var gate = new object();
+        int inFlight = 0, maxInFlight = 0;
+        var received = new MemoryStream();
+        _shellStream.WriteAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                lock (gate)
+                {
+                    inFlight++;
+                    maxInFlight = Math.Max(maxInFlight, inFlight);
+                    received.Write(call.ArgAt<byte[]>(0), call.ArgAt<int>(1), call.ArgAt<int>(2));
+                }
+
+                // 模拟发送窗口收紧/网络延迟:写挂起期间后续按键持续到达。
+                await Task.Delay(30);
+                lock (gate)
+                {
+                    inFlight--;
+                }
+            });
+
+        using var bridge = new SshTerminalBridge(_terminal, _shellStream);
+
+        byte[] typed = Encoding.UTF8.GetBytes("docker status");
+        foreach (byte b in typed)
+        {
+            _terminal.UserInput += Raise.Event<Action<byte[]>>(new[] { b });
+        }
+
+        Thread.Sleep(1000); // 串行 + 合并后最多几段写,足够全部落盘。
+
+        lock (gate)
+        {
+            Assert.AreEqual(1, maxInFlight, "出站写必须串行:任意时刻至多一个 WriteAsync 在途。");
+            Assert.AreEqual("docker status", Encoding.UTF8.GetString(received.ToArray()), "字节必须按击键顺序完整送达。");
+        }
+    }
+
+    [TestMethod]
     public void UserInput_WriteThrowsObjectDisposed_DoesNotPropagate()
     {
         _shellStream.CanRead.Returns(false);


### PR DESCRIPTION
为 SshTerminalBridge 增加唯一写者队列，所有输入统一入队，由单一写循环串行写入底层流，彻底杜绝并发 WriteAsync 导致的字节乱序，并提升写入效率。OnUserInput 事件仅负责入队，写操作全部交由 WriteLoopAsync 处理。新增回归测试，模拟高频击键和网络延迟，断言写入无并发且顺序完整，防止回归。补充详细文档，分析乱序根因、修复方案及架构建议。同步优化资源释放和异常处理，提升健壮性。