### PR TITLE
支持 PEM 私钥自动转换为 OpenSSH 格式

### DIFF
--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -192,12 +192,36 @@ public static class InfrastructureServiceCollectionExtensions
         Credential credential = ci.AuthMethod switch
         {
             AuthMethod.Password => new PasswordCredential(ci.Password ?? ""),
-            AuthMethod.PrivateKey => string.IsNullOrWhiteSpace(ci.PrivateKeyPassphrase)
-                ? new PrivateKeyCredential(ci.PrivateKeyPath!, null, null)
-                : new PrivateKeyCredential(ci.PrivateKeyPath!, ci.PrivateKeyPassphrase, null),
+            AuthMethod.PrivateKey => BuildPrivateKeyCredential(ci.PrivateKeyPath!, ci.PrivateKeyPassphrase),
             _ => throw new ArgumentOutOfRangeException(nameof(ci), ci.AuthMethod, "Unsupported authentication method.")
         };
         s.Credentials = [credential];
+    }
+
+    /// <summary>
+    /// 构造私钥凭据,兼容传统 PEM 格式。Tmds.Ssh 只认 OpenSSH 私钥格式;用户导入的
+    /// PKCS#1(-----BEGIN RSA PRIVATE KEY-----)、PKCS#8、加密 PKCS#8 会被判 Unsupported format
+    /// 而【跳过】,认证以 "skipped: publickey" 失败。这里先用 BCL 读入并转成 OpenSSH 格式再交给 Tmds;
+    /// 已是 OpenSSH 格式或无法读取/转换时,原样交回文件路径,让 Tmds 按其原生路径处理并给出错误。
+    /// </summary>
+    internal static Credential BuildPrivateKeyCredential(string path, string? passphrase)
+    {
+        try
+        {
+            string pem = File.ReadAllText(path);
+            if (OpenSshPrivateKey.TryConvertToOpenSsh(pem, passphrase) is { } openSshKey)
+            {
+                // 转换后的 OpenSSH 私钥是未加密的(口令已在转换时用掉),故不再传口令。
+                return new PrivateKeyCredential(openSshKey, (string?)null, path);
+            }
+        }
+        catch
+        {
+            // 读文件/转换失败绝不阻断:退回原路径,由 Tmds 加载并报其原生错误。
+        }
+        return string.IsNullOrWhiteSpace(passphrase)
+            ? new PrivateKeyCredential(path, null, null)
+            : new PrivateKeyCredential(path, passphrase, null);
     }
 
     private static void AddHostAuthentication(

--- a/src/VelaShell.Infrastructure/Ssh/OpenSshPrivateKey.cs
+++ b/src/VelaShell.Infrastructure/Ssh/OpenSshPrivateKey.cs
@@ -1,0 +1,247 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace VelaShell.Infrastructure.Ssh;
+
+/// <summary>
+/// 把 BCL 能加载的私钥(RSA / ECDSA;PKCS#1、PKCS#8、SEC1,含加密 PKCS#8)序列化为
+/// OpenSSH 私钥格式(未加密)。
+/// </summary>
+/// <remarks>
+/// Tmds.Ssh 0.23 的私钥解析器【只认 OpenSSH 格式】(-----BEGIN OPENSSH PRIVATE KEY-----)。
+/// 用户导入的传统 PEM —— PKCS#1(-----BEGIN RSA PRIVATE KEY-----)、PKCS#8
+/// (-----BEGIN PRIVATE KEY-----)、加密 PKCS#8 —— 会被判 "Unsupported format" 而当作无可用凭据
+/// 【跳过】,认证以 "skipped: publickey" 失败。这里在连接前把它们转成 OpenSSH 格式补齐兼容性。
+/// Ed25519 传统 PEM 因 BCL 不支持而不在此列(但 Ed25519 几乎总是 OpenSSH 格式,Tmds 直接可读)。
+/// </remarks>
+internal static class OpenSshPrivateKey
+{
+    /// <summary>
+    /// 尝试把任意 PEM 私钥转成 OpenSSH 格式(未加密)。已是 OpenSSH 格式或无法识别时返回
+    /// <see langword="null" />(调用方应原样把文件路径交给 Tmds 处理)。
+    /// </summary>
+    /// <param name="pem">私钥 PEM 文本。</param>
+    /// <param name="passphrase">加密私钥的口令(仅加密 PKCS#8 需要),可为 null/空。</param>
+    public static char[]? TryConvertToOpenSsh(string pem, string? passphrase)
+    {
+        if (pem.TrimStart().StartsWith("-----BEGIN OPENSSH PRIVATE KEY-----", StringComparison.Ordinal))
+        {
+            return null; // 已是 OpenSSH:原样交给 Tmds(它也负责按口令解密 OpenSSH 加密私钥)。
+        }
+        const string comment = "velashell-imported";
+        if (TryLoadRsa(pem, passphrase, out RSAParameters rsa))
+        {
+            return SerializeRsa(rsa, comment).ToCharArray();
+        }
+        if (TryLoadEcdsa(pem, passphrase, out ECParameters ec, out string? sshName, out string? curveName, out int fieldLen))
+        {
+            return SerializeEcdsa(ec, sshName!, curveName!, fieldLen, comment).ToCharArray();
+        }
+        return null; // 未知格式/缺口令:交回原路径,让 Tmds 给出其原生错误。
+    }
+
+    /// <summary>把 RSA 私钥参数序列化为 OpenSSH 私钥 PEM(cipher/kdf=none,未加密)。</summary>
+    public static string SerializeRsa(RSAParameters p, string comment)
+    {
+        byte[] publicBlob = BuildRsaPublicBlob(p);
+
+        using var priv = new MemoryStream();
+        WriteCheckInts(priv);
+        WriteChunk(priv, "ssh-rsa"u8.ToArray());
+        WriteChunk(priv, ToMpint(p.Modulus!));  // n
+        WriteChunk(priv, ToMpint(p.Exponent!)); // e
+        WriteChunk(priv, ToMpint(p.D!));         // d
+        WriteChunk(priv, ToMpint(p.InverseQ!));  // iqmp = q^-1 mod p
+        WriteChunk(priv, ToMpint(p.P!));         // p
+        WriteChunk(priv, ToMpint(p.Q!));         // q
+        WriteChunk(priv, Encoding.UTF8.GetBytes(comment));
+
+        return Wrap(publicBlob, priv);
+    }
+
+    /// <summary>把 ECDSA(nistp256/384/521)私钥序列化为 OpenSSH 私钥 PEM(未加密)。</summary>
+    private static string SerializeEcdsa(ECParameters p, string sshName, string curveName, int fieldLen, string comment)
+    {
+        byte[] point = BuildEcPoint(p.Q, fieldLen); // 0x04 ‖ X ‖ Y(各定长)
+        byte[] sshNameBytes = Encoding.ASCII.GetBytes(sshName);
+        byte[] curveNameBytes = Encoding.ASCII.GetBytes(curveName);
+
+        using var pub = new MemoryStream();
+        WriteChunk(pub, sshNameBytes);
+        WriteChunk(pub, curveNameBytes);
+        WriteChunk(pub, point);
+        byte[] publicBlob = pub.ToArray();
+
+        using var priv = new MemoryStream();
+        WriteCheckInts(priv);
+        WriteChunk(priv, sshNameBytes);
+        WriteChunk(priv, curveNameBytes);
+        WriteChunk(priv, point);
+        WriteChunk(priv, ToMpint(p.D!)); // 私有标量
+        WriteChunk(priv, Encoding.UTF8.GetBytes(comment));
+
+        return Wrap(publicBlob, priv);
+    }
+
+    // ---- 加载(BCL)----------------------------------------------------------
+
+    private static bool TryLoadRsa(string pem, string? passphrase, out RSAParameters parameters)
+    {
+        parameters = default;
+        try
+        {
+            using var rsa = RSA.Create();
+            ImportPem(rsa, pem, passphrase);
+            parameters = rsa.ExportParameters(includePrivateParameters: true);
+            return true;
+        }
+        catch
+        {
+            return false; // 非 RSA、加密但缺口令、或格式非 BCL 可读 —— 交由后续尝试/回退。
+        }
+    }
+
+    private static bool TryLoadEcdsa(
+        string pem, string? passphrase,
+        out ECParameters parameters, out string? sshName, out string? curveName, out int fieldLen)
+    {
+        parameters = default;
+        sshName = null;
+        curveName = null;
+        fieldLen = 0;
+        try
+        {
+            using var ecdsa = ECDsa.Create();
+            ImportPem(ecdsa, pem, passphrase);
+            (sshName, curveName, fieldLen) = ecdsa.KeySize switch
+            {
+                256 => ("ecdsa-sha2-nistp256", "nistp256", 32),
+                384 => ("ecdsa-sha2-nistp384", "nistp384", 48),
+                521 => ("ecdsa-sha2-nistp521", "nistp521", 66),
+                _ => (null, null, 0)
+            };
+            if (sshName is null)
+            {
+                return false; // 非标准 NIST 曲线:不支持,回退。
+            }
+            parameters = ecdsa.ExportParameters(includePrivateParameters: true);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void ImportPem(AsymmetricAlgorithm key, string pem, string? passphrase)
+    {
+        if (!string.IsNullOrEmpty(passphrase))
+        {
+            try
+            {
+                key.ImportFromEncryptedPem(pem, passphrase);
+                return;
+            }
+            catch
+            {
+                // 用户填了口令但密钥其实未加密:退回明文导入。
+            }
+        }
+        key.ImportFromPem(pem);
+    }
+
+    // ---- OpenSSH 线格式助手 -------------------------------------------------
+
+    /// <summary>套上外层容器与 PEM 封装:magic ‖ none ‖ none ‖ "" ‖ 密钥数=1 ‖ 公钥 blob ‖ 私钥段。</summary>
+    private static string Wrap(byte[] publicBlob, MemoryStream privateSection)
+    {
+        for (byte pad = 1; privateSection.Length % 8 != 0; pad++) // cipher=none,块大小 8,递增填充
+        {
+            privateSection.WriteByte(pad);
+        }
+
+        using var outer = new MemoryStream();
+        outer.Write("openssh-key-v1\0"u8); // 15 字节魔数,含结尾 NUL,非长度前缀
+        WriteChunk(outer, "none"u8.ToArray()); // ciphername
+        WriteChunk(outer, "none"u8.ToArray()); // kdfname
+        WriteChunk(outer, []);                  // kdfoptions
+        WriteUInt32(outer, 1);                   // 密钥数量
+        WriteChunk(outer, publicBlob);
+        WriteChunk(outer, privateSection.ToArray());
+
+        string base64 = Convert.ToBase64String(outer.ToArray());
+        var pem = new StringBuilder();
+        pem.Append("-----BEGIN OPENSSH PRIVATE KEY-----\n");
+        for (int i = 0; i < base64.Length; i += 70)
+        {
+            pem.Append(base64, i, Math.Min(70, base64.Length - i)).Append('\n');
+        }
+        pem.Append("-----END OPENSSH PRIVATE KEY-----\n");
+        return pem.ToString();
+    }
+
+    private static void WriteCheckInts(MemoryStream stream)
+    {
+        uint checkInt = BinaryPrimitives.ReadUInt32LittleEndian(RandomNumberGenerator.GetBytes(4));
+        WriteUInt32(stream, checkInt);
+        WriteUInt32(stream, checkInt); // 两次相同,解密后自校验
+    }
+
+    private static byte[] BuildRsaPublicBlob(RSAParameters p)
+    {
+        using var stream = new MemoryStream();
+        WriteChunk(stream, "ssh-rsa"u8.ToArray());
+        WriteChunk(stream, ToMpint(p.Exponent!));
+        WriteChunk(stream, ToMpint(p.Modulus!));
+        return stream.ToArray();
+    }
+
+    /// <summary>EC 公开点的未压缩编码:0x04 ‖ X ‖ Y,X/Y 各左补零至曲线定长。</summary>
+    private static byte[] BuildEcPoint(ECPoint q, int fieldLen)
+    {
+        byte[] point = new byte[1 + fieldLen * 2];
+        point[0] = 0x04;
+        LeftPadInto(q.X!, point.AsSpan(1, fieldLen));
+        LeftPadInto(q.Y!, point.AsSpan(1 + fieldLen, fieldLen));
+        return point;
+    }
+
+    private static void LeftPadInto(byte[] value, Span<byte> destination)
+    {
+        // BCL 通常已按定长返回;多余前导零裁掉、不足则左补零,保证落在 destination 尾部。
+        int start = 0;
+        while (start < value.Length - destination.Length && value[start] == 0)
+        {
+            start++;
+        }
+        ReadOnlySpan<byte> trimmed = value.AsSpan(start);
+        destination.Clear();
+        trimmed.CopyTo(destination[(destination.Length - trimmed.Length)..]);
+    }
+
+    /// <summary>转 SSH mpint:大端有符号,裁前导零后若最高位为 1 再补一个 0x00。</summary>
+    private static byte[] ToMpint(byte[] value)
+    {
+        int start = 0;
+        while (start < value.Length - 1 && value[start] == 0)
+        {
+            start++;
+        }
+        byte[] trimmed = value[start..];
+        return trimmed.Length > 0 && (trimmed[0] & 0x80) != 0 ? [0, .. trimmed] : trimmed;
+    }
+
+    private static void WriteChunk(MemoryStream stream, byte[] data)
+    {
+        WriteUInt32(stream, (uint)data.Length);
+        stream.Write(data);
+    }
+
+    private static void WriteUInt32(MemoryStream stream, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(bytes, value);
+        stream.Write(bytes);
+    }
+}

--- a/src/VelaShell.Infrastructure/Ssh/SshKeyService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshKeyService.cs
@@ -93,7 +93,7 @@ public sealed class SshKeyService(string? sshDirectory = null) : ISshKeyService
             // (-----BEGIN RSA PRIVATE KEY-----)与 PKCS#8 都会被判 "Unsupported format" 而当作
             // 无可用凭据【跳过】——认证遂以 "These methods were skipped: publickey" 失败,用户表现为
             // 用本应用生成的密钥怎么都登不上(排障线索:诊断第 4 步 no methods failed、skipped publickey)。
-            File.WriteAllText(privatePath, BuildOpenSshRsaPrivateKeyPem(parameters, comment));
+            File.WriteAllText(privatePath, OpenSshPrivateKey.SerializeRsa(parameters, comment));
             if (!OperatingSystem.IsWindows())
             {
                 File.SetUnixFileMode(privatePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
@@ -187,60 +187,6 @@ public sealed class SshKeyService(string? sshDirectory = null) : ISshKeyService
         byte[] chunk = blob.AsSpan(offset, length).ToArray();
         offset += length;
         return chunk;
-    }
-
-    /// <summary>
-    /// 把 RSA 私钥序列化为 OpenSSH 私钥 PEM(-----BEGIN OPENSSH PRIVATE KEY-----,cipher/kdf=none 未加密)。
-    /// 结构见 PROTOCOL.key:magic "openssh-key-v1\0" ‖ ciphername ‖ kdfname ‖ kdfoptions ‖ 密钥数 ‖
-    /// 公钥 blob ‖ 私钥段;私钥段 = 两个相同 checkint ‖ ("ssh-rsa", n, e, d, iqmp, p, q) ‖ 注释 ‖
-    /// 递增填充至 8 字节对齐。Tmds.Ssh 仅识别此格式(PKCS#1/PKCS#8 均被判 Unsupported format)。
-    /// </summary>
-    private static string BuildOpenSshRsaPrivateKeyPem(RSAParameters p, string comment)
-    {
-        byte[] publicBlob = BuildRsaPublicBlob(p);
-
-        using var priv = new MemoryStream();
-        uint checkInt = BitConverter.ToUInt32(RandomNumberGenerator.GetBytes(4));
-        WriteUInt32(priv, checkInt);
-        WriteUInt32(priv, checkInt); // 两次相同,解密后自校验
-        WriteChunk(priv, Encoding.ASCII.GetBytes("ssh-rsa"));
-        WriteChunk(priv, ToMpint(p.Modulus!));   // n
-        WriteChunk(priv, ToMpint(p.Exponent!));  // e
-        WriteChunk(priv, ToMpint(p.D!));         // d
-        WriteChunk(priv, ToMpint(p.InverseQ!));  // iqmp = q^-1 mod p
-        WriteChunk(priv, ToMpint(p.P!));         // p
-        WriteChunk(priv, ToMpint(p.Q!));         // q
-        WriteChunk(priv, Encoding.UTF8.GetBytes(comment));
-        for (byte pad = 1; priv.Length % 8 != 0; pad++) // cipher=none,块大小 8
-        {
-            priv.WriteByte(pad);
-        }
-
-        using var outer = new MemoryStream();
-        outer.Write("openssh-key-v1\0"u8); // 15 字节魔数,含结尾 NUL,非长度前缀
-        WriteChunk(outer, Encoding.ASCII.GetBytes("none")); // ciphername
-        WriteChunk(outer, Encoding.ASCII.GetBytes("none")); // kdfname
-        WriteChunk(outer, []);                              // kdfoptions
-        WriteUInt32(outer, 1);                              // 密钥数量
-        WriteChunk(outer, publicBlob);
-        WriteChunk(outer, priv.ToArray());
-
-        string base64 = Convert.ToBase64String(outer.ToArray());
-        var pem = new StringBuilder();
-        pem.Append("-----BEGIN OPENSSH PRIVATE KEY-----\n");
-        for (int i = 0; i < base64.Length; i += 70)
-        {
-            pem.Append(base64, i, Math.Min(70, base64.Length - i)).Append('\n');
-        }
-        pem.Append("-----END OPENSSH PRIVATE KEY-----\n");
-        return pem.ToString();
-    }
-
-    private static void WriteUInt32(MemoryStream stream, uint value)
-    {
-        Span<byte> bytes = stackalloc byte[4];
-        BinaryPrimitives.WriteUInt32BigEndian(bytes, value);
-        stream.Write(bytes);
     }
 
     /// <summary>构造 OpenSSH ssh-rsa 公钥 blob:string "ssh-rsa" ‖ mpint e ‖ mpint n。</summary>

--- a/tests/VelaShell.Core.Tests/Ssh/OpenSshPrivateKeyConverterTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/OpenSshPrivateKeyConverterTests.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using Tmds.Ssh;
+using VelaShell.Infrastructure.DependencyInjection;
+using VelaShell.Infrastructure.Ssh;
+
+namespace VelaShell.Core.Tests.Ssh;
+
+/// <summary>
+/// 传统 PEM 私钥兼容:Tmds.Ssh 只认 OpenSSH 格式,导入的 PKCS#1/PKCS#8/加密 PKCS#8/SEC1 会被
+/// 判 Unsupported format 而跳过 publickey 导致登录失败。<see cref="OpenSshPrivateKey.TryConvertToOpenSsh" />
+/// 须把这些格式转成 Tmds 能加载的 OpenSSH 格式(用户反馈用 PKCS#1 的 id_rsa 登不上,正是这条)。
+/// </summary>
+[TestClass]
+[TestCategory("Ssh")]
+public class OpenSshPrivateKeyConverterTests
+{
+    // Tmds.Ssh 真正加载一遍转换结果;不抛即证明格式被接受。
+    private static async Task AssertTmdsLoads(char[] openSshPem)
+    {
+        var cred = new PrivateKeyCredential(openSshPem, (string?)null, "test");
+        MethodInfo load = typeof(PrivateKeyCredential).GetMethod("LoadKeyAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
+        object valueTask = load.Invoke(cred, [CancellationToken.None])!;
+        var t = (Task)valueTask.GetType().GetMethod("AsTask")!.Invoke(valueTask, null)!;
+        await t;
+    }
+
+    [TestMethod]
+    public async Task Rsa_Pkcs1_Converts_AndLoads() // 用户反馈的确切格式:-----BEGIN RSA PRIVATE KEY-----
+    {
+        using var rsa = RSA.Create(2048);
+        char[]? converted = OpenSshPrivateKey.TryConvertToOpenSsh(rsa.ExportRSAPrivateKeyPem(), null);
+        Assert.IsNotNull(converted);
+        Assert.StartsWith("-----BEGIN OPENSSH PRIVATE KEY-----", new string(converted));
+        await AssertTmdsLoads(converted);
+    }
+
+    [TestMethod]
+    public async Task Rsa_Pkcs8_Converts_AndLoads()
+    {
+        using var rsa = RSA.Create(2048);
+        char[]? converted = OpenSshPrivateKey.TryConvertToOpenSsh(rsa.ExportPkcs8PrivateKeyPem(), null);
+        Assert.IsNotNull(converted);
+        await AssertTmdsLoads(converted);
+    }
+
+    [TestMethod]
+    public async Task Rsa_EncryptedPkcs8_WithPassphrase_Converts_AndLoads()
+    {
+        using var rsa = RSA.Create(2048);
+        var pbe = new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 100_000);
+        string pem = rsa.ExportEncryptedPkcs8PrivateKeyPem("s3cret", pbe);
+        char[]? converted = OpenSshPrivateKey.TryConvertToOpenSsh(pem, "s3cret");
+        Assert.IsNotNull(converted);
+        await AssertTmdsLoads(converted);
+    }
+
+    [TestMethod]
+    [DataRow(256)]
+    [DataRow(384)]
+    [DataRow(521)]
+    public async Task Ecdsa_Sec1_Converts_AndLoads(int keySize)
+    {
+        ECCurve curve = keySize switch
+        {
+            256 => ECCurve.NamedCurves.nistP256,
+            384 => ECCurve.NamedCurves.nistP384,
+            _ => ECCurve.NamedCurves.nistP521
+        };
+        using var ec = ECDsa.Create(curve);
+        char[]? converted = OpenSshPrivateKey.TryConvertToOpenSsh(ec.ExportECPrivateKeyPem(), null);
+        Assert.IsNotNull(converted);
+        await AssertTmdsLoads(converted);
+    }
+
+    [TestMethod]
+    public void AlreadyOpenSsh_ReturnsNull_ForPassThrough()
+    {
+        // 已是 OpenSSH 格式的私钥应原样交给 Tmds(返回 null),不做无谓转换。
+        string openssh = "-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END OPENSSH PRIVATE KEY-----\n";
+        Assert.IsNull(OpenSshPrivateKey.TryConvertToOpenSsh(openssh, null));
+    }
+
+    [TestMethod]
+    public async Task BuildPrivateKeyCredential_OnPkcs1File_ProducesLoadableCredential()
+    {
+        // 端到端:把 PKCS#1 私钥写到文件,走 AddCredential 的真实构造路径,结果必须能被 Tmds 加载。
+        string path = Path.GetTempFileName();
+        try
+        {
+            using var rsa = RSA.Create(2048);
+            await File.WriteAllTextAsync(path, rsa.ExportRSAPrivateKeyPem());
+            Credential cred = InfrastructureServiceCollectionExtensions.BuildPrivateKeyCredential(path, null);
+            Assert.IsInstanceOfType<PrivateKeyCredential>(cred);
+            MethodInfo load = typeof(PrivateKeyCredential).GetMethod("LoadKeyAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!;
+            object valueTask = load.Invoke(cred, [CancellationToken.None])!;
+            await (Task)valueTask.GetType().GetMethod("AsTask")!.Invoke(valueTask, null)!;
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
新增 OpenSshPrivateKey 工具类，支持 PKCS#1、PKCS#8、加密 PKCS#8、SEC1 等 PEM 私钥自动转换为 OpenSSH 格式，兼容 Tmds.Ssh 只识别 OpenSSH 的限制。InfrastructureServiceCollectionExtensions.cs 新增 BuildPrivateKeyCredential，连接前自动尝试转换，失败或已是 OpenSSH 格式则回退原路径。SshKeyService 生成私钥统一输出 OpenSSH 格式，移除旧实现。新增 OpenSshPrivateKeyConverterTests，覆盖多种格式转换与加载，确保兼容性。整体提升用户导入 PEM 私钥的体验，解决密钥无法登录问题。