### PR TITLE
支持 MSIX 商店版自动打包与运行时识别

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 #   Windows x64/arm64 → zip
 #   macOS   x64/arm64 → tar.gz + dmg(未签名/未公证;Unix 可执行位在原生 runner 上保留)
 #   Linux   x64/arm64 → tar.gz
+# 另有 build-msix 任务产出商店版 .msixbundle,但它不附加到 Release —— 作为工作流
+# artifact(store-msix)留存,由人工下载后提交 Partner Center。便携版与商店版是同一份二进制,
+# 只是容器不同;应用内自更新在商店版会自动关闭(运行时判定包身份,见 Services/AppPackaging.cs)。
 # macOS 双产物分工(动 latest.json 前先读这段):
 #   tar.gz — 应用内自更新器的资产,latest.json 只指向它。更新器是"原地换版"
 #            (zip/tar 按相对路径解进应用目录),不认识 dmg。
@@ -65,6 +68,44 @@ jobs:
         with:
           name: packages-windows
           path: dist/*
+          if-no-files-found: error
+
+  # 商店版:同一份源码、同一条发布命令,只是打进 MSIX 而非压成 zip。二者的行为差异
+  # 全部由运行时的包身份判定驱动(Services/AppPackaging.cs),装成 MSIX 就自动关掉应用内
+  # 自更新、改由商店接管,因此这里不需要任何特殊编译配置。
+  # 产物刻意不签名:提交到商店的 MSIX 由微软在认证通过后用商店证书签名,自己签会被替换掉。
+  # 上架前须在仓库变量里填好 Partner Center 的产品标识,否则打出来的包只能本地自测:
+  #   vars.MSIX_IDENTITY_NAME          ← Package/Identity/Name
+  #   vars.MSIX_PUBLISHER              ← Package/Identity/Publisher(形如 CN=<GUID>)
+  #   vars.MSIX_PUBLISHER_DISPLAY_NAME ← Package/Identity/PublisherDisplayName
+  build-msix:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Restore strong-name key
+        shell: pwsh
+        run: |
+          [IO.File]::WriteAllBytes("src/VelaShell.snk",
+            [Convert]::FromBase64String($env:SNK_B64))
+        env:
+          SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
+      - name: Build MSIX bundle (win-x64 + win-arm64)
+        shell: pwsh
+        run: |
+          $version = '${{ github.event.release.tag_name }}'.TrimStart('v')
+          ./build/msix/Build-Msix.ps1 -Version $version `
+            -IdentityName '${{ vars.MSIX_IDENTITY_NAME || 'VelaShell' }}' `
+            -Publisher '${{ vars.MSIX_PUBLISHER || 'CN=VelaShell' }}' `
+            -PublisherDisplayName '${{ vars.MSIX_PUBLISHER_DISPLAY_NAME || 'joesdu' }}'
+      # 单独上传,不并入 dist:.msixbundle 是给 Partner Center 手动提交用的,既不进
+      # latest.json(那是便携版自更新器的清单),也不该被当成可下载的安装包挂在 Release 上。
+      - uses: actions/upload-artifact@v4
+        with:
+          name: store-msix
+          path: dist/*.msixbundle
           if-no-files-found: error
 
   build-macos:
@@ -175,6 +216,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          # 只收便携版产物:store-msix 是给 Partner Center 手动提交的,不能混进 Release 资产
+          # (它未签名、装不上,还会污染 SHA256SUMS)。不加这道过滤就会被 merge-multiple 一并拉进来。
+          pattern: packages-*
           path: dist
           merge-multiple: true
       - name: Generate latest.json (in-app update manifest)

--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,7 @@ FodyWeavers.xsd
 .omc
 .sisyphus
 *.lscache
+
+# MSIX 打包中间产物与产出(build/msix/Build-Msix.ps1)
+dist/
+out/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ pwsh scripts/publish-all.ps1
 
 产物覆盖 Windows x64/arm64（便携 zip）、macOS 与 Linux x64/arm64（tar.gz），全部为含运行时的单文件发布,解压到任意目录即可运行。
 
+> 从 Microsoft Store 安装的版本(MSIX)更新由商店接管,应用内的更新操作会自动隐藏。商店版装在只读的 `WindowsApps` 下,数据目录被系统重定向到包私有位置,因此**与便携版的配置、会话、密钥互不相通**。
+
 **应用内自动更新**：设置 → 关于 → 检查更新。应用从 GitHub Releases 读取 `latest.json` 清单,下载对应平台压缩包到应用目录下的暂存目录,SHA-256 校验后解包,再由应用退出后才动手的外置换版进程完成换版并重启 —— 那时应用目录里没有任何文件被占用,不会留下删不掉的残骸。该"外置进程"就是更新包里新版主程序的一份临时副本(Release 为自包含单文件发布),因此无需随包分发额外的更新器。应用装在哪里就更新哪里,不限定安装位置;`%LocalAppData%/VelaShell` 数据目录与更新流程完全隔离,升级/回滚均不触碰用户数据。换版中途失败会自动还原到旧版本,若流程被意外中断卡住,关于页的"修复更新状态"可一键重置。更新通道（stable / preview）在设置页切换。
 
 **CI/CD**：[`.github/workflows/release.yml`](.github/workflows/release.yml) 在 GitHub 发布 Release 时触发，三平台原生 runner 并行构建同一套 6 产物（版本号取 Release 标签，`-p:Version` 覆盖，发版无需改代码），汇总 `SHA256SUMS.txt` 与自动更新清单 `latest.json` 后全部附加到该 Release。

--- a/build/msix/AppxManifest.template.xml
+++ b/build/msix/AppxManifest.template.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  VelaShell 的 MSIX 包清单模板。占位符由 build/msix/Build-Msix.ps1 在打包时替换:
+    {IDENTITY_NAME} {PUBLISHER} {PUBLISHER_DISPLAY_NAME}
+      三者必须与 Partner Center → 产品管理 → 产品标识 页面上的
+      Package/Identity/Name、Package/Identity/Publisher、Package/Identity/PublisherDisplayName
+      逐字一致,否则上传直接被拒。本地自测可用脚本的默认占位值。
+    {VERSION}  四段纯数字。商店要求第四段(修订号)保留给商店使用,必须为 0。
+    {ARCH}     x64 / arm64,每个架构单独出一个 .msix,最后 bundle 成一个 .msixbundle。
+
+  能力说明:
+    runFullTrust                — 桌面(Win32/Avalonia)应用的必备受限能力,商店自动批准。
+    internetClient              — SSH/SFTP 出站连接、检查 GitHub 上的资源。
+    privateNetworkClientServer  — 连内网主机(家庭/公司网段)所必需。
+  刻意不声明 unvirtualizedResources:它虽能关掉 AppData 写入虚拟化、让商店版与便携版共用
+  %LocalAppData%\VelaShell 数据目录,但微软限定该受限能力"仅供微软及合作伙伴发布的特定
+  PC 游戏使用",第三方应用申请基本不会过审。因此商店版的数据落在包私有目录,与便携版相互独立。
+-->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+
+  <Identity
+    Name="{IDENTITY_NAME}"
+    Publisher="{PUBLISHER}"
+    Version="{VERSION}"
+    ProcessorArchitecture="{ARCH}" />
+
+  <Properties>
+    <DisplayName>VelaShell</DisplayName>
+    <PublisherDisplayName>{PUBLISHER_DISPLAY_NAME}</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+    <Description>A modern, cross-platform SSH and SFTP client with a GPU-accelerated terminal.</Description>
+  </Properties>
+
+  <Dependencies>
+    <!-- 19041 = Windows 10 2004,自包含发布对系统组件没有更高要求。 -->
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-US" />
+    <Resource Language="zh-CN" />
+    <Resource Language="zh-TW" />
+    <Resource Language="ja-JP" />
+    <Resource Language="ko-KR" />
+  </Resources>
+
+  <Applications>
+    <!-- EntryPoint=Windows.FullTrustApplication:这是一个普通 Win32 可执行文件,不是 UWP。 -->
+    <Application Id="VelaShell" Executable="VelaShell.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="VelaShell"
+        Description="A modern, cross-platform SSH and SFTP client with a GPU-accelerated terminal."
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile
+          Wide310x150Logo="Assets\Wide310x150Logo.png"
+          Square71x71Logo="Assets\Square71x71Logo.png"
+          Square310x310Logo="Assets\Square310x310Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
+  </Capabilities>
+</Package>

--- a/build/msix/Build-Msix.ps1
+++ b/build/msix/Build-Msix.ps1
@@ -1,0 +1,206 @@
+<#
+.SYNOPSIS
+    把 VelaShell 打成上架 Microsoft Store 用的 MSIX 包(双架构 .msixbundle)。
+
+.DESCRIPTION
+    商店版与便携版共用同一份源码和同一条发布命令,差异全在运行时判定(见 Services/AppPackaging.cs):
+    装成 MSIX 就自动关掉应用内自更新,改由商店接管。因此这里不需要任何特殊的编译配置。
+
+    与便携版发布的唯一区别是 -p:PublishSingleFile=false —— 单文件在 MSIX 里没有意义
+    (包本身就是一个容器),摊开发布反而让商店的差量更新只传改动过的文件。
+
+    产物不签名:提交到商店的 MSIX 由微软在认证通过后用商店证书签名,自己签反而会被替换掉。
+    需要本地安装自测时,用 -SelfSignForLocalTest 生成一张自签证书就地签一份(仅供本机安装)。
+
+.NOTES
+    需要 Windows PowerShell 5.1 或 PowerShell 7+(图标缩放用 System.Drawing,故仅限 Windows),
+    以及 Windows SDK 里的 makeappx.exe(GitHub windows-latest runner 自带)。
+
+.EXAMPLE
+    pwsh build/msix/Build-Msix.ps1 -Version 1.2.3
+    pwsh build/msix/Build-Msix.ps1 -Version 1.2.3 -IdentityName 12345Publisher.VelaShell -Publisher "CN=ABCD1234-..."
+#>
+[CmdletBinding()]
+param(
+    # 语义版本(可带预发布后缀,会被剥掉:MSIX 版本号只能是纯数字)。
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    # 要打包的运行时标识;每个出一个 .msix,最后合成一个 .msixbundle。
+    [string[]]$Runtimes = @('win-x64', 'win-arm64'),
+
+    # 以下三项必须与 Partner Center → 产品管理 → 产品标识 完全一致,否则上传被拒。
+    [string]$IdentityName = 'VelaShell',
+    [string]$Publisher = 'CN=VelaShell',
+    [string]$PublisherDisplayName = 'joesdu',
+
+    [string]$OutputDirectory = 'dist',
+    [string]$IntermediateDirectory = 'out/msix',
+
+    # 仅供本机安装自测:用自签证书签名(商店提交请勿使用)。
+    [switch]$SelfSignForLocalTest
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$projectPath = Join-Path $repoRoot 'src\VelaShell\VelaShell.csproj'
+$templatePath = Join-Path $PSScriptRoot 'AppxManifest.template.xml'
+$sourceIcon = Join-Path $repoRoot 'src\VelaShell\Assets\velashell.png'
+
+# ———————————————————— 工具函数 ————————————————————
+
+function ConvertTo-MsixVersion {
+    <#  1.2.3-beta.1 → 1.2.3.0。商店规定第四段(修订号)保留给商店,必须为 0,
+        因此同一基础版本的多个预发布无法并存 —— 上架用的标签请使用纯 semver。 #>
+    param([string]$Semver)
+    $core = ($Semver -split '[-+]')[0]
+    $parts = @($core -split '\.')
+    while ($parts.Count -lt 3) { $parts += '0' }
+    if ($Semver -ne $core) {
+        Write-Warning "MSIX 版本号不支持预发布后缀,'$Semver' 已截断为 $($parts[0]).$($parts[1]).$($parts[2]).0"
+    }
+    return '{0}.{1}.{2}.0' -f $parts[0], $parts[1], $parts[2]
+}
+
+function Get-MakeAppxPath {
+    $sdkBin = 'C:\Program Files (x86)\Windows Kits\10\bin'
+    if (-not (Test-Path $sdkBin)) {
+        throw "找不到 Windows SDK($sdkBin)。请安装 Windows 10/11 SDK 后重试。"
+    }
+    $versions = Get-ChildItem $sdkBin -Directory |
+        Where-Object { $_.Name -like '10.*' } |
+        Sort-Object { [version]($_.Name) } -Descending
+    foreach ($dir in $versions) {
+        $candidate = Join-Path $dir.FullName 'x64\makeappx.exe'
+        if (Test-Path $candidate) { return $candidate }
+    }
+    throw "在 $sdkBin 下找不到 makeappx.exe。"
+}
+
+function New-ScaledPng {
+    <# 等比缩放并居中放到透明画布上(宽磁贴 310x150 与方形图标共用这一套)。 #>
+    param([string]$Source, [string]$Destination, [int]$Width, [int]$Height)
+
+    Add-Type -AssemblyName System.Drawing
+    $image = [System.Drawing.Image]::FromFile($Source)
+    try {
+        $bitmap = New-Object System.Drawing.Bitmap($Width, $Height)
+        try {
+            $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+            try {
+                $graphics.Clear([System.Drawing.Color]::Transparent)
+                $graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+                $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+                $graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+                $scale = [Math]::Min($Width / $image.Width, $Height / $image.Height)
+                $w = [int][Math]::Round($image.Width * $scale)
+                $h = [int][Math]::Round($image.Height * $scale)
+                $graphics.DrawImage($image, [int](($Width - $w) / 2), [int](($Height - $h) / 2), $w, $h)
+            }
+            finally { $graphics.Dispose() }
+            $bitmap.Save($Destination, [System.Drawing.Imaging.ImageFormat]::Png)
+        }
+        finally { $bitmap.Dispose() }
+    }
+    finally { $image.Dispose() }
+}
+
+function New-MsixAssets {
+    <# 生成 manifest 引用到的全部图标。targetsize-* 是任务栏/开始菜单用的无边距变体。 #>
+    param([string]$AssetsDirectory)
+
+    New-Item -ItemType Directory -Force $AssetsDirectory | Out-Null
+    $square = @{
+        'StoreLogo.png'          = 50
+        'Square44x44Logo.png'    = 44
+        'Square71x71Logo.png'    = 71
+        'Square150x150Logo.png'  = 150
+        'Square310x310Logo.png'  = 310
+    }
+    foreach ($name in $square.Keys) {
+        New-ScaledPng -Source $sourceIcon -Destination (Join-Path $AssetsDirectory $name) `
+                      -Width $square[$name] -Height $square[$name]
+    }
+    foreach ($size in @(16, 24, 32, 48, 256)) {
+        New-ScaledPng -Source $sourceIcon `
+                      -Destination (Join-Path $AssetsDirectory "Square44x44Logo.targetsize-$size`_altform-unplated.png") `
+                      -Width $size -Height $size
+    }
+    New-ScaledPng -Source $sourceIcon -Destination (Join-Path $AssetsDirectory 'Wide310x150Logo.png') `
+                  -Width 310 -Height 150
+}
+
+function New-AppxManifest {
+    param([string]$Destination, [string]$MsixVersion, [string]$Architecture)
+
+    $xml = Get-Content $templatePath -Raw -Encoding UTF8
+    $xml = $xml.Replace('{IDENTITY_NAME}', $IdentityName)
+    $xml = $xml.Replace('{PUBLISHER}', $Publisher)
+    $xml = $xml.Replace('{PUBLISHER_DISPLAY_NAME}', $PublisherDisplayName)
+    $xml = $xml.Replace('{VERSION}', $MsixVersion)
+    $xml = $xml.Replace('{ARCH}', $Architecture)
+    # 无 BOM 的 UTF-8:makeappx 对带 BOM 的 manifest 会报 XML 解析错误。
+    [System.IO.File]::WriteAllText($Destination, $xml, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+# ———————————————————— 主流程 ————————————————————
+
+$msixVersion = ConvertTo-MsixVersion $Version
+$makeappx = Get-MakeAppxPath
+Write-Host "MSIX 版本号 : $msixVersion"
+Write-Host "包标识      : $IdentityName / $Publisher"
+Write-Host "makeappx    : $makeappx"
+
+$outDir = Join-Path $repoRoot $OutputDirectory
+$intermediateRoot = Join-Path $repoRoot $IntermediateDirectory
+$bundleInput = Join-Path $intermediateRoot 'bundle-input'
+New-Item -ItemType Directory -Force $outDir | Out-Null
+if (Test-Path $bundleInput) { Remove-Item -Recurse -Force $bundleInput }
+New-Item -ItemType Directory -Force $bundleInput | Out-Null
+
+foreach ($rid in $Runtimes) {
+    $arch = $rid -replace '^win-', ''
+    $layout = Join-Path $intermediateRoot $rid
+    Write-Host "`n=== 发布 $rid ==="
+    if (Test-Path $layout) { Remove-Item -Recurse -Force $layout }
+
+    # PublishSingleFile=false:MSIX 本身就是容器,摊开发布才能让商店做差量更新。
+    & dotnet publish $projectPath -c Release -r $rid -o $layout `
+        -p:Version=$Version -p:SelfContained=true -p:PublishSingleFile=false `
+        -p:DebugType=None --nologo
+    if ($LASTEXITCODE -ne 0) { throw "dotnet publish 失败:$rid" }
+
+    Get-ChildItem $layout -Recurse -File -Filter '*.pdb' | Remove-Item -Force
+
+    New-MsixAssets -AssetsDirectory (Join-Path $layout 'Assets')
+    New-AppxManifest -Destination (Join-Path $layout 'AppxManifest.xml') `
+                     -MsixVersion $msixVersion -Architecture $arch
+
+    $msixPath = Join-Path $bundleInput "VelaShell-$Version-$rid.msix"
+    Write-Host "=== 打包 $rid ==="
+    & $makeappx pack /o /d $layout /p $msixPath
+    if ($LASTEXITCODE -ne 0) { throw "makeappx pack 失败:$rid" }
+}
+
+$bundlePath = Join-Path $outDir "VelaShell-$Version.msixbundle"
+Write-Host "`n=== 合成 msixbundle ==="
+& $makeappx bundle /o /d $bundleInput /p $bundlePath /bv $msixVersion
+if ($LASTEXITCODE -ne 0) { throw 'makeappx bundle 失败' }
+
+if ($SelfSignForLocalTest) {
+    # 仅供本机安装自测:证书的主题必须与 manifest 的 Publisher 逐字一致,否则安装被拒。
+    # 装之前需先把这张证书导入"受信任的人"或"受信任的根证书颁发机构"。
+    Write-Host "`n=== 自签(仅本地测试)==="
+    $cert = New-SelfSignedCertificate -Type Custom -Subject $Publisher `
+        -KeyUsage DigitalSignature -FriendlyName 'VelaShell local test' `
+        -CertStoreLocation 'Cert:\CurrentUser\My' `
+        -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}')
+    $signtool = (Get-MakeAppxPath) -replace 'makeappx\.exe$', 'signtool.exe'
+    & $signtool sign /fd SHA256 /sha1 $cert.Thumbprint $bundlePath
+    if ($LASTEXITCODE -ne 0) { throw 'signtool 签名失败' }
+    Write-Warning '已用自签证书签名,该包只能本机安装自测,请勿提交到商店。'
+}
+
+Write-Host "`n完成:$bundlePath"

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -959,6 +959,9 @@
   <data name="SetAbout_RestartToUpdate" xml:space="preserve">
     <value>再起動して更新</value>
   </data>
+  <data name="SetAbout_StoreManagedUpdates" xml:space="preserve">
+    <value>更新は Microsoft Store が管理します。ストアで更新を確認してください。</value>
+  </data>
   <data name="SetAbout_RepairUpdate" xml:space="preserve">
     <value>更新状態を修復</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -959,6 +959,9 @@
   <data name="SetAbout_RestartToUpdate" xml:space="preserve">
     <value>다시 시작하여 업데이트</value>
   </data>
+  <data name="SetAbout_StoreManagedUpdates" xml:space="preserve">
+    <value>업데이트는 Microsoft Store에서 관리합니다. 스토어에서 업데이트를 확인하세요.</value>
+  </data>
   <data name="SetAbout_RepairUpdate" xml:space="preserve">
     <value>업데이트 상태 복구</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1165,6 +1165,9 @@ Paste anyway?</value>
   <data name="SetAbout_RestartToUpdate" xml:space="preserve">
     <value>Restart &amp; update</value>
   </data>
+  <data name="SetAbout_StoreManagedUpdates" xml:space="preserve">
+    <value>Updates are managed by the Microsoft Store. Check for updates there.</value>
+  </data>
   <data name="SetAbout_RepairUpdate" xml:space="preserve">
     <value>Repair update state</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1256,6 +1256,9 @@
   <data name="SetAbout_RestartToUpdate" xml:space="preserve">
     <value>重启并更新</value>
   </data>
+  <data name="SetAbout_StoreManagedUpdates" xml:space="preserve">
+    <value>更新由 Microsoft Store 管理,请在商店中检查更新。</value>
+  </data>
   <data name="SetAbout_RepairUpdate" xml:space="preserve">
     <value>修复更新状态</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -959,6 +959,9 @@
   <data name="SetAbout_RestartToUpdate" xml:space="preserve">
     <value>重新啟動並更新</value>
   </data>
+  <data name="SetAbout_StoreManagedUpdates" xml:space="preserve">
+    <value>更新由 Microsoft Store 管理,請在商店中檢查更新。</value>
+  </data>
   <data name="SetAbout_RepairUpdate" xml:space="preserve">
     <value>修復更新狀態</value>
   </data>

--- a/src/VelaShell/Program.cs
+++ b/src/VelaShell/Program.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using ReactiveUI.Avalonia;
 using VelaShell.Core.Resources;
 using VelaShell.Infrastructure.Persistence;
+using VelaShell.Services;
 using VelaShell.Services.Update;
 
 // ReSharper disable InconsistentNaming
@@ -66,6 +67,12 @@ internal static partial class Program
     /// </summary>
     private static void FinalizePendingUpdate()
     {
+        if (AppPackaging.IsPackaged)
+        {
+            // 商店版从不自更新,安装目录(WindowsApps)也只读:没有换版现场要收拾,
+            // 更不该每次启动都去递归枚举一遍安装目录。
+            return;
+        }
         string appDir = Path.GetDirectoryName(Environment.ProcessPath) ?? AppContext.BaseDirectory;
         UpdateApplier applier = new(appDir);
         if (applier.TryFinalizeStartup())

--- a/src/VelaShell/Services/AppPackaging.cs
+++ b/src/VelaShell/Services/AppPackaging.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace VelaShell.Services;
+
+/// <summary>
+/// 判断本进程是否以 MSIX 包身份运行(即从 Microsoft Store 安装的版本)。
+/// <para>
+/// 便携版与商店版共用同一份源码、同一套二进制,两者的行为差异全部由这里的<b>运行时</b>判断驱动,
+/// 而不是编译期常量 —— 这样就不存在"商店构建误发到 GitHub Releases"或反过来的事故,
+/// CI 也不必维护两套编译配置:同样的发布产物,打进 MSIX 就是商店版,压成 zip 就是便携版。
+/// </para>
+/// <para>
+/// 目前唯一的差异是自更新:MSIX 装在 <c>C:\Program Files\WindowsApps</c>,该目录只读且 ACL 锁死,
+/// 换版根本无从谈起;商店政策也要求包应用只能经商店更新。见 <see cref="IUpdateService.IsStoreManaged" />。
+/// </para>
+/// </summary>
+internal static partial class AppPackaging
+{
+    /// <summary>缓冲区不足 —— 说明确实取到了包全名(本进程有包身份)。</summary>
+    private const uint ErrorInsufficientBuffer = 122;
+
+    /// <summary>本进程没有包身份(便携版直接运行的常态)。</summary>
+    private const uint AppModelErrorNoPackage = 15700;
+
+    /// <summary>本进程是否以 MSIX 包身份运行。进程内不会变化,构造一次即可。</summary>
+    public static bool IsPackaged { get; } = DetectPackageIdentity();
+
+    /// <summary>
+    /// 以长度 0 的缓冲区试探 <c>GetCurrentPackageFullName</c>:有包身份时因装不下返回
+    /// <see cref="ErrorInsufficientBuffer" />,没有则返回 <see cref="AppModelErrorNoPackage" />。
+    /// 这是官方推荐的判定法,比查进程路径是否落在 WindowsApps 之类的启发式可靠。
+    /// </summary>
+    private static bool DetectPackageIdentity()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+        try
+        {
+            int length = 0;
+            uint result = GetCurrentPackageFullName(ref length, IntPtr.Zero);
+            if (result is ErrorInsufficientBuffer or AppModelErrorNoPackage)
+            {
+                return result == ErrorInsufficientBuffer;
+            }
+            Trace.WriteLine($"[VelaShell] Unexpected GetCurrentPackageFullName result {result}; assuming unpackaged.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // Windows 8 以前没有这个导出;取不到就按便携版处理,自更新自会因目录不可写而止步。
+            Trace.WriteLine($"[VelaShell] Package identity probe failed, assuming unpackaged: {ex.Message}");
+            return false;
+        }
+    }
+
+    [LibraryImport("kernel32.dll", EntryPoint = "GetCurrentPackageFullName")]
+    private static partial uint GetCurrentPackageFullName(ref int packageFullNameLength, IntPtr packageFullName);
+}

--- a/src/VelaShell/Services/IUpdateService.cs
+++ b/src/VelaShell/Services/IUpdateService.cs
@@ -10,10 +10,17 @@ public interface IUpdateService
     string? AvailableVersion { get; }
 
     /// <summary>
-    /// 能否原地自更新:应用目录可写且平台受支持时为 true。装在 Program Files 等
+    /// 能否原地自更新:应用目录可写、平台受支持且非商店版时为 true。装在 Program Files 等
     /// 只读位置时为 false,发现新版本后只能提示用户手动下载。
     /// </summary>
     bool CanSelfUpdate { get; }
+
+    /// <summary>
+    /// 更新是否由 Microsoft Store 接管(即本进程以 MSIX 包身份运行)。为 true 时应用内的
+    /// 检查/下载/换版一律不做:安装目录只读,且商店政策要求包应用只能经商店更新。
+    /// 界面应据此把更新相关操作换成一句"更新由 Microsoft Store 管理"。
+    /// </summary>
+    bool IsStoreManaged { get; }
 
     /// <summary>检查是否有可用更新;返回 true 表示存在比当前版本更新的版本。</summary>
     Task<bool> CheckForUpdateAsync();

--- a/src/VelaShell/Services/UpdateService.cs
+++ b/src/VelaShell/Services/UpdateService.cs
@@ -33,13 +33,14 @@ public class UpdateService : IUpdateService
         : this(new GitHubReleaseSource(repositoryUrl), channelProvider)
     { }
 
-    /// <summary>核心构造,测试可注入更新源、应用目录、版本号与"关闭应用"动作。</summary>
+    /// <summary>核心构造,测试可注入更新源、应用目录、版本号、"关闭应用"动作与商店版标志。</summary>
     public UpdateService(
         IUpdateSource source,
         Func<Task<string>>? channelProvider = null,
         string? applicationDirectory = null,
         string? currentVersionOverride = null,
-        Action? shutdownForRestart = null)
+        Action? shutdownForRestart = null,
+        bool? storeManagedOverride = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         _source = source;
@@ -49,7 +50,11 @@ public class UpdateService : IUpdateService
             ?? AppContext.BaseDirectory);
         CurrentVersion = currentVersionOverride;
         _shutdownForRestart = shutdownForRestart ?? DefaultShutdown;
+        IsStoreManaged = storeManagedOverride ?? AppPackaging.IsPackaged;
     }
+
+    /// <inheritdoc />
+    public bool IsStoreManaged { get; }
 
     /// <summary>当前运行版本:程序集 InformationalVersion(含预发布后缀),读不到退回四段数字版。</summary>
     public string? CurrentVersion
@@ -71,15 +76,16 @@ public class UpdateService : IUpdateService
 
     /// <inheritdoc />
     public bool CanSelfUpdate =>
-        UpdateManifest.CurrentRid() != null && _applier.IsApplicationDirectoryWritable();
+        !IsStoreManaged && UpdateManifest.CurrentRid() != null && _applier.IsApplicationDirectoryWritable();
 
-    /// <summary>检查是否存在可用更新;平台不受支持或检查失败时返回 false。</summary>
+    /// <summary>检查是否存在可用更新;商店版、平台不受支持或检查失败时返回 false。</summary>
     public async Task<bool> CheckForUpdateAsync()
     {
         _manifest = null;
         _asset = null;
         _downloadedArchivePath = null;
-        if (UpdateManifest.CurrentRid() == null)
+        // 商店版连网络都不必发:更新归商店管,查到了也无从安装,徒增一次请求和一条误导提示。
+        if (IsStoreManaged || UpdateManifest.CurrentRid() == null)
         {
             return false;
         }

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -157,12 +157,26 @@ public class SettingsViewModel : ReactiveObject
         });
         RepairUpdateCommand = ReactiveCommand.CreateFromTask(RepairUpdateStateAsync);
 
+        // 商店版(MSIX)装在只读的 WindowsApps 下,更新由 Microsoft Store 接管:
+        // 应用内的检查/下载/换版/修复一律无意义,整块换成一句说明,免得用户白点。
+        UpdatesManagedByStore = _updateService?.IsStoreManaged ?? false;
+        ShowInAppUpdateControls = !UpdatesManagedByStore;
+        if (UpdatesManagedByStore)
+        {
+            UpdateStatus = Strings.Get("SetAbout_StoreManagedUpdates");
+        }
         // 上一轮换版由外置进程执行,它报的错没法当场弹给用户,只能落盘留到这时候如实展示。
-        if (_updateService?.LastUpdateError is { Length: > 0 } lastError)
+        else if (_updateService?.LastUpdateError is { Length: > 0 } lastError)
         {
             UpdateStatus = Strings.Format("SetAbout_PreviousUpdateFailed", lastError);
         }
     }
+
+    /// <summary>更新由 Microsoft Store 接管(商店版 MSIX);为真时关于页只显示说明,不提供更新操作。</summary>
+    public bool UpdatesManagedByStore { get; }
+
+    /// <summary>是否展示应用内更新操作(检查更新 / 重启并更新 / 修复更新状态)。</summary>
+    public bool ShowInAppUpdateControls { get; }
 
     /// <summary>
     /// 强制重置更新状态:回滚没换完的换版、清掉暂存目录与遗留文件,让下一次检查更新从干净起点开始。
@@ -562,6 +576,11 @@ public class SettingsViewModel : ReactiveObject
         if (_updateService is null)
         {
             UpdateStatus = Strings.Get("Msg_UpdateServiceNotAvailable");
+            return;
+        }
+        if (UpdatesManagedByStore)
+        {
+            UpdateStatus = Strings.Get("SetAbout_StoreManagedUpdates");
             return;
         }
         UpdateReady = false;

--- a/src/VelaShell/Views/Settings/AboutPage.axaml
+++ b/src/VelaShell/Views/Settings/AboutPage.axaml
@@ -105,7 +105,9 @@
 
     <!-- 按钮 -->
     <StackPanel Orientation="Horizontal" Spacing="8">
-      <Button Classes="dlg-primary" Content="{loc:Localize SetAbout_CheckUpdates}" Command="{Binding CheckUpdatesCommand}" />
+      <!-- 商店版(MSIX)更新由 Microsoft Store 接管,以下三个操作全部隐藏,只留状态说明。 -->
+      <Button Classes="dlg-primary" Content="{loc:Localize SetAbout_CheckUpdates}" Command="{Binding CheckUpdatesCommand}"
+              IsVisible="{Binding ShowInAppUpdateControls}" />
       <!-- 更新下载完毕后出现:点击重启应用完成安装。 -->
       <Button Classes="dlg-primary" Content="{loc:Localize SetAbout_RestartToUpdate}"
               Command="{Binding RestartToUpdateCommand}"
@@ -114,6 +116,7 @@
       <!-- 更新流程被意外中断卡住时的自愈出口:清掉残留,让检查更新重新走通。 -->
       <Button Classes="dlg-outline" Content="{loc:Localize SetAbout_RepairUpdate}"
               Command="{Binding RepairUpdateCommand}"
+              IsVisible="{Binding ShowInAppUpdateControls}"
               ToolTip.Tip="{loc:Localize SetAbout_RepairUpdateTip}" />
       <TextBlock Classes="row-desc" Text="{Binding UpdateStatus}" VerticalAlignment="Center"
                  IsVisible="{Binding UpdateStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />

--- a/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
@@ -309,6 +309,48 @@ public class UpdateServiceTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
+    public async Task StoreManaged_SkipsUpdateCheckEntirely()
+    {
+        // 商店版(MSIX)装在只读的 WindowsApps 下,更新归 Microsoft Store 管:连请求都不该发,
+        // 查到了也无从安装,只会给用户一条装不上的"有新版本"提示。
+        byte[] zip = CreateZipBytes(("app.txt", "new"));
+        _source.Manifest = CreateManifest("2.0.0", zip);
+        _source.AssetBytes = zip;
+        UpdateService service = new(
+            _source,
+            applicationDirectory: _appDir,
+            currentVersionOverride: "1.0.0",
+            shutdownForRestart: static () => { },
+            storeManagedOverride: true);
+
+        Assert.IsTrue(service.IsStoreManaged);
+        Assert.IsFalse(service.CanSelfUpdate, "商店版不得声称能自更新");
+        Assert.IsFalse(await service.CheckForUpdateAsync(), "有新版本也要返回 false");
+        Assert.AreEqual(0, _source.ManifestCalls, "商店版不该访问更新源");
+    }
+
+    [TestMethod]
+    [TestCategory("Update")]
+    public async Task PortableBuild_StillChecksForUpdates()
+    {
+        // 同一份二进制在便携形态下行为不变:商店判定只关掉商店版,不影响 GitHub 分发的那份。
+        byte[] zip = CreateZipBytes(("app.txt", "new"));
+        _source.Manifest = CreateManifest("2.0.0", zip);
+        _source.AssetBytes = zip;
+        UpdateService service = new(
+            _source,
+            applicationDirectory: _appDir,
+            currentVersionOverride: "1.0.0",
+            shutdownForRestart: static () => { },
+            storeManagedOverride: false);
+
+        Assert.IsFalse(service.IsStoreManaged);
+        Assert.IsTrue(await service.CheckForUpdateAsync());
+        Assert.IsTrue(service.CanSelfUpdate);
+    }
+
+    [TestMethod]
+    [TestCategory("Update")]
     public void ApplyUpdateAndRestart_WithoutDownload_ThrowsInvalidOperation()
     {
         Assert.ThrowsExactly<InvalidOperationException>(() => CreateService().ApplyUpdateAndRestart());
@@ -348,9 +390,11 @@ public class UpdateServiceTests : IDisposable
         public bool ThrowOnManifest { get; set; }
         public bool LastIncludePreRelease { get; private set; }
         public int DownloadCalls { get; private set; }
+        public int ManifestCalls { get; private set; }
 
         public Task<UpdateManifest?> GetLatestManifestAsync(bool includePreRelease, CancellationToken cancellationToken = default)
         {
+            ManifestCalls++;
             LastIncludePreRelease = includePreRelease;
             return ThrowOnManifest
                 ? Task.FromException<UpdateManifest?>(new HttpRequestException("offline"))


### PR DESCRIPTION
引入 MSIX 自动化打包流程与配置，完善 CI/CD 支持，区分便携版与商店版产物。运行时自动识别商店版，调整自更新逻辑，商店版下隐藏所有更新操作。设置与关于界面适配多环境，补充多语言资源与单元测试。完善文档说明，提升分发与维护效率。