### PR TITLE
使用 var 简化 Process 变量声明

### DIFF
--- a/src/VelaShell/Services/Update/UpdateRunner.cs
+++ b/src/VelaShell/Services/Update/UpdateRunner.cs
@@ -104,7 +104,7 @@ internal static class UpdateRunner
     {
         try
         {
-            using Process process = Process.GetProcessById(pid);
+            using var process = Process.GetProcessById(pid);
             return process.WaitForExit((int)ParentExitTimeout.TotalMilliseconds);
         }
         catch (ArgumentException)


### PR DESCRIPTION
将 using Process process = Process.GetProcessById(pid); 替换为 using var process = Process.GetProcessById(pid);，使代码更简洁，符合 C# 8.0 及以上推荐写法，功能保持不变。