### PR TITLE
为SidebarView按钮添加ToolTip右侧显示属性,消除鼠标处于边缘位置闪烁的问题.

### DIFF
--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -208,13 +208,13 @@
                     VerticalAlignment="Center">
           <Button Width="24" Height="24" Background="Transparent" Padding="0"
                   CornerRadius="3" Command="{Binding NotificationsCommand}"
-                  ToolTip.Tip="{x:Static res:Strings.Notifications}" Cursor="Hand">
+                  ToolTip.Tip="{x:Static res:Strings.Notifications}" ToolTip.Placement="Right" Cursor="Hand">
             <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.bell}"
                            Foreground="{DynamicResource VelaTextTertiary}" />
           </Button>
           <Button Width="24" Height="24" Background="Transparent" Padding="0"
                   CornerRadius="3" Click="OpenSettings_Click"
-                  ToolTip.Tip="{x:Static res:Strings.Settings}" Cursor="Hand">
+                  ToolTip.Tip="{x:Static res:Strings.Settings}" ToolTip.Placement="Right" Cursor="Hand">
             <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.settings}"
                            Foreground="{DynamicResource VelaTextTertiary}" />
           </Button>


### PR DESCRIPTION
在SidebarView.axaml中为两个Button增加了ToolTip.Placement="Right"属性，使悬浮提示显示在按钮右侧，其他代码保持不变。