### PR TITLE
提取上传按钮样式为全局资源并统一引用

### DIFF
--- a/src/VelaShell/App.axaml
+++ b/src/VelaShell/App.axaml
@@ -26,6 +26,7 @@
                 <ResourceInclude Source="avares://VelaShell.Controls/Themes/VelaTokens.axaml" />
                 <ResourceInclude Source="avares://VelaShell.Controls/Themes/VelaShellTokens.axaml" />
                 <ResourceInclude Source="avares://VelaShell.Controls/Themes/Icons.axaml" />
+                <ResourceInclude Source="avares://VelaShell/Themes/ButtonThemes.axaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- 界面字号默认值(设计 font-ui 13);运行时被 ApplyWindowAppearance 覆盖。 -->

--- a/src/VelaShell/Themes/ButtonThemes.axaml
+++ b/src/VelaShell/Themes/ButtonThemes.axaml
@@ -1,0 +1,63 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <!-- 强调色「药丸」按钮(SFTP 上传、隧道创建等主操作):半透明强调底 VelaAccentDim + 强调色描边/图标/文字。
+       比实心 VelaAccent 更柔和;且 VelaAccentDim 为半透明,能与背景图自然融合,不突兀。
+       图标/文字请自行用 VelaAccent 前景(见各调用处)。 -->
+  <ControlTheme x:Key="VelaAccentPillButtonTheme" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="3" />
+    <Setter Property="Padding" Value="8,0" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="PART_PillRoot"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <ContentPresenter x:Name="PART_ContentPresenter"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Foreground="{TemplateBinding Foreground}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:focus">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:focus:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="^:focus:pressed">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -10,62 +10,6 @@
              x:Class="VelaShell.Views.FileBrowserView"
              x:DataType="vm:FileBrowserViewModel">
 
-  <UserControl.Resources>
-    <ControlTheme x:Key="VelaUploadPillButtonTheme" TargetType="Button">
-      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-      <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="CornerRadius" Value="3" />
-      <Setter Property="Padding" Value="8,0" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="Template">
-        <ControlTemplate>
-          <Border x:Name="PART_UploadPillRoot"
-                  Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="{TemplateBinding CornerRadius}"
-                  Padding="{TemplateBinding Padding}">
-            <ContentPresenter x:Name="PART_ContentPresenter"
-                              Content="{TemplateBinding Content}"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                              Foreground="{TemplateBinding Foreground}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-          </Border>
-        </ControlTemplate>
-      </Setter>
-      <Style Selector="^:pointerover">
-        <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-      </Style>
-      <Style Selector="^:pressed">
-        <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-      </Style>
-      <Style Selector="^:focus">
-        <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
-      </Style>
-      <Style Selector="^:focus:pointerover">
-        <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-        <Setter Property="BorderThickness" Value="1" />
-      </Style>
-      <Style Selector="^:focus:pressed">
-        <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
-        <Setter Property="BorderThickness" Value="1" />
-      </Style>
-      <Style Selector="^:disabled">
-        <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
-        <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      </Style>
-    </ControlTheme>
-  </UserControl.Resources>
 
   <UserControl.Styles>
     <Style Selector="Button.toolbar-btn">
@@ -187,7 +131,7 @@
           <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
             <Button Classes="upload-pill" Height="24" Cursor="Hand"
                     FocusAdorner="{x:Null}"
-                    Theme="{StaticResource VelaUploadPillButtonTheme}"
+                    Theme="{DynamicResource VelaAccentPillButtonTheme}"
                     Command="{Binding UploadCommand}"
                     ToolTip.Tip="{x:Static res:Strings.Upload}">
               <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">

--- a/src/VelaShell/Views/TunnelPanelView.axaml
+++ b/src/VelaShell/Views/TunnelPanelView.axaml
@@ -316,15 +316,17 @@
                        Foreground="{DynamicResource VelaTextSecondary}"
                        FontFamily="{DynamicResource VelaUiFont}" FontSize="11" />
           </Button>
-          <Button Padding="10,4" CornerRadius="3"
-                  Background="{DynamicResource VelaAccent}"
+          <!-- 主操作按钮沿用 SFTP「上传」的强调药丸方案:半透明 VelaAccentDim 底 + 强调色描边/图标/文字,
+               而非实心 VelaAccent(过于突兀、且不与背景图融合)。Padding 保持 10,4 以与左侧取消按钮等高。 -->
+          <Button Padding="10,4" Cursor="Hand"
+                  Theme="{DynamicResource VelaAccentPillButtonTheme}"
                   Command="{Binding CreateTunnelCommand}">
-            <StackPanel Orientation="Horizontal" Spacing="4">
+            <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
               <pc:LucideIcon Width="11" Height="11"
                              Data="{StaticResource Icon.plus}"
-                             Foreground="{DynamicResource VelaAccentText}" VerticalAlignment="Center" />
+                             Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
               <TextBlock Text="{Binding SubmitButtonText}"
-                         Foreground="{DynamicResource VelaAccentText}"
+                         Foreground="{DynamicResource VelaAccent}"
                          FontFamily="{DynamicResource VelaUiFont}" FontSize="11" FontWeight="Medium" />
             </StackPanel>
           </Button>


### PR DESCRIPTION
将原 FileBrowserView.axaml 内的上传按钮样式提取至全局 ButtonThemes.axaml，命名为 VelaAccentPillButtonTheme，便于复用和维护。App.axaml 新增全局引用，FileBrowserView.axaml 和 TunnelPanelView.axaml 同步调整 Theme 属性。样式本身未变，提升了样式一致性和后续维护效率。