### PR TITLE
切换 RSA 私钥为 OpenSSH 格式并完善测试

### DIFF
--- a/src/VelaShell.Infrastructure/Ssh/SshKeyService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshKeyService.cs
@@ -85,14 +85,21 @@ public sealed class SshKeyService(string? sshDirectory = null) : ISshKeyService
                 throw new IOException(Strings.Format("KeySvc_AlreadyExists", name));
             }
             using var rsa = RSA.Create(bits);
-            File.WriteAllText(privatePath, rsa.ExportRSAPrivateKeyPem() + Environment.NewLine);
+            RSAParameters parameters = rsa.ExportParameters(true);
+            string comment = $"velashell@{Environment.MachineName}";
+
+            // 私钥必须写 OpenSSH 格式(-----BEGIN OPENSSH PRIVATE KEY-----)。
+            // Tmds.Ssh 0.23 的私钥解析器只认 OpenSSH 格式,ExportRSAPrivateKeyPem() 产出的 PKCS#1
+            // (-----BEGIN RSA PRIVATE KEY-----)与 PKCS#8 都会被判 "Unsupported format" 而当作
+            // 无可用凭据【跳过】——认证遂以 "These methods were skipped: publickey" 失败,用户表现为
+            // 用本应用生成的密钥怎么都登不上(排障线索:诊断第 4 步 no methods failed、skipped publickey)。
+            File.WriteAllText(privatePath, BuildOpenSshRsaPrivateKeyPem(parameters, comment));
             if (!OperatingSystem.IsWindows())
             {
                 File.SetUnixFileMode(privatePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             }
-            RSAParameters parameters = rsa.ExportParameters(false);
             byte[] blob = BuildRsaPublicBlob(parameters);
-            string publicLine = $"ssh-rsa {Convert.ToBase64String(blob)} velashell@{Environment.MachineName}";
+            string publicLine = $"ssh-rsa {Convert.ToBase64String(blob)} {comment}";
             File.WriteAllText(publicPath, publicLine + Environment.NewLine);
             return new SshKeyInfo(name, $"RSA {bits}", Fingerprint(blob), privatePath, publicLine);
         }, cancellationToken);
@@ -180,6 +187,60 @@ public sealed class SshKeyService(string? sshDirectory = null) : ISshKeyService
         byte[] chunk = blob.AsSpan(offset, length).ToArray();
         offset += length;
         return chunk;
+    }
+
+    /// <summary>
+    /// 把 RSA 私钥序列化为 OpenSSH 私钥 PEM(-----BEGIN OPENSSH PRIVATE KEY-----,cipher/kdf=none 未加密)。
+    /// 结构见 PROTOCOL.key:magic "openssh-key-v1\0" ‖ ciphername ‖ kdfname ‖ kdfoptions ‖ 密钥数 ‖
+    /// 公钥 blob ‖ 私钥段;私钥段 = 两个相同 checkint ‖ ("ssh-rsa", n, e, d, iqmp, p, q) ‖ 注释 ‖
+    /// 递增填充至 8 字节对齐。Tmds.Ssh 仅识别此格式(PKCS#1/PKCS#8 均被判 Unsupported format)。
+    /// </summary>
+    private static string BuildOpenSshRsaPrivateKeyPem(RSAParameters p, string comment)
+    {
+        byte[] publicBlob = BuildRsaPublicBlob(p);
+
+        using var priv = new MemoryStream();
+        uint checkInt = BitConverter.ToUInt32(RandomNumberGenerator.GetBytes(4));
+        WriteUInt32(priv, checkInt);
+        WriteUInt32(priv, checkInt); // 两次相同,解密后自校验
+        WriteChunk(priv, Encoding.ASCII.GetBytes("ssh-rsa"));
+        WriteChunk(priv, ToMpint(p.Modulus!));   // n
+        WriteChunk(priv, ToMpint(p.Exponent!));  // e
+        WriteChunk(priv, ToMpint(p.D!));         // d
+        WriteChunk(priv, ToMpint(p.InverseQ!));  // iqmp = q^-1 mod p
+        WriteChunk(priv, ToMpint(p.P!));         // p
+        WriteChunk(priv, ToMpint(p.Q!));         // q
+        WriteChunk(priv, Encoding.UTF8.GetBytes(comment));
+        for (byte pad = 1; priv.Length % 8 != 0; pad++) // cipher=none,块大小 8
+        {
+            priv.WriteByte(pad);
+        }
+
+        using var outer = new MemoryStream();
+        outer.Write("openssh-key-v1\0"u8); // 15 字节魔数,含结尾 NUL,非长度前缀
+        WriteChunk(outer, Encoding.ASCII.GetBytes("none")); // ciphername
+        WriteChunk(outer, Encoding.ASCII.GetBytes("none")); // kdfname
+        WriteChunk(outer, []);                              // kdfoptions
+        WriteUInt32(outer, 1);                              // 密钥数量
+        WriteChunk(outer, publicBlob);
+        WriteChunk(outer, priv.ToArray());
+
+        string base64 = Convert.ToBase64String(outer.ToArray());
+        var pem = new StringBuilder();
+        pem.Append("-----BEGIN OPENSSH PRIVATE KEY-----\n");
+        for (int i = 0; i < base64.Length; i += 70)
+        {
+            pem.Append(base64, i, Math.Min(70, base64.Length - i)).Append('\n');
+        }
+        pem.Append("-----END OPENSSH PRIVATE KEY-----\n");
+        return pem.ToString();
+    }
+
+    private static void WriteUInt32(MemoryStream stream, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(bytes, value);
+        stream.Write(bytes);
     }
 
     /// <summary>构造 OpenSSH ssh-rsa 公钥 blob:string "ssh-rsa" ‖ mpint e ‖ mpint n。</summary>

--- a/tests/VelaShell.Core.Tests/Ssh/SshKeyServiceFormatTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/SshKeyServiceFormatTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Tmds.Ssh;
+using VelaShell.Infrastructure.Ssh;
+
+namespace VelaShell.Core.Tests.Ssh;
+
+/// <summary>
+/// 生成的私钥必须是 Tmds.Ssh 能加载的 OpenSSH 格式。曾用 <c>ExportRSAPrivateKeyPem()</c> 写 PKCS#1
+/// (-----BEGIN RSA PRIVATE KEY-----),Tmds.Ssh 0.23 判 "Unsupported format" 而跳过 publickey,
+/// 用户用本应用生成的密钥无法登录(诊断第 4 步:no methods failed、skipped publickey)。
+/// </summary>
+[TestClass]
+[TestCategory("Ssh")]
+public class SshKeyServiceFormatTests
+{
+    [TestMethod]
+    public async Task GeneratedRsaKey_IsOpenSshFormat_AndLoadableByTmdsSsh()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "velashell-keytest-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var svc = new SshKeyService(dir);
+            var info = await svc.GenerateRsaKeyAsync("id_test", 2048);
+
+            string pem = await File.ReadAllTextAsync(info.PrivateKeyPath);
+            StringAssert.StartsWith(pem, "-----BEGIN OPENSSH PRIVATE KEY-----",
+                "私钥必须是 OpenSSH 格式,否则 Tmds.Ssh 无法加载");
+
+            // Tmds.Ssh 真正加载一遍:能取出密钥即证明格式被接受(不抛 Unsupported format)。
+            var cred = new PrivateKeyCredential(info.PrivateKeyPath, (string?)null, "test");
+            MethodInfo load = typeof(PrivateKeyCredential).GetMethod("LoadKeyAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
+            object valueTask = load.Invoke(cred, [CancellationToken.None])!;
+            var t = (Task)valueTask.GetType().GetMethod("AsTask")!.Invoke(valueTask, null)!;
+            await t; // 不抛即通过
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
本次修改将 RSA 私钥生成格式由 PKCS#1 切换为 OpenSSH 专用格式，确保 Tmds.Ssh 0.23 能正确识别和加载密钥，解决认证失败问题。新增 BuildOpenSshRsaPrivateKeyPem 方法，严格按 OpenSSH 规范序列化私钥，并统一公钥注释格式。补充 SshKeyServiceFormatTests 单元测试，自动验证私钥格式及兼容性，防止回归。