### PR TITLE
升级 ReactiveUI 至 24.x 并适配新命名空间类型

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,11 +11,11 @@
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Wayland" Version="12.1.0" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
     <!-- Microsoft.Extensions -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26359.118" />
     <!-- 其它 -->
-    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
+    <PackageVersion Include="ReactiveUI" Version="24.0.0" />
     <!-- MMDB 读取器(Apache 2.0)。只是格式读取库,不绑定 MaxMind 的数据 ——
          我们配的是 DB-IP Lite City(CC BY 4.0),同一格式。 -->
     <PackageVersion Include="MaxMind.Db" Version="5.1.0" />

--- a/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/QuickCommandRunnerViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 
 namespace VelaShell.Presentation.ViewModels;
 
@@ -48,13 +48,13 @@ public sealed class QuickCommandRunnerViewModel : ReactiveObject
     public bool CanRun => TargetSelector.CanSend;
 
     /// <summary>把命令文本发送到解析出的目标终端(不附加回车,由用户补全后自行执行)。</summary>
-    public ReactiveCommand<QuickCommandViewModel, Unit> SendCommand { get; }
+    public ReactiveCommand<QuickCommandViewModel, RxVoid> SendCommand { get; }
 
     /// <summary>选择全部目标终端。</summary>
-    public ReactiveCommand<Unit, Unit> SelectAllCommand => TargetSelector.SelectAllCommand;
+    public ReactiveCommand<RxVoid, RxVoid> SelectAllCommand => TargetSelector.SelectAllCommand;
 
     /// <summary>清除显式目标选择。</summary>
-    public ReactiveCommand<Unit, Unit> ClearSelectionCommand =>
+    public ReactiveCommand<RxVoid, RxVoid> ClearSelectionCommand =>
         TargetSelector.ClearSelectionCommand;
 
     /// <summary>命令及目标解析完成后发出的执行请求。</summary>

--- a/src/VelaShell.Presentation/ViewModels/QuickCommandsViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/QuickCommandsViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -110,25 +110,25 @@ public class QuickCommandsViewModel : ReactiveObject
     }
 
     /// <summary>打开新增片段表单。</summary>
-    public ReactiveCommand<Unit, Unit> AddCommandCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> AddCommandCommand { get; }
 
     /// <summary>删除指定自定义片段。</summary>
-    public ReactiveCommand<QuickCommandViewModel, Unit> DeleteCommandCommand { get; }
+    public ReactiveCommand<QuickCommandViewModel, RxVoid> DeleteCommandCommand { get; }
 
     /// <summary>保存新增片段。</summary>
-    public ReactiveCommand<Unit, Unit> SaveNewCommandCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SaveNewCommandCommand { get; }
 
     /// <summary>取消新增片段。</summary>
-    public ReactiveCommand<Unit, Unit> CancelAddCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelAddCommand { get; }
 
     /// <summary>开始编辑指定自定义片段。</summary>
-    public ReactiveCommand<QuickCommandViewModel, Unit> BeginEditCommand { get; }
+    public ReactiveCommand<QuickCommandViewModel, RxVoid> BeginEditCommand { get; }
 
     /// <summary>保存当前片段编辑。</summary>
-    public ReactiveCommand<Unit, Unit> SaveEditCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SaveEditCommand { get; }
 
     /// <summary>取消当前片段编辑。</summary>
-    public ReactiveCommand<Unit, Unit> CancelEditCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelEditCommand { get; }
 
     /// <summary>加载并迁移自定义快捷命令。</summary>
     public async Task LoadAsync()

--- a/src/VelaShell.Presentation/ViewModels/RecentConnectionsViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/RecentConnectionsViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 
@@ -36,10 +36,10 @@ public sealed class RecentConnectionsViewModel : ReactiveObject
     }
 
     /// <summary>快速连接头部 history 按钮:重新加载最近连接。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>清空最近连接历史,并同步清除当前列表。</summary>
-    public ReactiveCommand<Unit, Unit> ClearCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ClearCommand { get; }
 
     /// <summary>从连接历史重新加载列表;存储故障时保留现有内容,不影响主流程。</summary>
     public async Task RefreshAsync()

--- a/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
-using System.Reactive.Linq;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -97,35 +96,35 @@ public sealed class SessionTreeViewModel : ReactiveObject
     public ObservableCollection<SessionTreeNodeViewModel> GroupNodes { get; } = [];
 
     /// <summary>从仓储加载并重建整棵会话树。</summary>
-    public ReactiveCommand<Unit, Unit> LoadCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LoadCommand { get; }
 
     /// <summary>连接选中的会话,触发 <see cref="ConnectRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> ConnectCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ConnectCommand { get; }
 
     /// <summary>编辑选中的会话,触发 <see cref="EditRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> EditSessionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> EditSessionCommand { get; }
 
     /// <summary>删除选中的会话(含落库与树节点移除)。</summary>
-    public ReactiveCommand<Unit, Unit> DeleteSessionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DeleteSessionCommand { get; }
 
     // 复制选中的连接为“<名称> (副本)”并落库
     /// <summary>复制选中的会话为“&lt;名称&gt; (副本)”并落库,随后重建树。</summary>
-    public ReactiveCommand<Unit, Unit> DuplicateSessionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DuplicateSessionCommand { get; }
 
     /// <summary>为选中的会话打开 SFTP,触发 <see cref="OpenSftpRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> OpenSftpCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> OpenSftpCommand { get; }
 
     /// <summary>为选中的会话打开端口转发,触发 <see cref="PortForwardRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> PortForwardCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> PortForwardCommand { get; }
 
     /// <summary>断开选中会话的连接,触发 <see cref="DisconnectRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> DisconnectCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DisconnectCommand { get; }
 
     /// <summary>对选中的会话发起连接诊断,触发 <see cref="DiagnoseRequested" />。</summary>
-    public ReactiveCommand<Unit, Unit> DiagnoseCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DiagnoseCommand { get; }
 
     /// <summary>把选中的会话移动到指定分组节点(参数为“移动到分组”子菜单项)。</summary>
-    public ReactiveCommand<SessionTreeNodeViewModel, Unit> MoveToGroupCommand { get; }
+    public ReactiveCommand<SessionTreeNodeViewModel, RxVoid> MoveToGroupCommand { get; }
 
     /// <summary>右键“连接”或双击会话时触发,由宿主发起 SSH 连接。</summary>
     public event Action<SessionProfile>? ConnectRequested;

--- a/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
@@ -1,5 +1,5 @@
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 
 namespace VelaShell.Presentation.ViewModels;
@@ -59,6 +59,6 @@ public sealed class SidebarViewModel(
     }
 
     /// <summary>打开通知的命令。</summary>
-    public ReactiveCommand<Unit, Unit> NotificationsCommand { get; } =
+    public ReactiveCommand<RxVoid, RxVoid> NotificationsCommand { get; } =
         ReactiveCommand.Create(() => { });
 }

--- a/src/VelaShell.Presentation/ViewModels/StatusBarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/StatusBarViewModel.cs
@@ -1,15 +1,16 @@
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
 using VelaShell.Core.Resources;
 
 namespace VelaShell.Presentation.ViewModels;
 
 /// <summary>状态栏视图模型:维护连接状态、终端信息与 CPU/内存/磁盘/网络等实时指标,并驱动运行时长计时。</summary>
-public sealed class StatusBarViewModel(IScheduler scheduler) : ReactiveObject, IDisposable
+public sealed class StatusBarViewModel(ISequencer scheduler) : ReactiveObject, IDisposable
 {
-    private readonly CompositeDisposable _disposables = [];
+    private readonly MultipleDisposable _disposables = [];
 
     private DateTimeOffset _uptimeStart;
 
@@ -17,7 +18,7 @@ public sealed class StatusBarViewModel(IScheduler scheduler) : ReactiveObject, I
 
     /// <summary>使用默认调度器构造状态栏视图模型(供设计期/无注入场景使用)。</summary>
     public StatusBarViewModel()
-        : this(DefaultScheduler.Instance) { }
+        : this(ThreadPoolSequencer.Instance) { }
 
     // 指标分段始终可见;在首个采样前(或无已连接会话时)显示空闲占位符。
 
@@ -232,8 +233,8 @@ public sealed class StatusBarViewModel(IScheduler scheduler) : ReactiveObject, I
     {
         StopUptimeTimer();
         _uptimeStart = scheduler.Now;
-        _uptimeSubscription = Observable
-                              .Interval(TimeSpan.FromSeconds(1), scheduler)
+        _uptimeSubscription = Signal
+                              .Every(TimeSpan.FromSeconds(1), scheduler)
                               .Subscribe(_ =>
                               {
                                   TimeSpan elapsed = scheduler.Now - _uptimeStart;

--- a/src/VelaShell.Presentation/ViewModels/TabBarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/TabBarViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 
 namespace VelaShell.Presentation.ViewModels;
 
@@ -34,19 +34,19 @@ public sealed class TabBarViewModel : ReactiveObject
     }
 
     /// <summary>关闭指定标签的命令;关闭活动标签时会自动选中相邻标签。</summary>
-    public ReactiveCommand<TabViewModel, Unit> CloseTabCommand { get; }
+    public ReactiveCommand<TabViewModel, RxVoid> CloseTabCommand { get; }
 
     /// <summary>将指定标签设为活动标签的命令。</summary>
-    public ReactiveCommand<TabViewModel, Unit> SelectTabCommand { get; }
+    public ReactiveCommand<TabViewModel, RxVoid> SelectTabCommand { get; }
 
     /// <summary>关闭当前活动标签的命令。</summary>
-    public ReactiveCommand<Unit, Unit> CloseActiveTabCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseActiveTabCommand { get; }
 
     /// <summary>循环切换到下一个标签的命令。</summary>
-    public ReactiveCommand<Unit, Unit> NextTabCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> NextTabCommand { get; }
 
     /// <summary>循环切换到上一个标签的命令。</summary>
-    public ReactiveCommand<Unit, Unit> PreviousTabCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> PreviousTabCommand { get; }
 
     /// <summary>向标签集合追加一个标签,并将其设为当前活动标签。</summary>
     /// <param name="tab">要添加的标签视图模型,不能为 <see langword="null" />。</param>

--- a/src/VelaShell.Presentation/ViewModels/TerminalTargetSelectorViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/TerminalTargetSelectorViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 
 namespace VelaShell.Presentation.ViewModels;
 
@@ -38,10 +38,10 @@ public sealed class TerminalTargetSelectorViewModel : ReactiveObject
     public bool CanSend => ResolveTargetIds().Count > 0;
 
     /// <summary>选择全部已连接终端。</summary>
-    public ReactiveCommand<Unit, Unit> SelectAllCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SelectAllCommand { get; }
 
     /// <summary>清除显式终端选择。</summary>
-    public ReactiveCommand<Unit, Unit> ClearSelectionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ClearSelectionCommand { get; }
 
     /// <summary>刷新终端快照,保留仍存在终端的选中状态。</summary>
     public void UpdateTargets(IEnumerable<(Guid Id, string DisplayName)> targets)

--- a/src/VelaShell/ViewModels/AuthenticationDialogViewModel.cs
+++ b/src/VelaShell/ViewModels/AuthenticationDialogViewModel.cs
@@ -1,7 +1,6 @@
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Security;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 
@@ -183,25 +182,25 @@ public class AuthenticationDialogViewModel : ReactiveObject
     }
 
     /// <summary>从第 1 步进入第 2 步的命令(用户名非空时可用)。</summary>
-    public ReactiveCommand<Unit, Unit> NextCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> NextCommand { get; }
 
     /// <summary>从第 2 步返回第 1 步的命令。</summary>
-    public ReactiveCommand<Unit, Unit> BackCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> BackCommand { get; }
 
     /// <summary>取消弹窗的命令,返回空结果。</summary>
-    public ReactiveCommand<Unit, AuthenticationResult?> CancelCommand { get; }
+    public ReactiveCommand<RxVoid, AuthenticationResult?> CancelCommand { get; }
 
     /// <summary>确认登录的命令,构建并返回完整凭据结果(凭据齐备时可用)。</summary>
-    public ReactiveCommand<Unit, AuthenticationResult> LoginCommand { get; }
+    public ReactiveCommand<RxVoid, AuthenticationResult> LoginCommand { get; }
 
     /// <summary>切换到密码认证方式的命令。</summary>
-    public ReactiveCommand<Unit, Unit> SelectPasswordCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SelectPasswordCommand { get; }
 
     /// <summary>切换到密钥认证方式的命令。</summary>
-    public ReactiveCommand<Unit, Unit> SelectKeyCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SelectKeyCommand { get; }
 
     /// <summary>切换密码明文/密文显示状态的命令。</summary>
-    public ReactiveCommand<Unit, Unit> TogglePasswordVisibilityCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TogglePasswordVisibilityCommand { get; }
 
     private AuthenticationResult BuildResult()
     {

--- a/src/VelaShell/ViewModels/CommandPaletteViewModel.cs
+++ b/src/VelaShell/ViewModels/CommandPaletteViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 
 namespace VelaShell.ViewModels;
 
@@ -67,19 +67,19 @@ public sealed class CommandPaletteViewModel : ReactiveObject
     public bool HasResults => _flat.Count > 0;
 
     /// <summary>将选中项移到下一个匹配项。</summary>
-    public ReactiveCommand<Unit, Unit> MoveDownCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> MoveDownCommand { get; }
 
     /// <summary>将选中项移到上一个匹配项。</summary>
-    public ReactiveCommand<Unit, Unit> MoveUpCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> MoveUpCommand { get; }
 
     /// <summary>运行当前选中项并关闭命令面板。</summary>
-    public ReactiveCommand<Unit, Unit> ExecuteSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ExecuteSelectedCommand { get; }
 
     /// <summary>选中并立即运行所给条目(鼠标激活)。</summary>
-    public ReactiveCommand<CommandPaletteItem, Unit> ActivateCommand { get; }
+    public ReactiveCommand<CommandPaletteItem, RxVoid> ActivateCommand { get; }
 
     /// <summary>关闭命令面板浮层,不运行任何条目。</summary>
-    public ReactiveCommand<Unit, Unit> CloseCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseCommand { get; }
 
     /// <summary>从提供方重新加载条目、清空查询并显示命令面板。</summary>
     public void Open()

--- a/src/VelaShell/ViewModels/ConnectionDiagnosticsViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionDiagnosticsViewModel.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using System.Text;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Presentation.Services;
 
@@ -128,7 +128,7 @@ public class ConnectionDiagnosticsViewModel : ReactiveObject
     public ObservableCollection<string> Suggestions { get; }
 
     /// <summary>启动一次连接诊断的命令。</summary>
-    public ReactiveCommand<Unit, Unit> RunCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RunCommand { get; }
 
     /// <summary>是否正在执行诊断,用于禁用重复触发并显示进度。</summary>
     public bool IsBusy

--- a/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
@@ -1,8 +1,7 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Security;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -345,28 +344,28 @@ public class ConnectionProfileViewModel : ReactiveObject
     public bool ConnectAfterClose { get; private set; }
 
     /// <summary>保存配置命令;成功返回保存后的 <see cref="SessionProfile" />,失败返回 null。</summary>
-    public ReactiveCommand<Unit, SessionProfile?> SaveCommand { get; }
+    public ReactiveCommand<RxVoid, SessionProfile?> SaveCommand { get; }
 
     /// <summary>连接命令;先保存配置,再请求宿主窗口在弹窗关闭后立即连接。</summary>
-    public ReactiveCommand<Unit, SessionProfile?> ConnectCommand { get; }
+    public ReactiveCommand<RxVoid, SessionProfile?> ConnectCommand { get; }
 
     /// <summary>取消命令;关闭弹窗并返回 null。</summary>
-    public ReactiveCommand<Unit, SessionProfile?> CancelCommand { get; }
+    public ReactiveCommand<RxVoid, SessionProfile?> CancelCommand { get; }
 
     /// <summary>连接测试命令;不落库,仅探测能否连通并回填结果。</summary>
-    public ReactiveCommand<Unit, Unit> TestConnectionCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TestConnectionCommand { get; }
 
     /// <summary>浏览私钥文件命令;由视图层挂接文件选择对话框。</summary>
-    public ReactiveCommand<Unit, Unit> BrowseKeyFileCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> BrowseKeyFileCommand { get; }
 
     /// <summary>切换高级选项区域展开/收起的命令。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleAdvancedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleAdvancedCommand { get; }
 
     /// <summary>切换密码明文/掩码显示的命令。</summary>
-    public ReactiveCommand<Unit, Unit> TogglePasswordVisibilityCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TogglePasswordVisibilityCommand { get; }
 
     /// <summary>选择 SSH 或 SFTP;Telnet/串口没有对应命令,因此仍保持禁用。</summary>
-    public ReactiveCommand<ConnectionType, Unit> SelectConnectionTypeCommand { get; }
+    public ReactiveCommand<ConnectionType, RxVoid> SelectConnectionTypeCommand { get; }
 
     /// <summary>
     /// 从仓储加载分组下拉(“未分组” + 全部分组),并选中当前配置的分组;

--- a/src/VelaShell/ViewModels/FileBrowserViewModel.cs
+++ b/src/VelaShell/ViewModels/FileBrowserViewModel.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;
@@ -687,91 +687,91 @@ public class FileBrowserViewModel : ReactiveObject
     }
 
     /// <summary>导航到指定绝对路径的目录(面包屑点击等)。</summary>
-    public ReactiveCommand<string, Unit> NavigateToCommand { get; }
+    public ReactiveCommand<string, RxVoid> NavigateToCommand { get; }
 
     /// <summary>
     /// 行激活(双击 / Enter):进入目录,或将文件下载到临时文件夹并用
     /// 操作系统默认程序打开(§6)。
     /// </summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> ActivateCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> ActivateCommand { get; }
 
     /// <summary>返回上一级目录(已在根目录时无操作)。</summary>
-    public ReactiveCommand<Unit, Unit> GoUpCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> GoUpCommand { get; }
 
     /// <summary>重新列举当前目录。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>加载账户的主目录(规范:落在 ~,而非文件系统根)。</summary>
-    public ReactiveCommand<Unit, Unit> LoadInitialCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LoadInitialCommand { get; }
 
     /// <summary>将系统选中的文件上传到当前目录(工具栏 + 右键)。</summary>
-    public ReactiveCommand<Unit, Unit> UploadCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> UploadCommand { get; }
 
     /// <summary>将系统选中的文件夹(递归)上传到当前目录。</summary>
-    public ReactiveCommand<Unit, Unit> UploadFolderCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> UploadFolderCommand { get; }
 
     // 右键上下文菜单动作(规范:文件操作置于 SFTP 上下文菜单中)。
     /// <summary>在当前目录下新建文件夹(提示输入名称)。</summary>
-    public ReactiveCommand<Unit, Unit> NewFolderCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> NewFolderCommand { get; }
 
     /// <summary>在当前目录下新建空文件(提示输入名称)。</summary>
-    public ReactiveCommand<Unit, Unit> NewFileCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> NewFileCommand { get; }
 
     /// <summary>下载选中的单个文件或目录到本地(目录递归)。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> DownloadItemCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> DownloadItemCommand { get; }
 
     /// <summary>在同目录内重命名选中的条目(提示输入新名称)。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> RenameCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> RenameCommand { get; }
 
     /// <summary>把选中条目移动到输入的目标路径。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> MoveCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> MoveCommand { get; }
 
     /// <summary>把选中条目复制到另一个远程目录。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> CopyToCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> CopyToCommand { get; }
 
     /// <summary>把选中条目的完整远程路径复制到剪贴板。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> CopyPathCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> CopyPathCommand { get; }
 
     /// <summary>把选中条目的名称复制到剪贴板。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> CopyNameCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> CopyNameCommand { get; }
 
     /// <summary>属性弹窗(合并了 chmod 权限编辑,确定时应用变更)。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> PropertiesCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> PropertiesCommand { get; }
 
     /// <summary>删除选中的单个文件或目录(先弹确认)。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> DeleteItemCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> DeleteItemCommand { get; }
 
     /// <summary>「打开」:下载到临时副本后交给内置 AvaloniaEdit 编辑器(保存即上传)。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> OpenItemCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> OpenItemCommand { get; }
 
     /// <summary>「使用默认编辑器打开」:下载到 temp 交给设置里配置的编辑器,保存即上传。</summary>
-    public ReactiveCommand<RemoteFileInfoViewModel, Unit> OpenWithDefaultEditorCommand { get; }
+    public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> OpenWithDefaultEditorCommand { get; }
 
     /// <summary>批量下载所有选中的条目的本地文件夹(§6 多选)。</summary>
-    public ReactiveCommand<Unit, Unit> DownloadSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DownloadSelectedCommand { get; }
 
     /// <summary>一次确认后批量删除所有选中的条目(§6 多选)。</summary>
-    public ReactiveCommand<Unit, Unit> DeleteSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DeleteSelectedCommand { get; }
 
     /// <summary>取消进行中的删除,已完成的条目保留不移除。</summary>
-    public ReactiveCommand<Unit, Unit> CancelDeleteCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelDeleteCommand { get; }
 
     /// <summary>
     /// 重新打开传输浮窗,以便回顾历史/活动传输记录(上传按钮旁的工具栏按钮)。
     /// 没有它浮窗自动隐藏后就再也回不到传输历史了。
     /// </summary>
-    public ReactiveCommand<Unit, Unit> ShowTransfersCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ShowTransfersCommand { get; }
 
     /// <summary>切换文件浏览面板的显示/隐藏。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleVisibilityCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleVisibilityCommand { get; }
 
     /// <summary>切换点文件可见性(§6 头部开关)。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleHiddenFilesCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleHiddenFilesCommand { get; }
 
     /// <summary>
     /// 按列键排序("name" | "size" | "permissions" | "modified");再次点击当前排序列则翻转方向。
     /// </summary>
-    public ReactiveCommand<string, Unit> SortCommand { get; }
+    public ReactiveCommand<string, RxVoid> SortCommand { get; }
 
     /// <summary>列表当前按哪一列排序。</summary>
     public string SortColumn

--- a/src/VelaShell/ViewModels/FileTransferViewModel.cs
+++ b/src/VelaShell/ViewModels/FileTransferViewModel.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Reactive;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -109,22 +109,22 @@ public class FileTransferViewModel : ReactiveObject
     }
 
     /// <summary>隐藏传输面板(点击关闭按钮),任务继续在后台运行。</summary>
-    public ReactiveCommand<Unit, Unit> HidePanelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> HidePanelCommand { get; }
 
     /// <summary>取消指定 Id 的单个传输。</summary>
-    public ReactiveCommand<Guid, Unit> CancelTransferCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> CancelTransferCommand { get; }
 
     /// <summary>重试指定 Id 的失败传输,将其重新排队。</summary>
-    public ReactiveCommand<Guid, Unit> RetryTransferCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> RetryTransferCommand { get; }
 
     /// <summary>清除列表中所有已完成或已取消的传输项。</summary>
-    public ReactiveCommand<Unit, Unit> ClearCompletedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ClearCompletedCommand { get; }
 
     /// <summary>
     /// 取消当前批次中所有剩余文件:中止正在传输的那个并跳过其余
     /// (规范 §9:取消剩余传输)。
     /// </summary>
-    public ReactiveCommand<Unit, Unit> CancelAllCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelAllCommand { get; }
 
     /// <summary>
     /// 进入准备(目录扫描)状态:浮窗立即弹出并显示实时文件计数,

--- a/src/VelaShell/ViewModels/HostKeyPromptViewModel.cs
+++ b/src/VelaShell/ViewModels/HostKeyPromptViewModel.cs
@@ -1,5 +1,5 @@
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Ssh;
 
@@ -64,11 +64,11 @@ public class HostKeyPromptViewModel : ReactiveObject
     }
 
     /// <summary>“永久信任”命令:接受该密钥并写入 known_hosts。</summary>
-    public ReactiveCommand<Unit, Unit> TrustPermanentlyCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TrustPermanentlyCommand { get; }
 
     /// <summary>“仅本次信任”命令:接受该密钥但不落盘,仅本次运行有效。</summary>
-    public ReactiveCommand<Unit, Unit> TrustOnceCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TrustOnceCommand { get; }
 
     /// <summary>“取消”命令:拒绝该密钥并中止连接。</summary>
-    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelCommand { get; }
 }

--- a/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
+++ b/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 
@@ -66,46 +66,46 @@ public sealed class LocalFilePaneViewModel : ReactiveObject
     public ObservableCollection<LocalFileEntry> SelectedEntries { get; }
 
     /// <summary>导航到规范化的本地目录。</summary>
-    public ReactiveCommand<string, Unit> NavigateToCommand { get; }
+    public ReactiveCommand<string, RxVoid> NavigateToCommand { get; }
 
     /// <summary>进入一个被激活的目录行。</summary>
-    public ReactiveCommand<LocalFileEntry, Unit> ActivateCommand { get; }
+    public ReactiveCommand<LocalFileEntry, RxVoid> ActivateCommand { get; }
 
     /// <summary>导航到父目录。</summary>
-    public ReactiveCommand<Unit, Unit> GoUpCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> GoUpCommand { get; }
 
     /// <summary>刷新当前目录列举。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>将当前目录切换到所选根目录。</summary>
-    public ReactiveCommand<LocalRootEntry, Unit> SwitchRootCommand { get; }
+    public ReactiveCommand<LocalRootEntry, RxVoid> SwitchRootCommand { get; }
 
     /// <summary>重新加载可用的本地根列表。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshRootsCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshRootsCommand { get; }
 
     /// <summary>经确认后永久删除单个本地条目。</summary>
-    public ReactiveCommand<LocalFileEntry, Unit> DeleteItemCommand { get; }
+    public ReactiveCommand<LocalFileEntry, RxVoid> DeleteItemCommand { get; }
 
     /// <summary>经确认后永久删除选中的本地条目。</summary>
-    public ReactiveCommand<Unit, Unit> DeleteSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DeleteSelectedCommand { get; }
 
     /// <summary>由宿主提供的上传委托,用于独立 SFTP 文档。</summary>
-    public ReactiveCommand<Unit, Unit> UploadSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> UploadSelectedCommand { get; }
 
     /// <summary>就地重命名选中的本地条目。</summary>
-    public ReactiveCommand<LocalFileEntry, Unit> RenameCommand { get; }
+    public ReactiveCommand<LocalFileEntry, RxVoid> RenameCommand { get; }
 
     /// <summary>在当前目录中创建新文件夹。</summary>
-    public ReactiveCommand<Unit, Unit> NewFolderCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> NewFolderCommand { get; }
 
     /// <summary>用默认程序打开本地文件,或进入某个目录。</summary>
-    public ReactiveCommand<LocalFileEntry, Unit> OpenItemCommand { get; }
+    public ReactiveCommand<LocalFileEntry, RxVoid> OpenItemCommand { get; }
 
     /// <summary>由宿主提供、被 UploadSelectedCommand 调用的上传委托。</summary>
     public Func<Task>? UploadSelectedAsync { get; set; }
 
     /// <summary>按名称、大小或修改时间对可见行排序。</summary>
-    public ReactiveCommand<string, Unit> SortCommand { get; }
+    public ReactiveCommand<string, RxVoid> SortCommand { get; }
 
     /// <summary>注入的破坏性操作确认回调。</summary>
     public Func<string, Task<bool>>? ConfirmDelete { get; set; }

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1,15 +1,15 @@
 using System.ComponentModel;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using Avalonia;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
 using VelaShell.Core.Models;
@@ -240,9 +240,9 @@ public class MainWindowViewModel : ReactiveObject
         this.WhenAnyValue(x => x.ActiveTerminalTab)
             .Select(tab =>
                 tab is null
-                    ? Observable.Return(Unit.Default)
+                    ? Signal.Emit(RxVoid.Default)
                     : tab.WhenAnyValue(t => t.ConnectionStatus, t => t.Latency)
-                        .Select(_ => Unit.Default)
+                        .Select(_ => RxVoid.Default)
             )
             .Switch()
             .Subscribe(_ => UpdateStatusBarForActiveTab());
@@ -250,8 +250,8 @@ public class MainWindowViewModel : ReactiveObject
         this.WhenAnyValue(x => x.ActiveTerminalTab)
             .Select(tab =>
                 tab is null
-                    ? Observable.Return(Unit.Default)
-                    : tab.WhenAnyValue(t => t.IsConnected).Select(_ => Unit.Default)
+                    ? Signal.Emit(RxVoid.Default)
+                    : tab.WhenAnyValue(t => t.IsConnected).Select(_ => RxVoid.Default)
             )
             .Switch()
             .Subscribe(_ =>
@@ -267,32 +267,21 @@ public class MainWindowViewModel : ReactiveObject
         // 外观即时预览(设置窗口广播,未持久化):只重刷已打开标签的终端外观,
         // 不动 _latestSettings(新建标签仍用已保存的设置)。
         settingsPreviewService?.PreviewRequested += settings =>
-            RxSchedulers.MainThreadScheduler.Schedule(
-                Unit.Default,
-                (_, _) =>
-                {
-                    ApplyLiveSettingsToOpenTabs(settings);
-                    return Disposable.Empty;
-                }
-            );
+            RxSchedulers.MainThreadScheduler.Schedule(() => ApplyLiveSettingsToOpenTabs(settings));
 
         // 安全告警(设置 → 安全审计 → 告警通道):应用内 → 状态栏;提示音 → 系统提示音。
         securityAlertService?.Alerted += notice =>
-            RxSchedulers.MainThreadScheduler.Schedule(
-                Unit.Default,
-                (_, _) =>
+            RxSchedulers.MainThreadScheduler.Schedule(() =>
+            {
+                if (notice.InApp)
                 {
-                    if (notice.InApp)
-                    {
-                        StatusBar.Status = notice.Message;
-                    }
-                    if (notice.Sound)
-                    {
-                        SystemSound.Alert();
-                    }
-                    return Disposable.Empty;
+                    StatusBar.Status = notice.Message;
                 }
-            );
+                if (notice.Sound)
+                {
+                    SystemSound.Alert();
+                }
+            });
         StartStatusMetricsPolling();
         OpenSettingsCommand = ReactiveCommand.Create(() =>
             SettingsRequested?.Invoke(this, EventArgs.Empty)
@@ -302,7 +291,7 @@ public class MainWindowViewModel : ReactiveObject
         IObservable<bool> canToggleFileBrowser = this.WhenAnyValue(x => x.ActiveTerminalTab)
             .Select(tab =>
                 tab is null
-                    ? Observable.Return(false)
+                    ? Signal.Emit(false)
                     : tab.WhenAnyValue(t => t.IsConnected).Select(_ => CanToggleFileBrowser)
             )
             .Switch();
@@ -310,7 +299,7 @@ public class MainWindowViewModel : ReactiveObject
         IObservable<bool> canOpenProcessManager = this.WhenAnyValue(x => x.ActiveTerminalTab)
             .Select(tab =>
                 tab is null
-                    ? Observable.Return(false)
+                    ? Signal.Emit(false)
                     : tab.WhenAnyValue(t => t.IsConnected).Select(_ => CanOpenProcessManager)
             )
             .Switch();
@@ -327,7 +316,7 @@ public class MainWindowViewModel : ReactiveObject
     public ICommandRegistry Commands { get; } = new CommandRegistry();
 
     /// <summary>通过 id 执行一条注册命令(菜单项通过 CommandParameter 使用)。</summary>
-    public ReactiveCommand<string, Unit>? RunCommand { get; private set; }
+    public ReactiveCommand<string, RxVoid>? RunCommand { get; private set; }
 
     /// <summary>活动会话的隧道管理面板(设计 fuXS7,规范 §10)。</summary>
     public TunnelPanelViewModel? TunnelPanel
@@ -351,10 +340,10 @@ public class MainWindowViewModel : ReactiveObject
     public CommandPaletteViewModel CommandPalette { get; }
 
     /// <summary>打开命令面板(Ctrl+P / Ctrl+K)的命令。</summary>
-    public ReactiveCommand<Unit, Unit> OpenCommandPaletteCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> OpenCommandPaletteCommand { get; }
 
     /// <summary>显示或隐藏当前 SSH 会话的远程文件面板。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleFileBrowserCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleFileBrowserCommand { get; }
 
     /// <summary>当前活动标签是否支持打开远程文件面板。</summary>
     public bool CanToggleFileBrowser =>
@@ -467,16 +456,16 @@ public class MainWindowViewModel : ReactiveObject
     }
 
     /// <summary>打开设置窗口的命令(Ctrl+, / 菜单 / 侧边栏齿轮)。</summary>
-    public ReactiveCommand<Unit, Unit> OpenSettingsCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> OpenSettingsCommand { get; }
 
     /// <summary>关闭当前活动标签(Ctrl+W);走停靠层的关闭语义,保证传输层同时拆除。</summary>
-    public ReactiveCommand<Unit, Unit> CloseActiveTabCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseActiveTabCommand { get; }
 
     /// <summary>打开当前 SSH 会话的任务管理器;本地终端与 SFTP 标签下不可用。</summary>
-    public ReactiveCommand<Unit, Unit> OpenProcessManagerCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> OpenProcessManagerCommand { get; }
 
     /// <summary>打开链路追踪窗口;启用条件与 SFTP 资源管理器一致。</summary>
-    public ReactiveCommand<Unit, Unit> OpenTraceRouteCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> OpenTraceRouteCommand { get; }
 
     /// <summary>
     /// 请求为某个会话打开任务管理器窗口。参数依次为会话标识与窗口标题用的会话名称;
@@ -1669,7 +1658,7 @@ public class MainWindowViewModel : ReactiveObject
         {
             try
             {
-                await tree.LoadCommand.Execute();
+                await tree.LoadCommand.Execute().FirstAsync();
             }
             catch
             {
@@ -2771,9 +2760,7 @@ public class MainWindowViewModel : ReactiveObject
 
         // SaveSettingsAsync 可能在线程池的回调中完成;字体/字号涉及布局,
         // 因此编组到 UI 线程(主调度器即 Avalonia 的 Dispatcher)。
-        RxSchedulers.MainThreadScheduler.Schedule(
-            Unit.Default,
-            (_, _) =>
+        RxSchedulers.MainThreadScheduler.Schedule(() =>
             {
                 ApplyShellPreferences(settings);
                 ApplyLiveSettingsToOpenTabs(settings);
@@ -2791,7 +2778,6 @@ public class MainWindowViewModel : ReactiveObject
                     ApplyColumnVisibility(browser, settings.Transfer);
                 }
                 RevealActiveSessionInSidebar();
-                return Disposable.Empty;
             }
         );
     }

--- a/src/VelaShell/ViewModels/ProcessManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/ProcessManagerViewModel.cs
@@ -1,10 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reactive;
-using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Resources;
 
@@ -253,31 +252,31 @@ public sealed class ProcessManagerViewModel : ReactiveObject, IDisposable
     }
 
     /// <summary>手动刷新一次(F5 与刷新按钮)。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>按列排序;同列再次点击切换升/降序。</summary>
-    public ReactiveCommand<string, Unit> SortCommand { get; }
+    public ReactiveCommand<string, RxVoid> SortCommand { get; }
 
     /// <summary>切换刷新速度;参数为 <see cref="ProcessRefreshSpeed" /> 的枚举名。</summary>
-    public ReactiveCommand<string, Unit> SetSpeedCommand { get; }
+    public ReactiveCommand<string, RxVoid> SetSpeedCommand { get; }
 
     /// <summary>结束选中进程(SIGTERM)。</summary>
-    public ReactiveCommand<Unit, Unit> EndTaskCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> EndTaskCommand { get; }
 
     /// <summary>结束选中进程及其全部子孙(SIGTERM)。</summary>
-    public ReactiveCommand<Unit, Unit> EndTaskTreeCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> EndTaskTreeCommand { get; }
 
     /// <summary>强制结束选中进程(SIGKILL)。</summary>
-    public ReactiveCommand<Unit, Unit> ForceEndTaskCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ForceEndTaskCommand { get; }
 
     /// <summary>把选中进程的完整命令行复制到剪贴板。</summary>
-    public ReactiveCommand<Unit, Unit> CopyCommandLineCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CopyCommandLineCommand { get; }
 
     /// <summary>设置选中进程的优先级;参数为 nice 值的字符串形式。</summary>
-    public ReactiveCommand<string, Unit> SetPriorityCommand { get; }
+    public ReactiveCommand<string, RxVoid> SetPriorityCommand { get; }
 
     /// <summary>展开/折叠树形视图中的一个节点。</summary>
-    public ReactiveCommand<ProcessRowViewModel, Unit> ToggleExpandCommand { get; }
+    public ReactiveCommand<ProcessRowViewModel, RxVoid> ToggleExpandCommand { get; }
 
     private void ToggleExpand(ProcessRowViewModel row)
     {

--- a/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
+++ b/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using System.Text;
 using System.Text.Json;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Recording;
@@ -200,16 +200,16 @@ public class RecordingPlayerViewModel : ReactiveObject
     } = "";
 
     /// <summary>刷新录制列表命令。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>播放/暂停切换命令。</summary>
-    public ReactiveCommand<Unit, Unit> TogglePlayCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> TogglePlayCommand { get; }
 
     /// <summary>删除指定录制命令。</summary>
-    public ReactiveCommand<RecordingItemViewModel, Unit> DeleteCommand { get; }
+    public ReactiveCommand<RecordingItemViewModel, RxVoid> DeleteCommand { get; }
 
     /// <summary>切换自动录制开关命令。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleAutoRecordCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleAutoRecordCommand { get; }
 
     /// <summary>初始化:加载录制列表并读取自动录制设置。</summary>
     public async Task InitializeAsync()

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Reactive;
 using System.Reflection;
 using System.Text.Json;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Localization;
 using VelaShell.Core.Models;
@@ -333,7 +333,7 @@ public class SettingsViewModel : ReactiveObject
     } = true;
 
     /// <summary>删除一条已信任主机指纹;下次连接该主机将重新执行首次指纹流程。</summary>
-    public ReactiveCommand<KnownHost, Unit> RemoveKnownHostCommand { get; }
+    public ReactiveCommand<KnownHost, RxVoid> RemoveKnownHostCommand { get; }
 
     /// <summary>代码片段页(quick_commands 集合);无存储时为 null。</summary>
     public QuickCommandsViewModel? Snippets { get; }
@@ -527,31 +527,31 @@ public class SettingsViewModel : ReactiveObject
     ];
 
     /// <summary>载入设置命令:从服务读取配置并回填视图模型。</summary>
-    public ReactiveCommand<Unit, Unit> LoadCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LoadCommand { get; }
 
     /// <summary>保存设置命令:回写并落盘,主题/语言即时生效后关闭窗口。</summary>
-    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SaveCommand { get; }
 
     /// <summary>取消命令:请求关闭窗口(未保存改动由关闭流程回滚)。</summary>
-    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CancelCommand { get; }
 
     /// <summary>恢复默认命令:将所有设置回到出厂值并即时预览。</summary>
-    public ReactiveCommand<Unit, Unit> ResetCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ResetCommand { get; }
 
     /// <summary>设置强调色命令:以传入的十六进制色值更新 <see cref="AccentColor" />。</summary>
-    public ReactiveCommand<string, Unit> SetAccentCommand { get; }
+    public ReactiveCommand<string, RxVoid> SetAccentCommand { get; }
 
     /// <summary>清除历史记录命令:清空连接历史。</summary>
-    public ReactiveCommand<Unit, Unit> ClearHistoryCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ClearHistoryCommand { get; }
 
     /// <summary>检查更新命令:检查 → 下载(带进度)→ 就绪后提示重启。</summary>
-    public ReactiveCommand<Unit, Unit> CheckUpdatesCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CheckUpdatesCommand { get; }
 
     /// <summary>重启并应用已下载更新命令(仅在 <see cref="UpdateReady" /> 为真时有意义)。</summary>
-    public ReactiveCommand<Unit, Unit> RestartToUpdateCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RestartToUpdateCommand { get; }
 
     /// <summary>修复更新状态命令:清掉卡住的更新残留,让检查更新能重新走通。</summary>
-    public ReactiveCommand<Unit, Unit> RepairUpdateCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RepairUpdateCommand { get; }
 
     /// <summary>检查更新的状态提示文本。</summary>
     public string UpdateStatus

--- a/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
+++ b/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
@@ -1,5 +1,5 @@
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
 using VelaShell.Presentation.Services;
@@ -76,11 +76,11 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
     /// <summary>远程文件浏览器面板。</summary>
     public FileBrowserViewModel RemoteFiles { get; }
     /// <summary>将选中的本地文件上传到远程服务器的命令。</summary>
-    public ReactiveCommand<Unit, Unit> UploadSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> UploadSelectedCommand { get; }
     /// <summary>将选中的远程文件下载到本机的命令。</summary>
-    public ReactiveCommand<Unit, Unit> DownloadSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DownloadSelectedCommand { get; }
     /// <summary>删除选中的本地文件的命令。</summary>
-    public ReactiveCommand<Unit, Unit> DeleteLocalSelectedCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DeleteLocalSelectedCommand { get; }
     /// <summary>确认本地文件删除的回调。</summary>
     public Func<string, Task<bool>>? ConfirmLocalDelete { get; set; }
 

--- a/src/VelaShell/ViewModels/SshKeyManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/SshKeyManagerViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Ssh;
 
@@ -55,13 +55,13 @@ public class SshKeyManagerViewModel : ReactiveObject
     }
 
     /// <summary>重新枚举密钥列表的命令。</summary>
-    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> RefreshCommand { get; }
 
     /// <summary>删除指定密钥的命令。</summary>
-    public ReactiveCommand<SshKeyInfo, Unit> DeleteCommand { get; }
+    public ReactiveCommand<SshKeyInfo, RxVoid> DeleteCommand { get; }
 
     /// <summary>生成新 RSA 密钥的命令。</summary>
-    public ReactiveCommand<Unit, Unit> GenerateCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> GenerateCommand { get; }
 
     /// <summary>从密钥服务枚举密钥并刷新列表与下拉名单。</summary>
     public async Task RefreshAsync()

--- a/src/VelaShell/ViewModels/SyncViewModel.cs
+++ b/src/VelaShell/ViewModels/SyncViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using System.Reactive;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sync;
 
@@ -142,22 +142,22 @@ public class SyncViewModel : ReactiveObject
     }
 
     /// <summary>保存当前同步配置(含令牌/口令输入)的命令。</summary>
-    public ReactiveCommand<Unit, Unit> SaveConfigCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SaveConfigCommand { get; }
 
     /// <summary>立即执行一次双向同步的命令。</summary>
-    public ReactiveCommand<Unit, Unit> SyncNowCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> SyncNowCommand { get; }
 
     /// <summary>将本地数据推送到云端的命令。</summary>
-    public ReactiveCommand<Unit, Unit> PushCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> PushCommand { get; }
 
     /// <summary>从云端拉取数据到本地的命令。</summary>
-    public ReactiveCommand<Unit, Unit> PullCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> PullCommand { get; }
 
     /// <summary>加载云端版本历史列表的命令。</summary>
-    public ReactiveCommand<Unit, Unit> LoadRevisionsCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LoadRevisionsCommand { get; }
 
     /// <summary>将数据恢复到指定历史版本的命令。</summary>
-    public ReactiveCommand<GistRevision, Unit> RestoreRevisionCommand { get; }
+    public ReactiveCommand<GistRevision, RxVoid> RestoreRevisionCommand { get; }
 
     /// <summary>设置窗口打开时载入当前同步配置。</summary>
     public async Task LoadAsync()

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -1,7 +1,7 @@
-using System.Reactive;
 using System.Text;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Ssh;
@@ -163,13 +163,13 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     }
 
     /// <summary>暂停/恢复本标签的同步输入(横条“暂停”按钮)。</summary>
-    public ReactiveCommand<Unit, Unit> ToggleSyncPauseCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ToggleSyncPauseCommand { get; }
 
     /// <summary>让本标签退出频道(横条“离开频道”按钮与关闭钮)。</summary>
-    public ReactiveCommand<Unit, Unit> LeaveSyncChannelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> LeaveSyncChannelCommand { get; }
 
     /// <summary>请求关闭整个频道:所有成员标签一并退出(横条“关闭频道”按钮)。</summary>
-    public ReactiveCommand<Unit, Unit> CloseSyncChannelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseSyncChannelCommand { get; }
 
     /// <summary>“关闭频道”触发,由 SyncInputCoordinator 让频道内全部标签退出。</summary>
     public event Action<SyncInputChannel>? SyncChannelCloseRequested;
@@ -515,13 +515,13 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     public bool CanReconnect => ReconnectAttempts < MaxReconnectAttempts;
 
     /// <summary>断开实时传输,但保留标签(及其缓冲区)以便重连。</summary>
-    public ReactiveCommand<Unit, Unit> DisconnectCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> DisconnectCommand { get; }
 
     /// <summary>请求对已断开标签就地重连(等同于 Enter / Ctrl+R)。</summary>
-    public ReactiveCommand<Unit, Unit> ReconnectCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ReconnectCommand { get; }
 
     /// <summary>从标签页内失败/断开覆盖层(设计 yxjmg)关闭标签页。</summary>
-    public ReactiveCommand<Unit, Unit> CloseTabCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseTabCommand { get; }
 
     /// <summary>
     /// 释放标签资源:解绑事件、即时销毁终端模拟器(UI 安全),并把耗时的网络拆除

--- a/src/VelaShell/ViewModels/TraceRouteViewModel.cs
+++ b/src/VelaShell/ViewModels/TraceRouteViewModel.cs
@@ -1,9 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Reactive;
-using System.Reactive.Linq;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Diagnostics;
 using VelaShell.Core.Resources;
 
@@ -262,10 +261,10 @@ public sealed class TraceRouteViewModel : ReactiveObject, IDisposable
     public static string GeoDatabaseUrl => "https://download.db-ip.com/free/dbip-city-lite-2026-07.mmdb.gz";
 
     /// <summary>选择本地 .mmdb / .mmdb.gz 文件。</summary>
-    public ReactiveCommand<Unit, Unit> PickDatabaseCommand { get; private set; } = null!;
+    public ReactiveCommand<RxVoid, RxVoid> PickDatabaseCommand { get; private set; } = null!;
 
     /// <summary>在浏览器里打开数据库下载地址。</summary>
-    public ReactiveCommand<Unit, Unit> OpenDatabaseUrlCommand { get; private set; } = null!;
+    public ReactiveCommand<RxVoid, RxVoid> OpenDatabaseUrlCommand { get; private set; } = null!;
 
     /// <summary>由视图注入的文件选择器,返回选中文件的绝对路径;取消返回 null。</summary>
     public Func<Task<string?>>? DatabaseFilePicker { get; set; }
@@ -337,10 +336,10 @@ public sealed class TraceRouteViewModel : ReactiveObject, IDisposable
     }
 
     /// <summary>开始追踪。</summary>
-    public ReactiveCommand<Unit, Unit> StartCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> StartCommand { get; }
 
     /// <summary>停止追踪。</summary>
-    public ReactiveCommand<Unit, Unit> StopCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> StopCommand { get; }
 
     /// <summary>停止追踪并释放取消源。</summary>
     public void Dispose()

--- a/src/VelaShell/ViewModels/TunnelPanelViewModel.cs
+++ b/src/VelaShell/ViewModels/TunnelPanelViewModel.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Net.Sockets;
-using System.Reactive;
 using Avalonia;
 using Avalonia.Threading;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -264,28 +264,28 @@ public class TunnelPanelViewModel : ReactiveObject, IDisposable
     public string SubmitButtonText => IsEditing ? Strings.Get("Save") : Strings.Get("Msg_Create");
 
     /// <summary>按表单当前配置创建新隧道(或保存正在编辑的隧道)。</summary>
-    public ReactiveCommand<Unit, Unit> CreateTunnelCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CreateTunnelCommand { get; }
 
     /// <summary>停止指定隧道(按隧道 Id)。</summary>
-    public ReactiveCommand<Guid, Unit> StopTunnelCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> StopTunnelCommand { get; }
 
     /// <summary>启动一条已停止的隧道(按隧道 Id),必要时先建立后台连接。</summary>
-    public ReactiveCommand<Guid, Unit> StartTunnelCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> StartTunnelCommand { get; }
 
     /// <summary>删除指定隧道(按隧道 Id),并在无隧道时释放后台连接。</summary>
-    public ReactiveCommand<Guid, Unit> DeleteTunnelCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> DeleteTunnelCommand { get; }
 
     /// <summary>由视图设置:向用户确认删除某条隧道;返回 false 或未设置则取消。</summary>
     public Func<string, Task<bool>>? ConfirmDelete { get; set; }
 
     /// <summary>把某条隧道的配置填回表单进入编辑模式;保存时按新配置重建。</summary>
-    public ReactiveCommand<Guid, Unit> EditTunnelCommand { get; }
+    public ReactiveCommand<Guid, RxVoid> EditTunnelCommand { get; }
 
     /// <summary>取消按钮:清空表单与错误提示,并退出编辑模式。</summary>
-    public ReactiveCommand<Unit, Unit> ResetFormCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> ResetFormCommand { get; }
 
     /// <summary>收起面板。</summary>
-    public ReactiveCommand<Unit, Unit> CloseCommand { get; }
+    public ReactiveCommand<RxVoid, RxVoid> CloseCommand { get; }
 
     /// <summary>释放面板资源:停止实时刷新计时器。</summary>
     public void Dispose()

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI.Primitives;
 using VelaShell.Controls.Controls;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;

--- a/src/VelaShell/Views/HostKeyPromptView.axaml.cs
+++ b/src/VelaShell/Views/HostKeyPromptView.axaml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Input;
+using ReactiveUI.Primitives;
 using VelaShell.ViewModels;
 
 namespace VelaShell.Views;

--- a/src/VelaShell/Views/LocalFilePaneView.axaml.cs
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml.cs
@@ -1,9 +1,9 @@
-using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;
 using VelaShell.ViewModels;

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -9,6 +8,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
 using VelaShell.Core.Models;
@@ -38,7 +38,7 @@ public partial class MainWindow : Window
     private readonly Dictionary<Guid, ProcessManagerView> _processManagers = [];
 
     /// <summary>每个追踪目标至多一扇窗口,按目标主机去重。</summary>
-    private readonly Dictionary<string, TraceRouteWindow> _traceWindows = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, TraceRouteWindow> _traceWindows = [with(StringComparer.OrdinalIgnoreCase)];
 
     private IDisposable? _fileBrowserVisibilitySub;
     private bool _forceClose;
@@ -908,7 +908,7 @@ public partial class MainWindow : Window
         {
             return;
         }
-        await settingsViewModel.LoadCommand.Execute();
+        await settingsViewModel.LoadCommand.Execute().FirstAsync();
         var dialog = new SettingsView { DataContext = settingsViewModel };
         await dialog.ShowDialog(this);
     }

--- a/src/VelaShell/Views/ProcessManagerView.axaml.cs
+++ b/src/VelaShell/Views/ProcessManagerView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/SettingsView.axaml.cs
+++ b/src/VelaShell/Views/SettingsView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Services;

--- a/src/VelaShell/Views/TraceRouteWindow.axaml.cs
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0" />
-    <PackageVersion Include="ReactiveUI.Testing" Version="23.2.28" />
+    <PackageVersion Include="ReactiveUI.Testing" Version="24.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/VelaShell.Presentation.Tests/ViewModels/TabBarViewModelTests.cs
+++ b/tests/VelaShell.Presentation.Tests/ViewModels/TabBarViewModelTests.cs
@@ -1,3 +1,4 @@
+using ReactiveUI.Primitives;
 using VelaShell.Presentation.ViewModels;
 
 namespace VelaShell.Presentation.Tests.ViewModels;

--- a/tests/VelaShell.Tests/ModuleInit.cs
+++ b/tests/VelaShell.Tests/ModuleInit.cs
@@ -1,6 +1,6 @@
-using System.Reactive.Concurrency;
 using System.Runtime.CompilerServices;
 using ReactiveUI.Builder;
+using ReactiveUI.Primitives.Concurrency;
 
 // 本程序集的 UI 测试共用**同一条** headless UI 线程(各测试类都走
 // HeadlessUnitTestSession.GetOrStartForAssembly),Dispatch 的工作项在那条线程上顺序执行。
@@ -19,7 +19,7 @@ internal static class ModuleInit
         try
         {
             RxAppBuilder.CreateReactiveUIBuilder()
-                .WithMainThreadScheduler(CurrentThreadScheduler.Instance)
+                .WithMainThreadScheduler(CurrentThreadSequencer.Instance)
                 .WithCoreServices()
                 .BuildApp();
         }

--- a/tests/VelaShell.Tests/VelaShell.Tests.csproj
+++ b/tests/VelaShell.Tests/VelaShell.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
-    <PackageReference Include="Microsoft.Reactive.Testing" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReactiveUI.Testing" />
   </ItemGroup>

--- a/tests/VelaShell.Tests/ViewModels/AuthenticationDialogViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/AuthenticationDialogViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Security;

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -1,5 +1,5 @@
-using System.Reactive.Linq;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Behaviors;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;

--- a/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
@@ -1,5 +1,5 @@
-using System.Reactive.Linq;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;

--- a/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
@@ -1,4 +1,5 @@
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;

--- a/tests/VelaShell.Tests/ViewModels/LocalFilePaneViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/LocalFilePaneViewModelTests.cs
@@ -1,3 +1,4 @@
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.ViewModels;
 

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -1,6 +1,7 @@
-using System.Reactive.Concurrency;
 using NSubstitute;
 using ReactiveUI.Builder;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
@@ -23,7 +24,7 @@ public class MainWindowViewModelTests
         {
             RxAppBuilder
                 .CreateReactiveUIBuilder()
-                .WithMainThreadScheduler(CurrentThreadScheduler.Instance)
+                .WithMainThreadScheduler(CurrentThreadSequencer.Instance)
                 .WithCoreServices()
                 .BuildApp();
         }

--- a/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Processes;
 using VelaShell.ViewModels;
 

--- a/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/QuickCommandsViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Linq;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Infrastructure.Persistence;

--- a/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
@@ -1,5 +1,5 @@
-using System.Reactive.Linq;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Presentation.ViewModels;
@@ -325,8 +325,8 @@ public class SessionTreeViewModelTests
         _vm.PortForwardRequested += profile => portForwardRequested = profile;
 
         Assert.IsFalse(_vm.SelectedNode.IsSshProfile);
-        Assert.IsTrue(_vm.OpenSftpCommand.CanExecute.FirstAsync().Wait());
-        Assert.IsFalse(_vm.PortForwardCommand.CanExecute.FirstAsync().Wait());
+        Assert.IsTrue(await _vm.OpenSftpCommand.CanExecute.FirstAsync());
+        Assert.IsFalse(await _vm.PortForwardCommand.CanExecute.FirstAsync());
         await _vm.OpenSftpCommand.Execute().FirstAsync();
         await _vm.PortForwardCommand.Execute().FirstAsync();
         Assert.AreSame(source, requested);

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,5 +1,5 @@
-using System.Reactive.Linq;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Services;

--- a/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
@@ -1,10 +1,10 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Reactive.Linq;
 using System.Reflection;
 using Avalonia.Headless;
 using Avalonia.Threading;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;

--- a/tests/VelaShell.Tests/ViewModels/TraceRouteViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TraceRouteViewModelTests.cs
@@ -1,7 +1,8 @@
 using System.Net;
-using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
 using VelaShell.Core.Diagnostics;
 using VelaShell.ViewModels;
 
@@ -22,7 +23,7 @@ public class TraceRouteViewModelTests
     /// </summary>
     [ClassInitialize]
     public static void Init(TestContext _) =>
-        RxSchedulers.MainThreadScheduler = System.Reactive.Concurrency.ImmediateScheduler.Instance;
+        RxSchedulers.MainThreadScheduler = ImmediateSequencer.Instance;
 
     [TestMethod]
     public async Task Restart_KeepsRunningFlag_WhenTheOldRunFinishesLate()

--- a/tests/VelaShell.Tests/ViewModels/TunnelPanelViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TunnelPanelViewModelTests.cs
@@ -1,6 +1,5 @@
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
@@ -248,7 +247,7 @@ public class TunnelPanelViewModelTests
             return true;
         };
 
-        Task deleteTask = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync().ToTask();
+        Task deleteTask = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync();
         await confirmationStarted.Task;
         _vm.Tunnels.Clear();
         releaseConfirmation.SetResult(true);
@@ -274,9 +273,9 @@ public class TunnelPanelViewModelTests
         _workflowService.RemoveTunnelAsync(tunnelInfo.Id, Arg.Any<CancellationToken>())
                         .Returns(Task.CompletedTask);
 
-        Task first = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync().ToTask();
+        Task first = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync();
         await Task.Delay(20);
-        Task second = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync().ToTask();
+        Task second = _vm.DeleteTunnelCommand.Execute(tunnelInfo.Id).FirstAsync();
         releaseConfirmation.SetResult(true);
         await Task.WhenAll(first, second);
 

--- a/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
 using VelaShell.Behaviors;
 using VelaShell.Core.Models;
 using VelaShell.Security;

--- a/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
@@ -1,10 +1,10 @@
-using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Services;

--- a/tests/VelaShell.Tests/Views/Todo2PixelRegressionTests.cs
+++ b/tests/VelaShell.Tests/Views/Todo2PixelRegressionTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Security;
 using VelaShell.ViewModels;


### PR DESCRIPTION
本次提交将 ReactiveUI 相关依赖从 23.x 升级到 24.x，主要将所有 ReactiveCommand 的泛型参数由 Unit 替换为 RxVoid，涉及大量 ViewModel、测试和视图代码。替换 System.Reactive 的引用为 ReactiveUI.Primitives，并调整相关命名空间引用。调度器相关实现由 System.Reactive.Concurrency 切换为 ReactiveUI.Primitives.Concurrency，相关 Observable/Signal 也做了适配。测试代码同步适配新命名空间和类型，移除对 Microsoft.Reactive.Testing 的依赖。部分 ReactiveCommand 的 Execute 调用由直接调用改为 .FirstAsync()，以适配新返回类型。其它细节如字典初始化方式、调度器替换、调度相关代码简化等。整体为 ReactiveUI 24.x 兼容性升级，未涉及业务逻辑变更。