### PR TITLE
引入标签栏滑动强调线动画及样式优化

### DIFF
--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml
@@ -14,9 +14,11 @@
       <Setter Property="Opacity" Value="1" />
       <Setter Property="RenderTransform" Value="translateY(0px)" />
     </Style>
+    <!-- 内容"落定"起点:刻意不从 0 开始 —— 从全黑淡入会让每次切标签都像眨一下眼;
+         0.65 + 4px 让新内容立即可见、只带一丝浮起感,reparent 首帧的布局微调也被盖住。 -->
     <Style Selector="controls|ReparentingHost.settling">
-      <Setter Property="Opacity" Value="0" />
-      <Setter Property="RenderTransform" Value="translateY(2px)" />
+      <Setter Property="Opacity" Value="0.65" />
+      <Setter Property="RenderTransform" Value="translateY(4px)" />
     </Style>
   </UserControl.Styles>
 
@@ -66,21 +68,40 @@
       <ScrollViewer x:Name="TabScroll"
                     HorizontalScrollBarVisibility="Hidden"
                     VerticalScrollBarVisibility="Disabled">
-        <ItemsControl x:Name="TabsHost" ItemsSource="{Binding Documents}">
-          <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-              <StackPanel Orientation="Horizontal" />
-            </ItemsPanelTemplate>
-          </ItemsControl.ItemsPanel>
-          <ItemsControl.DataTemplates>
-            <DataTemplate x:DataType="docking:TerminalDocument">
-              <local:DockTabItem />
-            </DataTemplate>
-            <DataTemplate x:DataType="docking:SftpDocument">
-              <local:SftpDockTabItem />
-            </DataTemplate>
-          </ItemsControl.DataTemplates>
-        </ItemsControl>
+        <!-- 指示器与标签同处滚动内容里,滚动时二者天然同步,不需要任何偏移换算。 -->
+        <Panel x:Name="TabsOverlay">
+          <ItemsControl x:Name="TabsHost" ItemsSource="{Binding Documents}">
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Horizontal" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.DataTemplates>
+              <DataTemplate x:DataType="docking:TerminalDocument">
+                <local:DockTabItem />
+              </DataTemplate>
+              <DataTemplate x:DataType="docking:SftpDocument">
+                <local:SftpDockTabItem />
+              </DataTemplate>
+            </ItemsControl.DataTemplates>
+          </ItemsControl>
+          <!-- 激活标签的滑动强调线:单条 2px 线在标签间滑动(取代各标签自己顶线的突变),
+               位置/尺寸由代码后置按激活标签的实际边界驱动;水平模式贴顶,垂直模式贴内侧边。 -->
+          <Border x:Name="ActiveTabIndicator"
+                  Background="{DynamicResource VelaAccent}"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Top"
+                  IsVisible="False"
+                  IsHitTestVisible="False">
+            <Border.Transitions>
+              <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.18" Easing="CubicEaseOut" />
+                <DoubleTransition Property="Width" Duration="0:0:0.18" Easing="CubicEaseOut" />
+                <DoubleTransition Property="Height" Duration="0:0:0.18" Easing="CubicEaseOut" />
+              </Transitions>
+            </Border.Transitions>
+          </Border>
+        </Panel>
       </ScrollViewer>
     </DockPanel>
 
@@ -105,8 +126,8 @@
         <controls:ReparentingHost x:Name="ContentHost">
           <controls:ReparentingHost.Transitions>
             <Transitions>
-              <DoubleTransition Property="Opacity" Duration="0:0:0.12" Easing="CubicEaseOut" />
-              <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.12" Easing="CubicEaseOut" />
+              <DoubleTransition Property="Opacity" Duration="0:0:0.14" Easing="CubicEaseOut" />
+              <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.14" Easing="CubicEaseOut" />
             </Transitions>
           </controls:ReparentingHost.Transitions>
         </controls:ReparentingHost>

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
@@ -22,6 +22,9 @@ public partial class DockGroupControl : UserControl
     private Func<DockDocument, Control?>? _viewResolver;
     private int _contentMotionGeneration;
     private readonly Transitions _contentTransitions;
+    private readonly Transitions _indicatorTransitions;
+    private bool _indicatorPlaced;
+    private (double X, double Y, double W, double H) _indicatorGeometry = (-1, -1, -1, -1);
 
     /// <summary>初始化控件,订阅标签滚动变化并注册全组激活的指针处理器。</summary>
     public DockGroupControl()
@@ -29,7 +32,12 @@ public partial class DockGroupControl : UserControl
         InitializeComponent();
         _contentTransitions = ContentHost.Transitions
             ?? throw new InvalidOperationException("ContentHost transitions are not configured.");
+        _indicatorTransitions = ActiveTabIndicator.Transitions
+            ?? throw new InvalidOperationException("ActiveTabIndicator transitions are not configured.");
         TabScroll.ScrollChanged += (_, _) => UpdateScrollButtons();
+        // 标签宽度随标题变化、容器随集合重建 —— 指示器几何跟着布局走最省心;
+        // UpdateActiveTabIndicator 对相同几何短路,不会造成布局风暴。
+        TabsHost.LayoutUpdated += (_, _) => UpdateActiveTabIndicator();
         // 点击本组任意位置(含终端内容区)即把本组的选中文档设为全局激活 —— 对应原
         // Dock 的 FocusedDockable 语义;缺了它,分屏后点另一个窗格输入,SFTP 面板与
         // 状态栏不会跟随切换。Tunnel + handledEventsToo:终端控件会吞掉
@@ -100,10 +108,59 @@ public partial class DockGroupControl : UserControl
         {
             case nameof(DockGroup.ActiveDocument):
                 UpdateContent();
+                UpdateActiveTabIndicator();
                 break;
             case nameof(DockGroup.TabsPosition):
                 ApplyTabsPosition(Group?.TabsPosition ?? DockTabsPosition.Top);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// 把滑动强调线对齐到激活标签:水平模式为贴顶的 2px 横线,垂直模式为贴内侧边的
+    /// 2px 竖线(标签在左 → 线贴条带右缘,反之贴左缘)。首次落位不做动画(指示器
+    /// 不该从别的组的旧位置飘进来),此后位置/宽度经 180ms 过渡滑动 —— 这比每个标签
+    /// 自己的顶线瞬时跳变自然得多。
+    /// </summary>
+    private void UpdateActiveTabIndicator()
+    {
+        DockDocument? active = Group?.ActiveDocument;
+        Control? container = active is null ? null : TabsHost.ContainerFromItem(active);
+        if (container is null || container.Bounds.Width <= 0 || container.Bounds.Height <= 0)
+        {
+            ActiveTabIndicator.IsVisible = false;
+            _indicatorPlaced = false;
+            _indicatorGeometry = (-1, -1, -1, -1);
+            return;
+        }
+        Point origin = container.TranslatePoint(default, TabsOverlay) ?? default;
+        bool vertical = (Group?.TabsPosition ?? DockTabsPosition.Top) != DockTabsPosition.Top;
+        (double X, double Y, double W, double H) geometry = vertical
+            ? (Group?.TabsPosition == DockTabsPosition.Left ? Math.Max(0, TabsOverlay.Bounds.Width - 2) : 0,
+               Math.Round(origin.Y), 2, Math.Round(container.Bounds.Height))
+            : (Math.Round(origin.X), 0, Math.Round(container.Bounds.Width), 2);
+        if (geometry == _indicatorGeometry && ActiveTabIndicator.IsVisible)
+        {
+            return; // 布局回调高频触发;几何没变就绝不重写属性,避免过渡被反复重启。
+        }
+        _indicatorGeometry = geometry;
+
+        bool animate = _indicatorPlaced;
+        if (!animate)
+        {
+            ActiveTabIndicator.Transitions = null;
+        }
+        ActiveTabIndicator.Width = geometry.W;
+        ActiveTabIndicator.Height = geometry.H;
+        ActiveTabIndicator.RenderTransform = TransformOperations.Parse(
+            string.Create(System.Globalization.CultureInfo.InvariantCulture,
+                $"translate({geometry.X}px, {geometry.Y}px)"));
+        ActiveTabIndicator.IsVisible = true;
+        if (!animate)
+        {
+            _indicatorPlaced = true;
+            Dispatcher.UIThread.Post(() => ActiveTabIndicator.Transitions ??= _indicatorTransitions,
+                DispatcherPriority.Render);
         }
     }
 

--- a/src/VelaShell/Docking/Controls/DockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/DockTabItem.axaml
@@ -45,9 +45,11 @@
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
+    <!-- 激活顶线不再由标签自己画:改由 DockGroupControl 的滑动强调线统一呈现
+         (单条线在标签间滑动,替代逐标签顶线的瞬时跳变);TabRoot 的 2px 顶边厚度
+         保留为占位,保证滑线覆盖处与标签内容的间距不变。 -->
     <Style Selector="local|DockTabItem:selected Border#TabRoot">
       <Setter Property="Background" Value="{DynamicResource VelaTabActiveBg}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
     </Style>
   </UserControl.Styles>
 

--- a/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
@@ -38,9 +38,9 @@
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
+    <!-- 激活顶线由 DockGroupControl 的滑动强调线统一呈现(与 DockTabItem 同理)。 -->
     <Style Selector="local|SftpDockTabItem:selected Border#TabRoot">
       <Setter Property="Background" Value="{DynamicResource VelaTabActiveBg}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
     </Style>
   </UserControl.Styles>
 

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -113,23 +113,24 @@
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
       <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
     </Style>
+    <!-- 选中态只变前景色;下划线由标签条底部的滑动指示条统一呈现(在 SSH/SFTP 间滑动)。 -->
     <Style Selector="Button.proto-tab.selected">
-      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
     </Style>
-    <!-- Avalonia 的 :focus 状态是该控件的键盘焦点钩子。保持选中下划线层级不变;
-         带记号的焦点填充是额外的键盘可感知反馈。 -->
-    <Style Selector="Button.proto-tab:focus">
+    <!-- 焦点记号只给键盘导航(:focus-visible)。此前用 :focus,鼠标点完标签后强调色
+         填充+描边会一直挂在按钮上直到焦点移走 —— 看起来像卡住的高亮,是这个窗口
+         标签切换观感崩坏的主因。 -->
+    <Style Selector="Button.proto-tab:focus-visible">
       <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
     </Style>
     <!-- Fluent 的焦点层位于 Button 背景之上;只覆盖这个类,
          使其系统强调色无法替换 Vela 的焦点记号。 -->
-    <Style Selector="Button.proto-tab:focus /template/ ContentPresenter">
+    <Style Selector="Button.proto-tab:focus-visible /template/ ContentPresenter">
       <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
       <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
       <Setter Property="BorderThickness" Value="1" />
     </Style>
-    <Style Selector="Button.proto-tab:focus /template/ Border#PART_FocusAdorner">
+    <Style Selector="Button.proto-tab:focus-visible /template/ Border#PART_FocusAdorner">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
       <Setter Property="BorderThickness" Value="1" />
@@ -174,26 +175,43 @@
       <Border Height="36" Padding="20,0"
               BorderThickness="0,0,0,1"
               BorderBrush="{DynamicResource VelaBorderPrimary}">
-        <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom">
-          <Button Classes="proto-tab" Classes.selected="{Binding IsSshSelected}"
-                  Command="{Binding SelectConnectionTypeCommand}"
-                  CommandParameter="{x:Static models:ConnectionType.SSH}">
-            <TextBlock Classes="proto-label" Text="SSH" FontWeight="Medium" />
-          </Button>
-          <Button Classes="proto-tab" Classes.selected="{Binding IsSftpSelected}"
-                  Command="{Binding SelectConnectionTypeCommand}"
-                  CommandParameter="{x:Static models:ConnectionType.SFTP}">
-            <TextBlock Classes="proto-label" Text="SFTP" FontWeight="Medium" />
-          </Button>
-          <Border Classes="proto-tab" IsEnabled="False" ToolTip.Tip="{loc:Localize Profile_NotSupported}">
-            <TextBlock Classes="proto-label" Text="Telnet"
-                       Foreground="{DynamicResource VelaTextTertiary}" />
+        <Panel x:Name="ProtoTabsPanel" VerticalAlignment="Bottom">
+          <StackPanel Orientation="Horizontal">
+            <Button x:Name="SshTab" Classes="proto-tab" Classes.selected="{Binding IsSshSelected}"
+                    Command="{Binding SelectConnectionTypeCommand}"
+                    CommandParameter="{x:Static models:ConnectionType.SSH}">
+              <TextBlock Classes="proto-label" Text="SSH" FontWeight="Medium" />
+            </Button>
+            <Button x:Name="SftpTab" Classes="proto-tab" Classes.selected="{Binding IsSftpSelected}"
+                    Command="{Binding SelectConnectionTypeCommand}"
+                    CommandParameter="{x:Static models:ConnectionType.SFTP}">
+              <TextBlock Classes="proto-label" Text="SFTP" FontWeight="Medium" />
+            </Button>
+            <Border Classes="proto-tab" IsEnabled="False" ToolTip.Tip="{loc:Localize Profile_NotSupported}">
+              <TextBlock Classes="proto-label" Text="Telnet"
+                         Foreground="{DynamicResource VelaTextTertiary}" />
+            </Border>
+            <Border Classes="proto-tab" IsEnabled="False" ToolTip.Tip="{loc:Localize Profile_NotSupported}">
+              <TextBlock Classes="proto-label" Text="{loc:Localize Profile_Serial}"
+                         Foreground="{DynamicResource VelaTextTertiary}" />
+            </Border>
+          </StackPanel>
+          <!-- 滑动下划线:2px 强调色,在 SSH/SFTP 间平移;位置由代码后置按按钮实际边界驱动。 -->
+          <Border x:Name="ProtoTabIndicator"
+                  Height="2"
+                  Background="{DynamicResource VelaAccent}"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Bottom"
+                  IsVisible="False"
+                  IsHitTestVisible="False">
+            <Border.Transitions>
+              <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.18" Easing="CubicEaseOut" />
+                <DoubleTransition Property="Width" Duration="0:0:0.18" Easing="CubicEaseOut" />
+              </Transitions>
+            </Border.Transitions>
           </Border>
-          <Border Classes="proto-tab" IsEnabled="False" ToolTip.Tip="{loc:Localize Profile_NotSupported}">
-            <TextBlock Classes="proto-label" Text="{loc:Localize Profile_Serial}"
-                       Foreground="{DynamicResource VelaTextTertiary}" />
-          </Border>
-        </StackPanel>
+        </Panel>
       </Border>
 
       <!-- 表单 -->

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -13,11 +14,58 @@ namespace VelaShell.Views;
 /// <summary>连接配置编辑窗口,用于新建或编辑连接档案并支持保存后立即连接。</summary>
 public partial class ConnectionProfileView : Window
 {
+    private bool _protoIndicatorPlaced;
+    private Avalonia.Animation.Transitions? _protoIndicatorTransitions;
+    private (double X, double W) _protoIndicatorGeometry = (-1, -1);
+
     /// <summary>初始化连接配置窗口,并在打开时绑定命令与加载分组数据。</summary>
     public ConnectionProfileView()
     {
         InitializeComponent();
         Opened += OnOpened;
+        // 滑动下划线跟随布局(字体加载、DPI 变化都会改按钮宽度);几何未变时短路。
+        LayoutUpdated += (_, _) => UpdateProtoTabIndicator();
+    }
+
+    /// <summary>
+    /// 把滑动下划线对齐到当前协议标签(SSH/SFTP):首次落位不动画,此后位置与宽度经
+    /// 180ms 过渡滑动 —— 取代旧实现里两个按钮各自下划线的瞬时跳变。
+    /// </summary>
+    private void UpdateProtoTabIndicator()
+    {
+        if (DataContext is not ConnectionProfileViewModel viewModel)
+        {
+            return;
+        }
+        Button target = viewModel.IsSftpSelected ? SftpTab : SshTab;
+        if (target.Bounds.Width <= 0)
+        {
+            return;
+        }
+        Avalonia.Point origin = target.TranslatePoint(default, ProtoTabsPanel) ?? default;
+        (double X, double W) geometry = (Math.Round(origin.X), Math.Round(target.Bounds.Width));
+        if (geometry == _protoIndicatorGeometry && ProtoTabIndicator.IsVisible)
+        {
+            return;
+        }
+        _protoIndicatorGeometry = geometry;
+        bool animate = _protoIndicatorPlaced;
+        if (!animate)
+        {
+            _protoIndicatorTransitions ??= ProtoTabIndicator.Transitions;
+            ProtoTabIndicator.Transitions = null;
+        }
+        ProtoTabIndicator.Width = geometry.W;
+        ProtoTabIndicator.RenderTransform = Avalonia.Media.Transformation.TransformOperations.Parse(
+            string.Create(System.Globalization.CultureInfo.InvariantCulture, $"translateX({geometry.X}px)"));
+        ProtoTabIndicator.IsVisible = true;
+        if (!animate)
+        {
+            _protoIndicatorPlaced = true;
+            Avalonia.Threading.Dispatcher.UIThread.Post(
+                () => ProtoTabIndicator.Transitions ??= _protoIndicatorTransitions,
+                Avalonia.Threading.DispatcherPriority.Render);
+        }
     }
 
     private void ApplyProtoTabFocusAdorner()
@@ -45,7 +93,9 @@ public partial class ConnectionProfileView : Window
 
     private void ProtoTab_GotFocus(object? sender, FocusChangedEventArgs e)
     {
-        if (sender is Button button)
+        // 焦点框只属于键盘导航:鼠标点击同样会落焦,若不区分,点完标签后强调色
+        // 填充+描边会一直挂在按钮上直到焦点移走 —— 正是本窗口标签切换"高亮卡住"的元凶。
+        if (sender is Button button && e.NavigationMethod is NavigationMethod.Tab or NavigationMethod.Directional)
         {
             AdornerLayer.SetAdorner(button, CreateVelaFocusAdorner());
         }
@@ -78,6 +128,16 @@ public partial class ConnectionProfileView : Window
             return;
         }
         ApplyProtoTabFocusAdorner();
+        // 协议切换只改按钮前景色、不触发布局,滑动下划线必须由 VM 属性变化驱动。
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is nameof(ConnectionProfileViewModel.IsSshSelected)
+                or nameof(ConnectionProfileViewModel.IsSftpSelected))
+            {
+                UpdateProtoTabIndicator();
+            }
+        };
+        UpdateProtoTabIndicator();
         viewModel.SaveCommand.Subscribe(Close);
         viewModel.ConnectCommand.Subscribe(Close);
         viewModel.CancelCommand.Subscribe(Close);

--- a/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -64,6 +65,51 @@ public sealed class ConnectionProfileViewUiTests
             Assert.IsTrue(vm.IsSftpSelected);
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void ProtocolTabIndicator_SlidesToSelectedTab()
+    {
+        _session.Dispatch(() =>
+        {
+            var vm = new ConnectionProfileViewModel
+            {
+                Host = "files.example.com",
+                Username = "root",
+                Password = SecureStringConvert.FromPlaintext("secret"),
+            };
+            var window = new ConnectionProfileView { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var indicator = window.FindControl<Border>("ProtoTabIndicator")
+                ?? throw new AssertFailedException("ProtoTabIndicator not found.");
+            var sshTab = window.FindControl<Button>("SshTab")!;
+            var sftpTab = window.FindControl<Button>("SftpTab")!;
+
+            // 初始:下划线对齐 SSH。
+            Assert.IsTrue(indicator.IsVisible);
+            AssertIndicatorAligned(indicator, sshTab);
+
+            // 切到 SFTP:下划线经 180ms 过渡滑到 SFTP(断言读基值,与动画时间解耦)。
+            vm.SelectConnectionTypeCommand.Execute(ConnectionType.SFTP).Subscribe();
+            Dispatcher.UIThread.RunJobs();
+            AssertIndicatorAligned(indicator, sftpTab);
+
+            window.Close();
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    private static void AssertIndicatorAligned(Border indicator, Button tab)
+    {
+        // 读基值(过渡目标)而非属性现值:现值在 180ms 滑动期间是动画中间值。
+        Visual panel = indicator.GetVisualParent()!;
+        Point origin = tab.TranslatePoint(default, panel) ?? default;
+        double actualX = indicator.GetBaseValue(Visual.RenderTransformProperty).GetValueOrDefault()?.Value.M31 ?? -1;
+        double actualWidth = indicator.GetBaseValue(Avalonia.Layout.Layoutable.WidthProperty).GetValueOrDefault(double.NaN);
+        Assert.AreEqual(Math.Round(origin.X), actualX, 0.6, "下划线应与选中协议标签左缘对齐。");
+        Assert.AreEqual(Math.Round(tab.Bounds.Width), actualWidth, 0.6, "下划线宽度应等于选中协议标签宽度。");
     }
 
     private static void AssertProtocolTabMotion(IReadOnlyList<Button> protocolButtons)

--- a/tests/VelaShell.Tests/Views/DockMotionUiTests.cs
+++ b/tests/VelaShell.Tests/Views/DockMotionUiTests.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
+using Avalonia.Layout;
 using Avalonia.Headless;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -51,7 +52,8 @@ public sealed class DockMotionUiTests
             Assert.AreSame(host.Target, host.Child);
             Assert.IsTrue(host.Classes.Contains("settling"));
             Assert.IsNull(host.Transitions);
-            Assert.AreEqual(0, host.Opacity);
+            // 落定起点刻意非 0:从全黑淡入会让每次切标签都像眨眼(0.65 = 立即可见 + 一丝浮起)。
+            Assert.AreEqual(0.65, host.Opacity);
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();
             Assert.IsFalse(host.Classes.Contains("settling"));
@@ -71,6 +73,57 @@ public sealed class DockMotionUiTests
 
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void ActiveTabIndicator_AlignsToActiveTab_AndFollowsActivation()
+    {
+        _session.Dispatch(() =>
+        {
+            var workspace = new DockWorkspace();
+            var first = new TestDocument("first-tab");
+            var second = new TestDocument("second-tab");
+            workspace.AddDocument(first);
+            workspace.AddDocument(second);
+
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 640, Height = 360, Content = dock };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            DockGroupControl groupControl = dock.GetVisualDescendants().OfType<DockGroupControl>().Single();
+            Border indicator = groupControl.GetVisualDescendants().OfType<Border>()
+                                           .Single(border => border.Name == "ActiveTabIndicator");
+            ItemsControl tabs = groupControl.GetVisualDescendants().OfType<ItemsControl>()
+                                            .Single(items => items.Name == "TabsHost");
+
+            // 激活标签的滑动强调线必须可见,且几何对齐激活标签(取代逐标签顶线)。
+            Assert.IsTrue(indicator.IsVisible);
+            AssertIndicatorAlignedTo(indicator, tabs, workspace.ActiveDocument!);
+
+            DockDocument other = ReferenceEquals(workspace.ActiveDocument, second) ? first : second;
+            workspace.ActivateDocument(other);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            AssertIndicatorAlignedTo(indicator, tabs, other);
+
+            window.Close();
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    private static void AssertIndicatorAlignedTo(Border indicator, ItemsControl tabs, DockDocument document)
+    {
+        // 读基值(过渡目标)而非属性现值:切换后位置/宽度经 180ms 过渡滑动,
+        // 现值是动画中间值,基值才是应当停下的终点 —— 断言与真实时间彻底解耦。
+        Control container = tabs.ContainerFromItem(document)
+            ?? throw new AssertFailedException("Active tab has no realized container.");
+        Visual panel = (Visual)indicator.GetVisualParent()!;
+        Point origin = container.TranslatePoint(default, panel) ?? default;
+        double actualX = indicator.GetBaseValue(Visual.RenderTransformProperty).GetValueOrDefault()?.Value.M31 ?? -1;
+        double actualWidth = indicator.GetBaseValue(Layoutable.WidthProperty).GetValueOrDefault(double.NaN);
+        Assert.AreEqual(Math.Round(origin.X), actualX, 0.6, "滑动强调线应与激活标签左缘对齐。");
+        Assert.AreEqual(Math.Round(container.Bounds.Width), actualWidth, 0.6, "滑动强调线宽度应等于激活标签宽度。");
     }
 
     private static void SaveOptionalFrame(TopLevel topLevel, string fileName)
@@ -95,11 +148,11 @@ public sealed class DockMotionUiTests
         Assert.Contains(transition =>
             transition is DoubleTransition { Property: var property, Duration: var duration }
             && property == Visual.OpacityProperty
-            && duration == TimeSpan.FromMilliseconds(120), host.Transitions);
+            && duration == TimeSpan.FromMilliseconds(140), host.Transitions);
         Assert.Contains(transition =>
             transition is TransformOperationsTransition { Property: var property, Duration: var duration }
             && property == Visual.RenderTransformProperty
-            && duration == TimeSpan.FromMilliseconds(120), host.Transitions);
+            && duration == TimeSpan.FromMilliseconds(140), host.Transitions);
     }
 
     private sealed class TestDocument : DockDocument, IDockViewProvider


### PR DESCRIPTION
为 VelaShell 标签栏和协议选择界面新增滑动强调线动画，提升标签切换的视觉流畅性。主标签栏和协议选择页签均采用平滑滑动的强调线替代原有突变高亮，相关样式与逻辑同步调整。完善测试用例，断言强调线动画对齐与切换效果，动画时长优化至 140ms/180ms。详细注释设计动机与实现细节，整体提升交互体验。