### PR TITLE
调整终端字体优先级及回退链逻辑

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -360,7 +360,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             RelayoutFromBounds();
             InvalidateVisual();
         }
-    } = new("Cascadia Mono, Consolas, JetBrains Mono, Microsoft YaHei, Segoe UI, monospace");
+    } = new("fonts:VelaShell#Cascadia Mono, Cascadia Mono, JetBrains Mono, Consolas, Microsoft YaHei, Segoe UI, monospace");
 
     /// <summary>终端字号(磅);修改后重算单元格度量、重排网格并重绘。</summary>
     public double FontSize

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -179,7 +179,7 @@ public class SettingsViewModel : ReactiveObject
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
-    } = "JetBrains Mono";
+    } = "Cascadia Mono";
 
     /// <summary>终端字号(磅)。</summary>
     public int TerminalFontSize

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -42,9 +42,10 @@ public partial class FileBrowserView : UserControl
     /// <summary>表头/行的左右内边距合计(axaml 里 Padding="14,0")。</summary>
     private const double HorizontalPadding = 28;
 
-    private static readonly FontFamily TerminalFont = new(
-        "JetBrains Mono, Cascadia Mono, Consolas, monospace"
-    );
+    // 必须与 axaml 里渲染用的 VelaTerminalFont 令牌(内置 Cascadia Mono 打头)一致:
+    // 列宽是用这个字体度量的,若度量字体与实际渲染字体不同(旧值以 JetBrains Mono 打头,
+    // 且不含内置 Cascadia),字形步进不一致会导致列自适应/截断错位。
+    private static readonly FontFamily TerminalFont = new("fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace");
     private static readonly Typeface TerminalTypeface = new(TerminalFont);
     private string? _activeSplitter;
     private double _dragStartX;

--- a/src/VelaShell/Views/WindowCloseExtensions.cs
+++ b/src/VelaShell/Views/WindowCloseExtensions.cs
@@ -11,7 +11,7 @@ namespace VelaShell.Views;
 /// 同步 <see cref="Window.Close()" /> 会立刻销毁窗口的 PlatformImpl,而本轮手势/按键尚未
 /// 走完的后续路由(PointerReleased、KeyUp 等)仍会派发到这个已销毁的窗口,Avalonia 便刷一条
 /// <c>[Control] PlatformImpl is null, couldn't handle input</c>(输入被丢弃,无害但刷屏)。
-/// 把 Close 推迟到当前输入事件出栈之后(<see cref="Dispatcher.Post(System.Action)" />)再执行,
+/// 把 Close 推迟到当前输入事件出栈之后再执行,
 /// 后续路由就落在仍存活的窗口上,警告消失。<see cref="Window.ShowDialog{TResult}" /> 的返回值
 /// 照常透传(推迟只影响关闭的时刻,不影响结果)。
 /// </remarks>

--- a/tests/VelaShell.Core.Tests/Ssh/SshKeyServiceFormatTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/SshKeyServiceFormatTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Tmds.Ssh;
+using VelaShell.Core.Ssh;
 using VelaShell.Infrastructure.Ssh;
 
 namespace VelaShell.Core.Tests.Ssh;
@@ -20,10 +21,10 @@ public class SshKeyServiceFormatTests
         try
         {
             var svc = new SshKeyService(dir);
-            var info = await svc.GenerateRsaKeyAsync("id_test", 2048);
+            SshKeyInfo info = await svc.GenerateRsaKeyAsync("id_test", 2048);
 
             string pem = await File.ReadAllTextAsync(info.PrivateKeyPath);
-            StringAssert.StartsWith(pem, "-----BEGIN OPENSSH PRIVATE KEY-----",
+            Assert.StartsWith("-----BEGIN OPENSSH PRIVATE KEY-----", pem,
                 "私钥必须是 OpenSSH 格式,否则 Tmds.Ssh 无法加载");
 
             // Tmds.Ssh 真正加载一遍:能取出密钥即证明格式被接受(不抛 Unsupported format)。

--- a/tests/VelaShell.Tests/Views/TerminalFontFallbackTests.cs
+++ b/tests/VelaShell.Tests/Views/TerminalFontFallbackTests.cs
@@ -1,0 +1,39 @@
+using Avalonia.Media;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 用户自定义终端字体必须优先于内置回退。终端字体链把内置 <c>fonts:VelaShell#Cascadia Mono</c>
+/// 放在用户字体【之后】作回退;须确保 Avalonia 不会因中段的 <c>源#族名</c> 前缀错拆族名链、
+/// 把用户字体吞掉而回落到内置 Cascadia(用户选了自己的字体却渲染成内置字体就尴尬了)。
+/// </summary>
+[TestClass]
+[TestCategory("Fonts")]
+public class TerminalFontFallbackTests
+{
+    // 复刻 MainWindowViewModel.ApplyLiveTerminalSettings 构造的族名链(ResolveTerminalFontFamily 内联)。
+    private static string BuildChain(string userFont)
+    {
+        string resolved = userFont == "Cascadia Mono" ? $"fonts:VelaShell#{userFont}" : userFont;
+        return $"{resolved}, fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace";
+    }
+
+    [TestMethod]
+    public void UserFont_StaysPrimary_OverEmbeddedFallback()
+    {
+        var ff = FontFamily.Parse(BuildChain("Fira Code"));
+        Assert.AreEqual("Fira Code", ff.FamilyNames[0],
+            "用户字体必须是首选族名,内置 Cascadia 只作回退");
+        Assert.Contains("Cascadia Mono", [.. ff.FamilyNames], "内置 Cascadia 仍须在链中作回退");
+        Assert.Contains("JetBrains Mono", [.. ff.FamilyNames], "JetBrains Mono 保留为 Cascadia 之后的回退");
+    }
+
+    [TestMethod]
+    public void UserPicksCascadiaMono_ResolvesToEmbedded()
+    {
+        var ff = FontFamily.Parse(BuildChain("Cascadia Mono"));
+        Assert.AreEqual("Cascadia Mono", ff.FamilyNames[0]);
+        Assert.Contains("fonts:VelaShell", ff.Key?.ToString() ?? "",
+            "用户显式填 Cascadia Mono 时应命中随程序分发的内置字体,而非碰运气的系统同名字体");
+    }
+}


### PR DESCRIPTION
统一终端字体链为 "fonts:VelaShell#Cascadia Mono"，确保用户自定义字体优先，Cascadia Mono 仅作回退，JetBrains Mono 仅为备用，避免渲染错位。新增 TerminalFontFallbackTests 单元测试，验证字体链逻辑正确。修正 SshKeyServiceFormatTests 断言方式，提升规范性。优化 WindowCloseExtensions 注释，明确窗口关闭延迟原因。