### PR TITLE
新增硬件加速渲染设置项，支持切换 GPU 加速

### DIFF
--- a/docs/性能与内存优化-2026-07.md
+++ b/docs/性能与内存优化-2026-07.md
@@ -50,3 +50,83 @@ Avalonia 是保留模式渲染,GlyphRun 被场景图持有到合成期,复用底
   基本清零;大文件 ZModem 传输的 UI 派发 10⁴×↓。这些不体现在空载启动数字上。
 - 遗留的低优先级项(未做,见审计):渲染缓存"到顶全清"换 LRU、录制回放流式读取、
   ResourceMonitor 定向通知、VtParser 泛型去虚化。
+
+---
+
+# 追加批次(2026-07-25):基线内存的大头是 GPU 栈,不是应用数据
+
+上一批把"启动约 280MB 由窗口合成主导"记为不可优化项。本次用转储与模块表把这个数字拆开,
+结论是**它可优化,而且是目前最大的一项**。
+
+## 实测拆分(Release,空载无连接,Intel 核显机器)
+
+| 项 | 数值 | 来源 |
+| --- | --- | --- |
+| WorkingSet | 396 MB | `Process.WorkingSet64` |
+| Private | 312 MB | `Process.PrivateMemorySize64` |
+| **托管堆合计** | **23 MB**(204,408 个对象) | `dotnet-dump analyze` → `dumpheap -stat` |
+| 已加载模块映像合计 | 286 MB / 177 个模块 | `Process.Modules` |
+| └ `igc64.dll`(Intel 图形着色器编译器) | **82.5 MB** | 同上 |
+| └ `igd10um64xe.dll` | 17.1 MB | 同上 |
+| └ `libSkiaSharp` + `av_libGLESv2` + `d3dcompiler_47` + `igdgmm64` | 合计 27 MB | 同上 |
+
+**托管对象只占 8%**。堆里最大的一类是 `System.Byte[]` 7.5MB,其余全是 Avalonia 的属性存储、
+样式实例与合成器节点,没有一处异常。也就是说:针对 C# 数据结构的优化(cell 布局、零拷贝、
+对象池)动不了这个基线 —— 它们的战场在**稳态增长**,不在空载常驻。
+
+跳变时点也对得上:进程启动后第 3 秒一次性涨 187MB,正是 GPU 后端初始化、驱动模块被映射进来的时刻。
+
+## 落地:硬件加速开关(设置 → 外观 → 渲染)
+
+`Win32PlatformOptions.RenderingMode` 由 `Appearance.HardwareAcceleration` 决定。同机实测:
+
+| 模式 | WorkingSet | Private | 模块 |
+| --- | --- | --- | --- |
+| 硬件加速(默认) | 396 MB | 312 MB | 286 MB |
+| 软件渲染 | **213 MB** | **124 MB** | 163 MB |
+
+**省 183 MB WorkingSet / 188 MB Private。**代价是绘制交给 CPU;终端以文本为主,多数机器无感,
+但显卡好、内存充裕时保持默认更顺滑,因此做成开关而非默认关闭。
+
+实现上的三个约束,改动时勿破坏:
+
+1. **渲染后端必须在 Avalonia 初始化前定下**,那时 DI 与 SonnetDB 都还没起来,读不到设置。
+   为此 `SaveSettingsAsync` 把这一项额外镜像成单行小文件 `%LocalAppData%/VelaShell/render.mode`,
+   `Program.ResolveRenderingMode()` 只做一次 `File.ReadAllText`,不引入数据库初始化开销。
+2. **软件渲染兜底始终留在 GPU 模式列表末尾**(`[AngleEgl, Software]`),远程桌面或驱动异常时
+   不至于起不来。
+3. 该项不参与 Gist 同步(机器相关,见 `GistSyncService.ScrubDeviceLocalFields`)。
+
+`VELASHELL_SOFTWARE_RENDER=1` 环境变量可强制软件渲染,用于测量与排障,优先级高于设置。
+
+## 仍需盯的:回滚行数不随默认值下调
+
+`ScrollbackLines` 上次把默认值 50000 降到 10000 时**不强改已存配置**,老用户至今仍是 50000。
+按当前 cell 布局(48B 行对象 + 24B 数组头 + 20B×列 + 8B List 槽位)算每行成本:
+
+| 列宽 | 每行 | 10000 行 | 50000 行 |
+| --- | --- | --- | --- |
+| 80 | 1,680 B | 16.0 MB | **80 MB** |
+| 120 | 2,480 B | 23.7 MB | **118 MB** |
+| 200 | 4,080 B | 38.9 MB | **194 MB** |
+
+这是**每标签**上限,且只在缓冲真正填满后才达到 —— 空载 23MB 的托管堆说明它平时远没填满。
+
+## 下一个结构性优化(已评估,未做)
+
+**行尾空白裁剪**:`TerminalRow` 无论内容多少都分配 `TerminalCell[columns]`,而退休进 scrollback 的
+行多数只用到列宽的 20~30%。在行退休时把数组裁到最后一个非空白格,典型 shell 输出可省 3~5 倍
+scrollback 内存,且与用户配的行数无关。
+
+阻碍在渲染侧:`VelaTerminalControl.Render` 传给 `RenderLine` 的是 **screen.Columns**(:1301)
+而非 `line.Columns` —— 裁短的行会越界。要做必须同时改 `RenderLine` 以及选区/搜索/复制的列循环,
+让越界列按默认背景处理。这是全应用最热、最吃正确性的一段代码,**需要单独一轮改动 + 真实会话
+目视验证**,不适合顺手带过。
+
+## 顺带澄清:读路径的"零拷贝"
+
+`SshTerminalBridge.ReadLoopAsync` 每次读都 `new byte[bytesRead]` + `Array.Copy`(:243)。改成
+`ArrayPool` 确实能消掉这份 Gen0 churn,但**它省的是 GC 时间,不是常驻内存** —— 这些块在下一帧
+`FlushPending` 就被消费掉了,压根活不到 Gen2。在托管堆总共才 23MB 的前提下,把它排在
+GPU 开关和 scrollback 之后是正确的优先级。真要做,注意 `DataReceived` 的订阅者(会话日志/录制)
+拿到的是同一个数组,归还池之前必须确认无人持有。

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -335,6 +335,21 @@ public class AppearanceOptions : ObservableOptions
         set => Set(ref field, value);
     } = "remember";
 
+    /// <summary>
+    /// 是否启用 GPU 硬件加速渲染;默认开启。关闭后改用软件渲染。
+    /// </summary>
+    /// <remarks>
+    /// 这是目前最大的一项内存开关:开启时显卡驱动会把它自己的着色器编译器等一大批模块映射进
+    /// 本进程(实测 Intel 核显上 igc64.dll 一个就 82MB),空载常驻约 376MB;软件渲染下约 206MB,
+    /// 相差 170MB。代价是滚动与全屏 TUI 重绘由 CPU 承担。终端以文本为主,多数机器上感知不到差别,
+    /// 但显卡好、内存充裕时保持开启更顺滑。改动需重启生效。
+    /// </remarks>
+    public bool HardwareAcceleration
+    {
+        get;
+        set => Set(ref field, value);
+    } = true;
+
     // “记住上次”窗口状态的持久化槽位(不出现在设置界面,由主窗口关闭时回写)。
     /// <summary>「记住上次」窗口宽度的持久化槽位(由主窗口关闭时回写)。</summary>
     public double LastWindowWidth

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2980,6 +2980,15 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Proc_TreeView" xml:space="preserve">
     <value>ツリー表示</value>
   </data>
+  <data name="SetAppear_RenderSection" xml:space="preserve">
+    <value>レンダリング</value>
+  </data>
+  <data name="SetAppear_HardwareAcceleration" xml:space="preserve">
+    <value>ハードウェアアクセラレーション</value>
+  </data>
+  <data name="SetAppear_HardwareAccelerationDesc" xml:space="preserve">
+    <value>// GPU で描画します。オフにするとソフトウェアレンダリングに切り替わり、グラフィックスドライバーのモジュールがプロセスに読み込まれなくなるため約 170MB を節約できます。再起動後に有効。</value>
+  </data>
   <data name="Proc_Refresh" xml:space="preserve">
     <value>今すぐ更新</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2980,6 +2980,15 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Proc_TreeView" xml:space="preserve">
     <value>트리 보기</value>
   </data>
+  <data name="SetAppear_RenderSection" xml:space="preserve">
+    <value>렌더링</value>
+  </data>
+  <data name="SetAppear_HardwareAcceleration" xml:space="preserve">
+    <value>하드웨어 가속</value>
+  </data>
+  <data name="SetAppear_HardwareAccelerationDesc" xml:space="preserve">
+    <value>// GPU로 그립니다. 끄면 소프트웨어 렌더링으로 전환되어 그래픽 드라이버 모듈이 프로세스에 매핑되지 않으므로 약 170MB를 절약합니다. 다시 시작해야 적용됩니다.</value>
+  </data>
   <data name="Proc_Refresh" xml:space="preserve">
     <value>지금 새로 고침</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2981,6 +2981,15 @@ Overwrite it?</value>
   <data name="Proc_TreeView" xml:space="preserve">
     <value>Tree view</value>
   </data>
+  <data name="SetAppear_RenderSection" xml:space="preserve">
+    <value>Rendering</value>
+  </data>
+  <data name="SetAppear_HardwareAcceleration" xml:space="preserve">
+    <value>Hardware acceleration</value>
+  </data>
+  <data name="SetAppear_HardwareAccelerationDesc" xml:space="preserve">
+    <value>// Draws with the GPU. Turning it off switches to software rendering and frees around 170 MB, because the graphics driver stops mapping its modules into this process. Restart to apply.</value>
+  </data>
   <data name="Proc_Refresh" xml:space="preserve">
     <value>Refresh now</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3072,6 +3072,15 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Proc_TreeView" xml:space="preserve">
     <value>树形视图</value>
   </data>
+  <data name="SetAppear_RenderSection" xml:space="preserve">
+    <value>渲染</value>
+  </data>
+  <data name="SetAppear_HardwareAcceleration" xml:space="preserve">
+    <value>硬件加速</value>
+  </data>
+  <data name="SetAppear_HardwareAccelerationDesc" xml:space="preserve">
+    <value>// 用 GPU 绘制。关闭后改用软件渲染,可省约 170MB 内存——显卡驱动不再把自己的模块映射进本进程。重启后生效。</value>
+  </data>
   <data name="Proc_Refresh" xml:space="preserve">
     <value>立即刷新</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2980,6 +2980,15 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Proc_TreeView" xml:space="preserve">
     <value>樹狀檢視</value>
   </data>
+  <data name="SetAppear_RenderSection" xml:space="preserve">
+    <value>轉譯</value>
+  </data>
+  <data name="SetAppear_HardwareAcceleration" xml:space="preserve">
+    <value>硬體加速</value>
+  </data>
+  <data name="SetAppear_HardwareAccelerationDesc" xml:space="preserve">
+    <value>// 用 GPU 繪製。關閉後改用軟體轉譯,可省約 170MB 記憶體——顯示卡驅動不再把自己的模組對應進本行程。重新啟動後生效。</value>
+  </data>
   <data name="Proc_Refresh" xml:space="preserve">
     <value>立即重新整理</value>
   </data>

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbSettingsService.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbSettingsService.cs
@@ -48,6 +48,7 @@ public sealed class SonnetDbSettingsService(SonnetDbEngine engine, IReadOnlyList
         string json = SonnetDbJson.Serialize(settings);
         await UpsertJsonAsync(SettingsDocId, json).ConfigureAwait(false);
         _settingsJsonCache = json;
+        MirrorRenderMode(settings);
         SettingsSaved?.Invoke(settings);
     }
 
@@ -115,5 +116,27 @@ public sealed class SonnetDbSettingsService(SonnetDbEngine engine, IReadOnlyList
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// 把渲染模式镜像成一个单行文件。渲染后端要在 Avalonia 初始化前定下,那时数据库还没起来,
+    /// 启动路径读不了这份设置 —— 见 <see cref="VelaShellStoragePaths.RenderModeFile" />。
+    /// 写失败只意味着下次启动沿用上一次的模式,不值得打断保存。
+    /// </summary>
+    private static void MirrorRenderMode(AppSettings settings)
+    {
+        try
+        {
+            var paths = new VelaShellStoragePaths();
+            Directory.CreateDirectory(paths.RootDirectory);
+            File.WriteAllText(
+                paths.RenderModeFile,
+                settings.Appearance.HardwareAcceleration ? "gpu" : "software"
+            );
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // 尽力而为。
+        }
     }
 }

--- a/src/VelaShell.Infrastructure/Persistence/VelaShellStoragePaths.cs
+++ b/src/VelaShell.Infrastructure/Persistence/VelaShellStoragePaths.cs
@@ -20,6 +20,7 @@ public sealed class VelaShellStoragePaths
         SessionsFile = Path.Combine(root, "sessions.json");
         SonnetDbDirectory = Path.Combine(root, "sonnetdb");
         SecretKeyFile = Path.Combine(root, "secret.key");
+        RenderModeFile = Path.Combine(root, "render.mode");
         LegacyDotDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".velashell"
@@ -29,6 +30,13 @@ public sealed class VelaShellStoragePaths
 
     /// <summary>VelaShell 所有持久化数据的根目录。</summary>
     public string RootDirectory { get; }
+
+    /// <summary>
+    /// 渲染模式标记文件。渲染后端必须在 Avalonia 初始化之前定下来,而那时 DI 与
+    /// SonnetDB 都还没起来 —— 为此把这一项设置额外镜像成一个单行小文件,
+    /// 启动路径只做一次 File.ReadAllText,不引入任何数据库初始化开销。
+    /// </summary>
+    public string RenderModeFile { get; }
 
     /// <summary>历史 JSON 设置文件(仅用于一次性迁移导入)。</summary>
     public string SettingsFile { get; }

--- a/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
+++ b/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
@@ -657,6 +657,8 @@ public sealed class GistSyncService(
         settings.Appearance.LastWindowWidth = defaults.Appearance.LastWindowWidth;
         settings.Appearance.LastWindowHeight = defaults.Appearance.LastWindowHeight;
         settings.Appearance.LastWindowMaximized = defaults.Appearance.LastWindowMaximized;
+        // 硬件加速取决于这台机器的显卡与内存,跨设备同步只会把弱机的将就设置推给强机(反之亦然)。
+        settings.Appearance.HardwareAcceleration = defaults.Appearance.HardwareAcceleration;
         settings.Transfer.LocalDownloadDirectory = defaults.Transfer.LocalDownloadDirectory;
         settings.Transfer.DefaultEditorPath = defaults.Transfer.DefaultEditorPath;
         settings.Transfer.LogDirectory = defaults.Transfer.LogDirectory;
@@ -672,6 +674,7 @@ public sealed class GistSyncService(
         incoming.Appearance.LastWindowWidth = local.Appearance.LastWindowWidth;
         incoming.Appearance.LastWindowHeight = local.Appearance.LastWindowHeight;
         incoming.Appearance.LastWindowMaximized = local.Appearance.LastWindowMaximized;
+        incoming.Appearance.HardwareAcceleration = local.Appearance.HardwareAcceleration;
         incoming.Transfer.LocalDownloadDirectory = local.Transfer.LocalDownloadDirectory;
         incoming.Transfer.DefaultEditorPath = local.Transfer.DefaultEditorPath;
         incoming.Transfer.LogDirectory = local.Transfer.LogDirectory;

--- a/src/VelaShell/Program.cs
+++ b/src/VelaShell/Program.cs
@@ -157,10 +157,40 @@ internal static partial class Program
             Trace.WriteLine($"[VelaShell] Unhandled domain exception: {e.ExceptionObject}");
     }
 
+    /// <summary>
+    /// 解析渲染后端(设置 → 外观 → 硬件加速)。渲染模式必须在 Avalonia 初始化之前定下来,
+    /// 那时 DI 与 SonnetDB 都还没起来,因此读的是设置保存时镜像出来的单行小文件,
+    /// 而不是数据库 —— 启动路径上只有一次 File.ReadAllText。
+    /// </summary>
+    /// <remarks>
+    /// 关掉硬件加速能省下约 170MB 常驻内存:GPU 后端会把显卡驱动的一整套模块映射进本进程
+    /// (Intel 核显上 igc64.dll 一个就 82MB)。代价是绘制交给 CPU。
+    /// </remarks>
+    private static IReadOnlyList<Win32RenderingMode> ResolveRenderingMode()
+    {
+        // 软件渲染兜底始终留在列表末尾:GPU 初始化失败(远程桌面、驱动异常)时不至于起不来。
+        IReadOnlyList<Win32RenderingMode> gpu = [Win32RenderingMode.AngleEgl, Win32RenderingMode.Software];
+        IReadOnlyList<Win32RenderingMode> software = [Win32RenderingMode.Software];
+        if (Environment.GetEnvironmentVariable("VELASHELL_SOFTWARE_RENDER") == "1")
+        {
+            return software; // 测量与排障用的强制开关
+        }
+        try
+        {
+            string path = new VelaShellStoragePaths().RenderModeFile;
+            return File.Exists(path) && File.ReadAllText(path).Trim() is "software" ? software : gpu;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return gpu;
+        }
+    }
+
     // Avalonia 配置,勿删除;可视化设计器也用到。
     private static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<App>()
                   .UsePlatformDetect()
+                  .With(new Win32PlatformOptions { RenderingMode = ResolveRenderingMode() })
 #if LINUX
                   .UseWayland()
 #endif

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
@@ -98,6 +98,18 @@
 
     <Border Classes="sep" />
 
+    <!-- 渲染 -->
+    <TextBlock Classes="section-title" Text="{loc:Localize SetAppear_RenderSection}" />
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetAppear_HardwareAcceleration}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_HardwareAccelerationDesc}" TextWrapping="Wrap" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding Appearance.HardwareAcceleration}" VerticalAlignment="Center" />
+    </Grid>
+
+    <Border Classes="sep" />
+
     <!-- 字体 -->
     <TextBlock Classes="section-title" Text="{loc:Localize Font}" />
     <Grid ColumnDefinitions="*,Auto">


### PR DESCRIPTION
允许用户在“设置 → 外观”界面切换是否启用 GPU 加速，关闭后使用软件渲染以节省约 170MB 内存。切换后需重启生效。 AppearanceOptions 新增 HardwareAcceleration 属性，并补充多语言文案。 渲染模式保存为 render.mode 文件，启动时决定 Avalonia 渲染后端，避免依赖数据库。 Gist 同步时排除 HardwareAcceleration，防止弱机设置影响强机。
AppearanceSettingsPage.axaml 增加相关 UI 控件及说明。