### PR TITLE
实现文件浏览器跟随终端目录（map-pin）

### DIFF
--- a/src/VelaShell.Controls/Themes/Icons.axaml
+++ b/src/VelaShell.Controls/Themes/Icons.axaml
@@ -7,6 +7,7 @@
   <StreamGeometry x:Key="Icon.copy">M10 8h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2Z M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2</StreamGeometry>
   <StreamGeometry x:Key="Icon.columns-2">M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z M12 3v18</StreamGeometry>
   <StreamGeometry x:Key="Icon.route">M6 16a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z M18 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15</StreamGeometry>
+  <StreamGeometry x:Key="Icon.map-pin">M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z M15 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z</StreamGeometry>
   <StreamGeometry x:Key="Icon.zap">M13 2 3 14h9l-1 8 10-12h-9l1-8Z</StreamGeometry>
   <StreamGeometry x:Key="Icon.link-2">M9 17H7A5 5 0 0 1 7 7h2 M15 7h2a5 5 0 1 1 0 10h-2 M8 12h8</StreamGeometry>
   <StreamGeometry x:Key="Icon.send">M22 2 15 22l-4-9-9-4Z M22 2 11 13</StreamGeometry>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -82,6 +82,9 @@
   <data name="Sftp_RefreshRemotePane" xml:space="preserve">
     <value>Refresh remote pane</value>
   </data>
+  <data name="Sftp_FollowTerminal" xml:space="preserve">
+    <value>Follow terminal directory (sync to the terminal's current path)</value>
+  </data>
   <data name="TransferHistory" xml:space="preserve">
     <value>Transfer history</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -183,6 +183,9 @@
   <data name="Sftp_RefreshRemotePane" xml:space="preserve">
     <value>刷新远程栏</value>
   </data>
+  <data name="Sftp_FollowTerminal" xml:space="preserve">
+    <value>跟随终端目录(同步到终端当前路径)</value>
+  </data>
   <data name="TransferHistory" xml:space="preserve">
     <value>传输记录</value>
   </data>

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -445,8 +445,41 @@ public sealed class TerminalEmulator : IVtActions
                     }
                 }
                 break;
+            case 7:
+                // OSC 7:shell 上报当前工作目录(file://host/path)。用于「文件浏览器跟随终端目录」。
+                // 由 VelaShell 注入的 bash 提示符脚本发出(见 MainWindowViewModel.PromptNewlineFix)。
+                if (p.Count > 1 && ParseOsc7Path(p[1]) is { Length: > 0 } dir)
+                {
+                    WorkingDirectoryChanged?.Invoke(dir);
+                }
+                break;
                 // 4(调色板)、8(超链接)目前有意接受并忽略。
         }
+    }
+
+    /// <summary>从 OSC 7 载荷 file://host/path 提取绝对路径(百分号编码按需解码);非法/非绝对路径返回 null。</summary>
+    private static string? ParseOsc7Path(string payload)
+    {
+        const string scheme = "file://";
+        if (!payload.StartsWith(scheme, StringComparison.Ordinal))
+        {
+            return null;
+        }
+        int slash = payload.IndexOf('/', scheme.Length); // 跳过 host,定位路径起点(file:///abs 时即第三个斜杠)
+        if (slash < 0)
+        {
+            return null;
+        }
+        string path = payload[slash..];
+        try
+        {
+            path = Uri.UnescapeDataString(path); // VTE 等会百分号编码;我们注入的脚本发原始路径,解码对纯 ASCII 无副作用
+        }
+        catch (Exception)
+        {
+            // 解码失败:用原始路径。
+        }
+        return path.StartsWith('/') ? path : null;
     }
 
     /// <summary>分发 DCS 序列;目前处理 DECRQSS 状态请求,其余静默消费。</summary>
@@ -477,6 +510,9 @@ public sealed class TerminalEmulator : IVtActions
 
     /// <summary>OSC 0/2 窗口标题变更。</summary>
     public event Action<string>? TitleChanged;
+
+    /// <summary>OSC 7 当前工作目录变更(绝对路径)。事件来自 feed 线程,消费者需自行编组到 UI 线程。</summary>
+    public event Action<string>? WorkingDirectoryChanged;
 
     /// <summary>收到 BEL(0x07)。</summary>
     public event Action? Bell;

--- a/src/VelaShell.Terminal/ITerminalEmulator.cs
+++ b/src/VelaShell.Terminal/ITerminalEmulator.cs
@@ -84,6 +84,12 @@ public interface ITerminalEmulator : IDisposable
     event Action<int, int>? PtySizeChanged;
 
     /// <summary>
+    /// shell 经 OSC 7 上报当前工作目录时触发(绝对路径)。用于「文件浏览器跟随终端目录」。
+    /// 仅在 shell 发出 OSC 7 时有效(VelaShell 注入的 bash 提示符脚本会发)。来自 feed 线程。
+    /// </summary>
+    event Action<string>? WorkingDirectoryChanged;
+
+    /// <summary>
     /// 以编程方式发送输入字节,如同用户键入一样
     /// </summary>
     void WriteInput(byte[] data);

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -630,6 +630,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         remove => Emulator.TitleChanged -= value;
     }
 
+    /// <summary>OSC 7 当前工作目录变更(直通仿真器)。</summary>
+    public event Action<string>? WorkingDirectoryChanged
+    {
+        add => Emulator.WorkingDirectoryChanged += value;
+        remove => Emulator.WorkingDirectoryChanged -= value;
+    }
+
     /// <summary>设置主机输出字符集(默认 UTF-8;支持 GBK/Big5 等)。</summary>
     public void SetEncoding(Encoding encoding) => Emulator.SetEncoding(encoding);
 

--- a/src/VelaShell/ViewModels/FileBrowserViewModel.cs
+++ b/src/VelaShell/ViewModels/FileBrowserViewModel.cs
@@ -284,6 +284,58 @@ public class FileBrowserViewModel : ReactiveObject
     /// <summary>成功进入不同目录后触发,视图据此把滚动条重置到顶部。</summary>
     public event EventHandler? DirectoryChanged;
 
+    private bool _followTerminal;
+    private string? _pendingTerminalPath;
+
+    /// <summary>
+    /// 「跟随终端目录」(map-pin 按钮):开启时,本会话终端 shell 的 cwd 变化(经 OSC 7)会自动把文件浏览器
+    /// 切到该目录。开启当下立即同步到终端当前目录;关闭则不同步。手动切换目录不影响开关——终端下次 cd 到
+    /// 新目录时再同步到最新。仅在 shell 发出 OSC 7 时有效(VelaShell 注入的 bash 提示符脚本会发)。
+    /// </summary>
+    public bool FollowTerminal
+    {
+        get => _followTerminal;
+        set
+        {
+            if (_followTerminal == value)
+            {
+                return;
+            }
+            this.RaiseAndSetIfChanged(ref _followTerminal, value);
+            if (value && _pendingTerminalPath is { Length: > 0 } path)
+            {
+                SyncToTerminalPath(path); // 开启当下立即同步到终端当前目录
+            }
+        }
+    }
+
+    /// <summary>本会话终端 cwd 变化时由宿主调用(仅在终端 cd 到新目录时,已在 TerminalTabViewModel 去重)。
+    /// 记住最新终端目录(供开启开关时立即同步);若正在跟随则立刻切换。</summary>
+    public void OnTerminalWorkingDirectoryChanged(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+        _pendingTerminalPath = path;
+        if (_followTerminal)
+        {
+            SyncToTerminalPath(path);
+        }
+    }
+
+    private void SyncToTerminalPath(string path)
+    {
+        // OSC 7 事件源自终端 feed 线程;导航须在 UI 线程。目录相同则不折腾。
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_sessionId != Guid.Empty && !string.Equals(path, CurrentPath, StringComparison.Ordinal))
+            {
+                NavigateToCommand.Execute(path).Subscribe(_ => { }, _ => { });
+            }
+        });
+    }
+
     /// <summary>当前浏览的远程目录绝对路径;赋值时同步刷新 <see cref="Breadcrumbs" />。</summary>
     public string CurrentPath
     {

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -42,8 +42,10 @@ public class MainWindowViewModel : ReactiveObject
     /// bash 提示符补行脚本(内置,静默注入):命令输出末尾无换行时,经 DSR(ESC[6n)
     /// 查询光标列,不在行首则先补一个换行再画提示符(zsh 的默认行为)。
     /// </summary>
+    // 末尾 printf 发 OSC 7(file://主机/当前目录),供「文件浏览器跟随终端目录」(map-pin)读取 shell cwd。
+    // 仅 bash 会调用 prompt_nl(经 PROMPT_COMMAND),故 \e/\$PWD 等 bash-only 语法对 dash/sh 无副作用(它们从不调用)。
     private const string PromptNewlineFix =
-        """prompt_nl() { local c; IFS='[;' read -p $'\e[6n' -d R -rs _ _ c; ((c>1)) && echo; }; PROMPT_COMMAND=prompt_nl""";
+        """prompt_nl() { local c; IFS='[;' read -p $'\e[6n' -d R -rs _ _ c; ((c>1)) && echo; printf '\e]7;file://%s%s\e\\' "$HOSTNAME" "$PWD"; }; PROMPT_COMMAND=prompt_nl""";
 
     /// <summary>RIS(ESC c)完全重置序列:重开会话前清掉旧进程的残留缓冲。</summary>
     private static readonly byte[] RisResetSequence = [0x1B, (byte)'c']; // ESC c
@@ -861,6 +863,14 @@ public class MainWindowViewModel : ReactiveObject
             ServerDisplayName = serverName,
             AccentBrush = tab.Profile is { } p ? ConnectionAccent.BrushFor(p.Id) : null,
         };
+        // 「文件浏览器跟随终端目录」(map-pin):该会话终端 shell 的 cwd(OSC 7)变化 → 面板同步(仅在开启跟随时)。
+        // 先播种当前已知 cwd(供开启开关时立即同步),再订阅后续变化。二者同会话、同生共死,eviction 时解绑。
+        if (tab.TerminalWorkingDirectory is { } cwd)
+        {
+            browser.OnTerminalWorkingDirectoryChanged(cwd);
+        }
+        tab.WorkingDirectoryChanged += browser.OnTerminalWorkingDirectoryChanged;
+
         _fileBrowserCache[tab.SessionId] = browser;
         FileBrowser = browser;
         if (wasVisible)
@@ -882,6 +892,11 @@ public class MainWindowViewModel : ReactiveObject
         }
         if (_fileBrowserCache.Remove(sessionId, out FileBrowserViewModel? cached))
         {
+            // 解绑「跟随终端目录」订阅(该会话的终端标签 → 面板),再拆除面板。
+            if (TabBar.Tabs.OfType<TerminalTabViewModel>().FirstOrDefault(t => t.SessionId == sessionId) is { } tab)
+            {
+                tab.WorkingDirectoryChanged -= cached.OnTerminalWorkingDirectoryChanged;
+            }
             cached.Detach();
         }
         if (FileBrowser.SessionId != sessionId)

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -49,6 +49,9 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
         InputTracker.CommandSubmitted += OnTrackedCommandSubmitted;
         InputTracker.UnknownLineSubmitted += OnUnknownLineSubmitted;
 
+        // OSC 7:shell 上报当前工作目录 → 供「文件浏览器跟随终端目录」用。仅在 cwd 真正变化时向外播报。
+        TerminalEmulator.WorkingDirectoryChanged += OnEmulatorWorkingDirectoryChanged;
+
         // 工具栏快捷操作:拆除传输但保留标签,
         // 或请求宿主就地重连(#19 流程)。
         DisconnectCommand = ReactiveCommand.Create(
@@ -377,6 +380,24 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     /// <summary>本标签持有的终端模拟器,跨重连保持不变(拥有滚动缓冲区)。</summary>
     public ITerminalEmulator TerminalEmulator { get; }
 
+    /// <summary>该终端 shell 当前工作目录(经 OSC 7 上报);未知/未上报时为 null。</summary>
+    public string? TerminalWorkingDirectory { get; private set; }
+
+    /// <summary>终端 shell 工作目录【变化】时触发(去重:同值不重复触发)。参数为绝对路径。</summary>
+    public event Action<string>? WorkingDirectoryChanged;
+
+    private void OnEmulatorWorkingDirectoryChanged(string path)
+    {
+        // OSC 7 每次提示符都发(即使 cwd 未变);只在真正变化时对外播报,避免把用户在文件浏览器里
+        // 的手动切换在每次回车时都拽回终端目录(仅当终端 cd 到新目录才同步)。
+        if (string.IsNullOrEmpty(path) || string.Equals(path, TerminalWorkingDirectory, StringComparison.Ordinal))
+        {
+            return;
+        }
+        TerminalWorkingDirectory = path;
+        WorkingDirectoryChanged?.Invoke(path);
+    }
+
     /// <summary>当前挂载的 shell 数据流;未连接或断开后为 null。</summary>
     public IShellStreamWrapper? ShellStream { get; private set; }
 
@@ -508,6 +529,7 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
         IsConnected = false;
         TerminalEmulator.PtySizeChanged -= OnPtySizeChanged;
         TerminalEmulator.TypedInput -= OnUserInputForTracker;
+        TerminalEmulator.WorkingDirectoryChanged -= OnEmulatorWorkingDirectoryChanged;
         InputTracker.CommandSubmitted -= OnTrackedCommandSubmitted;
         InputTracker.UnknownLineSubmitted -= OnUnknownLineSubmitted;
 

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -21,6 +21,30 @@
     <Style Selector="Button.toolbar-btn:pointerover /template/ ContentPresenter">
       <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
     </Style>
+    <!-- 「跟随终端目录」开关钮:安静图标钮,开启(checked)时图标染强调色;中和 Fluent ToggleButton
+         默认选中背景,使外观与其它工具栏图标钮一致(仅颜色区分开/关)。 -->
+    <Style Selector="ToggleButton.follow-pin">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+    </Style>
+    <Style Selector="ToggleButton.follow-pin:checked">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="ToggleButton.follow-pin /template/ ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="ToggleButton.follow-pin:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.follow-pin:checked /template/ ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="ToggleButton.follow-pin:checked:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
     <Style Selector="Button.col-header">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
@@ -145,6 +169,16 @@
                            VerticalAlignment="Center" />
               </StackPanel>
             </Button>
+            <!-- 「跟随终端目录」(map-pin):开启后本会话终端 cd 到新目录时文件浏览器自动同步;
+                 关闭则不同步。手动切目录不改开关,终端下次 cd 再同步到最新(见 FileBrowserViewModel.FollowTerminal)。 -->
+            <ToggleButton Classes="follow-pin" Width="24" Height="24" Padding="0"
+                          HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                          IsChecked="{Binding FollowTerminal}"
+                          ToolTip.Tip="{loc:Localize Sftp_FollowTerminal}">
+              <pc:LucideIcon Width="13" Height="13"
+                             Data="{StaticResource Icon.map-pin}"
+                             Foreground="{Binding $parent[ToggleButton].Foreground}" />
+            </ToggleButton>
             <Button Classes="toolbar-btn" Width="24" Height="24" Padding="0"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Command="{Binding ShowTransfersCommand}"

--- a/tests/VelaShell.Terminal.Tests/Emulation/Osc7WorkingDirectoryTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/Osc7WorkingDirectoryTests.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests.Emulation;
+
+/// <summary>
+/// OSC 7(shell 上报当前工作目录 file://host/path)解析:驱动「文件浏览器跟随终端目录」。
+/// 由 VelaShell 注入的 bash 提示符脚本发出;解析结果须为绝对路径,非法/非绝对一律不触发。
+/// </summary>
+[TestClass]
+[TestCategory("Emulator")]
+public class Osc7WorkingDirectoryTests
+{
+    private static TerminalEmulator New() => new(20, 6, TerminalType.XtermColor256);
+
+    private static string? CaptureCwd(string oscSequence)
+    {
+        TerminalEmulator e = New();
+        string? captured = null;
+        e.WorkingDirectoryChanged += path => captured = path;
+        e.Feed(Encoding.UTF8.GetBytes(oscSequence));
+        return captured;
+    }
+
+    [TestMethod]
+    public void Osc7_WithHost_StTerminator_ExtractsPath()
+    {
+        // ESC ] 7 ; file://host/root/temp ESC \
+        Assert.AreEqual("/root/temp", CaptureCwd("\e]7;file://myhost/root/temp\e\\"));
+    }
+
+    [TestMethod]
+    public void Osc7_EmptyHost_ExtractsPath()
+    {
+        Assert.AreEqual("/var/log", CaptureCwd("\e]7;file:///var/log\e\\"));
+    }
+
+    [TestMethod]
+    public void Osc7_PercentEncoded_IsDecoded()
+    {
+        Assert.AreEqual("/a b/c", CaptureCwd("\e]7;file://h/a%20b/c\e\\"));
+    }
+
+    [TestMethod]
+    public void Osc7_NonFileScheme_DoesNotFire()
+    {
+        Assert.IsNull(CaptureCwd("\e]7;http://example.com/x\e\\"));
+    }
+
+    [TestMethod]
+    public void Osc7_MalformedNoPath_DoesNotFire()
+    {
+        Assert.IsNull(CaptureCwd("\e]7;file://host\e\\"));
+    }
+}


### PR DESCRIPTION
终端模拟器支持 OSC 7 解析并通过 WorkingDirectoryChanged 事件通知外部，接口与视图模型链路同步。TerminalTabViewModel 去重广播 cwd 变化。FileBrowserViewModel 增加 FollowTerminal 属性及同步/开关逻辑，支持 UI 层 map-pin ToggleButton 控制。完善事件订阅管理，新增本地化字符串和 map-pin 图标。补充 OSC 7 解析单元测试，提升健壮性。