### PR TITLE
优化终端粘贴焦点恢复及传输历史性能

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -2654,10 +2654,19 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             && MultilinePasteConfirmation is { } confirm
             && text.IndexOfAny(['\r', '\n']) >= 0
             && text.TrimEnd('\r', '\n').IndexOfAny(['\r', '\n']) >= 0
-            && !await confirm(text)
         )
         {
-            return;
+            bool approved = await confirm(text);
+
+            // 确认框是模态窗口:它关闭后 Avalonia 只把焦点还给宿主窗口,不会回到弹窗前的焦点
+            // 控件,于是粘贴完终端是失焦的 —— 用户必须先点一下才能敲回车执行。这里主动把焦点
+            // 收回来(取消粘贴时同样收回,否则一样敲不了键)。用 Post 而不是直接 Focus():
+            // 关窗时的焦点还原发生在本延续之后,同步抢焦点会被它覆盖掉。
+            Dispatcher.UIThread.Post(() => Focus(), DispatcherPriority.Input);
+            if (!approved)
+            {
+                return;
+            }
         }
         WritePasteInput(text);
     }

--- a/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
+++ b/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
@@ -8,13 +8,13 @@ public enum SemanticKind
     /// <summary>URL,例如 http 或 https 链接。</summary>
     Url,
 
-    /// <summary>错误相关关键词(error、failed、fatal、panic 等)。</summary>
+    /// <summary>错误或否定关键词(error、failed、fatal、panic、no 等)。</summary>
     Error,
 
     /// <summary>警告相关关键词(warn、deprecated、caution 等)。</summary>
     Warning,
 
-    /// <summary>成功或健康状态关键词(ok、done、ready 等)。</summary>
+    /// <summary>成功、健康或肯定关键词(ok、done、ready、yes 等)。</summary>
     Success,
 
     /// <summary>点分 IPv4 地址。</summary>
@@ -50,13 +50,15 @@ public sealed partial class SemanticMatcher
     [GeneratedRegex(@"\b(?:\d{1,3}\.){3}\d{1,3}\b")]
     private static partial Regex IpRegex();
 
-    [GeneratedRegex(@"\b(?:error|errors|failed|failure|fatal|panic|exception|denied)\b", RegexOptions.IgnoreCase)]
+    // no 一并算作否定态:大量工具的表格输出(sshd -T、systemctl show、docker inspect)用 yes/no
+    // 成对表达开关,把 no 标红后一眼能看出哪一项没开(yes 见 SuccessRegex)。
+    [GeneratedRegex(@"\b(?:error|errors|failed|failure|fatal|panic|exception|denied|no)\b", RegexOptions.IgnoreCase)]
     private static partial Regex ErrorRegex();
 
-    [GeneratedRegex(@"\b(?:warn|warning|deprecated|caution|notice)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?:warn|warning|warnings|deprecated|caution|notice)\b", RegexOptions.IgnoreCase)]
     private static partial Regex WarningRegex();
 
-    [GeneratedRegex(@"\b(?:success|successful|successfully|succeeded|ok|done|enabled|active|running|started|listening|pass|passed|ready|healthy|online|connected)\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\b(?:success|successful|successfully|succeeded|ok|done|yes|enabled|active|running|started|listening|pass|passed|ready|healthy|online|connected)\b", RegexOptions.IgnoreCase)]
     private static partial Regex SuccessRegex();
 
     // 命令行选项标志,如 -x、--now、--color=auto。做了锚定,因此绝不会在一个单词或带连字符的词内误触发(如 well-known、re-run)。

--- a/src/VelaShell/ViewModels/FileTransferViewModel.cs
+++ b/src/VelaShell/ViewModels/FileTransferViewModel.cs
@@ -26,7 +26,7 @@ public class FileTransferViewModel : ReactiveObject
 
     private const string HistoryId = "recent";
 
-    /// <summary>历史最多保留的记录数,超出丢弃最旧的。</summary>
+    /// <summary>历史最多保留的记录数(既是落盘上限,也是面板里同时存在的行数上限),超出丢弃最旧的。</summary>
     private const int HistoryLimit = 100;
 
     // 可空:无参构造的宿主(单元测试/无 SFTP 服务的场景)不提供传输管理器。
@@ -477,13 +477,53 @@ public class FileTransferViewModel : ReactiveObject
         }
     }
 
+    // 落盘合流:一个大目录的传输会在几秒内打出成百上千次"新增行 / 行落定"的变更,
+    // 每次都独立发起一次全量写会把存储引擎(以及它背后的锁)按在地上打,IO 争用又反过来
+    // 拖慢传输本身。这里改为"同时最多一个写在飞":飞行期间的变更只置脏标记,
+    // 写完再补最后一次 —— 落盘结果与逐次写完全一致,只是省掉了中间那些注定被覆盖的版本。
+    private bool _saveDirty;
+    private bool _saveRunning;
+
     private void SaveTransferHistory()
     {
         if (_dataStore is null || _restoringHistory)
         {
             return;
         }
-        var doc = new TransferHistoryDocument
+        _saveDirty = true;
+        if (_saveRunning)
+        {
+            return;
+        }
+        _saveRunning = true;
+        _ = SaveAsync();
+
+        async Task SaveAsync()
+        {
+            try
+            {
+                while (_saveDirty)
+                {
+                    _saveDirty = false;
+
+                    // 快照必须在续回 UI 线程后取:Transfers 只在 UI 线程上被增删。
+                    TransferHistoryDocument doc = BuildHistoryDocument();
+                    await _dataStore.UpsertAsync(HistoryCollection, HistoryId, doc).ConfigureAwait(true);
+                }
+            }
+            catch
+            {
+                // 历史记不上不影响传输本身;下一次状态变化会再试。
+            }
+            finally
+            {
+                _saveRunning = false;
+            }
+        }
+    }
+
+    private TransferHistoryDocument BuildHistoryDocument() =>
+        new()
         {
             Items = Transfers.Take(HistoryLimit)
                              .Select(t => new TransferHistoryRecord
@@ -496,20 +536,6 @@ public class FileTransferViewModel : ReactiveObject
                              })
                              .ToList()
         };
-        _ = SaveAsync();
-
-        async Task SaveAsync()
-        {
-            try
-            {
-                await _dataStore.UpsertAsync(HistoryCollection, HistoryId, doc).ConfigureAwait(false);
-            }
-            catch
-            {
-                // 历史记不上不影响传输本身;下一次状态变化会再试。
-            }
-        }
-    }
 
     private void ScheduleAutoHide()
     {
@@ -530,6 +556,29 @@ public class FileTransferViewModel : ReactiveObject
         var item = new TransferItemViewModel(task);
         // 新任务出现在顶部,这样进行中的上传无需滚动即可看到。
         Transfers.Insert(0, item);
+        TrimToLimit();
+    }
+
+    /// <summary>
+    /// 把面板里的行数压在 <see cref="HistoryLimit" /> 条以内。一次传几千个文件时这个列表
+    /// 原本会无限增长,而落盘的历史早就只留最近 100 条 —— 多出来的行既进不了历史,还要
+    /// 每新增一条就重新布局一次面板,拖窗口与敲命令都跟着卡。
+    ///
+    /// 只丢弃"用户已经知道结果、也不需要再处理"的旧行:已完成与已取消。
+    /// 失败行必须留着 —— 它是用户唯一能看到"哪些文件没传成功"的地方,还挂着重试入口;
+    /// 传 5000 个文件挤掉那几条失败记录,用户会以为全部成功。进行中的行同理不能丢。
+    /// 代价是失败/进行中的行超过 100 条时列表会突破上限,这是刻意的:
+    /// 宁可多渲染几行,也不能把失败悄悄吞掉。
+    /// </summary>
+    private void TrimToLimit()
+    {
+        for (int i = Transfers.Count - 1; i >= 0 && Transfers.Count > HistoryLimit; i--)
+        {
+            if (Transfers[i].Status is TransferStatus.Completed or TransferStatus.Cancelled)
+            {
+                Transfers.RemoveAt(i);
+            }
+        }
     }
 
     /// <summary>按 Id 查找传输项,未找到时返回 <see langword="null" />。</summary>

--- a/src/VelaShell/Views/FileTransferView.axaml
+++ b/src/VelaShell/Views/FileTransferView.axaml
@@ -105,6 +105,15 @@
                     HorizontalScrollBarVisibility="Disabled"
                     MaxHeight="280">
         <ItemsControl ItemsSource="{Binding Transfers}">
+          <!-- 虚拟化:面板最多只露出约 5 行,但列表可以攒到 100 条。默认的 StackPanel 会把
+               每一条都实现成一整棵可视树(边框 + 网格 + 三段文本 + 进度条),于是每新增一个
+               文件都要重新布局全部行 —— 传输期间拖窗口、敲命令的卡顿正出在这里。
+               换成 VirtualizingStackPanel 后开销只跟"看得见的行数"有关,与历史条数无关。 -->
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="vm:TransferItemViewModel">
               <Border Padding="12,8"

--- a/tests/VelaShell.Terminal.Tests/SemanticMatcherTests.cs
+++ b/tests/VelaShell.Terminal.Tests/SemanticMatcherTests.cs
@@ -66,6 +66,26 @@ public class SemanticMatcherTests
     }
 
     [TestMethod]
+    public void Match_YesIsSuccess_NoIsError()
+    {
+        // sshd -T / systemctl show 这类开关表:yes 绿、no 红,一眼看出哪项没开。
+        const string line = "PermitRootLogin no PasswordAuthentication yes";
+        IReadOnlyList<SemanticSpan> spans = SemanticMatcher.Match(line);
+        SemanticSpan error = spans.Single(s => s.Kind == SemanticKind.Error);
+        SemanticSpan success = spans.Single(s => s.Kind == SemanticKind.Success);
+        Assert.AreEqual("no", line.Substring(error.Start, error.Length));
+        Assert.AreEqual("yes", line.Substring(success.Start, success.Length));
+    }
+
+    [TestMethod]
+    public void Match_NoAndYes_DoNotFireInsideWords()
+    {
+        // node / nobody / eyes 里的 no、yes 不能被着色。
+        Assert.IsEmpty(SemanticMatcher.Match("node nobody eyes")
+                                      .Where(s => s.Kind is SemanticKind.Error or SemanticKind.Success));
+    }
+
+    [TestMethod]
     public void Match_FindsOptionFlag()
     {
         const string line = "systemctl enable --now cockpit.socket";

--- a/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
@@ -225,6 +225,57 @@ public class FileTransferViewModelTests
 
     [TestMethod]
     [TestCategory("FileTransfer")]
+    public void AddTransfer_CapsListAtHistoryLimit_DroppingOldestSettledRows()
+    {
+        // 传一个几千文件的目录时,面板列表原本会无限增长,每加一行都要重排整个面板 ——
+        // 传输期间拖窗口 / 敲命令的卡顿正出在这里。上限与落盘历史一致:100 条。
+        for (int i = 0; i < 150; i++)
+        {
+            _vm.AddTransfer(CreateTask(status: TransferStatus.Completed, remotePath: $"/srv/f{i}.bin"));
+        }
+
+        Assert.HasCount(100, _vm.Transfers);
+        // 新的在前:最后加进来的那条必须还在,被丢掉的是最旧的。
+        Assert.AreEqual("f149.bin", _vm.Transfers[0].FileName);
+        Assert.AreEqual("f50.bin", _vm.Transfers[99].FileName);
+    }
+
+    [TestMethod]
+    [TestCategory("FileTransfer")]
+    public void AddTransfer_OverLimit_NeverDropsInFlightOrFailedTransfers()
+    {
+        // 超限时只能丢"已完成/已取消"这类用户已知结果的行。
+        // 失败行是用户唯一能看到"哪些文件没传成功"的地方(还挂着重试入口),
+        // 被后续几千个成功的文件挤掉就等于谎报全部成功;进行中的行同理不能丢。
+        TransferTask running = CreateTask(status: TransferStatus.InProgress, remotePath: "/srv/live.bin");
+        TransferTask failed = CreateTask(status: TransferStatus.Failed, remotePath: "/srv/broken.bin");
+        _vm.AddTransfer(running);
+        _vm.AddTransfer(failed);
+        for (int i = 0; i < 150; i++)
+        {
+            _vm.AddTransfer(CreateTask(status: TransferStatus.Completed, remotePath: $"/srv/f{i}.bin"));
+        }
+
+        Assert.Contains(t => t.Id == running.Id, _vm.Transfers);
+        Assert.Contains(t => t.Id == failed.Id, _vm.Transfers);
+        Assert.HasCount(100, _vm.Transfers);
+    }
+
+    [TestMethod]
+    [TestCategory("FileTransfer")]
+    public void AddTransfer_WhenFailuresExceedLimit_KeepsThemAllRatherThanSwallowingThem()
+    {
+        // 失败多到超过上限时,宁可让列表突破 100 行,也不能悄悄吞掉失败记录。
+        for (int i = 0; i < 120; i++)
+        {
+            _vm.AddTransfer(CreateTask(status: TransferStatus.Failed, remotePath: $"/srv/bad{i}.bin"));
+        }
+
+        Assert.HasCount(120, _vm.Transfers);
+    }
+
+    [TestMethod]
+    [TestCategory("FileTransfer")]
     public void TimeRemainingFormatting_ShowsReadableString()
     {
         // Arrange


### PR DESCRIPTION
改进终端多行粘贴后焦点自动恢复，无需手动点击。语义高亮规则优化，"no" 标红、"yes" 标绿，避免单词内部误判。文件传输历史面板新增写入合流机制，提升性能，限制记录数为 100，仅移除已完成/取消项，失败和进行中任务永不丢弃。ItemsControl 改用 VirtualizingStackPanel，提升大批量传输 UI 性能。补充单元测试，覆盖高亮、历史上限、失败任务保留等场景。