### PR TITLE
支持SFTP上传保留时间戳功能

### DIFF
--- a/src/VelaShell.Core/Sftp/SftpService.cs
+++ b/src/VelaShell.Core/Sftp/SftpService.cs
@@ -53,7 +53,7 @@ public class SftpService(
         string fileName = Path.GetFileName(localPath);
         var reporter = new ProgressThrottle(progress, fileName, totalBytes);
         Action<ulong>? onBytes = reporter.IsEnabled ? bytes => reporter.Report((long)bytes) : null;
-        (long uploadBps, _, _) = await GetTransferTuningAsync().ConfigureAwait(false);
+        (long uploadBps, _, bool preserveTimestamps) = await GetTransferTuningAsync().ConfigureAwait(false);
 
         // 以此刻的远端状态重新核实续传起点;核实不通过会抛错,核实为"无可续"则整份重传。
         if (resumeOffset > 0)
@@ -77,6 +77,25 @@ public class SftpService(
 
             // 节流会丢弃最后一个时间片内的上报,不强制收尾进度条会停在 99%。
             reporter.ReportFinal(totalBytes);
+
+            // 保留时间戳(设置 → 文件传输,scp -p 语义):把远端 mtime 设回本地源文件的
+            // mtime(下载方向的对等实现见 DownloadFileAsync)。尽力而为——个别服务器
+            // 禁 setstat,不能让一次时间戳设置失败把已完成的上传标成失败。
+            if (preserveTimestamps)
+            {
+                try
+                {
+                    await client.SetLastWriteTimeAsync(remotePath, fileInfo.LastWriteTimeUtc, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // 时间戳只是尽力而为。
+                }
+            }
         }
         catch (Exception ex) when (cancellationToken.IsCancellationRequested && ex is not OperationCanceledException)
         {

--- a/src/VelaShell.Core/Ssh/ISftpClientWrapper.cs
+++ b/src/VelaShell.Core/Ssh/ISftpClientWrapper.cs
@@ -88,6 +88,12 @@ public interface ISftpClientWrapper : IDisposable
     Task ChangePermissionsAsync(string path, short mode, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// 设置远端条目的最后修改时间(SFTP setstat)。用于"保留时间戳"的上传收尾
+    /// (scp -p 语义):上传完成后把远端 mtime 设回本地源文件的 mtime。
+    /// </summary>
+    Task SetLastWriteTimeAsync(string path, DateTimeOffset lastWriteTime, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// 以读或写方式打开远端文件。
     /// <para>
     /// **实现必须返回可 Seek 的流**(<see cref="Stream.CanSeek" /> 为 <c>true</c>):

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
@@ -223,6 +223,18 @@ public sealed class TmdsSftpClientWrapper(Func<Task<SftpClient>> clientFactory) 
         }, ct);
     }
 
+    /// <summary>设置远端条目的最后修改时间(SFTP setstat;协议要求 atime/mtime 成对下发,atime 取同值)。</summary>
+    public Task SetLastWriteTimeAsync(string path, DateTimeOffset lastWriteTime, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return GuardedAsync(async () =>
+        {
+            await EnsureClient()
+                .SetAttributesAsync(path, times: (lastWriteTime, lastWriteTime), cancellationToken: ct)
+                .ConfigureAwait(false);
+        }, ct);
+    }
+
     /// <summary>
     /// Opens a file at the specified path on the SFTP server with the given mode and access. If the client is not connected, an <see cref="InvalidOperationException" /> is thrown.
     /// </summary>
@@ -382,7 +394,7 @@ public sealed class TmdsSftpClientWrapper(Func<Task<SftpClient>> clientFactory) 
         return entries;
     }
 
-    private static SftpEntry MapEntry(string fullPath, FileEntryAttributes attrs)
+    internal static SftpEntry MapEntry(string fullPath, FileEntryAttributes attrs)
     {
         string fn = Path.GetFileName(fullPath);
         UnixFilePermissions p = attrs.Permissions;
@@ -392,7 +404,11 @@ public sealed class TmdsSftpClientWrapper(Func<Task<SftpClient>> clientFactory) 
             FullName = fullPath,
             Length = attrs.Length,
             IsDirectory = attrs.FileType == UnixFileType.Directory,
-            LastWriteTime = attrs.LastWriteTime.DateTime,
+            // 必须 LocalDateTime 而非 .DateTime:后者把 DateTimeOffset 的偏移剥掉,留下
+            // "UTC 墙钟数 + Kind=Unspecified" —— 文件浏览器显示成 +0 时区,下载保留时间戳
+            // (File.SetLastWriteTime 按本地解读)还会再错一次时差。SFTP mtime 是 Unix 纪元秒,
+            // 换算本地时间展示才与 ls -l / date 一致。
+            LastWriteTime = attrs.LastWriteTime.LocalDateTime,
             UserId = attrs.Uid,
             GroupId = attrs.Gid,
             OwnerCanRead = (p & UnixFilePermissions.UserRead) != 0,

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -39,6 +39,56 @@ public class SftpServiceTests
     }
 
     [TestMethod]
+    public async Task UploadFileAsync_PreserveTimestampsOn_SetsRemoteMtimeToLocalFileMtime()
+    {
+        // 默认(无设置服务)保留时间戳 = true:上传完成后必须把远端 mtime 设回本地源文件的 mtime(scp -p 语义)。
+        string localPath = Path.Combine(Path.GetTempPath(), $"vela-mtime-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(localPath, "timestamp probe");
+        var knownUtc = new DateTime(2026, 7, 20, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(localPath, knownUtc);
+        try
+        {
+            _sftpClient.UploadAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<Action<ulong>>(), Arg.Any<CancellationToken>())
+                       .Returns(Task.CompletedTask);
+
+            await _sftpService.UploadFileAsync(_sessionId, localPath, "/home/user/up.txt");
+
+            await _sftpClient.Received(1).SetLastWriteTimeAsync(
+                "/home/user/up.txt",
+                Arg.Is<DateTimeOffset>(d => d.UtcDateTime == knownUtc),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            File.Delete(localPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task UploadFileAsync_PreserveTimestampsOff_DoesNotTouchRemoteMtime()
+    {
+        var settings = Substitute.For<VelaShell.Core.Data.ISettingsService>();
+        settings.GetSettingsAsync().Returns(new AppSettings { Transfer = { PreserveTimestamps = false } });
+        var service = new SftpService(_connectionService, _ => _sftpClient, settings);
+        string localPath = Path.Combine(Path.GetTempPath(), $"vela-mtime-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(localPath, "timestamp probe");
+        try
+        {
+            _sftpClient.UploadAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<Action<ulong>>(), Arg.Any<CancellationToken>())
+                       .Returns(Task.CompletedTask);
+
+            await service.UploadFileAsync(_sessionId, localPath, "/home/user/up.txt");
+
+            await _sftpClient.DidNotReceive().SetLastWriteTimeAsync(
+                Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            File.Delete(localPath);
+        }
+    }
+
+    [TestMethod]
     public async Task GetWorkingDirectoryAsync_ReturnsClientWorkingDirectory()
     {
         _sftpClient.WorkingDirectory.Returns("/home/testuser");

--- a/tests/VelaShell.Core.Tests/Ssh/TmdsSftpEntryMappingTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/TmdsSftpEntryMappingTests.cs
@@ -1,0 +1,38 @@
+using Tmds.Ssh;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Ssh;
+
+namespace VelaShell.Core.Tests.Ssh;
+
+/// <summary>
+/// Tmds 目录条目 → <see cref="SftpEntry" /> 映射回归:修改时间必须换算为本地时区。
+/// 2026-07-23 事故:曾用 <c>DateTimeOffset.DateTime</c> 剥掉偏移,文件浏览器显示 +0 时区
+/// 时间(与系统 date -R 的 +8 不符),下载保留时间戳还会再错一次时差。
+/// </summary>
+[TestClass]
+[TestCategory("SftpMapping")]
+public class TmdsSftpEntryMappingTests
+{
+    [TestMethod]
+    public void MapEntry_ConvertsLastWriteTimeToLocalKindAndInstant()
+    {
+        // SFTP mtime 本质是 Unix 纪元秒(UTC 瞬间);以一个确定的 UTC 时刻构造。
+        var utcInstant = new DateTimeOffset(2026, 7, 23, 1, 14, 55, TimeSpan.Zero);
+        var attrs = new FileEntryAttributes
+        {
+            Length = 42,
+            Uid = 1000,
+            Gid = 1000,
+            FileType = UnixFileType.RegularFile,
+            Permissions = UnixFilePermissions.UserRead | UnixFilePermissions.UserWrite,
+            LastAccessTime = utcInstant,
+            LastWriteTime = utcInstant
+        };
+
+        SftpEntry entry = TmdsSftpClientWrapper.MapEntry("/home/rocktech/a.txt", attrs);
+
+        Assert.AreEqual(DateTimeKind.Local, entry.LastWriteTime.Kind, "映射结果必须是本地时区时间(Kind=Local)。");
+        Assert.AreEqual(utcInstant.LocalDateTime, entry.LastWriteTime, "墙钟数应为该 UTC 瞬间换算到本机时区的值。");
+        Assert.AreEqual(utcInstant.UtcDateTime, entry.LastWriteTime.ToUniversalTime(), "换算不得改变时间瞬间本身。");
+    }
+}


### PR DESCRIPTION
SftpService.UploadFileAsync 增加可选设置远端 mtime（scp -p 语义），异常不影响主流程。ISftpClientWrapper 新增 SetLastWriteTimeAsync，TmdsSftpClientWrapper 实现并通过 SFTP setstat 设置 atime/mtime。修正 SftpEntry.LastWriteTime 映射为 LocalDateTime，避免时区偏移。新增单元测试验证保留时间戳开关行为，补充 TmdsSftpEntryMappingTests 回归本地时区时间映射。