### PR TITLE
新增应用背景图片及不透明度自定义功能

### DIFF
--- a/src/VelaShell.Controls/Themes/VelaShellTokens.axaml
+++ b/src/VelaShell.Controls/Themes/VelaShellTokens.axaml
@@ -10,7 +10,15 @@
            原 #21222C 与终端 #282A36 落差过大,分界生硬。 -->
       <SolidColorBrush x:Key="VelaBgSidebar" Color="#252734" />
       <SolidColorBrush x:Key="VelaBgTerminal" Color="#282A36" />
+      <!-- SFTP 文件面板底(默认同终端色);单列出来是为了背景图功能可与终端分开调不透明度。 -->
+      <SolidColorBrush x:Key="VelaBgSftpPanel" Color="#282A36" />
+      <!-- Dock 文档容器底(默认同终端色);单列出来是为了背景图时它保持透明,
+           让终端 tint 只由 TerminalHost 单个 Border 承担,避免与之嵌套叠加成双层。 -->
+      <SolidColorBrush x:Key="VelaBgDockDocument" Color="#282A36" />
       <SolidColorBrush x:Key="VelaBgSurface" Color="#343746" />
+      <!-- 内容区表头/工具条底(默认同 Surface 色);单列出来是为了背景图时可随内容半透明,
+           而 VelaBgSurface 仍需给弹层/对话框保持不透明。 -->
+      <SolidColorBrush x:Key="VelaBgContentHeader" Color="#343746" />
       <SolidColorBrush x:Key="VelaBgActive" Color="#44475A" />
       <SolidColorBrush x:Key="VelaBgHover" Color="#363948" />
       <SolidColorBrush x:Key="VelaBgInput" Color="#282A36" />
@@ -22,7 +30,10 @@
       <SolidColorBrush x:Key="VelaBgPage" Color="#F2EDDA" />
       <SolidColorBrush x:Key="VelaBgSidebar" Color="#F8F4E4" />
       <SolidColorBrush x:Key="VelaBgTerminal" Color="#FFFBEB" />
+      <SolidColorBrush x:Key="VelaBgSftpPanel" Color="#FFFBEB" />
+      <SolidColorBrush x:Key="VelaBgDockDocument" Color="#FFFBEB" />
       <SolidColorBrush x:Key="VelaBgSurface" Color="#FFFBEB" />
+      <SolidColorBrush x:Key="VelaBgContentHeader" Color="#FFFBEB" />
       <SolidColorBrush x:Key="VelaBgActive" Color="#644AC922" />
       <SolidColorBrush x:Key="VelaBgHover" Color="#EDE7D0" />
       <SolidColorBrush x:Key="VelaBgInput" Color="#F7F2DF" />

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -273,6 +273,33 @@ public class AppearanceOptions : ObservableOptions
         set => Set(ref field, value);
     } = 100;
 
+    /// <summary>
+    /// 应用背景图片的本地文件绝对路径。空 = 不使用背景图(默认,行为与旧版完全一致)。
+    /// 设置后图片铺在窗口最底层(UniformToFill),透过半透明的终端与文件面板背景显示。
+    /// </summary>
+    public string BackgroundImagePath
+    {
+        get;
+        set => Set(ref field, value ?? "");
+    } = "";
+
+    /// <summary>背景图片图层的不透明度(百分比,0-100);越低图片越淡。仅在设置了背景图时生效。</summary>
+    public int BackgroundImageOpacity
+    {
+        get;
+        set => Set(ref field, value);
+    } = 100;
+
+    /// <summary>
+    /// 内容背景(整窗遮罩)的不透明度(百分比,20-100);越高越盖住背景图、内容越实,越低越透出背景图。
+    /// 统一作用于终端、SFTP 面板、侧边栏等所有内容区(由一层整窗 scrim 遮罩承担,不分区)。仅在设置了背景图时生效。
+    /// </summary>
+    public int ContentBackgroundOpacity
+    {
+        get;
+        set => Set(ref field, value);
+    } = 85;
+
     /// <summary>标签栏位置(如 top / bottom)。</summary>
     public string TabBarPosition
     {

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1381,6 +1381,30 @@ Paste anyway?</value>
   <data name="SetAppear_AccentColorDesc" xml:space="preserve">
     <value>// Application accent color (leave empty for theme default)</value>
   </data>
+  <data name="SetAppear_BackgroundImage" xml:space="preserve">
+    <value>Background image</value>
+  </data>
+  <data name="SetAppear_BackgroundImageDesc" xml:space="preserve">
+    <value>// Image shown behind the app; tune with the opacity sliders below</value>
+  </data>
+  <data name="SetAppear_BackgroundImageBrowse" xml:space="preserve">
+    <value>Browse…</value>
+  </data>
+  <data name="SetAppear_BackgroundImageClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="SetAppear_BackgroundImageOpacity" xml:space="preserve">
+    <value>Background image opacity</value>
+  </data>
+  <data name="SetAppear_BackgroundImageOpacityDesc" xml:space="preserve">
+    <value>// Lower = fainter image</value>
+  </data>
+  <data name="SetAppear_ContentBgOpacity" xml:space="preserve">
+    <value>Content background opacity</value>
+  </data>
+  <data name="SetAppear_ContentBgOpacityDesc" xml:space="preserve">
+    <value>// Dims the image behind all content (terminal, SFTP, sidebar); lower reveals more of the image</value>
+  </data>
   <data name="SetAppear_Ansi16" xml:space="preserve">
     <value>Terminal ANSI 16 colors</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1472,6 +1472,30 @@
   <data name="SetAppear_AccentColorDesc" xml:space="preserve">
     <value>// 应用程序的强调色(留空用主题默认)</value>
   </data>
+  <data name="SetAppear_BackgroundImage" xml:space="preserve">
+    <value>背景图片</value>
+  </data>
+  <data name="SetAppear_BackgroundImageDesc" xml:space="preserve">
+    <value>// 铺在应用背后的图片,配合下方不透明度滑块调节</value>
+  </data>
+  <data name="SetAppear_BackgroundImageBrowse" xml:space="preserve">
+    <value>浏览…</value>
+  </data>
+  <data name="SetAppear_BackgroundImageClear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="SetAppear_BackgroundImageOpacity" xml:space="preserve">
+    <value>背景图不透明度</value>
+  </data>
+  <data name="SetAppear_BackgroundImageOpacityDesc" xml:space="preserve">
+    <value>// 越低图片越淡</value>
+  </data>
+  <data name="SetAppear_ContentBgOpacity" xml:space="preserve">
+    <value>内容背景不透明度</value>
+  </data>
+  <data name="SetAppear_ContentBgOpacityDesc" xml:space="preserve">
+    <value>// 遮罩整窗内容(终端、SFTP、侧栏等)后的背景图,越低越透出背景图</value>
+  </data>
   <data name="SetAppear_Ansi16" xml:space="preserve">
     <value>终端 ANSI 16 色</value>
   </data>

--- a/src/VelaShell.Core/Services/SettingsPreviewService.cs
+++ b/src/VelaShell.Core/Services/SettingsPreviewService.cs
@@ -20,6 +20,15 @@ public interface ISettingsPreviewService
 
     /// <summary>广播窗口不透明度百分比(钳位到 10..100),不产生 AppSettings/JSON 开销。</summary>
     void PreviewWindowOpacity(int percent);
+
+    /// <summary>
+    /// 背景图/内容背景不透明度即时预览事件(均为百分比)。绕过防抖的 JSON 快照路径,
+    /// 使拖动滑杆时不透明度线性平滑跟随、且不重复解码图片。在 UI 线程触发。
+    /// </summary>
+    event Action<(int Image, int Content)>? BackgroundOpacityPreviewRequested;
+
+    /// <summary>广播背景图/内容背景不透明度百分比,不产生 AppSettings/JSON 开销。</summary>
+    void PreviewBackgroundOpacity(int imageOpacity, int contentOpacity);
 }
 
 /// <summary><see cref="ISettingsPreviewService" /> 的默认实现:将预览请求同步转发给订阅者。</summary>
@@ -42,5 +51,15 @@ public sealed class SettingsPreviewService : ISettingsPreviewService
     public void PreviewWindowOpacity(int percent)
     {
         WindowOpacityPreviewRequested?.Invoke(Math.Clamp(percent, 10, 100));
+    }
+
+    /// <inheritdoc />
+    public event Action<(int Image, int Content)>? BackgroundOpacityPreviewRequested;
+
+    /// <inheritdoc />
+    public void PreviewBackgroundOpacity(int imageOpacity, int contentOpacity)
+    {
+        BackgroundOpacityPreviewRequested?.Invoke(
+            (Math.Clamp(imageOpacity, 0, 100), Math.Clamp(contentOpacity, 0, 100)));
     }
 }

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -954,6 +954,49 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         palette.SetAnsi(15, Rgba.FromRgb(0xFF, 0xFF, 0xFF));
     }
 
+    /// <summary>
+    /// 终端「默认背景」整屏填充的不透明度(0..1,默认 1=不透明,行为不变)。低于 1 时整屏默认背景变半透明,
+    /// 透出其后的应用背景图(设置→外观→背景图片)。只作用于整屏默认背景填充,不影响单元格自身着色的背景
+    /// (选区、彩色底等仍不透明),因此不牺牲文本可读性。仅在设置了背景图时由 MainWindowViewModel 下调。
+    /// </summary>
+    public double BackgroundOpacity
+    {
+        get => _backgroundOpacity;
+        set
+        {
+            double clamped = Math.Clamp(value, 0.0, 1.0);
+            if (Math.Abs(clamped - _backgroundOpacity) < 0.001)
+            {
+                return;
+            }
+            _backgroundOpacity = clamped;
+            InvalidateVisual();
+        }
+    }
+
+    private double _backgroundOpacity = 1.0;
+    private ImmutableSolidColorBrush? _bgFillBrush;
+    private uint _bgFillPacked;
+    private int _bgFillOp = -1;
+
+    /// <summary>整屏默认背景填充画刷:不透明时走共享缓存,半透明时按(颜色×不透明度)缓存一支专用画刷。</summary>
+    private ImmutableSolidColorBrush DefaultBackgroundBrush(Rgba bg)
+    {
+        if (_backgroundOpacity >= 0.999)
+        {
+            return BrushFor(bg);
+        }
+        int op = (int)Math.Round(_backgroundOpacity * 1000);
+        if (_bgFillBrush is null || _bgFillPacked != bg.Packed || _bgFillOp != op)
+        {
+            byte a = (byte)Math.Round(bg.A * _backgroundOpacity);
+            _bgFillBrush = new(Color.FromArgb(a, bg.R, bg.G, bg.B));
+            _bgFillPacked = bg.Packed;
+            _bgFillOp = op;
+        }
+        return _bgFillBrush;
+    }
+
     private ImmutableSolidColorBrush BrushFor(Rgba c)
     {
         if (_brushCache.TryGetValue(c.Packed, out ImmutableSolidColorBrush? brush))
@@ -1222,7 +1265,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     {
         TerminalScreen screen = Emulator.Screen;
         TerminalPalette palette = Emulator.Palette;
-        context.FillRectangle(BrushFor(palette.DefaultBackground), new(Bounds.Size));
+        context.FillRectangle(DefaultBackgroundBrush(palette.DefaultBackground), new(Bounds.Size));
         int rows = screen.Rows;
         int cols = screen.Columns;
 

--- a/src/VelaShell/Converters/StringNotEmptyConverter.cs
+++ b/src/VelaShell/Converters/StringNotEmptyConverter.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace VelaShell.Converters;
+
+/// <summary>字符串非空(非 null 且去空白后有内容)→ true;用于按“是否已填值”控制显隐。</summary>
+public sealed class StringNotEmptyConverter : IValueConverter
+{
+    /// <summary>可在 XAML 中直接引用的共享单例。</summary>
+    public static readonly StringNotEmptyConverter Instance = new();
+
+    /// <summary>非空白字符串返回 true,否则返回 false。</summary>
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string s && !string.IsNullOrWhiteSpace(s);
+
+    /// <summary>不支持反向转换,调用即抛出 <see cref="NotSupportedException" />。</summary>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml
@@ -113,7 +113,7 @@
 
     <!-- 内容区:终端视图经工作区缓存复用,ReparentingHost 保证单父级。
          组为空时(拆分留下的空面板)显示拖放提示。 -->
-    <Border Background="{DynamicResource VelaBgTerminal}" ClipToBounds="True">
+    <Border Background="{DynamicResource VelaBgDockDocument}" ClipToBounds="True">
       <Panel>
         <TextBlock x:Name="EmptyHint"
                    Text="{loc:Localize Dock_DropTabHere}"

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -2544,6 +2544,11 @@ public class MainWindowViewModel : ReactiveObject
         {
             control.FontSize = settings.TerminalFontSize;
         }
+        // 背景图开启时,终端控件自绘填充置全透明(不画背景),终端 tint 改由 TerminalHost 边框单层承担
+        // (VelaBgTerminal 令牌半透明,MainWindow 负责)。若这里仍按不透明度上色,会与该边框两层叠加、
+        // 保存后终端又变得几乎不透明。未开启背景图则恒为不透明(行为不变)。
+        bool backgroundImageActive = !string.IsNullOrWhiteSpace(settings.Appearance.BackgroundImagePath);
+        control.BackgroundOpacity = backgroundImageActive ? 0.0 : 1.0;
         TerminalBehaviorOptions behavior = settings.TerminalBehavior;
         control.LineHeight = behavior.LineHeight;
         control.CursorStyle = behavior.CursorStyle;
@@ -2582,6 +2587,21 @@ public class MainWindowViewModel : ReactiveObject
         control.PaletteOverrides = TerminalAppearanceMapper.BuildPaletteOverrides(
             settings.Appearance
         );
+    }
+
+    /// <summary>
+    /// 把终端默认背景不透明度实时应用到所有已打开的终端标签(背景图即时预览用:拖动滑杆时视图层直接调,
+    /// 不经保存/重建标签)。opacity=1 即不透明,还原默认。
+    /// </summary>
+    public void ApplyTerminalBackgroundOpacityToAllTabs(double opacity)
+    {
+        foreach (TerminalTabViewModel tab in TabBar.Tabs.OfType<TerminalTabViewModel>())
+        {
+            if (tab.TerminalEmulator.Control is VelaTerminalControl control)
+            {
+                control.BackgroundOpacity = opacity;
+            }
+        }
     }
 
     private void OnSettingsSaved(AppSettings settings)

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1118,6 +1118,20 @@ public class SettingsViewModel : ReactiveObject
             _previewService.PreviewWindowOpacity(Appearance.WindowOpacityPercent);
             return;
         }
+        // 背景图/终端背景不透明度走即时通道:与窗口不透明度同理,绕过防抖 JSON 快照,拖动线性平滑,
+        // 且不触发背景图重新解码(否则每帧读盘,滑杆卡顿、数值跳变)。
+        if (e.PropertyName is nameof(AppearanceOptions.BackgroundImageOpacity)
+            or nameof(AppearanceOptions.ContentBackgroundOpacity))
+        {
+            if (_suppressPreview || _previewService is null)
+            {
+                return;
+            }
+            _previewed = true;
+            _previewService.PreviewBackgroundOpacity(
+                Appearance.BackgroundImageOpacity, Appearance.ContentBackgroundOpacity);
+            return;
+        }
         SchedulePreviewBroadcast();
     }
 

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -112,7 +112,7 @@
   <!-- SFTP 面板底色与终端一致(#282A36 家族),而非窗口铬色。 -->
   <Border BorderThickness="0,1,0,0"
           BorderBrush="{DynamicResource VelaBorderPrimary}"
-          Background="{DynamicResource VelaBgTerminal}"
+          Background="{DynamicResource VelaBgSftpPanel}"
           IsVisible="{Binding IsVisible}"
           VerticalAlignment="Stretch"
           MinHeight="120">
@@ -267,7 +267,7 @@
       <Grid RowDefinitions="26,*">
 
         <Border Grid.Row="0"
-                Background="{DynamicResource VelaBgSurface}"
+                Background="{DynamicResource VelaBgContentHeader}"
                 BorderBrush="{DynamicResource VelaBorderPrimary}"
                 BorderThickness="0,0,0,1"
                 Padding="14,0">

--- a/src/VelaShell/Views/LocalFilePaneView.axaml
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml
@@ -54,7 +54,7 @@
     </Style>
   </UserControl.Styles>
 
-  <Border Background="{DynamicResource VelaBgTerminal}"
+  <Border Background="{DynamicResource VelaBgSftpPanel}"
           BorderBrush="{DynamicResource VelaBorderPrimary}"
           BorderThickness="0,1,0,0">
     <DockPanel>
@@ -128,7 +128,7 @@
         </Grid>
       </Border>
       <Border DockPanel.Dock="Top" Height="26" Padding="14,0"
-              Background="{DynamicResource VelaBgSurface}"
+              Background="{DynamicResource VelaBgContentHeader}"
               BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
         <Grid ColumnDefinitions="*,90,130">
           <TextBlock Text="{x:Static res:Strings.FileName}" FontFamily="{DynamicResource VelaTerminalFont}"

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -43,6 +43,11 @@
        TitleBarView(BeginMoveDrag,原生移动循环,Win11 边缘贴靠仍有效);
        窗口四周为自绘缩放抓取区(BeginResizeDrag)。 -->
   <Panel>
+    <!-- 背景图层(设置→外观→背景图片):铺在窗口最底层,UniformToFill。默认无图=不可见,行为与旧版一致。 -->
+    <Image x:Name="BackgroundImageLayer" Stretch="UniformToFill" IsHitTestVisible="False" IsVisible="False" />
+    <!-- 遮罩 scrim:铺在图片之上、所有内容之下的一层半透明主题底色。有图时所有内容背景令牌置透明,
+         于是整窗内容一律透出「scrim+图片」,不存在多层嵌套叠加。Background/Opacity/可见性由 ApplyBackgroundOpacities 装配。 -->
+    <Border x:Name="BackgroundScrim" IsHitTestVisible="False" IsVisible="False" />
     <Grid RowDefinitions="Auto,*"
           Margin="{Binding $parent[Window].OffScreenMargin}">
 

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -3,7 +3,9 @@ using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,6 +89,10 @@ public partial class MainWindow : Window
             sidebar.SettingsRequested += (_, _) => _ = OpenSettingsAsync();
         }
         DataContextChanged += (_, _) => HookFileBrowserVisibility();
+        // 主题(暗/亮)切换时,按新主题色重建背景令牌覆盖画刷。否则之前设的覆盖仍持旧主题色、
+        // 一直 shadow 掉换主题后的令牌值,导致终端/SFTP/侧栏等背景停在旧色,须再动一次滑杆才同步。
+        ActualThemeVariantChanged += (_, _) =>
+            ApplyBackgroundOpacities(_lastImageOpacity, _lastContentOpacity);
         Opened += OnWindowOpened;
         if (OperatingSystem.IsWindows())
         {
@@ -412,6 +418,9 @@ public partial class MainWindow : Window
                 previewService.WindowOpacityPreviewRequested += OnSettingsOpacityPreviewedForWindow;
                 Closed += (_, _) =>
                     previewService.WindowOpacityPreviewRequested -= OnSettingsOpacityPreviewedForWindow;
+                previewService.BackgroundOpacityPreviewRequested += OnBackgroundOpacityPreviewedForWindow;
+                Closed += (_, _) =>
+                    previewService.BackgroundOpacityPreviewRequested -= OnBackgroundOpacityPreviewedForWindow;
             }
             try
             {
@@ -489,6 +498,7 @@ public partial class MainWindow : Window
         AppearanceOptions a = settings.Appearance;
         ApplyWindowOpacity(a.WindowOpacityPercent);
         ApplySidebarPosition(a.SidebarPosition == "right");
+        ApplyBackgroundImage(a);
         if (Application.Current is not { } app)
         {
             return;
@@ -511,6 +521,130 @@ public partial class MainWindow : Window
         app.Resources["VelaUiFontSize"] = uiFontSize;
         app.Resources["ControlContentThemeFontSize"] = uiFontSize;
     }
+
+    private Bitmap? _backgroundBitmap;
+    private string? _loadedBackgroundPath;
+    // 最近一次应用的不透明度:主题切换时需按新主题色重建 scrim,故缓存以便重放。
+    private int _lastImageOpacity = 100, _lastContentOpacity = 85;
+
+    // 单一整窗 scrim 方案:背景图铺最底层,其上叠一层【半透明遮罩 scrim】(主题底色,整窗一层),
+    // 再上面所有内容背景令牌全部置【透明】,于是终端/SFTP/侧栏/面板一律透出 scrim+图片。
+    // 因全透明,任意嵌套容器都不会叠加(透明×N 仍透明),彻底消除"多层叠加致某区域偏暗"的问题。
+    // scrim 底色 = 主题 page 色(与 VelaShellTokens 两套变体一致,改那边记得同步)。
+    private static readonly Color ScrimDark = Color.Parse("#191A21");
+    private static readonly Color ScrimLight = Color.Parse("#F2EDDA");
+
+    // 有背景图时置全透明、让 scrim+图片透出的内容背景令牌(仅本窗口)。
+    // VelaBgSurface(弹层/对话框/卡片)、VelaBgInput(输入框)刻意不在其列,保持不透明以保证可读性。
+    private static readonly string[] ContentTokenKeys =
+    [
+        "VelaBgPage", "VelaBgSidebar", "VelaBgTerminal", "VelaBgSftpPanel", "VelaBgDockDocument",
+    ];
+
+    // 内容区的小块「强调底」(选项卡标题、选中项、悬停、输入框/下拉、表头):不能全透明(会丢失可辨识度),
+    // 而是有背景图时压成【半透明】,既保留强调作用又与背景图融合,不再突兀。颜色须与 VelaShellTokens 两套变体一致;
+    // Fraction = 保留的不透明比例(越低越透)。VelaBgSurface 不在其列(弹层/对话框/下拉浮层需不透明保证可读),
+    // 内容区表头改用专门的 VelaBgContentHeader。
+    private static readonly (string Key, Color Dark, Color Light, double Fraction)[] AccentTranslucentTokens =
+    [
+        ("VelaTabActiveBg", Color.Parse("#282A36"), Color.Parse("#FFFBEB"), 0.75),
+        ("VelaTabInactiveBg", Color.Parse("#191A21"), Color.Parse("#EBE5CC"), 0.45),
+        ("VelaBgActive", Color.Parse("#44475A"), Color.Parse("#644AC922"), 0.65),
+        ("VelaBgHover", Color.Parse("#363948"), Color.Parse("#EDE7D0"), 0.5),
+        ("VelaBgInput", Color.Parse("#282A36"), Color.Parse("#F7F2DF"), 0.7),
+        ("VelaBgContentHeader", Color.Parse("#343746"), Color.Parse("#FFFBEB"), 0.6),
+    ];
+
+    /// <summary>
+    /// 应用背景图片(设置 → 外观 → 背景图片):装配窗口最底层的 <c>BackgroundImageLayer</c>。
+    /// 仅在【路径变化】时(重新)解码图片,避免拖动不透明度滑杆时反复读盘;不透明度由
+    /// <see cref="ApplyBackgroundOpacities" /> 单独装配(可被即时预览直接调用)。
+    /// </summary>
+    private void ApplyBackgroundImage(AppearanceOptions a)
+    {
+        string path = a.BackgroundImagePath?.Trim() ?? "";
+        if (!string.Equals(path, _loadedBackgroundPath, StringComparison.Ordinal))
+        {
+            _backgroundBitmap?.Dispose();
+            _backgroundBitmap = null;
+            if (path.Length > 0 && File.Exists(path))
+            {
+                try
+                {
+                    _backgroundBitmap = new Bitmap(path);
+                }
+                catch
+                {
+                    _backgroundBitmap = null; // 解码失败:当作未设置,不打断启动/预览。
+                }
+            }
+            _loadedBackgroundPath = path;
+            if (this.FindControl<Image>("BackgroundImageLayer") is { } layer)
+            {
+                layer.Source = _backgroundBitmap;
+                layer.IsVisible = _backgroundBitmap is not null;
+            }
+        }
+        ApplyBackgroundOpacities(a.BackgroundImageOpacity, a.ContentBackgroundOpacity);
+    }
+
+    /// <summary>
+    /// 装配背景图相关的不透明度(即时预览与保存共用,不涉及图片解码,故可高频调用):图片图层不透明度、
+    /// scrim 遮罩不透明度、以及把内容背景令牌整体置透明(仅本窗口,弹层/对话框/输入框不受影响)。
+    /// 无背景图时隐藏 scrim、移除令牌覆盖、终端填充还原为不透明,完全恢复旧行为。
+    /// </summary>
+    private void ApplyBackgroundOpacities(int imageOpacity, int contentOpacity)
+    {
+        (_lastImageOpacity, _lastContentOpacity) = (imageOpacity, contentOpacity);
+        bool active = _backgroundBitmap is not null;
+        if (this.FindControl<Image>("BackgroundImageLayer") is { } layer)
+        {
+            layer.Opacity = Math.Clamp(imageOpacity, 0, 100) / 100.0;
+        }
+
+        if (this.FindControl<Border>("BackgroundScrim") is { } scrim)
+        {
+            Color baseColor = ActualThemeVariant == ThemeVariant.Light ? ScrimLight : ScrimDark;
+            scrim.Background = new SolidColorBrush(baseColor);
+            scrim.Opacity = Math.Clamp(contentOpacity, 0, 100) / 100.0; // 遮罩越不透明,越盖住背景图
+            scrim.IsVisible = active;
+        }
+
+        foreach (string key in ContentTokenKeys)
+        {
+            if (active)
+            {
+                Resources[key] = Brushes.Transparent;
+            }
+            else
+            {
+                Resources.Remove(key);
+            }
+        }
+
+        // 强调底压成半透明(而非全透明):选项卡标题、选中项、悬停、输入框、内容表头等,融入背景图不再突兀。
+        bool light = ActualThemeVariant == ThemeVariant.Light;
+        foreach ((string key, Color dark, Color lightColor, double fraction) in AccentTranslucentTokens)
+        {
+            if (active)
+            {
+                Color c = light ? lightColor : dark;
+                Resources[key] = new SolidColorBrush(Color.FromArgb((byte)Math.Round(c.A * fraction), c.R, c.G, c.B));
+            }
+            else
+            {
+                Resources.Remove(key);
+            }
+        }
+
+        // 终端控件自绘填充:有图时置全透明(不画背景),透出 scrim+背景图;无图时恒不透明(=1),行为不变。
+        // 终端文字与彩色单元格底(选区/彩色输出)不受影响,照常绘制,不伤可读性。
+        (DataContext as MainWindowViewModel)?.ApplyTerminalBackgroundOpacityToAllTabs(active ? 0.0 : 1.0);
+    }
+
+    /// <summary>背景图/内容背景不透明度的即时预览(拖动滑杆):只调不透明度,不重新解码图片。</summary>
+    private void OnBackgroundOpacityPreviewedForWindow((int Image, int Content) v) =>
+        RunOnUiThread(() => ApplyBackgroundOpacities(v.Image, v.Content));
 
     private void ApplyWindowOpacity(int percent) => Opacity = Math.Clamp(percent, 10, 100) / 100.0;
 

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml
@@ -98,7 +98,7 @@
       </Border>
 
       <!-- 编辑器 -->
-      <Border Grid.Row="1" Background="{DynamicResource VelaBgTerminal}">
+      <Border Grid.Row="1" Background="{DynamicResource VelaBgSftpPanel}">
         <ae:TextEditor Name="Editor"
                        FontFamily="{DynamicResource VelaTerminalFont}"
                        FontSize="13"

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
@@ -51,6 +51,51 @@
       </StackPanel>
     </Grid>
 
+    <!-- 背景图片(设计新增,放在主题色下):图片铺在应用最底层,透过半透明的终端/文件面板显示。 -->
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetAppear_BackgroundImage}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_BackgroundImageDesc}" />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <TextBox Width="200" Text="{Binding Appearance.BackgroundImagePath}"
+                 IsReadOnly="True" ToolTip.Tip="{Binding Appearance.BackgroundImagePath}" />
+        <Button Classes="dlg-outline" Content="{loc:Localize SetAppear_BackgroundImageBrowse}"
+                Click="PickBackgroundImage_Click" />
+        <Button Classes="dlg-outline" Content="{loc:Localize SetAppear_BackgroundImageClear}"
+                Click="ClearBackgroundImage_Click" />
+      </StackPanel>
+    </Grid>
+    <!-- 背景图相关滑块仅在设置了背景图后才有意义:未设图时隐藏,避免误导。 -->
+    <Grid ColumnDefinitions="*,Auto"
+          IsVisible="{Binding Appearance.BackgroundImagePath, Converter={x:Static conv:StringNotEmptyConverter.Instance}}">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetAppear_BackgroundImageOpacity}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_BackgroundImageOpacityDesc}" />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <Slider Width="120" Minimum="0" Maximum="100"
+                Value="{Binding Appearance.BackgroundImageOpacity}" VerticalAlignment="Center" />
+        <TextBlock Width="40" TextAlignment="Right" VerticalAlignment="Center"
+                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="12"
+                   Text="{Binding Appearance.BackgroundImageOpacity, StringFormat={}{0}%}" />
+      </StackPanel>
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto"
+          IsVisible="{Binding Appearance.BackgroundImagePath, Converter={x:Static conv:StringNotEmptyConverter.Instance}}">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetAppear_ContentBgOpacity}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_ContentBgOpacityDesc}" />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <Slider Width="120" Minimum="20" Maximum="100"
+                Value="{Binding Appearance.ContentBackgroundOpacity}" VerticalAlignment="Center" />
+        <TextBlock Width="40" TextAlignment="Right" VerticalAlignment="Center"
+                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="12"
+                   Text="{Binding Appearance.ContentBackgroundOpacity, StringFormat={}{0}%}" />
+      </StackPanel>
+    </Grid>
+
     <Border Classes="sep" />
 
     <!-- 字体 -->

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
@@ -1,13 +1,48 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using VelaShell.Core.Resources;
+using VelaShell.ViewModels;
 
 namespace VelaShell.Views.Settings;
 
-/// <summary>外观设置页:配置主题、字体等界面外观相关选项。</summary>
+/// <summary>外观设置页:配置主题、字体、背景图片等界面外观相关选项。</summary>
 public partial class AppearanceSettingsPage : UserControl
 {
     /// <summary>初始化外观设置页并加载 XAML 组件。</summary>
     public AppearanceSettingsPage()
     {
         InitializeComponent();
+    }
+
+    /// <summary>“浏览…”:选一张本地图片作为应用背景;写入 Appearance.BackgroundImagePath(触发即时预览与保存)。</summary>
+    private async void PickBackgroundImage_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SettingsViewModel vm || TopLevel.GetTopLevel(this)?.StorageProvider is not { } storage)
+        {
+            return;
+        }
+        IReadOnlyList<IStorageFile> files = await storage.OpenFilePickerAsync(new()
+        {
+            Title = Strings.Get("SetAppear_BackgroundImage"),
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new("Images") { Patterns = ["*.png", "*.jpg", "*.jpeg", "*.bmp", "*.gif", "*.webp"] }
+            ]
+        });
+        if (files.Count > 0 && files[0].TryGetLocalPath() is { Length: > 0 } path)
+        {
+            vm.Appearance.BackgroundImagePath = path;
+        }
+    }
+
+    /// <summary>“清除”:移除背景图,恢复纯色主题背景(路径置空即触发所有相关背景还原)。</summary>
+    private void ClearBackgroundImage_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is SettingsViewModel vm)
+        {
+            vm.Appearance.BackgroundImagePath = "";
+        }
     }
 }

--- a/src/VelaShell/Views/SftpDocumentView.axaml
+++ b/src/VelaShell/Views/SftpDocumentView.axaml
@@ -9,7 +9,9 @@
              mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="600"
              x:Class="VelaShell.Views.SftpDocumentView"
              x:DataType="vm:SftpDocumentViewModel">
-  <Border Background="{DynamicResource VelaBgTerminal}">
+  <!-- 外层包裹用 VelaBgDockDocument(有背景图时置透明),避免与内部 LocalFilePaneView/FileBrowserView
+       的 VelaBgSftpPanel 底叠加成双层(双列 SFTP 曾因此完全不透明)。tint 由内部各面板单层承担。 -->
+  <Border Background="{DynamicResource VelaBgDockDocument}">
     <DockPanel>
       <Grid MinWidth="564">
         <Grid.ColumnDefinitions>

--- a/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
@@ -105,6 +105,27 @@ public class ModelSerializationTests
     }
 
     [TestMethod]
+    public void AppearanceOptions_BackgroundImage_DefaultsAndRoundTrip()
+    {
+        // 默认:无背景图,行为与旧版一致(路径空、图片不透明度 100、内容背景不透明度 85 但仅在设图后生效)。
+        var fresh = new AppearanceOptions();
+        Assert.AreEqual("", fresh.BackgroundImagePath);
+        Assert.AreEqual(100, fresh.BackgroundImageOpacity);
+        Assert.AreEqual(85, fresh.ContentBackgroundOpacity);
+
+        var settings = new AppSettings();
+        settings.Appearance.BackgroundImagePath = "/home/user/wall.png";
+        settings.Appearance.BackgroundImageOpacity = 60;
+        settings.Appearance.ContentBackgroundOpacity = 40;
+        string json = JsonSerializer.Serialize(settings, _options);
+        Assert.Contains("\"backgroundImagePath\":", json);
+        var back = JsonSerializer.Deserialize<AppSettings>(json, _options)!;
+        Assert.AreEqual("/home/user/wall.png", back.Appearance.BackgroundImagePath);
+        Assert.AreEqual(60, back.Appearance.BackgroundImageOpacity);
+        Assert.AreEqual(40, back.Appearance.ContentBackgroundOpacity);
+    }
+
+    [TestMethod]
     public void AppSettings_ShouldSerializeWithCamelCase()
     {
         var settings = new AppSettings


### PR DESCRIPTION
允许用户设置本地图片为应用背景，支持单独调整图片和内容遮罩不透明度，内容区整体半透明，弹层/输入框保持不透明。AppearanceOptions 增加相关属性并实现序列化和测试。设置界面支持图片选择、清除及滑块，新增 StringNotEmptyConverter 控制显隐。主窗口底层新增背景图片和遮罩层，主题切换时自动同步遮罩色，内容区背景令牌自动透明，强调色融合背景图。终端控件支持背景填充不透明度调整，SFTP/文件面板/远程编辑器等内容区背景令牌细分。设置预览服务支持即时预览，国际化资源补充相关描述，XAML 文件同步调整背景令牌引用。