### PR TITLE
完善 MSIX 打包配置与标识校验逻辑

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,12 @@ jobs:
   # 全部由运行时的包身份判定驱动(Services/AppPackaging.cs),装成 MSIX 就自动关掉应用内
   # 自更新、改由商店接管,因此这里不需要任何特殊编译配置。
   # 产物刻意不签名:提交到商店的 MSIX 由微软在认证通过后用商店证书签名,自己签会被替换掉。
-  # 上架前须在仓库变量里填好 Partner Center 的产品标识,否则打出来的包只能本地自测:
+  # 包标识默认值即本产品在 Partner Center 的真实标识(非机密,商店包里人人可读),
+  # 无需额外配置即可出可提交的包。如需改用别的产品(换账户/换产品条目),用仓库变量覆盖:
   #   vars.MSIX_IDENTITY_NAME          ← Package/Identity/Name
   #   vars.MSIX_PUBLISHER              ← Package/Identity/Publisher(形如 CN=<GUID>)
-  #   vars.MSIX_PUBLISHER_DISPLAY_NAME ← Package/Identity/PublisherDisplayName
+  #   vars.MSIX_PUBLISHER_DISPLAY_NAME ← Package/Properties/PublisherDisplayName
+  # 三者填错时上传会被拒;脚本会就地算出包系列名(PFN)打印出来,与产品标识页一比即知。
   build-msix:
     runs-on: windows-latest
     steps:
@@ -97,9 +99,9 @@ jobs:
         run: |
           $version = '${{ github.event.release.tag_name }}'.TrimStart('v')
           ./build/msix/Build-Msix.ps1 -Version $version `
-            -IdentityName '${{ vars.MSIX_IDENTITY_NAME || 'VelaShell' }}' `
-            -Publisher '${{ vars.MSIX_PUBLISHER || 'CN=VelaShell' }}' `
-            -PublisherDisplayName '${{ vars.MSIX_PUBLISHER_DISPLAY_NAME || 'joesdu' }}'
+            -IdentityName '${{ vars.MSIX_IDENTITY_NAME || 'B0B5EDED.VelaShell' }}' `
+            -Publisher '${{ vars.MSIX_PUBLISHER || 'CN=3CDE21EE-6AB1-414B-BD2D-EDE8A225854B' }}' `
+            -PublisherDisplayName '${{ vars.MSIX_PUBLISHER_DISPLAY_NAME || '鹿宝丶' }}'
       # 单独上传,不并入 dist:.msixbundle 是给 Partner Center 手动提交用的,既不进
       # latest.json(那是便携版自更新器的清单),也不该被当成可下载的安装包挂在 Release 上。
       - uses: actions/upload-artifact@v4

--- a/build/msix/AppxManifest.template.xml
+++ b/build/msix/AppxManifest.template.xml
@@ -3,8 +3,11 @@
   VelaShell 的 MSIX 包清单模板。占位符由 build/msix/Build-Msix.ps1 在打包时替换:
     {IDENTITY_NAME} {PUBLISHER} {PUBLISHER_DISPLAY_NAME}
       三者必须与 Partner Center → 产品管理 → 产品标识 页面上的
-      Package/Identity/Name、Package/Identity/Publisher、Package/Identity/PublisherDisplayName
-      逐字一致,否则上传直接被拒。本地自测可用脚本的默认占位值。
+      Package/Identity/Name、Package/Identity/Publisher、Package/Properties/PublisherDisplayName
+      逐字一致(含大小写与非 ASCII 字符),否则上传直接被验证拒绝。
+      其中 PublisherDisplayName 跟随账户的发布者显示名,不是随便起的:要改它得去
+      账户设置改账户级别的发布者显示名(影响名下所有产品),而不是改这里迁就代码。
+      本地自测可用脚本的默认占位值。
     {VERSION}  四段纯数字。商店要求第四段(修订号)保留给商店使用,必须为 0。
     {ARCH}     x64 / arm64,每个架构单独出一个 .msix,最后 bundle 成一个 .msixbundle。
 

--- a/build/msix/Build-Msix.ps1
+++ b/build/msix/Build-Msix.ps1
@@ -29,10 +29,13 @@ param(
     # 要打包的运行时标识;每个出一个 .msix,最后合成一个 .msixbundle。
     [string[]]$Runtimes = @('win-x64', 'win-arm64'),
 
-    # 以下三项必须与 Partner Center → 产品管理 → 产品标识 完全一致,否则上传被拒。
-    [string]$IdentityName = 'VelaShell',
-    [string]$Publisher = 'CN=VelaShell',
-    [string]$PublisherDisplayName = 'joesdu',
+    # 以下三项必须与 Partner Center → 产品管理 → 产品标识 逐字一致(含大小写与非 ASCII 字符),
+    # 否则上传会被验证拒绝。默认值即本产品的真实标识,可直接出可提交的包。
+    # 这些不是机密:任何人从商店下载的包里都能读到,提交到公开仓库无妨。
+    # 包系列名(PFN)由 Name + Publisher 哈希而来,故这两项一旦写错,PFN 也跟着错。
+    [string]$IdentityName = 'B0B5EDED.VelaShell',
+    [string]$Publisher = 'CN=3CDE21EE-6AB1-414B-BD2D-EDE8A225854B',
+    [string]$PublisherDisplayName = '鹿宝丶',
 
     [string]$OutputDirectory = 'dist',
     [string]$IntermediateDirectory = 'out/msix',
@@ -62,6 +65,27 @@ function ConvertTo-MsixVersion {
         Write-Warning "MSIX 版本号不支持预发布后缀,'$Semver' 已截断为 $($parts[0]).$($parts[1]).$($parts[2]).0"
     }
     return '{0}.{1}.{2}.0' -f $parts[0], $parts[1], $parts[2]
+}
+
+function Get-PublisherIdHash {
+    <#  按 MSIX 的公开算法推导包系列名后半段:对 UTF-16LE 编码的 Publisher 串取 SHA-256,
+        截前 8 字节(64 位),末尾补一个 0 位凑成 65 位,再按 13 组 5 位做 base32 编码。
+        字母表刻意去掉了 i/l/o/u(避免与 1/0 混淆,也避免拼出脏词)。 #>
+    param([string]$PublisherString)
+
+    $bytes = [System.Text.Encoding]::Unicode.GetBytes($PublisherString)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try { $hash = $sha.ComputeHash($bytes) } finally { $sha.Dispose() }
+
+    $alphabet = '0123456789abcdefghjkmnpqrstvwxyz'
+    $bits = ''
+    foreach ($b in $hash[0..7]) { $bits += [Convert]::ToString($b, 2).PadLeft(8, '0') }
+    $bits += '0'
+    $result = ''
+    for ($i = 0; $i -lt 65; $i += 5) {
+        $result += $alphabet[[Convert]::ToInt32($bits.Substring($i, 5), 2)]
+    }
+    return $result
 }
 
 function Get-MakeAppxPath {
@@ -151,7 +175,17 @@ $msixVersion = ConvertTo-MsixVersion $Version
 $makeappx = Get-MakeAppxPath
 Write-Host "MSIX 版本号 : $msixVersion"
 Write-Host "包标识      : $IdentityName / $Publisher"
+Write-Host "发布者显示名: $PublisherDisplayName"
 Write-Host "makeappx    : $makeappx"
+
+# 包系列名由 Name + Publisher 推导,是"标识填对了没有"的唯一可验证凭据。就地算出来打印,
+# 与 Partner Center 产品标识页上的 Package Family Name 一比即知,不必靠上传失败才发现填错。
+$publisherHash = Get-PublisherIdHash $Publisher
+Write-Host "包系列名    : ${IdentityName}_$publisherHash"
+if ($publisherHash -ne 'xj3aay9s28z3c') {
+    Write-Warning ("包系列名与 Partner Center 登记的 B0B5EDED.VelaShell_xj3aay9s28z3c 不符," +
+        "Publisher 多半填错了。上传会被拒,请核对 Partner Center → 产品管理 → 产品标识。")
+}
 
 $outDir = Join-Path $repoRoot $OutputDirectory
 $intermediateRoot = Join-Path $repoRoot $IntermediateDirectory


### PR DESCRIPTION
确保包标识与 Partner Center 完全一致，避免上传被拒。将 IdentityName、Publisher、PublisherDisplayName 替换为实际注册值，并补充注释说明 PublisherDisplayName 必须与账户显示名一致。新增 Get-PublisherIdHash 函数，自动计算并打印包系列名，若与登记值不符则警告，防止因标识错误导致上传失败。优化注释，强调标识大小写和字符一致性。