### PR TITLE
终端渲染与内存优化，服务层与 UI 修复

### DIFF
--- a/docs/性能与内存优化-2026-07.md
+++ b/docs/性能与内存优化-2026-07.md
@@ -1,0 +1,52 @@
+# 性能与内存优化(2026-07-23 夜间批次)
+
+> 三路并行审计(渲染热路径 / 内存与泄漏 / VM 与服务层)→ 按收益排序逐项落地。
+> 全部改动经 1061 项测试回归(Terminal 228 / Core 224 / App 609),零失败零警告。
+
+## 一、渲染热路径(全屏 TUI 卡顿与 GC 压力)
+
+| 改动 | 位置 | 说明 |
+| --- | --- | --- |
+| 语义高亮跳过备用屏 | VelaTerminalControl.RenderLine | vim/htop/btop 自带配色且行内容每帧都变(缓存必 MISS),此前每行每帧跑 7 条正则全扫——头号热点,直接跳过 |
+| 语义计算缓冲复用 | ComputeSemanticColumns | StringBuilder / List / SemanticKind?[] 三件套改成员复用,消灭每行每帧的堆分配 |
+| 语义匹配去 LINQ | SemanticMatcher.Match | chosen.Any(委托) 换手写循环,渲染路径零委托分配 |
+| 侧栏文本塑形缓存 | GutterText(新) | 时间戳/行号/折叠标记的 FormattedText 按文本缓存(帧间高度重复),画刷/字体变化时失效,上限 512 |
+| 输出更新合批 | OnEmulatorUpdated / ApplyOutputUpdate | 跨线程 Post 合并为每帧一次;滚动几何没变(htop 原地重绘、进度条)不再惊动 ScrollChanged 订阅者 |
+| reflow 段拷贝 | TerminalScreen.ReflowResize | 收集缓冲跨逻辑行复用 + row.Span 段拷贝替代逐格 Add,拖拽改宽不再是 O(缓冲区) 分配风暴 |
+| 折叠列画笔缓存 | RenderFoldColumn | new Pen 换 PenFor 缓存 |
+
+**审计确认已良好、刻意不动的**:光标闪烁定时器(失焦即停、无多标签空转)、Utf8Sink 零分配解码、
+scrollback 头指针摊销裁剪、GlyphRun 批量化主路径。FlushGlyphRun 的 ToArray×2 **有意保留**:
+Avalonia 是保留模式渲染,GlyphRun 被场景图持有到合成期,复用底层数组会腐蚀已录制的绘制,
+每 run 独立数组是正确性要求而非疏漏。
+
+## 二、内存占用
+
+| 改动 | 位置 | 量级 |
+| --- | --- | --- |
+| 回滚默认 50000 → 10000 | AppSettings.ScrollbackLines | 满载单标签 100–240MB → 20–48MB(5×);已存配置不强改,老用户可自行下调 |
+| TerminalCell 去托管引用 | TerminalCell + CombiningPool(新) | `string? Combining` 换驻留池 int 索引:每格 24B→20B,且整个回滚缓冲(可达数百万格)不再被 GC 逐格扫描;`Combining` 属性签名不变,调用点零改动 |
+| 内存契约测试 | TerminalCellMemoryTests | `IsReferenceOrContainsReferences<TerminalCell>() == false` 锁死 blittable;组合字符端到端行为回归 |
+
+审计核查结论:事件订阅/定时器关闭路径全部正确闭环,**无确定性泄漏**;渲染各缓存均有上界;
+录制回放是唯一大 byte[] 峰值持有点(窗口关闭即释放,记录在案未改)。
+
+## 三、VM 与服务层
+
+| 改动 | 位置 | 说明 |
+| --- | --- | --- |
+| ZModem 进度节流 | ZModemTransferObserver | 补齐与 SFTP ProgressThrottle 同款的 100ms 时间片:100MB 传输从约 10 万次 UI Post + 70 万次字符串分配 → 约每秒 10 次;完成回调必带 100% 末次刷新 |
+| 传输行通知按变化触发 | TransferItemViewModel.UpdateProgress | 同值 tick 不再空发 InfoLine/ProgressText(每次都是字符串拼装+重绑) |
+| 命令建议防抖 | TerminalTabView | 停键 90ms 才查询提供者(此前每个可打印字节全量过滤 500 条历史+排序);幽灵文本本地即时消耗不受影响,手感不变 |
+| 启动同步 IO 后台化 | App.axaml.cs | 日志清理(目录枚举+删除)真正 Task.Run;快捷命令迁移标记并入自动同步后台链(保持"先标记后同步"顺序),不再 GetResult() 阻塞 UI |
+| 命令历史落盘防抖 | CommandHistoryService | 每条命令全量序列化 500 条 → 静默 1s 合并一次;Clear 仍即时 |
+| 最小化暂停状态轮询 | MainWindowViewModel + MainWindow | 窗口最小化/隐入托盘时停掉每秒 SSH exec 探测与周期 ICMP,恢复即重启 |
+
+## 四、测量说明(诚实记录)
+
+- 启动内存由窗口合成(Skia/GPU)主导,约 280MB WorkingSet / 195MB Private,优化前后**无差异**
+  (夜间曾测得一次 78.6MB 的基线,经"完整回退重测"证伪为环境异常值,勿引用)。
+- 本批优化的收益在**稳态**:回滚满载内存 5×↓ + 每格 17%↓ + GC 扫描面归零;全屏 TUI 每帧堆分配
+  基本清零;大文件 ZModem 传输的 UI 派发 10⁴×↓。这些不体现在空载启动数字上。
+- 遗留的低优先级项(未做,见审计):渲染缓存"到顶全清"换 LRU、录制回放流式读取、
+  ResourceMonitor 定向通知、VtParser 泛型去虚化。

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -21,8 +21,13 @@ public class AppSettings
     /// <summary>终端字体字号(磅)。</summary>
     public int TerminalFontSize { get; set; } = 14;
 
-    /// <summary>终端可回滚保留的最大历史行数。</summary>
-    public int ScrollbackLines { get; set; } = 50000;
+    /// <summary>
+    /// 终端可回滚保留的最大历史行数。默认 10000(对齐 Windows Terminal 量级):
+    /// 满载时每标签约 20 行宽 KB 级——旧默认 50000 满载单标签可达 100-240MB,
+    /// 十个长会话标签就是 GB 级,是全应用内存占用的第一大头。
+    /// 已保存 50000 的旧配置不强改(用户可自行调整),仅影响新配置。
+    /// </summary>
+    public int ScrollbackLines { get; set; } = 10000;
 
     /// <summary>新建 SSH 连接的默认端口。</summary>
     public int DefaultPort { get; set; } = 22;

--- a/src/VelaShell.Core/Sftp/SerializedSftpService.cs
+++ b/src/VelaShell.Core/Sftp/SerializedSftpService.cs
@@ -43,7 +43,7 @@ public sealed class SerializedSftpService(ISftpService inner, Guid sessionId) : 
     public Task UploadFileAsync(Guid sessionId, string localPath, string remotePath, IProgress<TransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) => ExecuteAsync(sessionId, token => _inner.UploadFileAsync(sessionId, localPath, remotePath, progress, resumeOffset, token), cancellationToken, serialize: false);
 
     /// <summary>下载文件的透传;不占串行闸(见类型说明),但计入在途,关闭时会被排空。</summary>
-    public Task DownloadFileAsync(Guid sessionId, string remotePath, string localPath, IProgress<TransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) => ExecuteAsync(sessionId, token => _inner.DownloadFileAsync(sessionId, remotePath, localPath, progress, resumeOffset, token ), cancellationToken, serialize: false);
+    public Task DownloadFileAsync(Guid sessionId, string remotePath, string localPath, IProgress<TransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) => ExecuteAsync(sessionId, token => _inner.DownloadFileAsync(sessionId, remotePath, localPath, progress, resumeOffset, token), cancellationToken, serialize: false);
 
     /// <summary>删除远端文件或目录的串行化透传。</summary>
     public Task DeleteAsync(Guid sessionId, string remotePath, IProgress<SftpDeleteProgress>? progress = null, CancellationToken cancellationToken = default) => ExecuteAsync(sessionId, token => _inner.DeleteAsync(sessionId, remotePath, progress, token), cancellationToken);

--- a/src/VelaShell.Terminal/Emulation/CombiningPool.cs
+++ b/src/VelaShell.Terminal/Emulation/CombiningPool.cs
@@ -1,0 +1,66 @@
+namespace VelaShell.Terminal.Emulation;
+
+/// <summary>
+/// 组合标记字符串的进程级驻留池:<see cref="TerminalCell" /> 只存 <c>int</c> 索引而非
+/// <c>string?</c> 引用。这让单元格结构不含任何托管引用(blittable)——整个回滚缓冲
+/// (可达数百万格)从此不再被 GC 逐格扫描,每格还省下 4 字节。
+/// 真实世界的组合标记来自极小的字符集(重音、变音符),池天然收敛到几十条。
+/// </summary>
+/// <remarks>
+/// 写路径(驻留)只发生在解析到组合字符时,极罕见,加锁无碍;读路径(渲染/取文本)
+/// 只按索引读已发布的数组——数组内容一经发布不再变更,扩容以"新数组 + volatile 发布"
+/// 完成,无锁读安全。恶意输入理论上可制造大量唯一组合序列,超出上限后停止驻留、
+/// 静默丢弃新标记(显示退化为基础字符),不会无界增长。
+/// </remarks>
+internal static class CombiningPool
+{
+    /// <summary>池上限:正常使用永远到不了;是对抗性输入的无界增长保险丝。</summary>
+    private const int MaxEntries = 65536;
+
+    private static readonly Lock Gate = new();
+    private static readonly Dictionary<string, int> Lookup = [];
+    private static volatile string?[] _byIndex = new string?[64]; // [0] 恒为 null = 无组合标记。
+    private static int _count = 1;
+
+    /// <summary>驻留一段组合标记,返回其索引;null/空串返回 0;池满返回 0(丢弃标记)。</summary>
+    public static int Intern(string? marks)
+    {
+        if (string.IsNullOrEmpty(marks))
+        {
+            return 0;
+        }
+        lock (Gate)
+        {
+            if (Lookup.TryGetValue(marks, out int existing))
+            {
+                return existing;
+            }
+            if (_count >= MaxEntries)
+            {
+                return 0;
+            }
+            if (_count == _byIndex.Length)
+            {
+                string?[] grown = new string?[_byIndex.Length * 2];
+                Array.Copy(_byIndex, grown, _byIndex.Length);
+                _byIndex = grown; // volatile 发布:读者要么看到旧数组(内容仍有效),要么看到新数组。
+            }
+            int index = _count;
+            _byIndex[index] = marks;
+            _count = index + 1;
+            Lookup[marks] = index;
+            return index;
+        }
+    }
+
+    /// <summary>按索引取回组合标记;0 或越界返回 null。</summary>
+    public static string? Get(int index)
+    {
+        if (index <= 0)
+        {
+            return null;
+        }
+        string?[] snapshot = _byIndex;
+        return index < snapshot.Length ? snapshot[index] : null;
+    }
+}

--- a/src/VelaShell.Terminal/Emulation/TerminalCell.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalCell.cs
@@ -13,8 +13,18 @@ public struct TerminalCell : IEquatable<TerminalCell>
     /// </summary>
     public int Rune;
 
+    /// <summary>
+    /// 组合标记在 <see cref="CombiningPool" /> 中的索引;0 = 无。存索引而非字符串引用,
+    /// 使本结构不含托管引用:回滚缓冲的数百万格从此不被 GC 逐格扫描,每格再省 4 字节。
+    /// </summary>
+    public int CombiningIndex;
+
     /// <summary>追加在 <see cref="Rune" /> 之后的可选组合标记。常见情况下为 Null。</summary>
-    public string? Combining;
+    public string? Combining
+    {
+        readonly get => CombiningPool.Get(CombiningIndex);
+        set => CombiningIndex = CombiningPool.Intern(value);
+    }
 
     /// <summary>单元格的前景(文字)颜色。</summary>
     public TerminalColor Foreground;
@@ -86,7 +96,7 @@ public struct TerminalCell : IEquatable<TerminalCell>
     /// <returns>各字段均相等时返回 true。</returns>
     public readonly bool Equals(TerminalCell other) =>
         Rune == other.Rune &&
-        Combining == other.Combining &&
+        CombiningIndex == other.CombiningIndex && // 池内驻留:同串必同索引。
         Foreground == other.Foreground &&
         Background == other.Background &&
         Flags == other.Flags;
@@ -98,7 +108,7 @@ public struct TerminalCell : IEquatable<TerminalCell>
 
     /// <summary>返回基于全部字段的哈希码。</summary>
     /// <returns>单元格的哈希码。</returns>
-    public override readonly int GetHashCode() => HashCode.Combine(Rune, Combining, Foreground, Background, Flags);
+    public override readonly int GetHashCode() => HashCode.Combine(Rune, CombiningIndex, Foreground, Background, Flags);
 
     /// <summary>判断两个单元格是否相等。</summary>
     /// <param name="left">左操作数。</param>

--- a/src/VelaShell.Terminal/Emulation/TerminalRow.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalRow.cs
@@ -32,6 +32,9 @@ public sealed class TerminalRow(int columns)
     /// <summary>返回指定列处单元格的可变引用,用于就地编辑。</summary>
     public ref TerminalCell CellRef(int col) => ref _cells[col];
 
+    /// <summary>整行单元格的只读切片(reflow 等批量拷贝路径用,免去逐格索引)。</summary>
+    public ReadOnlySpan<TerminalCell> Span => _cells;
+
     /// <summary>用给定单元格填满整行,并清除 wrapped 标志与时间戳。</summary>
     public void Fill(in TerminalCell cell)
     {

--- a/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
@@ -512,6 +512,9 @@ public sealed class TerminalScreen
 
         // 2. 按新宽度重新生成逻辑行。
         var rebuilt = new List<TerminalRow>(physical.Count);
+        // 收集缓冲跨逻辑行复用:拖拽改宽会对整个缓冲区反复 reflow,若每条逻辑行
+        // 都 new 一个 List 再逐格 Add,就是一场 O(缓冲区) 的分配风暴。
+        var cells = new List<TerminalCell>(newCols * 2);
         int newCursorRow = -1, newCursorCol = 0;
         int i = 0;
         while (i < physical.Count)
@@ -525,7 +528,7 @@ public sealed class TerminalScreen
 
             // 收集其单元格:被换行的段落贡献其完整宽度,最后一段
             // 在最后一个非空单元格处截断(扩展以覆盖光标)。
-            var cells = new List<TerminalCell>();
+            cells.Clear();
             int cursorOffset = -1;
             DateTime? lineTimestamp = null;
             for (int r = i; r <= j; r++)
@@ -544,10 +547,7 @@ public sealed class TerminalScreen
                     len = Math.Max(len, cursorCol + 1);
                     cursorOffset = cells.Count + cursorCol;
                 }
-                for (int c = 0; c < len; c++)
-                {
-                    cells.Add(row[c]);
-                }
+                cells.AddRange(row.Span[..len]);
             }
             int emittedStart = rebuilt.Count;
             EmitLogicalLine(cells, cursorOffset, newCols, blank, rebuilt, ref newCursorRow, ref newCursorCol);

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -45,13 +45,25 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private readonly Dictionary<GlyphKey, FormattedText> _glyphCache = [];
     private readonly List<char> _runChars = [];
     private readonly List<GlyphInfo> _runGlyphs = [];
-    private readonly SemanticMatcher _semanticMatcher = new();
 
     // 客户端语义着色(URL、IP、错误/警告/成功词、选项标志、数字),针对
     // 远端程序留在默认颜色下的文本,使普通日志/MOTD 也能被高亮,
     // 且绝不破坏显式 SGR 颜色(ls --color、git 等)。正则结果按行文本缓存,
     // 因为可见行每一帧都会被重新扫描(光标闪烁、输出)。
     private readonly Dictionary<string, IReadOnlyList<SemanticSpan>> _semanticSpanCache = [];
+
+    // 侧栏文本(时间戳/行号/折叠标记)的 FormattedText 缓存:这些文本帧间高度重复
+    // (行号在滚动稳定时完全不变),不缓存则每行每帧做一次文本塑形。
+    // 键为文本本身;暗色画刷随主题变化时整体失效(见 GutterText)。
+    private readonly Dictionary<string, FormattedText> _gutterTextCache = [];
+    private ImmutableSolidColorBrush? _gutterTextCacheBrush;
+
+    // ComputeSemanticColumns 的复用缓冲:该方法对每个可见行、每一帧都会执行,
+    // 若每次都 new StringBuilder/List/数组,全屏 TUI 下就是每帧几百次堆分配直喂 GC。
+    // 三者都只在 UI 线程的渲染路径内短暂使用,跨行复用安全。
+    private readonly StringBuilder _semanticLineBuilder = new();
+    private readonly List<int> _semanticColByChar = [];
+    private SemanticKind?[] _semanticByColumn = [];
 
     // ---- Glyph-run batching -------------------------------------------------
     // 每个可见行被绘制为少数几个 GlyphRun —— 每个连续且共享同一字体风格与前景色的
@@ -713,15 +725,22 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
     }
 
+    // 跨线程输出更新的合批标志:同一帧内多次 Feed 只排一次 UI 回调,后续搭便车。
+    private int _outputUpdateQueued;
+
     private void OnEmulatorUpdated()
     {
         if (Dispatcher.UIThread.CheckAccess())
         {
             ApplyOutputUpdate();
         }
-        else
+        else if (Interlocked.CompareExchange(ref _outputUpdateQueued, 1, 0) == 0)
         {
-            Dispatcher.UIThread.Post(ApplyOutputUpdate);
+            Dispatcher.UIThread.Post(() =>
+            {
+                Interlocked.Exchange(ref _outputUpdateQueued, 0);
+                ApplyOutputUpdate();
+            });
         }
     }
 
@@ -731,6 +750,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         // 视图固定不动,以免后台输出把其拽回下方(修复 #15)—— 除非
         // 设置 → 终端 → 有输出时自动滚动已开启,此时会把视图拉回实时底部。
         int scrollback = Emulator.Screen.ScrollbackCount;
+        int offsetBefore = _scrollOffset;
         if (ScrollOnOutput && _scrollOffset > 0 && scrollback > _lastScrollbackCount)
         {
             _scrollOffset = 0;
@@ -739,9 +759,15 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             _scrollOffset = PinScrollOffset(_scrollOffset, _lastScrollbackCount, scrollback);
         }
+        bool scrollStateChanged = scrollback != _lastScrollbackCount || _scrollOffset != offsetBefore;
         _lastScrollbackCount = scrollback;
         InvalidateVisual();
-        ScrollChanged?.Invoke();
+        // 滚动几何没变(如 htop 原地重绘、进度条刷新)就不惊动滚动条等订阅者:
+        // 稳态输出下这是每次 Feed 一趟的下游刷新,省掉是纯赚。
+        if (scrollStateChanged)
+        {
+            ScrollChanged?.Invoke();
+        }
         _imeClient?.NotifyCursorMoved();
     }
 
@@ -966,6 +992,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
         // 缓存的字形绑定在旧的字体/字号上;任何度量变化都应丢弃它们。
         _glyphCache.Clear();
+        _gutterTextCache.Clear();
+        _gutterTextCacheBrush = null;
         _ghostFormatted = null;
         _styleTypefacesReady = false;
     }
@@ -1269,6 +1297,32 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     internal static bool ShowsGutterFor(TerminalRow line, int absoluteRow, int cursorAbsoluteRow) =>
         line.LastNonBlank() >= 0 || (line.Timestamp is not null && absoluteRow <= cursorAbsoluteRow);
 
+    /// <summary>
+    /// 侧栏文本的缓存取用:命中直接复用已塑形的 <see cref="FormattedText" />。
+    /// 画刷实例变化(主题切换/画刷缓存重建)时整体失效;字体/字号变化时随
+    /// <c>_glyphCache</c> 一起清空。上限防长会话滚动把历史行号无界积累。
+    /// </summary>
+    private FormattedText GutterText(string text, Typeface typeface, ImmutableSolidColorBrush brush)
+    {
+        if (!ReferenceEquals(_gutterTextCacheBrush, brush))
+        {
+            _gutterTextCache.Clear();
+            _gutterTextCacheBrush = brush;
+        }
+        if (_gutterTextCache.TryGetValue(text, out FormattedText? cached))
+        {
+            return cached;
+        }
+        if (_gutterTextCache.Count > 512)
+        {
+            _gutterTextCache.Clear();
+        }
+        var formatted = new FormattedText(
+            text, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, brush);
+        _gutterTextCache[text] = formatted;
+        return formatted;
+    }
+
     private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows)
     {
         // 侧栏底色刻意保持与终端背景一致(不再叠色):正文区域整体右移,侧栏落在开头那次全局底色填充上,
@@ -1297,17 +1351,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 string stamp =
                     "[" + ts.ToString(GutterTimeFormat, CultureInfo.InvariantCulture) + "] ";
-                context.DrawText(
-                    new(
-                        stamp,
-                        CultureInfo.InvariantCulture,
-                        FlowDirection.LeftToRight,
-                        typeface,
-                        FontSize,
-                        dimBrush
-                    ),
-                    new Point(0, y)
-                );
+                context.DrawText(GutterText(stamp, typeface, dimBrush), new Point(0, y));
             }
             if (ShowLineNumber)
             {
@@ -1315,17 +1359,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                     (absoluteRow + 1)
                         .ToString(CultureInfo.InvariantCulture)
                         .PadLeft(GutterLayout.NumberDigits) + " ";
-                context.DrawText(
-                    new(
-                        number,
-                        CultureInfo.InvariantCulture,
-                        FlowDirection.LeftToRight,
-                        typeface,
-                        FontSize,
-                        dimBrush
-                    ),
-                    new Point(numberLeft, y)
-                );
+                context.DrawText(GutterText(number, typeface, dimBrush), new Point(numberLeft, y));
             }
         }
         if (lastContentRow < 0)
@@ -1355,7 +1389,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         GutterLayout g = Gutter;
         double cx = g.FoldLeft + g.FoldWidth / 2;
         context.DrawLine(
-            new Pen(BrushFor(Blend(dim, palette.DefaultBackground, 0.4)), 1),
+            PenFor(Blend(dim, palette.DefaultBackground, 0.4)),
             new Point(cx, 0),
             new Point(cx, contentBottom)
         );
@@ -1376,14 +1410,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             if (glyph is not null)
             {
                 context.DrawText(
-                    new(
-                        glyph,
-                        CultureInfo.InvariantCulture,
-                        FlowDirection.LeftToRight,
-                        typeface,
-                        FontSize,
-                        glyphBrush
-                    ),
+                    GutterText(glyph, typeface, glyphBrush),
                     new Point(g.FoldLeft, screenRow * CellHeightForTest + _glyphYOffset)
                 );
             }
@@ -1418,11 +1445,32 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <summary>清空所有折叠(列宽 reflow 会重建行对象使引用失效,resize 时调用)。</summary>
     private void ClearFolds() => _foldModel.Clear();
 
+    /// <summary>
+    /// 该绝对行是否可作为折叠交互目标(悬停显示 ▾、点击折叠)。
+    /// 只放行"有内容的行"与既有折叠头:最后一行输出之下的空白屏幕行也是合法的活动屏行,
+    /// 若不拦截,悬停会在空白区凭空冒出 ▾,误点一下就把上方内容整段折叠——
+    /// 看起来就是"终端内容凭空消失"(2026-07-23 实证,用户误点空白区折叠所致)。
+    /// 折叠头无条件放行,保证已折叠的区域永远能展开。
+    /// </summary>
+    internal bool IsFoldTargetRow(int abs)
+    {
+        TerminalScreen screen = Emulator.Screen;
+        if (abs < 0 || abs >= screen.TotalRows)
+        {
+            return false;
+        }
+        if (_foldModel.IsAnchor(screen, abs))
+        {
+            return true;
+        }
+        return ShowsGutterFor(screen.ViewLine(abs), abs, screen.ScrollbackCount + screen.CursorY);
+    }
+
     /// <summary>折叠交互:点击折叠列某屏幕行 —— 折叠头则展开,否则把上方内容折叠到该行(见 <see cref="GutterFoldModel" />)。</summary>
     private void ToggleFoldAt(int screenRow)
     {
         int abs = AbsoluteForScreenRow(screenRow);
-        if (abs >= 0 && _foldModel.Toggle(Emulator.Screen, abs))
+        if (IsFoldTargetRow(abs) && _foldModel.Toggle(Emulator.Screen, abs))
         {
             AfterFoldChange();
         }
@@ -1523,7 +1571,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         ((int Row, int Col) Start, (int Row, int Col) End)? sel
     )
     {
-        SemanticKind?[]? semantic = SemanticHighlightingEnabled
+        // 备用屏(vim/htop/less 等全屏程序)自带配色且行内容每帧都在变:语义扫描
+        // 既无视觉价值又必然缓存 MISS(整行文本为键),是全屏 TUI 卡顿的头号来源,直接跳过。
+        SemanticKind?[]? semantic = SemanticHighlightingEnabled && !Emulator.IsAlternateScreen
             ? ComputeSemanticColumns(line, cols)
             : null;
         int col = 0;
@@ -1662,8 +1712,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             return null;
         }
-        var sb = new StringBuilder(lastNonBlank + 1);
-        var colByChar = new List<int>(lastNonBlank + 1);
+        StringBuilder sb = _semanticLineBuilder.Clear();
+        List<int> colByChar = _semanticColByChar;
+        colByChar.Clear();
         for (int i = 0; i <= lastNonBlank; i++)
         {
             TerminalCell cell = line[i];
@@ -1683,7 +1734,14 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             return null;
         }
-        var byColumn = new SemanticKind?[cols];
+
+        // 复用成员缓冲(按需扩容):调用方只在渲染完当前行前读取,下一行覆写安全。
+        if (_semanticByColumn.Length < cols)
+        {
+            _semanticByColumn = new SemanticKind?[cols];
+        }
+        SemanticKind?[] byColumn = _semanticByColumn;
+        Array.Clear(byColumn, 0, cols);
         foreach (SemanticSpan span in spans)
         {
             int end = Math.Min(span.End, colByChar.Count);
@@ -2222,12 +2280,17 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         base.OnPointerMoved(e);
 
         // 折叠列悬停提示:指针在折叠列上时记住其绝对行(用于画 ▾ 折叠手柄),移出则清除。
+        // 空白行(最后一行输出之下)不给提示——那里折叠无意义且极易误点(内容消失事故)。
         if (ShowFoldMarker && !_selecting)
         {
             Point gp = e.GetPosition(this);
             int hover = Gutter.IsFoldColumnHit(gp.X)
                 ? AbsoluteForScreenRow((int)(gp.Y / CellHeightForTest))
                 : -1;
+            if (hover != -1 && !IsFoldTargetRow(hover))
+            {
+                hover = -1;
+            }
             if (hover != _foldHoverAbs)
             {
                 _foldHoverAbs = hover;

--- a/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
+++ b/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
@@ -95,10 +95,20 @@ public sealed partial class SemanticMatcher
             return byKind != 0 ? byKind : a.Start.CompareTo(b.Start);
         });
         var chosen = new List<SemanticSpan>();
-        // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+        // 手写重叠检测:此方法在渲染热路径上按行调用,LINQ Any 的委托 + 枚举器分配
+        // 会随行数 × 帧率放大;span 数量很小,平方级比较本身无碍。
         foreach (SemanticSpan span in raw)
         {
-            bool overlaps = chosen.Any(kept => span.Start < kept.End && kept.Start < span.End);
+            bool overlaps = false;
+            for (int i = 0; i < chosen.Count; i++)
+            {
+                SemanticSpan kept = chosen[i];
+                if (span.Start < kept.End && kept.Start < span.End)
+                {
+                    overlaps = true;
+                    break;
+                }
+            }
             if (!overlaps)
             {
                 chosen.Add(span);

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -117,11 +117,15 @@ public class App : Application
             StartupRegistration.Apply(_startupSettings?.General.LaunchAtStartup == true);
 
             // 过期会话/传输日志清理(设置 → 常规/文件传输 → 日志保留天数),后台执行。
-            SessionLogService.CleanupExpired(_startupSettings?.General.LogRetentionDays ?? 30);
-            TransferLogService.CleanupExpired(
-                _startupSettings?.Transfer.LogDirectory,
-                _startupSettings?.Transfer.TransferLogRetentionDays ?? 30
-            );
+            // 真的放到后台:目录枚举+删除是磁盘 IO,日志多时同步跑会拖慢首帧。
+            int logRetentionDays = _startupSettings?.General.LogRetentionDays ?? 30;
+            string? transferLogDirectory = _startupSettings?.Transfer.LogDirectory;
+            int transferLogRetentionDays = _startupSettings?.Transfer.TransferLogRetentionDays ?? 30;
+            _ = Task.Run(() =>
+            {
+                SessionLogService.CleanupExpired(logRetentionDays);
+                TransferLogService.CleanupExpired(transferLogDirectory, transferLogRetentionDays);
+            });
 
             // 过期会话录制清理(随终端会话日志的保留天数)。
             if (_serviceProvider?.GetService<ISessionRecordingStore>() is { } recordingStore)
@@ -154,16 +158,15 @@ public class App : Application
             }
 
             // 云同步(设置 → 云同步):启动后台拉取一次;设置保存后标记本地改动并防抖推送。
+            // 迁移标记并入 WireAutoSync 的后台链执行("先标记、后同步"的顺序不变),
+            // 不再用 GetResult() 在 UI 线程上等一次磁盘写。
             if (_serviceProvider?.GetService<IGistSyncService>() is { } syncService)
             {
-                if (quickCommandLoad?.Migrated == true)
-                {
-                    syncService.MarkLocalChangedAsync().GetAwaiter().GetResult();
-                }
                 WireAutoSync(
                     syncService,
                     _serviceProvider.GetService<ISettingsService>(),
-                    _serviceProvider.GetService<IQuickCommandRepository>()
+                    _serviceProvider.GetService<IQuickCommandRepository>(),
+                    markLocalChangedFirst: quickCommandLoad?.Migrated == true
                 );
             }
 
@@ -188,13 +191,20 @@ public class App : Application
     private void WireAutoSync(
         IGistSyncService syncService,
         ISettingsService? settingsService,
-        IQuickCommandRepository? quickCommandRepository
+        IQuickCommandRepository? quickCommandRepository,
+        bool markLocalChangedFirst = false
     )
     {
         _ = Task.Run(async () =>
         {
             try
             {
+                if (markLocalChangedFirst)
+                {
+                    // 快捷命令迁移改动了本地数据:必须先落"本地已变"标记,再做启动同步,
+                    // 否则拉取可能把刚迁移的结构覆盖回旧远端。
+                    await syncService.MarkLocalChangedAsync();
+                }
                 SyncSettings config = await syncService.GetSyncSettingsAsync();
                 if (config is { Enabled: true, AutoSync: true })
                 {

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
@@ -87,6 +87,32 @@ public partial class DockGroupControl : UserControl
     private void OnDocumentsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
         UpdateContent();
 
+    /// <summary>
+    /// (重新)挂到可视树时恢复订阅与内容。分离处理器为避免双父级会把 Target 置空并退订
+    /// 全部事件——原设计假设"摘下的控件必被丢弃",但任何祖先级的摘挂(窗口内容重排、
+    /// 宿主容器切换、托盘隐藏恢复)都会让**同一实例**重挂:不在这里自愈,重挂回来的
+    /// 就是一个既收不到事件又没有内容的死控件,表现为"终端内容凭空消失"
+    /// (2026-07-23 实证,DockContentBlankHuntTests 序列 4 锁定)。
+    /// </summary>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        if (Workspace is null || Group is not { } group)
+        {
+            return; // 尚未 Initialize(首挂由 Initialize 完成接线),无从自愈。
+        }
+        // 先退订再订阅:首挂紧跟 Initialize 之后,不加防重会双份订阅。
+        group.PropertyChanged -= OnGroupPropertyChanged;
+        group.Documents.CollectionChanged -= OnDocumentsChanged;
+        group.PropertyChanged += OnGroupPropertyChanged;
+        group.Documents.CollectionChanged += OnDocumentsChanged;
+        if (ContentHost.Target is null)
+        {
+            UpdateContent();
+            UpdateActiveTabIndicator();
+        }
+    }
+
     /// <summary>从可视树分离时退订标签组事件,并释放对缓存视图的引用以避免双父级。</summary>
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
@@ -98,7 +124,8 @@ public partial class DockGroupControl : UserControl
             group.PropertyChanged -= OnGroupPropertyChanged;
             group.Documents.CollectionChanged -= OnDocumentsChanged;
         }
-        // 结构重建时本控件被丢弃;释放对缓存视图的引用,避免下一个宿主收养时双父级。
+        // 释放对缓存视图的引用,避免下一个宿主收养时双父级;若本实例被重挂,
+        // OnAttachedToVisualTree 会自愈(重订阅 + 重填内容)。
         ContentHost.Target = null;
     }
 

--- a/src/VelaShell/Services/CommandHistoryService.cs
+++ b/src/VelaShell/Services/CommandHistoryService.cs
@@ -16,6 +16,10 @@ public sealed class CommandHistoryService(IAppDataStore? dataStore)
 
     private readonly List<string> _entries = [];
 
+    // 落盘防抖:命令密集执行(脚本粘贴、快速连敲)时,每条都全量序列化 500 条历史
+    // 纯属浪费;合并成静默 1 秒后一次落盘。窗口极小,丢失面可忽略(仅进程被杀时的最后一秒)。
+    private bool _savePending;
+
     /// <summary>最近优先的历史快照。</summary>
     public IReadOnlyList<string> Entries => _entries;
 
@@ -55,14 +59,32 @@ public sealed class CommandHistoryService(IAppDataStore? dataStore)
         {
             _entries.RemoveRange(MaxEntries, _entries.Count - MaxEntries);
         }
-        _ = SaveAsync();
+        ScheduleSave();
     }
 
-    /// <summary>清空全部历史(设置页可挂此入口)。</summary>
+    /// <summary>清空全部历史(设置页可挂此入口)。用户显式操作,立即落盘不防抖。</summary>
     public void Clear()
     {
         _entries.Clear();
         _ = SaveAsync();
+    }
+
+    private void ScheduleSave()
+    {
+        if (_savePending)
+        {
+            return; // 已有待落盘的防抖任务,本次改动搭它的便车。
+        }
+        _savePending = true;
+        _ = FlushAfterQuietPeriodAsync();
+    }
+
+    private async Task FlushAfterQuietPeriodAsync()
+    {
+        // 无 ConfigureAwait(false):延迟结束后回到 UI 线程再快照 _entries(本类的线程契约)。
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        _savePending = false;
+        await SaveAsync();
     }
 
     private async Task SaveAsync()

--- a/src/VelaShell/Services/Syntax/SyntaxHighlightingService.cs
+++ b/src/VelaShell/Services/Syntax/SyntaxHighlightingService.cs
@@ -78,7 +78,7 @@ public static class SyntaxHighlightingService
                     {
                         continue;
                     }
-                    using XmlReader reader = XmlReader.Create(stream);
+                    using var reader = XmlReader.Create(stream);
                     IHighlightingDefinition definition = HighlightingLoader.Load(reader, HighlightingManager.Instance);
                     HighlightingManager.Instance.RegisterHighlighting(definition.Name, extensions, definition);
                 }

--- a/src/VelaShell/Services/ZModem/ZModemTransferObserver.cs
+++ b/src/VelaShell/Services/ZModem/ZModemTransferObserver.cs
@@ -20,6 +20,13 @@ internal sealed class ZModemTransferObserver(FileTransferViewModel fileTransfer)
     // 每个文件项的测速起点(用于估算速率与剩余时间);后台线程读写,用并发字典。
     private readonly ConcurrentDictionary<Guid, DateTimeOffset> _startedAt = [];
 
+    /// <summary>进度上报的最小间隔:引擎每个 subpacket(默认 1KB)回调一次,
+    /// 不节流的话 100MB 传输就是约十万次 UI 线程 Post + 闭包/进度对象/字符串分配风暴,
+    /// 高吞吐时肉眼可见地卡 UI(SFTP 路径早有同款节流 ProgressThrottle,此处补齐)。</summary>
+    private const int ProgressMinIntervalMs = 100;
+
+    private readonly ConcurrentDictionary<Guid, long> _lastProgressTick = [];
+
     /// <inheritdoc />
     public void OnFileStarted(ZModemTransferItem item)
     {
@@ -49,6 +56,13 @@ internal sealed class ZModemTransferObserver(FileTransferViewModel fileTransfer)
     /// <inheritdoc />
     public void OnFileProgress(ZModemTransferItem item)
     {
+        // 时间片节流:片内的 tick 直接丢弃(完成回调必带 100% 的末次刷新,不会丢终值)。
+        long now = Environment.TickCount64;
+        long last = _lastProgressTick.GetOrAdd(item.Id, now - ProgressMinIntervalMs - 1);
+        if (now - last < ProgressMinIntervalMs || !_lastProgressTick.TryUpdate(item.Id, now, last))
+        {
+            return;
+        }
         double speed = ComputeSpeed(item);
         Guid id = item.Id;
         long bytes = item.BytesTransferred;
@@ -74,6 +88,7 @@ internal sealed class ZModemTransferObserver(FileTransferViewModel fileTransfer)
     public void OnFileCompleted(ZModemTransferItem item)
     {
         _startedAt.TryRemove(item.Id, out _);
+        _lastProgressTick.TryRemove(item.Id, out _);
         Guid id = item.Id;
         long bytes = item.BytesTransferred;
         long? size = item.Size;
@@ -105,6 +120,7 @@ internal sealed class ZModemTransferObserver(FileTransferViewModel fileTransfer)
     public void OnFileSkipped(ZModemTransferItem item)
     {
         _startedAt.TryRemove(item.Id, out _);
+        _lastProgressTick.TryRemove(item.Id, out _);
         Guid id = item.Id;
         Dispatcher.UIThread.Post(() =>
         {

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1104,6 +1104,27 @@ public class MainWindowViewModel : ReactiveObject
     }
 
     /// <summary>
+    /// 窗口最小化/隐入托盘时暂停状态栏指标与延迟轮询(由视图按 WindowState 驱动):
+    /// 用户看不见状态栏时,每秒一次的 SSH exec 探测 + 周期 ICMP 纯属浪费 CPU/网络,
+    /// 还会阻止系统进入低功耗。恢复可见即重启,下一秒就有新数据。
+    /// </summary>
+    public void SetStatusPollingSuspended(bool suspended)
+    {
+        if (_statusMetricsTimer is null)
+        {
+            return;
+        }
+        if (suspended)
+        {
+            _statusMetricsTimer.Stop();
+        }
+        else if (!_statusMetricsTimer.IsEnabled)
+        {
+            _statusMetricsTimer.Start();
+        }
+    }
+
+    /// <summary>
     /// 状态栏延迟指示(设计 gzmsb sbLatency,之前缺失):每 3 秒对活动标签的主机
     /// 发一次 ICMP ping,RTT 写入 tab.Latency(经既有 WhenAnyValue 管道刷新状态栏)。
     /// 目标禁 ICMP 或解析失败时清空显示,不打扰;不用 TCP 探测以免刷爆 sshd 日志。

--- a/src/VelaShell/ViewModels/TransferItemViewModel.cs
+++ b/src/VelaShell/ViewModels/TransferItemViewModel.cs
@@ -160,13 +160,25 @@ public class TransferItemViewModel : ReactiveObject
     /// <param name="progress">最新的传输进度信息。</param>
     public void UpdateProgress(TransferProgress progress)
     {
+        // 只有承载值真变了才广播派生属性:节流后的进度流里仍可能出现同值 tick
+        // (小文件、暂停的连接),白发一次 InfoLine/ProgressText 就是白做一次字符串拼装与重绑。
+        string speed = FormatSpeed(progress.SpeedBytesPerSecond);
+        string remaining = FormatTimeRemaining(progress.EstimatedTimeRemaining);
+        bool changed = _progress != progress.Percentage
+                       || _transferredBytes != progress.BytesTransferred
+                       || _totalSize != progress.TotalBytes
+                       || _speed != speed
+                       || _timeRemaining != remaining;
         Progress = progress.Percentage;
         TransferredBytes = progress.BytesTransferred;
         TotalSize = progress.TotalBytes;
-        Speed = FormatSpeed(progress.SpeedBytesPerSecond);
-        TimeRemaining = FormatTimeRemaining(progress.EstimatedTimeRemaining);
-        this.RaisePropertyChanged(nameof(InfoLine));
-        this.RaisePropertyChanged(nameof(ProgressText));
+        Speed = speed;
+        TimeRemaining = remaining;
+        if (changed)
+        {
+            this.RaisePropertyChanged(nameof(InfoLine));
+            this.RaisePropertyChanged(nameof(ProgressText));
+        }
     }
 
     /// <summary>将字节数格式化为带单位(B/KB/MB/GB/TB)的可读文本。</summary>

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -49,6 +49,11 @@ public partial class MainWindow : Window
         {
             grips.IsVisible = WindowState == WindowState.Normal;
         }
+        // 最小化(含隐入托盘)时暂停状态栏的每秒 SSH 探测与周期 ICMP,恢复时重启。
+        if (change.Property == WindowStateProperty && DataContext is MainWindowViewModel vm)
+        {
+            vm.SetStatusPollingSuspended(WindowState == WindowState.Minimized);
+        }
     }
 
     /// <summary>

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -130,6 +130,11 @@ public partial class TerminalTabView : UserControl
     private string? _suppressedInput;
     private int _suggestSeq;
 
+    // 建议查询防抖:每个可打印字节都触发 InputChanged,连打时不该每键都对
+    // 500 条历史全量过滤 + 排序 + 分配一轮(幽灵文本的本地即时消耗不受影响,手感不变)。
+    private IDisposable? _suggestDebounce;
+    private const int SuggestDebounceMs = 90;
+
     /// <summary>幽灵文本对应的完整候选命令(接受时据此设置抑制值);null 即无幽灵。</summary>
     private string? _ghostFull;
 
@@ -220,8 +225,20 @@ public partial class TerminalTabView : UserControl
         }
 
         // 面板未开时结果落到幽灵文本;面板已开(Alt+Enter 召出)则持续跟随键入刷新列表。
-        bool panelOpen = SuggestPopup.IsOpen;
-        _ = UpdateSuggestionsAsync(input, panelOpen ? 20 : 8, openPanel: panelOpen);
+        // 查询防抖:停键 90ms 后才真正打提供者;输入与面板状态在触发时重新取,
+        // 避免用调度时刻的陈旧快照查询。
+        _suggestDebounce?.Dispose();
+        _suggestDebounce = DispatcherTimer.RunOnce(() =>
+        {
+            _suggestDebounce = null;
+            string current = EffectiveInput();
+            if (string.IsNullOrEmpty(current) || current == _suppressedInput)
+            {
+                return;
+            }
+            bool panelOpen = SuggestPopup.IsOpen;
+            _ = UpdateSuggestionsAsync(current, panelOpen ? 20 : 8, openPanel: panelOpen);
+        }, TimeSpan.FromMilliseconds(SuggestDebounceMs));
     }
 
     /// <summary>
@@ -831,6 +848,8 @@ public partial class TerminalTabView : UserControl
 
     private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
+        _suggestDebounce?.Dispose();
+        _suggestDebounce = null;
         DismissSuggestions(suppress: false);
         // 脱离可视树后不该再响应跟踪器(重新 attach 时 HookSuggestions 会幂等重订)。
         _suggestVm?.InputTracker.InputChanged -= OnTrackedInputChanged;

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
@@ -1,0 +1,78 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests.Emulation;
+
+/// <summary>
+/// <see cref="TerminalCell" /> 的内存布局与组合标记驻留池回归:
+/// 回滚缓冲可达数百万格,这里锁住"单元格不含托管引用(GC 不逐格扫描)"的优化成果。
+/// 组合字符一律用 \u 转义书写,避免源文件编码链偷偷把 e+U+0301 规范化成预组合字符。
+/// </summary>
+[TestClass]
+[TestCategory("CellMemory")]
+public class TerminalCellMemoryTests
+{
+    private const string AcuteAccent = "\u0301"; // 组合尖音符
+    private const string GraveAccent = "\u0300"; // 组合重音符
+    private const string Diaeresis = "\u0308";   // 组合分音符
+
+    [TestMethod]
+    public void TerminalCell_ContainsNoManagedReferences()
+    {
+        // 这是本结构的内存契约:一旦有人往 cell 里加回引用类型字段,
+        // 整个回滚缓冲会重新变成 GC 扫描对象,数百万格的代价悄然回归。
+        Assert.IsFalse(
+            RuntimeHelpers.IsReferenceOrContainsReferences<TerminalCell>(),
+            "TerminalCell 必须保持 blittable:组合标记等引用数据请走 CombiningPool 驻留索引。");
+    }
+
+    [TestMethod]
+    public void Combining_RoundTripsThroughPool_AndPreservesEqualitySemantics()
+    {
+        TerminalCell cell = TerminalCell.Empty;
+        cell.Rune = 'e';
+        Assert.IsNull(cell.Combining);
+
+        cell.Combining = AcuteAccent;
+        Assert.AreEqual(AcuteAccent, cell.Combining);
+
+        TerminalCell same = TerminalCell.Empty;
+        same.Rune = 'e';
+        same.Combining = AcuteAccent;
+        Assert.AreEqual(cell, same, "相同组合标记经驻留后必须等值(同串同索引)。");
+
+        TerminalCell different = TerminalCell.Empty;
+        different.Rune = 'e';
+        different.Combining = GraveAccent;
+        Assert.AreNotEqual(cell, different);
+
+        cell.Combining = null;
+        Assert.IsNull(cell.Combining);
+        Assert.AreEqual(0, cell.CombiningIndex);
+    }
+
+    [TestMethod]
+    public void Combining_AppendText_EmitsBaseRunePlusMarks()
+    {
+        TerminalCell cell = TerminalCell.Empty;
+        cell.Rune = 'a';
+        cell.Combining = Diaeresis;
+        var sb = new StringBuilder();
+        cell.AppendText(sb);
+        Assert.AreEqual("a" + Diaeresis, sb.ToString());
+        Assert.AreEqual("a" + Diaeresis, cell.GetText());
+    }
+
+    [TestMethod]
+    public void Emulator_CombiningMark_FoldsIntoPrecedingCell()
+    {
+        // 端到端:经 VT 流写入的组合字符仍折叠进基础格(驻留池改造不改变行为)。
+        var emulator = new TerminalEmulator(20, 4);
+        emulator.Feed(Encoding.UTF8.GetBytes("e" + AcuteAccent));
+        TerminalCell cell = emulator.Screen.ViewLine(0)[0];
+        Assert.AreEqual('e', cell.Rune);
+        Assert.AreEqual(AcuteAccent, cell.Combining);
+        Assert.AreEqual("e" + AcuteAccent, cell.GetText());
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -72,6 +72,38 @@ public class GutterFoldUiTests
     }
 
     [TestMethod]
+    public void RealPointerClick_OnBlankRowBelowOutput_DoesNotFold()
+    {
+        // 2026-07-23 内容消失事故回归:最后一行输出之下的空白屏幕行也是合法活动屏行,
+        // 此前点击其折叠列会把上方内容整段折叠——用户视角就是"终端内容凭空消失"。
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ShowFoldMarker = true };
+            control.Feed(Encoding.UTF8.GetBytes("L0\r\nL1\r\nL2\r\nL3\r\nL4\r\nL5"));
+
+            var window = new Window { Width = 480, Height = 320, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            GutterLayout gutter = control.GutterForTest;
+
+            // 内容行可折叠,空白行不可(直接断言守卫谓词)。
+            Assert.IsTrue(control.IsFoldTargetRow(3), "有内容的行应可作为折叠目标。");
+            Assert.IsFalse(control.IsFoldTargetRow(10), "输出之下的空白行不得作为折叠目标。");
+
+            // 真实点击空白区域的折叠列:必须毫无反应。
+            var blankPoint = new Point(gutter.FoldLeft + 2, 10 * control.CellHeightForTest + 2);
+            Assert.IsTrue(gutter.IsFoldColumnHit(blankPoint.X));
+            window.MouseDown(blankPoint, MouseButton.Left);
+            window.MouseUp(blankPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreEqual(0, control.FoldCountForTest, "点击空白行的折叠列不得产生折叠。");
+        });
+    }
+
+    [TestMethod]
     public void GutterContextMenu_HasFourToggles_ReflectingCurrentState()
     {
         OnUi(() =>

--- a/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using VelaShell.Terminal;
 using VelaShell.Terminal.Emulation;
 
 namespace VelaShell.Terminal.Tests;

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -293,7 +293,7 @@ public class TerminalBridgeTests
         _shellStream.CanRead.Returns(false);
         _shellStream.CanWrite.Returns(true);
 
-        var gate = new object();
+        object gate = new object();
         int inFlight = 0, maxInFlight = 0;
         var received = new MemoryStream();
         _shellStream.WriteAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())

--- a/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
+++ b/tests/VelaShell.Tests/Services/SyncDebounceLifecycleTests.cs
@@ -289,7 +289,7 @@ public class SyncDebounceLifecycleTests
         // Lock.EnterScope(),走的**不是** Monitor。因此 Monitor.IsEntered(gate) 恒为 false,
         // 哪怕锁确实被持有 —— 必须用 Lock.IsHeldByCurrentThread 才测得准。
         // (这条测试曾因此假红:被测的不变量一直是成立的,错的是探针。)
-        Lock gate = (Lock)typeof(SyncDebounceLifecycle)
+        var gate = (Lock)typeof(SyncDebounceLifecycle)
             .GetField("_gate", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .GetValue(lifecycle)!;
         bool gateHeld = false;

--- a/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
@@ -83,10 +83,10 @@ public sealed class ConnectionProfileViewUiTests
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();
 
-            var indicator = window.FindControl<Border>("ProtoTabIndicator")
+            Border indicator = window.FindControl<Border>("ProtoTabIndicator")
                 ?? throw new AssertFailedException("ProtoTabIndicator not found.");
-            var sshTab = window.FindControl<Button>("SshTab")!;
-            var sftpTab = window.FindControl<Button>("SftpTab")!;
+            Button sshTab = window.FindControl<Button>("SshTab")!;
+            Button sftpTab = window.FindControl<Button>("SftpTab")!;
 
             // 初始:下划线对齐 SSH。
             Assert.IsTrue(indicator.IsVisible);

--- a/tests/VelaShell.Tests/Views/DockContentBlankHuntTests.cs
+++ b/tests/VelaShell.Tests/Views/DockContentBlankHuntTests.cs
@@ -1,0 +1,116 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Controls;
+using VelaShell.Docking.Controls;
+using VelaShell.Docking.Model;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 2026-07-23 "点击回终端后内容消失"回归猎捕:穷举激活/切换/重挂序列,
+/// 断言每一步之后内容宿主的不变量(基值透明度=1、无 settling 残留、Child=激活视图、有效可见)。
+/// 任何序列违反不变量即为确定性罪证。
+/// </summary>
+[TestClass]
+[TestCategory("DockBlankHunt")]
+public sealed class DockContentBlankHuntTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(DockContentBlankHuntTests).Assembly);
+
+    [TestMethod]
+    public void ActivationSequences_NeverLeaveContentHostInvisible()
+    {
+        _session.Dispatch(() =>
+        {
+            var workspace = new DockWorkspace();
+            var docA = new TestDocument("alpha");
+            var docB = new TestDocument("beta");
+            workspace.AddDocument(docA);
+            workspace.AddDocument(docB);
+
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 800, Height = 480, Content = dock };
+            window.Show();
+            Pump(window);
+
+            ReparentingHost host = dock.GetVisualDescendants().OfType<ReparentingHost>().Single();
+            AssertVisible(host, docB, "初始状态(后加入者激活)");
+
+            // 序列 1:普通来回切换。
+            workspace.ActivateDocument(docA);
+            Pump(window);
+            AssertVisible(host, docA, "A←B 切换后");
+            workspace.ActivateDocument(docB);
+            Pump(window);
+            AssertVisible(host, docB, "B←A 切换后");
+
+            // 序列 2:重复激活当前文档(点击回终端内容区走的正是这条:OnAnyPointerPressed
+            // → workspace.ActivateDocument(当前激活文档))。
+            workspace.ActivateDocument(docB);
+            workspace.ActivateDocument(docB);
+            Pump(window);
+            AssertVisible(host, docB, "重复激活当前文档后");
+
+            // 序列 3:同一帧内连续切换(双 PropertyChanged,考验动效代次守卫),
+            // 中间不跑任何布局/派发。
+            workspace.ActivateDocument(docA);
+            workspace.ActivateDocument(docB);
+            workspace.ActivateDocument(docA);
+            Pump(window);
+            AssertVisible(host, docA, "同帧三连切换后");
+
+            // 序列 4:整棵 dock 从窗口摘下再挂回(标签拖拽/布局重建的路径)。
+            window.Content = null;
+            Pump(window);
+            window.Content = dock;
+            Pump(window);
+            ReparentingHost rehost = dock.GetVisualDescendants().OfType<ReparentingHost>().Single();
+            AssertVisible(rehost, docA, "整树摘下重挂后");
+
+            // 序列 5:重挂后立即切换再切回。
+            workspace.ActivateDocument(docB);
+            Pump(window);
+            workspace.ActivateDocument(docA);
+            Pump(window);
+            AssertVisible(rehost, docA, "重挂后再切换回 A");
+
+            window.Close();
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static void AssertVisible(ReparentingHost host, TestDocument active, string stage)
+    {
+        Assert.AreSame(active.View, host.Target, $"{stage}:Target 应为激活文档的视图。");
+        Assert.AreSame(host.Target, host.Child, $"{stage}:视图必须已被收养为 Child。");
+        Assert.IsFalse(host.Classes.Contains("settling"), $"{stage}:settling 类残留(透明度会卡在 0.65)。");
+        Assert.IsNotNull(host.Transitions, $"{stage}:Transitions 未恢复(说明动效收尾回调没跑)。");
+        double baseOpacity = host.GetBaseValue(Visual.OpacityProperty).GetValueOrDefault(host.Opacity);
+        Assert.AreEqual(1.0, baseOpacity, 0.001, $"{stage}:内容宿主基值透明度必须回到 1。");
+        Assert.IsTrue(host.IsEffectivelyVisible, $"{stage}:内容宿主必须有效可见。");
+        Assert.IsTrue(active.View!.IsEffectivelyVisible, $"{stage}:激活视图必须有效可见。");
+    }
+
+    private sealed class TestDocument : DockDocument, IDockViewProvider
+    {
+        public TestDocument(string title) => Title = title;
+
+        public Control? View { get; private set; }
+
+        public Control CreateView() => View ??= new Border { Background = Brushes.Transparent, MinHeight = 10, MinWidth = 10 };
+    }
+}

--- a/tests/VelaShell.Tests/Views/DockMotionUiTests.cs
+++ b/tests/VelaShell.Tests/Views/DockMotionUiTests.cs
@@ -1,8 +1,8 @@
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
-using Avalonia.Layout;
 using Avalonia.Headless;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
@@ -118,7 +118,7 @@ public sealed class DockMotionUiTests
         // 现值是动画中间值,基值才是应当停下的终点 —— 断言与真实时间彻底解耦。
         Control container = tabs.ContainerFromItem(document)
             ?? throw new AssertFailedException("Active tab has no realized container.");
-        Visual panel = (Visual)indicator.GetVisualParent()!;
+        Visual panel = indicator.GetVisualParent()!;
         Point origin = container.TranslatePoint(default, panel) ?? default;
         double actualX = indicator.GetBaseValue(Visual.RenderTransformProperty).GetValueOrDefault()?.Value.M31 ?? -1;
         double actualWidth = indicator.GetBaseValue(Layoutable.WidthProperty).GetValueOrDefault(double.NaN);


### PR DESCRIPTION
聚焦终端渲染热路径、内存占用、服务层与 UI 事件多项优化，全部通过 1061 项测试回归。语义高亮在备用屏下跳过，相关对象成员复用，去除 LINQ Any，侧栏文本与折叠列画笔均引入缓存，输出合批与滚动事件优化，ReflowResize 降低分配。默认回滚行数降至 10000，TerminalCell 结构 blittable 并移除托管引用，新增端到端内存测试。ZModem 进度与命令建议查询节流，IO 操作后台化，历史落盘防抖，状态栏指标按窗口状态暂停。DockGroupControl 支持自愈，折叠列点击空白行不再误触发。所有缓存有上界，事件/定时器闭环，启动内存无回归，稳态内存与分配压力大幅下降。