### PR TITLE
引入资源管理器式框选，完善批量操作与拖放

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -641,6 +641,15 @@
   <data name="MoveToPrompt" xml:space="preserve">
     <value>移動先(完全パス)</value>
   </data>
+  <data name="MoveSelectedToPrompt" xml:space="preserve">
+    <value>選択項目の移動先(フォルダー)</value>
+  </data>
+  <data name="CopySelectedToPrompt" xml:space="preserve">
+    <value>選択項目のコピー先(フォルダー)</value>
+  </data>
+  <data name="BatchOpPartialFailure" xml:space="preserve">
+    <value>{0} 件が失敗しました。最初のエラー: {1}</value>
+  </data>
   <data name="CopyTo" xml:space="preserve">
     <value>コピー先…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -641,6 +641,15 @@
   <data name="MoveToPrompt" xml:space="preserve">
     <value>이동 위치(전체 경로)</value>
   </data>
+  <data name="MoveSelectedToPrompt" xml:space="preserve">
+    <value>선택 항목을 옮길 폴더</value>
+  </data>
+  <data name="CopySelectedToPrompt" xml:space="preserve">
+    <value>선택 항목을 복사할 폴더</value>
+  </data>
+  <data name="BatchOpPartialFailure" xml:space="preserve">
+    <value>{0}개 실패. 첫 번째 오류: {1}</value>
+  </data>
   <data name="CopyTo" xml:space="preserve">
     <value>복사 대상…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -323,6 +323,15 @@
   <data name="MoveToPrompt" xml:space="preserve">
     <value>Move to (full destination path)</value>
   </data>
+  <data name="MoveSelectedToPrompt" xml:space="preserve">
+    <value>Move selected items to (destination folder)</value>
+  </data>
+  <data name="CopySelectedToPrompt" xml:space="preserve">
+    <value>Copy selected items to (destination folder)</value>
+  </data>
+  <data name="BatchOpPartialFailure" xml:space="preserve">
+    <value>{0} item(s) failed. First error — {1}</value>
+  </data>
   <data name="CopyTo" xml:space="preserve">
     <value>Copy To…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -415,6 +415,15 @@
   <data name="MoveToPrompt" xml:space="preserve">
     <value>移动到（目标完整路径）</value>
   </data>
+  <data name="MoveSelectedToPrompt" xml:space="preserve">
+    <value>将选中项移动到(目标文件夹)</value>
+  </data>
+  <data name="CopySelectedToPrompt" xml:space="preserve">
+    <value>将选中项复制到(目标文件夹)</value>
+  </data>
+  <data name="BatchOpPartialFailure" xml:space="preserve">
+    <value>{0} 项失败,首个错误:{1}</value>
+  </data>
   <data name="CopyTo" xml:space="preserve">
     <value>复制到…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -641,6 +641,15 @@
   <data name="MoveToPrompt" xml:space="preserve">
     <value>移動到(目的地完整路徑)</value>
   </data>
+  <data name="MoveSelectedToPrompt" xml:space="preserve">
+    <value>將選取項目移動到(目標資料夾)</value>
+  </data>
+  <data name="CopySelectedToPrompt" xml:space="preserve">
+    <value>將選取項目複製到(目標資料夾)</value>
+  </data>
+  <data name="BatchOpPartialFailure" xml:space="preserve">
+    <value>{0} 項失敗,首個錯誤:{1}</value>
+  </data>
   <data name="CopyTo" xml:space="preserve">
     <value>複製到…</value>
   </data>

--- a/src/VelaShell/ViewModels/FileBrowserViewModel.cs
+++ b/src/VelaShell/ViewModels/FileBrowserViewModel.cs
@@ -2532,54 +2532,145 @@ public class FileBrowserViewModel : ReactiveObject
         }
     }
 
+    /// <summary>
+    /// 菜单动作的作用对象:当前选中的真实条目,再并上右键所指的那一行。
+    /// <para>
+    /// 右键本身已经会把所指行并入选区(见 FileBrowserView.FileRow_PointerPressed),这里再兜一次底,
+    /// 好让"对着一行点菜单"和"框选一片再点菜单"走的是同一条路 —— 前者就是后者的 n=1 情形。
+    /// </para>
+    /// </summary>
+    private List<RemoteFileInfoViewModel> SelectionOrRow(RemoteFileInfoViewModel? row)
+    {
+        List<RemoteFileInfoViewModel> targets = [.. SelectedFiles.Where(f => !f.IsParentEntry)];
+        if (row is not null && !row.IsParentEntry && !targets.Any(f => f.FullPath == row.FullPath))
+        {
+            targets.Add(row);
+        }
+        return targets;
+    }
+
     private async Task MoveAsync(RemoteFileInfoViewModel? file, CancellationToken ct = default)
     {
-        if (PromptForText is null || file is null || file.IsParentEntry)
+        if (PromptForText is null)
         {
             return;
         }
-        string? destination = await PromptForText(Strings.MoveToPrompt, file.FullPath);
-        if (string.IsNullOrWhiteSpace(destination) || destination.Trim() == file.FullPath)
+        List<RemoteFileInfoViewModel> targets = SelectionOrRow(file);
+        if (targets.Count == 0)
         {
             return;
         }
-        try
+
+        // 单个:仍按"完整目标路径"提示 —— 顺手改个名是这个入口的老用法,不该因为支持批量就丢掉。
+        if (targets.Count == 1)
         {
-            ErrorMessage = null;
-            await _sftpService.RenameAsync(_sessionId, file.FullPath, destination.Trim(), ct);
-            await RefreshAsync(ct);
+            RemoteFileInfoViewModel only = targets[0];
+            string? destination = await PromptForText(Strings.MoveToPrompt, only.FullPath);
+            if (string.IsNullOrWhiteSpace(destination) || destination.Trim() == only.FullPath)
+            {
+                return;
+            }
+            try
+            {
+                ErrorMessage = null;
+                await _sftpService.RenameAsync(_sessionId, only.FullPath, destination.Trim(), ct);
+                await RefreshAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = ex.Message;
+            }
+            return;
         }
-        catch (Exception ex)
+
+        // 多个:只问一次目标目录,各自按原名落进去(逐个问完整路径没法用)。
+        string? directory = await PromptForText(Strings.Get("MoveSelectedToPrompt"), CurrentPath);
+        if (string.IsNullOrWhiteSpace(directory))
         {
-            ErrorMessage = ex.Message;
+            return;
         }
+        string destDir = directory.Trim();
+        ErrorMessage = null;
+        var failures = new List<string>();
+        foreach (RemoteFileInfoViewModel item in targets)
+        {
+            string dest = CombinePath(destDir, item.Name);
+            if (dest == item.FullPath)
+            {
+                continue;
+            }
+            try
+            {
+                await _sftpService.RenameAsync(_sessionId, item.FullPath, dest, ct);
+            }
+            catch (Exception ex)
+            {
+                // 一条失败不该把剩下的也拦住:批量操作半途而废比"跑完再报告"更难收拾。
+                failures.Add($"{item.Name}: {ex.Message}");
+            }
+        }
+        // 先刷新再报告:RefreshAsync 会把 ErrorMessage 清掉,反过来写就等于什么都没报。
+        await RefreshAsync(ct);
+        ReportBatchFailures(failures);
     }
+
+    /// <summary>把批量操作里失败的那几条汇总到错误条上(全成功则清空)。</summary>
+    private void ReportBatchFailures(List<string> failures) =>
+        ErrorMessage = failures.Count == 0
+            ? null
+            : Strings.Format("BatchOpPartialFailure", failures.Count, failures[0]);
 
     private async Task CopyToAsync(RemoteFileInfoViewModel? file, CancellationToken ct = default)
     {
-        if (PromptForText is null || file is null || file.IsParentEntry)
+        if (PromptForText is null)
         {
             return;
         }
-        // Pre-fill with current parent directory and same name for easy copy-to-same-dir.
-        string parentDir = ParentOf(file.FullPath);
-        string suggested = CombinePath(parentDir, file.Name);
-        string? destination = await PromptForText(Strings.SftpCopyToPrompt, suggested);
-        if (string.IsNullOrWhiteSpace(destination) || destination.Trim() == file.FullPath)
+        List<RemoteFileInfoViewModel> targets = SelectionOrRow(file);
+        if (targets.Count == 0)
         {
             return;
         }
+
+        List<PlannedFileTransfer> plan;
+        if (targets.Count == 1)
+        {
+            // 单个:提示完整目标路径(预填同目录同名,方便就地复制一份)。
+            RemoteFileInfoViewModel only = targets[0];
+            string suggested = CombinePath(ParentOf(only.FullPath), only.Name);
+            string? destination = await PromptForText(Strings.SftpCopyToPrompt, suggested);
+            if (string.IsNullOrWhiteSpace(destination) || destination.Trim() == only.FullPath)
+            {
+                return;
+            }
+            plan = [new(TransferType.Copy, only.FullPath, destination.Trim())];
+        }
+        else
+        {
+            // 多个:只问一次目标目录,各自按原名落进去。
+            string? directory = await PromptForText(Strings.Get("CopySelectedToPrompt"), CurrentPath);
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                return;
+            }
+            string destDir = directory.Trim();
+            plan =
+            [
+                .. targets
+                    .Select(item => new PlannedFileTransfer(TransferType.Copy, item.FullPath, CombinePath(destDir, item.Name)))
+                    .Where(item => item.RemotePath != item.LocalPath),
+            ];
+            if (plan.Count == 0)
+            {
+                return;
+            }
+        }
+
         try
         {
             ErrorMessage = null;
-            string destPath = destination.Trim();
 
-            // Route through the unified transfer pipeline for proper progress,
-            // cancellation, failure status, and toast lifecycle.
-            var plan = new List<PlannedFileTransfer>
-            {
-                new(TransferType.Copy, file.FullPath, destPath)
-            };
+            // 走统一的传输管线:进度、取消、失败状态与浮窗生命周期都是现成的。
             bool ok = await RunTransferBatchAsync(plan, ct);
             if (ok)
             {

--- a/src/VelaShell/Views/DragSelectionResolver.cs
+++ b/src/VelaShell/Views/DragSelectionResolver.cs
@@ -1,0 +1,62 @@
+namespace VelaShell.Views;
+
+/// <summary>Resolves the entries represented by a drag without depending on either pane's item type.</summary>
+internal static class DragSelectionResolver
+{
+    public static void SynchronizeSelection<T>(
+        IList<T> selection,
+        IReadOnlyList<T> dragItems,
+        IEqualityComparer<T>? comparer = null)
+    {
+        for (int i = selection.Count - 1; i >= 0; i--)
+        {
+            if (!dragItems.Contains(selection[i], comparer))
+            {
+                selection.RemoveAt(i);
+            }
+        }
+
+        foreach (T item in dragItems)
+        {
+            if (!selection.Contains(item, comparer))
+            {
+                selection.Add(item);
+            }
+        }
+    }
+
+    public static IReadOnlyList<T> ResolveAtDragStart<T>(
+        IEnumerable<T> selectionAtPress,
+        IEnumerable<T> currentSelection,
+        T source,
+        Func<T, bool> isParent,
+        bool usePressSnapshot = true,
+        IEqualityComparer<T>? comparer = null)
+    {
+        var pressedItems = selectionAtPress
+            .Where(item => !isParent(item))
+            .ToList();
+        IEnumerable<T> selection = usePressSnapshot && pressedItems.Contains(source, comparer)
+            ? pressedItems
+            : currentSelection;
+        return Resolve(selection, source, isParent, comparer);
+    }
+
+    public static IReadOnlyList<T> Resolve<T>(
+        IEnumerable<T> selected,
+        T source,
+        Func<T, bool> isParent,
+        IEqualityComparer<T>? comparer = null)
+    {
+        var selectedItems = selected
+            .Where(item => !isParent(item))
+            .ToList();
+
+        if (selectedItems.Contains(source, comparer))
+        {
+            return selectedItems;
+        }
+
+        return isParent(source) ? [] : [source];
+    }
+}

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -410,8 +410,9 @@
           </Grid>
         </Border>
 
-        <ListBox Grid.Row="1"
-                 x:Name="FileList"
+        <!-- 列表外面套一层 Panel,是为了在它上面叠一个框选矩形(见 MarqueeOverlay)。 -->
+        <Panel Grid.Row="1">
+        <ListBox x:Name="FileList"
                  ItemsSource="{Binding Files}"
                  SelectedItems="{Binding SelectedFiles}"
                  SelectionMode="Multiple"
@@ -645,27 +646,28 @@
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
                       <!-- 设计 dyuii 图标:琥珀色文件夹、素色文件、".." 用 corner-left-up。 -->
-                      <pc:LucideIcon Width="13" Height="13"
+                      <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13"
                                      Foreground="{DynamicResource VelaFileFolderIcon}"
                                      IsVisible="{Binding IsRegularDirectory}"
                                      Margin="0,0,7,0"
                                      Data="{StaticResource Icon.folder}" />
-                      <pc:LucideIcon Width="13" Height="13"
+                      <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13"
                                      Foreground="{DynamicResource VelaTextTertiary}"
                                      IsVisible="{Binding !IsDirectory}"
                                      Margin="0,0,7,0"
                                      Data="{StaticResource Icon.file}" />
-                      <pc:LucideIcon Width="13" Height="13"
+                      <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13"
                                      Foreground="{DynamicResource VelaTextTertiary}"
                                      IsVisible="{Binding IsParentEntry}"
                                      Margin="0,0,7,0"
                                      Data="{StaticResource Icon.corner-left-up}" />
-                      <TextBlock Grid.Column="1"
+                      <TextBlock Classes="dnd-surface" Grid.Column="1"
                                  Text="{Binding DisplayName}"
                                  Foreground="{DynamicResource VelaTextSecondary}"
                                  FontFamily="{DynamicResource VelaTerminalFont}"
                                  FontSize="11"
                                  VerticalAlignment="Center"
+                                 HorizontalAlignment="Left"
                                  TextTrimming="CharacterEllipsis"
                                  Classes.dir="{Binding IsRegularDirectory}">
                         <TextBlock.Styles>
@@ -676,57 +678,71 @@
                       </TextBlock>
                     </Grid>
 
-                    <TextBlock Grid.Column="2"
+                    <TextBlock Classes="dnd-surface" Grid.Column="2"
                                Text="{Binding FormattedSize}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowSizeColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
-                               VerticalAlignment="Center" />
-                    <TextBlock Grid.Column="4"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Left" />
+                    <TextBlock Classes="dnd-surface" Grid.Column="4"
                                Text="{Binding Permissions}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowPermissionsColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
-                               VerticalAlignment="Center" />
-                    <TextBlock Grid.Column="6"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Left" />
+                    <TextBlock Classes="dnd-surface" Grid.Column="6"
                                Text="{Binding Owner}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowOwnerColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
-                    <TextBlock Grid.Column="8"
+                    <TextBlock Classes="dnd-surface" Grid.Column="8"
                                Text="{Binding Group}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowGroupColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
-                    <TextBlock Grid.Column="10"
+                    <TextBlock Classes="dnd-surface" Grid.Column="10"
                                Text="{Binding FileTypeDisplay}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowTypeColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
-                    <TextBlock Grid.Column="12"
+                    <TextBlock Classes="dnd-surface" Grid.Column="12"
                                Text="{Binding FormattedModifiedTime}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowModifiedColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
                                FontFamily="{DynamicResource VelaTerminalFont}"
                                FontSize="11"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
                   </Grid>
                 </Border>
               </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
+
+          <!-- 框选矩形。IsHitTestVisible=False:它盖在列表上,不能把指针事件吃掉。 -->
+          <Border Name="MarqueeOverlay" IsVisible="False" IsHitTestVisible="False"
+                  HorizontalAlignment="Left" VerticalAlignment="Top"
+                  Background="{DynamicResource VelaAccent}" Opacity="0.18"
+                  BorderBrush="{DynamicResource VelaAccent}" BorderThickness="1"
+                  CornerRadius="1" />
+        </Panel>
 
       </Grid>
 

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -56,6 +56,8 @@ public partial class FileBrowserView : UserControl
     private Point _dragOrigin;
     private RemoteFileInfoViewModel? _dragRow;
     private PointerPressedEventArgs? _dragPointerArgs;
+    private readonly List<RemoteFileInfoViewModel> _selectionAtPress = [];
+    private bool _selectionRestoredForPendingDrag;
     private const double DragThreshold = 5;
 
     /// <summary>按下拖拽条那一刻的列宽快照(列键 → 像素),拖拽期间按位移量增量应用。</summary>
@@ -90,16 +92,32 @@ public partial class FileBrowserView : UserControl
             vm.ConfirmRemoteOverwrite = ConfirmRemoteOverwriteAsync;
         };
 
+        // 框选与跨栏拖放使用不相交的按下表面。终端模式没有拖放时,
+        // 所有行内容也都留给框选。
+        if (this.FindControl<ListBox>("FileList") is { } list
+            && this.FindControl<Border>("MarqueeOverlay") is { } overlay)
+        {
+            MarqueeSelection.Attach(
+                list,
+                overlay,
+                item => item is RemoteFileInfoViewModel { IsParentEntry: false },
+                e => DataContext is not FileBrowserViewModel { IsDragEnabled: true }
+                    || !MarqueeSelection.IsDndSurface(e.Source, FileList, e.GetPosition(FileList))
+            );
+        }
+
         // 拖放接收:操作系统文件拖入(始终启用)+ 跨面板拖入。
         if (this.FindControl<ListBox>("FileList") is { } fileList)
         {
             DragDrop.SetAllowDrop(fileList, true);
             fileList.AddHandler(DragDrop.DragOverEvent, OnFileListDragOver);
             fileList.AddHandler(DragDrop.DropEvent, OnFileListDrop);
+            fileList.AddHandler(InputElement.PointerPressedEvent, OnRemoteDragPointerPressedTunnel, RoutingStrategies.Tunnel, true);
+            fileList.AddHandler(InputElement.PointerPressedEvent, OnRemoteDragPointerPressedBubble, RoutingStrategies.Bubble, true);
 
             // 跨面板拖拽发起(行 → 本地面板)。
             fileList.AddHandler(PointerMovedEvent, OnRemoteDragPointerMoved);
-            fileList.AddHandler(PointerReleasedEvent, OnRemoteDragPointerReleased);
+            fileList.AddHandler(PointerReleasedEvent, OnRemoteDragPointerReleased, RoutingStrategies.Bubble, true);
         }
         AddHandler(PointerMovedEvent, OnColumnSplitterPointerMoved, RoutingStrategies.Tunnel);
         AddHandler(PointerReleasedEvent, OnColumnSplitterReleased, RoutingStrategies.Tunnel);
@@ -578,7 +596,8 @@ public partial class FileBrowserView : UserControl
             // 左键:为可能拖往本地面板做准备(仅 SFTP 模式)。
             if (DataContext is FileBrowserViewModel { IsDragEnabled: true }
                 && sender is Border { DataContext: RemoteFileInfoViewModel file }
-                && !file.IsParentEntry)
+                && !file.IsParentEntry
+                && MarqueeSelection.IsDndSurface(e.Source, (Visual)sender, e.GetPosition((Visual)sender)))
             {
                 _dragOrigin = e.GetPosition(this.FindControl<ListBox>("FileList"));
                 _dragRow = file;
@@ -605,10 +624,49 @@ public partial class FileBrowserView : UserControl
         }
     }
 
+    private void OnRemoteDragPointerPressedTunnel(object? sender, PointerPressedEventArgs e)
+    {
+        _selectionAtPress.Clear();
+        if (!e.GetCurrentPoint(FileList).Properties.IsLeftButtonPressed
+            || FileList.SelectedItems is not { } selected)
+        {
+            return;
+        }
+
+        foreach (object? item in selected)
+        {
+            if (item is RemoteFileInfoViewModel file && !file.IsParentEntry)
+            {
+                _selectionAtPress.Add(file);
+            }
+        }
+    }
+
+    private void OnRemoteDragPointerPressedBubble(object? sender, PointerPressedEventArgs e)
+    {
+        if (_dragRow is not { } source
+            || _selectionAtPress.Count <= 1
+            || !_selectionAtPress.Contains(source)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+            || DataContext is not FileBrowserViewModel vm)
+        {
+            return;
+        }
+
+        DragSelectionResolver.SynchronizeSelection(vm.SelectedFiles, _selectionAtPress);
+        _selectionRestoredForPendingDrag = true;
+    }
+
     private void OnRemoteDragPointerMoved(object? sender, PointerEventArgs e)
     {
         if (_isDragging || _dragRow is null || _dragPointerArgs is null)
         {
+            return;
+        }
+        if (!e.GetCurrentPoint(FileList).Properties.IsLeftButtonPressed)
+        {
+            ResetRemoteDragGesture();
             return;
         }
         Point current = e.GetPosition(this.FindControl<ListBox>("FileList"));
@@ -623,34 +681,61 @@ public partial class FileBrowserView : UserControl
 
     private void OnRemoteDragPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        _isDragging = false;
-        _dragRow = null;
-        _dragPointerArgs = null;
+        if (!_isDragging
+            && _selectionRestoredForPendingDrag
+            && _dragRow is { } source
+            && DataContext is FileBrowserViewModel vm)
+        {
+            DragSelectionResolver.SynchronizeSelection(vm.SelectedFiles, [source]);
+        }
+        ResetRemoteDragGesture();
     }
 
     private async Task StartRemoteDragAsync(RemoteFileInfoViewModel source, PointerPressedEventArgs pointerArgs)
     {
-        // 收集所有选中的远程文件路径。
-        var paths = new List<string>();
         if (DataContext is FileBrowserViewModel vm)
         {
-            foreach (RemoteFileInfoViewModel item in vm.SelectedFiles)
-            {
-                if (!item.IsParentEntry) paths.Add(item.FullPath);
-            }
+            IReadOnlyList<RemoteFileInfoViewModel> entries = DragSelectionResolver.ResolveAtDragStart(
+                _selectionAtPress,
+                vm.SelectedFiles,
+                source,
+                item => item.IsParentEntry,
+                usePressSnapshot: !pointerArgs.KeyModifiers.HasFlag(KeyModifiers.Control)
+                    && !pointerArgs.KeyModifiers.HasFlag(KeyModifiers.Shift));
+            DragSelectionResolver.SynchronizeSelection(vm.SelectedFiles, entries);
+            string[] paths = [.. entries.Select(item => item.FullPath)];
+            await StartRemoteDragAsync(paths, pointerArgs);
+            return;
         }
-        if (paths.Count == 0) paths.Add(source.FullPath);
+        await StartRemoteDragAsync([source.FullPath], pointerArgs);
+    }
 
+    private async Task StartRemoteDragAsync(
+        IReadOnlyList<string> paths,
+        PointerPressedEventArgs pointerArgs)
+    {
         var data = new DataTransfer();
         var dragItem = new DataTransferItem();
         dragItem.SetText(DragDropFormats.RemotePaths + string.Join("\n", paths));
         data.Add(dragItem);
 
-        await DragDrop.DoDragDropAsync(pointerArgs, data, DragDropEffects.Copy);
+        try
+        {
+            await DragDrop.DoDragDropAsync(pointerArgs, data, DragDropEffects.Copy);
+        }
+        finally
+        {
+            ResetRemoteDragGesture();
+        }
+    }
 
+    private void ResetRemoteDragGesture()
+    {
         _isDragging = false;
         _dragRow = null;
         _dragPointerArgs = null;
+        _selectionAtPress.Clear();
+        _selectionRestoredForPendingDrag = false;
     }
 
     /// <summary>

--- a/src/VelaShell/Views/LocalFilePaneView.axaml
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml
@@ -146,6 +146,8 @@
               Background="{DynamicResource VelaBgActive}" Padding="8,4">
         <TextBlock Text="{Binding ErrorMessage}" Foreground="{DynamicResource VelaAccent}" FontSize="11" />
       </Border>
+      <!-- 列表外面套一层 Panel,是为了在它上面叠一个框选矩形(见 MarqueeOverlay)。 -->
+      <Panel>
       <ListBox x:Name="FileList" ItemsSource="{Binding Entries}" SelectedItems="{Binding SelectedEntries}"
                SelectionMode="Multiple" Background="Transparent" BorderThickness="0"
                DoubleTapped="OnFileDoubleTapped">
@@ -182,28 +184,39 @@
               <Grid ColumnDefinitions="*,90,130">
                 <Grid Classes="local-name-cell" ColumnDefinitions="Auto,*" MinWidth="0"
                       ClipToBounds="True" VerticalAlignment="Center">
-                  <pc:LucideIcon Width="13" Height="13" Margin="0,0,7,0"
+                  <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.folder}" Foreground="{DynamicResource VelaFileFolderIcon}"
                                  IsVisible="{Binding IsRegularDirectory}" />
-                  <pc:LucideIcon Width="13" Height="13" Margin="0,0,7,0"
+                  <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.file}" Foreground="{DynamicResource VelaTextTertiary}"
                                  IsVisible="{Binding IsRegularFile}" />
-                  <pc:LucideIcon Width="13" Height="13" Margin="0,0,7,0"
+                  <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.corner-left-up}" Foreground="{DynamicResource VelaTextTertiary}"
                                  IsVisible="{Binding IsParentEntry}" />
-                  <TextBlock Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaTerminalFont}"
+                  <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaTerminalFont}"
                              FontSize="11" Foreground="{DynamicResource VelaTextSecondary}"
-                             VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                             VerticalAlignment="Center" HorizontalAlignment="Left"
+                             TextTrimming="CharacterEllipsis" />
                 </Grid>
-                <TextBlock Classes="local-size-cell" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
+                <TextBlock Classes="local-size-cell dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
+                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
+                           HorizontalAlignment="Left" />
+                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
+                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
+                           HorizontalAlignment="Left" />
               </Grid>
             </Border>
           </DataTemplate>
         </ListBox.ItemTemplate>
       </ListBox>
+
+        <!-- 框选矩形。IsHitTestVisible=False:它盖在列表上,不能把指针事件吃掉。 -->
+        <Border Name="MarqueeOverlay" IsVisible="False" IsHitTestVisible="False"
+                HorizontalAlignment="Left" VerticalAlignment="Top"
+                Background="{DynamicResource VelaAccent}" Opacity="0.18"
+                BorderBrush="{DynamicResource VelaAccent}" BorderThickness="1"
+                CornerRadius="1" />
+      </Panel>
     </DockPanel>
   </Border>
 </UserControl>

--- a/src/VelaShell/Views/LocalFilePaneView.axaml.cs
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 using ReactiveUI.Primitives;
@@ -18,6 +19,8 @@ public partial class LocalFilePaneView : UserControl
     private Point _dragOrigin;
     private LocalFileEntry? _dragRow;
     private PointerPressedEventArgs? _dragPointerArgs;
+    private readonly List<LocalFileEntry> _selectionAtPress = [];
+    private bool _selectionRestoredForPendingDrag;
     private const double DragThreshold = 5;
 
     /// <summary>初始化本地文件面板视图,并接线 VM 委托。</summary>
@@ -34,14 +37,28 @@ public partial class LocalFilePaneView : UserControl
             }
         };
 
+        // 框选与跨栏拖放使用不相交的按下表面:只有 XAML 标记的内容表面发起拖放。
+        if (this.FindControl<ListBox>("FileList") is { } list
+            && this.FindControl<Border>("MarqueeOverlay") is { } overlay)
+        {
+            MarqueeSelection.Attach(
+                list,
+                overlay,
+                item => item is LocalFileEntry { IsParentEntry: false },
+                e => !MarqueeSelection.IsDndSurface(e.Source, FileList, e.GetPosition(FileList))
+            );
+        }
+
         // 拖放:接收远端文件拖入 + 发起本地文件拖拽。
         if (this.FindControl<ListBox>("FileList") is { } fileList)
         {
             DragDrop.SetAllowDrop(fileList, true);
             fileList.AddHandler(DragDrop.DragOverEvent, OnLocalDropDragOver);
             fileList.AddHandler(DragDrop.DropEvent, OnLocalDrop);
+            fileList.AddHandler(InputElement.PointerPressedEvent, OnLocalDragPointerPressedTunnel, RoutingStrategies.Tunnel, true);
+            fileList.AddHandler(InputElement.PointerPressedEvent, OnLocalDragPointerPressedBubble, RoutingStrategies.Bubble, true);
             fileList.AddHandler(PointerMovedEvent, OnLocalDragPointerMoved);
-            fileList.AddHandler(PointerReleasedEvent, OnLocalDragPointerReleased);
+            fileList.AddHandler(PointerReleasedEvent, OnLocalDragPointerReleased, RoutingStrategies.Bubble, true);
         }
     }
 
@@ -89,7 +106,9 @@ public partial class LocalFilePaneView : UserControl
         if (!e.GetCurrentPoint(null).Properties.IsRightButtonPressed)
         {
             // 非父行上按左键:为拖往远端面板做准备。
-            if (sender is Border { DataContext: LocalFileEntry entry } && !entry.IsParentEntry)
+            if (sender is Border { DataContext: LocalFileEntry entry }
+                && !entry.IsParentEntry
+                && MarqueeSelection.IsDndSurface(e.Source, (Visual)sender, e.GetPosition((Visual)sender)))
             {
                 _dragOrigin = e.GetPosition(this.FindControl<ListBox>("FileList"));
                 _dragRow = entry;
@@ -115,6 +134,40 @@ public partial class LocalFilePaneView : UserControl
             selection.Clear();
             selection.Add(entry2);
         }
+    }
+
+    private void OnLocalDragPointerPressedTunnel(object? sender, PointerPressedEventArgs e)
+    {
+        _selectionAtPress.Clear();
+        if (!e.GetCurrentPoint(FileList).Properties.IsLeftButtonPressed
+            || FileList.SelectedItems is not { } selected)
+        {
+            return;
+        }
+
+        foreach (object? item in selected)
+        {
+            if (item is LocalFileEntry entry && !entry.IsParentEntry)
+            {
+                _selectionAtPress.Add(entry);
+            }
+        }
+    }
+
+    private void OnLocalDragPointerPressedBubble(object? sender, PointerPressedEventArgs e)
+    {
+        if (_dragRow is not { } source
+            || _selectionAtPress.Count <= 1
+            || !_selectionAtPress.Contains(source)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+            || DataContext is not LocalFilePaneViewModel vm)
+        {
+            return;
+        }
+
+        DragSelectionResolver.SynchronizeSelection(vm.SelectedEntries, _selectionAtPress);
+        _selectionRestoredForPendingDrag = true;
     }
 
     private async Task<string?> PromptForTextAsync(string title, string initialValue)
@@ -144,6 +197,11 @@ public partial class LocalFilePaneView : UserControl
         {
             return;
         }
+        if (!e.GetCurrentPoint(FileList).Properties.IsLeftButtonPressed)
+        {
+            ResetLocalDragGesture();
+            return;
+        }
         Point current = e.GetPosition(this.FindControl<ListBox>("FileList"));
         if (Math.Abs(current.X - _dragOrigin.X) < DragThreshold && Math.Abs(current.Y - _dragOrigin.Y) < DragThreshold)
         {
@@ -156,33 +214,62 @@ public partial class LocalFilePaneView : UserControl
 
     private void OnLocalDragPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        _isDragging = false;
-        _dragRow = null;
-        _dragPointerArgs = null;
+        if (!_isDragging
+            && _selectionRestoredForPendingDrag
+            && _dragRow is { } source
+            && DataContext is LocalFilePaneViewModel vm)
+        {
+            DragSelectionResolver.SynchronizeSelection(vm.SelectedEntries, [source]);
+        }
+        ResetLocalDragGesture();
     }
 
     private async Task StartLocalDragAsync(LocalFileEntry source, PointerPressedEventArgs pointerArgs)
     {
-        var paths = new List<string>();
         if (DataContext is LocalFilePaneViewModel vm)
         {
-            foreach (LocalFileEntry item in vm.SelectedEntries)
-            {
-                if (!item.IsParentEntry) paths.Add(item.FullPath);
-            }
+            IReadOnlyList<LocalFileEntry> entries = DragSelectionResolver.ResolveAtDragStart(
+                _selectionAtPress,
+                vm.SelectedEntries,
+                source,
+                item => item.IsParentEntry,
+                usePressSnapshot: !pointerArgs.KeyModifiers.HasFlag(KeyModifiers.Control)
+                    && !pointerArgs.KeyModifiers.HasFlag(KeyModifiers.Shift));
+            DragSelectionResolver.SynchronizeSelection(vm.SelectedEntries, entries);
+            string[] paths = [.. entries.Select(item => item.FullPath)];
+            await StartDragAsync(paths, pointerArgs, DragDropFormats.LocalPaths);
+            return;
         }
-        if (paths.Count == 0) paths.Add(source.FullPath);
+        await StartDragAsync([source.FullPath], pointerArgs, DragDropFormats.LocalPaths);
+    }
 
+    private async Task StartDragAsync(
+        IReadOnlyList<string> paths,
+        PointerPressedEventArgs pointerArgs,
+        string format)
+    {
         var data = new DataTransfer();
         var dragItem = new DataTransferItem();
-        dragItem.SetText(DragDropFormats.LocalPaths + string.Join("\n", paths));
+        dragItem.SetText(format + string.Join("\n", paths));
         data.Add(dragItem);
 
-        await DragDrop.DoDragDropAsync(pointerArgs, data, DragDropEffects.Copy);
+        try
+        {
+            await DragDrop.DoDragDropAsync(pointerArgs, data, DragDropEffects.Copy);
+        }
+        finally
+        {
+            ResetLocalDragGesture();
+        }
+    }
 
+    private void ResetLocalDragGesture()
+    {
         _isDragging = false;
         _dragRow = null;
         _dragPointerArgs = null;
+        _selectionAtPress.Clear();
+        _selectionRestoredForPendingDrag = false;
     }
 
     // ── 放置处理(远端 → 本地) ──────────────────────────────────

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml
@@ -208,8 +208,8 @@
           <DataTemplate x:DataType="vm:LocalFileEntry">
             <Border Classes="file-row" Classes.parent="{Binding IsParentEntry}" Height="28" Padding="16,0"
                     BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
-              <Grid ColumnDefinitions="*,90,130">
-                <Grid ColumnDefinitions="Auto,*" MinWidth="0" ClipToBounds="True" VerticalAlignment="Center">
+                <Grid ColumnDefinitions="*,90,130">
+                <Grid Classes="dnd-surface" ColumnDefinitions="Auto,*" MinWidth="0" ClipToBounds="True" VerticalAlignment="Center">
                   <pc:LucideIcon Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.folder}" Foreground="{DynamicResource VelaFileFolderIcon}"
                                  IsVisible="{Binding IsRegularDirectory}" />
@@ -223,9 +223,9 @@
                              FontSize="11" Foreground="{DynamicResource VelaTextSecondary}"
                              VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
                 </Grid>
-                <TextBlock Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
+                <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
                            FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
+                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
                            FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
               </Grid>
             </Border>

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml.cs
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml.cs
@@ -38,15 +38,14 @@ public partial class LocalPathPickerDialog : Window
         ViewModel.SelectedEntries.CollectionChanged += (_, _) => UpdateSelectionSummary();
         UpdateSelectionSummary();
 
-        // 框选:必须 handledEventsToo。ListBoxItem 会把 PointerPressed 标记为已处理
-        // (它要用这一下做选中),不带这个标志就永远收不到按下,框选也就无从起头。
-        FileList.AddHandler(PointerPressedEvent, OnListPointerPressed, RoutingStrategies.Bubble, true);
-        FileList.AddHandler(PointerMovedEvent, OnListPointerMoved, RoutingStrategies.Bubble, true);
-        FileList.AddHandler(PointerReleasedEvent, OnListPointerReleased, RoutingStrategies.Bubble, true);
-
-        // 捕获被系统抢走(切窗口、拖出窗体等)时也要收摊,否则矩形留在屏幕上、
-        // 自动滚动的计时器还在空转。
-        FileList.PointerCaptureLost += (_, _) => EndMarquee();
+        // 框选。这里的行不发起拖放,不存在"拖行 = 拖文件"的歧义,所以放开从行上起框 ——
+        // 行是撑满整行宽的,只准从空白起框等于文件一多就用不上,正是最需要它的时候。
+        _marquee = MarqueeSelection.Attach(
+            FileList,
+            Marquee,
+            item => item is LocalFileEntry { IsParentEntry: false },
+                _ => true
+        );
 
         if (loadInitial)
         {
@@ -55,6 +54,15 @@ public partial class LocalPathPickerDialog : Window
     }
 
     private LocalFilePaneViewModel ViewModel { get; }
+
+    private readonly MarqueeSelection _marquee;
+
+    /// <summary>关窗时务必收起框选,否则自动滚动的计时器会拽着已关闭的窗口继续跑。</summary>
+    protected override void OnClosed(EventArgs e)
+    {
+        _marquee.End();
+        base.OnClosed(e);
+    }
 
     /// <summary>
     /// 打开选择器,返回用户选中的本地路径(文件与文件夹混合);取消则返回空列表。
@@ -82,10 +90,7 @@ public partial class LocalPathPickerDialog : Window
             : Strings.Format("Sftp_PickUploadSelected", picked.Count - folders, folders);
 
         // 没选东西时不给按,免得开一个空批次。
-        if (ConfirmButton is not null)
-        {
-            ConfirmButton.IsEnabled = picked.Count > 0;
-        }
+        ConfirmButton?.IsEnabled = picked.Count > 0;
     }
 
     /// <summary>双击:目录(含 "..")进去,文件直接当作选定并确认 —— 单选是最常见的用法。</summary>
@@ -149,221 +154,5 @@ public partial class LocalPathPickerDialog : Window
         {
             BeginMoveDrag(e);
         }
-    }
-
-    // ── 框选 ─────────────────────────────────────────────────────────
-    //
-    // 像资源管理器那样按住左键拖出一个矩形,划过的行成片选中。列表里的行是撑满整行宽的,
-    // 空白区只在最后一行下面才有 —— 只允许"从空白处起框"等于文件一多就用不上,正是最需要它的时候。
-    // 所以这里也允许从行上起框:按下先照常选中那一行,指针移动超过阈值才升级成框选。
-    // 这个对话框里的行不发起拖放,不存在"拖行 = 拖文件"的歧义,可以这么做。
-
-    /// <summary>升级成框选所需的拖动距离,低于此距离仍按普通点击处理。</summary>
-    private const double MarqueeThreshold = 4;
-
-    /// <summary>行高兜底值:与 XAML 行模板里的 Height 一致,取不到实测值时用它。</summary>
-    private const double FallbackRowHeight = 28;
-
-    private bool _pointerDown;
-    private bool _marqueeActive;
-
-    /// <summary>按下点(视口坐标)。</summary>
-    private Point _marqueeOrigin;
-
-    /// <summary>按下时的滚动偏移:自动滚动会改变偏移,起点必须锚在内容坐标上。</summary>
-    private double _marqueeOriginOffset;
-
-    /// <summary>按住 Ctrl 起框时保留的原有选中项。</summary>
-    private readonly List<LocalFileEntry> _marqueeBaseSelection = [];
-
-    /// <summary>拖到列表上下边界外时的自动滚动。</summary>
-    private DispatcherTimer? _autoScroll;
-    private double _autoScrollDelta;
-
-    /// <summary>
-    /// 自动滚动期间的当前指针位置。必须放在字段里让计时器每次读:
-    /// 若把它闭包进计时器,指针继续移动时矩形就会卡在起框那一刻的位置不再跟手。
-    /// </summary>
-    private Point _autoScrollPointer;
-
-    private void OnListPointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (!e.GetCurrentPoint(FileList).Properties.IsLeftButtonPressed)
-        {
-            return;
-        }
-        _pointerDown = true;
-        _marqueeOrigin = e.GetPosition(FileList);
-        _marqueeOriginOffset = ScrollOffsetY;
-        _marqueeBaseSelection.Clear();
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
-        {
-            _marqueeBaseSelection.AddRange(ViewModel.SelectedEntries);
-        }
-    }
-
-    private void OnListPointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (!_pointerDown)
-        {
-            return;
-        }
-        Point current = e.GetPosition(FileList);
-        if (!_marqueeActive)
-        {
-            if (Math.Abs(current.X - _marqueeOrigin.X) < MarqueeThreshold
-                && Math.Abs(current.Y - _marqueeOrigin.Y) < MarqueeThreshold)
-            {
-                return;
-            }
-            _marqueeActive = true;
-            e.Pointer.Capture(FileList);
-            Marquee.IsVisible = true;
-        }
-        UpdateMarquee(current);
-
-        // 拖出上下边界就持续滚动,否则一屏之外的行永远框不到。
-        double overshoot = current.Y < 0
-            ? current.Y
-            : current.Y > FileList.Bounds.Height ? current.Y - FileList.Bounds.Height : 0;
-        SetAutoScroll(overshoot, current);
-    }
-
-    private void OnListPointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        _pointerDown = false;
-        if (!_marqueeActive)
-        {
-            return;
-        }
-        EndMarquee();
-        e.Pointer.Capture(null);
-
-        // 框选拖动不该被当成一次点击落到行上(否则松手瞬间选中集会被那一行顶掉)。
-        e.Handled = true;
-    }
-
-    /// <summary>收起框选:停自动滚动、藏掉矩形。重复调用无害。</summary>
-    private void EndMarquee()
-    {
-        _pointerDown = false;
-        _marqueeActive = false;
-        StopAutoScroll();
-        if (Marquee is not null)
-        {
-            Marquee.IsVisible = false;
-        }
-    }
-
-    /// <summary>画出矩形,并把它覆盖到的行同步进选中集。</summary>
-    private void UpdateMarquee(Point current)
-    {
-        double originY = _marqueeOrigin.Y + _marqueeOriginOffset - ScrollOffsetY;
-        double left = Math.Max(Math.Min(_marqueeOrigin.X, current.X), 0);
-        double top = Math.Max(Math.Min(originY, current.Y), 0);
-        double right = Math.Min(Math.Max(_marqueeOrigin.X, current.X), FileList.Bounds.Width);
-        double bottom = Math.Min(Math.Max(originY, current.Y), FileList.Bounds.Height);
-        Marquee.Margin = new(left, top, 0, 0);
-        Marquee.Width = Math.Max(right - left, 0);
-        Marquee.Height = Math.Max(bottom - top, 0);
-
-        // 命中判定走内容坐标(视口坐标 + 滚动偏移),这样滚动过程中已划过的行不会掉出来。
-        (int first, int last) = MarqueeSelectionMath.RowsInBand(
-            _marqueeOrigin.Y + _marqueeOriginOffset,
-            current.Y + ScrollOffsetY,
-            RowHeight(),
-            ViewModel.Entries.Count
-        );
-        ApplyMarqueeSelection(first, last);
-    }
-
-    private void ApplyMarqueeSelection(int first, int last)
-    {
-        var target = new HashSet<LocalFileEntry>(_marqueeBaseSelection);
-        for (int i = first; i >= 0 && i <= last; i++)
-        {
-            LocalFileEntry entry = ViewModel.Entries[i];
-            if (!entry.IsParentEntry)
-            {
-                target.Add(entry);
-            }
-        }
-
-        // 逐项增删而不是清空重建:清空会让绑定过去的选中集合抖动一次,
-        // 列表跟着重画,拖动过程中肉眼可见地闪。
-        for (int i = ViewModel.SelectedEntries.Count - 1; i >= 0; i--)
-        {
-            if (!target.Contains(ViewModel.SelectedEntries[i]))
-            {
-                ViewModel.SelectedEntries.RemoveAt(i);
-            }
-        }
-        foreach (LocalFileEntry entry in target)
-        {
-            if (!ViewModel.SelectedEntries.Contains(entry))
-            {
-                ViewModel.SelectedEntries.Add(entry);
-            }
-        }
-    }
-
-    /// <summary>实测行高(取第一个已实现的容器),取不到时用模板里的固定值。</summary>
-    private double RowHeight()
-    {
-        foreach (Control container in FileList.GetRealizedContainers())
-        {
-            if (container.Bounds.Height > 0)
-            {
-                return container.Bounds.Height;
-            }
-        }
-        return FallbackRowHeight;
-    }
-
-    private double ScrollOffsetY => FileList.Scroll?.Offset.Y ?? 0;
-
-    private void SetAutoScroll(double overshoot, Point current)
-    {
-        _autoScrollPointer = current;
-        if (overshoot == 0)
-        {
-            StopAutoScroll();
-            return;
-        }
-
-        // 越界越多滚得越快,但压在一行的量级上,免得一冲到底。
-        _autoScrollDelta = Math.Clamp(overshoot / 2, -RowHeight(), RowHeight());
-        if (_autoScroll is not null)
-        {
-            return;
-        }
-        _autoScroll = new(TimeSpan.FromMilliseconds(30), DispatcherPriority.Background, (_, _) =>
-        {
-            if (FileList.Scroll is not { } scroll)
-            {
-                return;
-            }
-            double y = Math.Clamp(
-                scroll.Offset.Y + _autoScrollDelta,
-                0,
-                Math.Max(scroll.Extent.Height - scroll.Viewport.Height, 0)
-            );
-            scroll.Offset = scroll.Offset.WithY(y);
-            UpdateMarquee(_autoScrollPointer);
-        });
-        _autoScroll.Start();
-    }
-
-    private void StopAutoScroll()
-    {
-        _autoScroll?.Stop();
-        _autoScroll = null;
-    }
-
-    /// <summary>关窗时务必停掉自动滚动的计时器,否则它会拽着已关闭的窗口继续跑。</summary>
-    protected override void OnClosed(EventArgs e)
-    {
-        EndMarquee();
-        base.OnClosed(e);
     }
 }

--- a/src/VelaShell/Views/MarqueeSelection.cs
+++ b/src/VelaShell/Views/MarqueeSelection.cs
@@ -1,0 +1,333 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace VelaShell.Views;
+
+/// <summary>
+/// 给 <see cref="ListBox" /> 加上资源管理器式的框选:按住左键拖出矩形,划过的行成片选中。
+/// <para>
+/// 几何在 <see cref="MarqueeSelectionMath" />(可脱离 UI 单测),这里只管接线:指针事件、
+/// 矩形绘制、选中集同步、拖出边界时的自动滚动。
+/// </para>
+/// <para>
+/// <b>能不能从按下位置起框</b>由每次按下的 start policy 决定。双栏拖放只占用
+/// XAML 明确标记的 bounded <c>dnd-surface</c>,行和列的其它空白始终留给框选。
+/// </para>
+/// </summary>
+internal sealed class MarqueeSelection
+{
+    /// <summary>升级成框选所需的拖动距离,低于此距离仍按普通点击处理。</summary>
+    private const double Threshold = 4;
+
+    /// <summary>取不到实测行高时的兜底值。</summary>
+    private const double FallbackRowHeight = 24;
+
+    private readonly ListBox _list;
+    private readonly Border _overlay;
+    private readonly Func<object, bool> _canSelect;
+    private readonly Func<PointerPressedEventArgs, bool> _canStart;
+    private readonly List<object> _baseSelection = [];
+    private readonly List<object> _pressSelection = [];
+
+    private bool _pointerDown;
+    private bool _active;
+    private Point _origin;
+    private double _originOffset;
+
+    private DispatcherTimer? _autoScroll;
+    private double _autoScrollDelta;
+
+    /// <summary>
+    /// 自动滚动期间的当前指针位置。必须放字段里让计时器每次读:
+    /// 闭包进去的话指针继续移动时矩形会卡在起框那一刻不再跟手。
+    /// </summary>
+    private Point _autoScrollPointer;
+
+    private MarqueeSelection(
+        ListBox list,
+        Border overlay,
+        Func<object, bool> canSelect,
+        Func<PointerPressedEventArgs, bool> canStart)
+    {
+        _list = list;
+        _overlay = overlay;
+        _canSelect = canSelect;
+        _canStart = canStart;
+    }
+
+    /// <summary>
+    /// 把框选接到 <paramref name="list" /> 上,矩形画在 <paramref name="overlay" />
+    /// (需与列表同处一个 Panel、<c>IsHitTestVisible=False</c>)。
+    /// </summary>
+    /// <param name="list">接收框选指针事件的列表。</param>
+    /// <param name="overlay">绘制框选矩形的覆盖层。</param>
+    /// <param name="canSelect">哪些数据项可以被框中(用来排除合成的 ".." 行)。</param>
+    /// <param name="canStart">按下位置是否属于框选手势;每次按下都会重新判断。</param>
+    public static MarqueeSelection Attach(
+        ListBox list,
+        Border overlay,
+        Func<object, bool> canSelect,
+        Func<PointerPressedEventArgs, bool> canStart
+    )
+    {
+        var marquee = new MarqueeSelection(list, overlay, canSelect, canStart);
+
+        // ListBoxItem mutates selection during its tunnel/bubble route. Snapshot before
+        // that happens so Ctrl-marquee is additive to the selection at mouse-down time.
+        list.AddHandler(InputElement.PointerPressedEvent, marquee.OnPointerPressedPreview, RoutingStrategies.Tunnel, true);
+        // handledEventsToo 是必须的:ListBoxItem 会把 PointerPressed 标记为已处理
+        // (它要用这一下做选中),不带这个标志就永远收不到按下,框选无从起头。
+        list.AddHandler(InputElement.PointerPressedEvent, marquee.OnPointerPressed, RoutingStrategies.Bubble, true);
+        list.AddHandler(InputElement.PointerMovedEvent, marquee.OnPointerMoved, RoutingStrategies.Bubble, true);
+        list.AddHandler(InputElement.PointerReleasedEvent, marquee.OnPointerReleased, RoutingStrategies.Bubble, true);
+
+        // 捕获被系统抢走(切窗口、拖出窗体)时也要收摊,否则矩形留在屏幕上、计时器空转。
+        list.PointerCaptureLost += (_, _) => marquee.End();
+        return marquee;
+    }
+
+    /// <summary>收起框选:停自动滚动、藏掉矩形。重复调用无害。</summary>
+    public void End()
+    {
+        _pointerDown = false;
+        _active = false;
+        StopAutoScroll();
+        _overlay.IsVisible = false;
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(_list).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        if (!_canStart(e))
+        {
+            return;
+        }
+        _pointerDown = true;
+        _origin = e.GetPosition(_list);
+        _originOffset = ScrollOffsetY;
+        _baseSelection.Clear();
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            _baseSelection.AddRange(_pressSelection);
+        }
+    }
+
+    private void OnPointerPressedPreview(object? sender, PointerPressedEventArgs e)
+    {
+        _pressSelection.Clear();
+        if (!e.GetCurrentPoint(_list).Properties.IsLeftButtonPressed
+            || !e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || _list.SelectedItems is not { } selected)
+        {
+            return;
+        }
+
+        foreach (object? item in selected)
+        {
+            if (item is not null)
+            {
+                _pressSelection.Add(item);
+            }
+        }
+    }
+
+    internal static bool IsDndSurface(object? source)
+    {
+        for (var current = source as Visual; current is not null; current = current.GetVisualParent())
+        {
+            if (current is Control control && control.Classes.Contains("dnd-surface"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool IsDndSurface(object? source, Visual? hitRoot, Point position)
+    {
+        if (IsDndSurface(source))
+        {
+            return true;
+        }
+
+        if (hitRoot is null)
+        {
+            return false;
+        }
+
+        foreach (Control control in hitRoot.GetVisualDescendants().OfType<Control>())
+        {
+            if (!control.Classes.Contains("dnd-surface") || !control.IsVisible)
+            {
+                continue;
+            }
+
+            Point? topLeft = control.TranslatePoint(new(), hitRoot);
+            if (topLeft is { } point
+                && new Rect(point, control.Bounds.Size).Contains(position))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_pointerDown)
+        {
+            return;
+        }
+        Point current = e.GetPosition(_list);
+        if (!_active)
+        {
+            if (Math.Abs(current.X - _origin.X) < Threshold && Math.Abs(current.Y - _origin.Y) < Threshold)
+            {
+                return;
+            }
+            _active = true;
+            e.Pointer.Capture(_list);
+            _overlay.IsVisible = true;
+        }
+        Update(current);
+
+        // 拖出上下边界就持续滚动,否则一屏之外的行永远框不到。
+        double overshoot = current.Y < 0
+            ? current.Y
+            : current.Y > _list.Bounds.Height ? current.Y - _list.Bounds.Height : 0;
+        SetAutoScroll(overshoot, current);
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        _pointerDown = false;
+        if (!_active)
+        {
+            return;
+        }
+        End();
+        e.Pointer.Capture(null);
+
+        // 框选拖动不该再被当成一次点击落到行上(否则松手瞬间选中集会被那一行顶掉)。
+        e.Handled = true;
+    }
+
+    /// <summary>画出矩形,并把它覆盖到的行同步进选中集。</summary>
+    private void Update(Point current)
+    {
+        double originY = _origin.Y + _originOffset - ScrollOffsetY;
+        double left = Math.Max(Math.Min(_origin.X, current.X), 0);
+        double top = Math.Max(Math.Min(originY, current.Y), 0);
+        double right = Math.Min(Math.Max(_origin.X, current.X), _list.Bounds.Width);
+        double bottom = Math.Min(Math.Max(originY, current.Y), _list.Bounds.Height);
+        _overlay.Margin = new(left, top, 0, 0);
+        _overlay.Width = Math.Max(right - left, 0);
+        _overlay.Height = Math.Max(bottom - top, 0);
+
+        // 命中判定走内容坐标(视口坐标 + 滚动偏移),这样滚动过程中已划过的行不会掉出来。
+        (int first, int last) = MarqueeSelectionMath.RowsInBand(
+            _origin.Y + _originOffset,
+            current.Y + ScrollOffsetY,
+            RowHeight(),
+            _list.ItemCount
+        );
+        ApplySelection(first, last);
+    }
+
+    private void ApplySelection(int first, int last)
+    {
+        if (_list.SelectedItems is not { } selection)
+        {
+            return;
+        }
+        var swept = new List<object>();
+        for (int i = first; i >= 0 && i <= last; i++)
+        {
+            object? item = _list.ItemsView[i];
+            if (item is not null && _canSelect(item))
+            {
+                swept.Add(item);
+            }
+        }
+        var target = new HashSet<object>(MarqueeSelectionMath.MergeSelection(_baseSelection, swept));
+
+        // 逐项增删而不是清空重建:清空会让绑定过去的选中集合抖动一次,
+        // 列表跟着重画,拖动过程中肉眼可见地闪。
+        for (int i = selection.Count - 1; i >= 0; i--)
+        {
+            if (selection[i] is { } existing && !target.Contains(existing))
+            {
+                selection.RemoveAt(i);
+            }
+        }
+        foreach (object item in target)
+        {
+            if (!selection.Contains(item))
+            {
+                selection.Add(item);
+            }
+        }
+    }
+
+    /// <summary>实测行高(取第一个已实现的容器),取不到时用兜底值。</summary>
+    private double RowHeight()
+    {
+        foreach (Control container in _list.GetRealizedContainers())
+        {
+            if (container.Bounds.Height > 0)
+            {
+                return container.Bounds.Height;
+            }
+        }
+        return FallbackRowHeight;
+    }
+
+    private double ScrollOffsetY => _list.Scroll?.Offset.Y ?? 0;
+
+    private void SetAutoScroll(double overshoot, Point current)
+    {
+        _autoScrollPointer = current;
+        if (overshoot == 0)
+        {
+            StopAutoScroll();
+            return;
+        }
+
+        // 越界越多滚得越快,但压在一行的量级上,免得一冲到底。
+        _autoScrollDelta = Math.Clamp(overshoot / 2, -RowHeight(), RowHeight());
+        if (_autoScroll is not null)
+        {
+            return;
+        }
+        _autoScroll = new(TimeSpan.FromMilliseconds(30), DispatcherPriority.Background, (_, _) =>
+        {
+            if (_list.Scroll is not { } scroll)
+            {
+                return;
+            }
+            double y = Math.Clamp(
+                scroll.Offset.Y + _autoScrollDelta,
+                0,
+                Math.Max(scroll.Extent.Height - scroll.Viewport.Height, 0)
+            );
+            scroll.Offset = scroll.Offset.WithY(y);
+            Update(_autoScrollPointer);
+        });
+        _autoScroll.Start();
+    }
+
+    private void StopAutoScroll()
+    {
+        _autoScroll?.Stop();
+        _autoScroll = null;
+    }
+}

--- a/src/VelaShell/Views/MarqueeSelectionMath.cs
+++ b/src/VelaShell/Views/MarqueeSelectionMath.cs
@@ -10,6 +10,13 @@ namespace VelaShell.Views;
 /// </summary>
 internal static class MarqueeSelectionMath
 {
+    /// <summary>Combines the mouse-down snapshot with rows swept by a Ctrl-marquee.</summary>
+    public static IReadOnlyList<T> MergeSelection<T>(
+        IEnumerable<T> snapshot,
+        IEnumerable<T> swept,
+        IEqualityComparer<T>? comparer = null) =>
+        [.. snapshot.Concat(swept).Distinct(comparer)];
+
     /// <summary>
     /// 求内容坐标区间 <paramref name="top" />..<paramref name="bottom" /> 覆盖到的行下标(闭区间)。
     /// 两端可以任意顺序传入(向上拖时 bottom &lt; top)。没有覆盖到任何行时返回 <c>(-1, -1)</c>。

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -576,10 +576,8 @@ public class SftpServiceTests
         Assert.IsGreaterThanOrEqualTo(1, progressReports.Count);
         Assert.AreEqual(100, progressReports[^1].Percentage);
         Assert.AreEqual(10000, progressReports[^1].BytesTransferred);
-        CollectionAssert.AreEqual(
-            progressReports.Select(p => p.BytesTransferred).OrderBy(b => b).ToList(),
-            progressReports.Select(p => p.BytesTransferred).ToList(),
-            "进度必须单调不回退");
+        Assert.AreSequenceEqual(
+            [.. progressReports.Select(p => p.BytesTransferred).OrderBy(b => b)], [.. progressReports.Select(p => p.BytesTransferred)], "进度必须单调不回退");
 
         // Cleanup
         File.Delete(localPath);

--- a/tests/VelaShell.Tests/Integration/SshIntegrationTests.cs
+++ b/tests/VelaShell.Tests/Integration/SshIntegrationTests.cs
@@ -249,7 +249,7 @@ public class SshIntegrationTests
         var service = new SshConnectionService(_ => mockClient);
         ConnectionInfo connectionInfo = CreateTestConnectionInfo();
         SshSession session = await service.ConnectAsync(connectionInfo);
-        Assert.AreEqual(1, service.Sessions.Count);
+        Assert.HasCount(1, service.Sessions);
         Assert.IsNotNull(service.GetSession(session.SessionId));
         Assert.AreEqual(SessionStatus.Connected, service.GetSession(session.SessionId)!.Status);
         await service.DisposeAsync();

--- a/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
@@ -662,6 +662,110 @@ public class FileBrowserViewModelTests
 
     [TestMethod]
     [TestCategory("FileBrowser")]
+    public async Task Move_WithSeveralSelected_AsksOnceForAFolderAndMovesThemAllIntoIt()
+    {
+        // 框选一片再"移动到":逐个问完整路径没法用,只问一次目标目录,各自按原名落进去。
+        int prompts = 0;
+        _vm.PromptForText = (_, _) =>
+        {
+            prompts++;
+            return Task.FromResult<string?>("/srv/archive");
+        };
+        _sftpService
+            .ListDirectoryAsync(_sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<RemoteFileInfo>()));
+        List<RemoteFileInfo> files = CreateTestFiles();
+        _vm.SelectedFiles.Add(new(files[1])); // readme.txt
+        _vm.SelectedFiles.Add(new(files[2]));
+
+        await _vm.MoveCommand.Execute(new(files[1])).FirstAsync();
+
+        Assert.AreEqual(1, prompts, "批量移动只该问一次目标目录。");
+        await _sftpService.Received(1).RenameAsync(
+            _sessionId, files[1].FullPath, $"/srv/archive/{files[1].Name}", Arg.Any<CancellationToken>());
+        await _sftpService.Received(1).RenameAsync(
+            _sessionId, files[2].FullPath, $"/srv/archive/{files[2].Name}", Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public async Task Move_WhenOneItemFails_StillMovesTheRestAndReportsTheFailure()
+    {
+        // 批量半途中断比"跑完再报告"更难收拾:一条失败不该把剩下的也拦住。
+        _vm.PromptForText = (_, _) => Task.FromResult<string?>("/srv/archive");
+        _sftpService
+            .ListDirectoryAsync(_sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<RemoteFileInfo>()));
+        List<RemoteFileInfo> files = CreateTestFiles();
+        _sftpService
+            .RenameAsync(_sessionId, files[1].FullPath, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new IOException("permission denied")));
+        _vm.SelectedFiles.Add(new(files[1]));
+        _vm.SelectedFiles.Add(new(files[2]));
+
+        await _vm.MoveCommand.Execute(new(files[1])).FirstAsync();
+
+        // 失败的那条不该挡住后面的。
+        await _sftpService.Received(1).RenameAsync(
+            _sessionId, files[2].FullPath, $"/srv/archive/{files[2].Name}", Arg.Any<CancellationToken>());
+        Assert.IsNotNull(_vm.ErrorMessage);
+        StringAssert.Contains(_vm.ErrorMessage, "permission denied");
+    }
+
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public async Task Move_WithASingleItem_KeepsTheFullPathPromptSoRenamingStillWorks()
+    {
+        // n=1 时保留老用法:提示的是完整目标路径,可以顺手改名。
+        string? prompted = null;
+        _vm.PromptForText = (_, initial) =>
+        {
+            prompted = initial;
+            return Task.FromResult<string?>("/tmp/renamed.txt");
+        };
+        _sftpService
+            .ListDirectoryAsync(_sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<RemoteFileInfo>()));
+        List<RemoteFileInfo> files = CreateTestFiles();
+        _vm.SelectedFiles.Add(new(files[1]));
+
+        await _vm.MoveCommand.Execute(new(files[1])).FirstAsync();
+
+        Assert.AreEqual(files[1].FullPath, prompted, "单个移动应预填完整路径,而不是目录。");
+        await _sftpService.Received(1).RenameAsync(
+            _sessionId, files[1].FullPath, "/tmp/renamed.txt", Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public async Task CopyTo_WithSeveralSelected_AsksOnceAndCopiesEachIntoTheFolder()
+    {
+        int prompts = 0;
+        _vm.PromptForText = (_, _) =>
+        {
+            prompts++;
+            return Task.FromResult<string?>("/srv/backup");
+        };
+        _sftpService
+            .ListDirectoryAsync(_sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<RemoteFileInfo>()));
+        List<RemoteFileInfo> files = CreateTestFiles();
+        _vm.SelectedFiles.Add(new(files[1]));
+        _vm.SelectedFiles.Add(new(files[2]));
+
+        await _vm.CopyToCommand.Execute(new(files[1])).FirstAsync();
+
+        Assert.AreEqual(1, prompts, "批量复制只该问一次目标目录。");
+        await _sftpService.Received(1).CopyAsync(
+            _sessionId, files[1].FullPath, $"/srv/backup/{files[1].Name}",
+            Arg.Any<IProgress<TransferProgress>?>(), Arg.Any<CancellationToken>());
+        await _sftpService.Received(1).CopyAsync(
+            _sessionId, files[2].FullPath, $"/srv/backup/{files[2].Name}",
+            Arg.Any<IProgress<TransferProgress>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    [TestCategory("FileBrowser")]
     public async Task CopyPath_And_CopyName_WriteToClipboard()
     {
         string? copied = null;
@@ -1719,7 +1823,7 @@ public class FileBrowserViewModelTests
         );
 
         // nested 已经被 root 包住,再单列一次就会把同一个文件传两遍、写同一个远端路径。
-        CollectionAssert.AreEquivalent(new[] { root, sibling }, kept.ToArray());
+        Assert.AreSequenceEqual([root, sibling], [.. kept], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]
@@ -1732,6 +1836,6 @@ public class FileBrowserViewModelTests
 
         IReadOnlyList<string> kept = FileBrowserViewModel.NormalizeUploadRoots([a, b]);
 
-        CollectionAssert.AreEquivalent(new[] { a, b }, kept.ToArray());
+        Assert.AreSequenceEqual([a, b], [.. kept], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 }

--- a/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
@@ -136,7 +136,7 @@ public class ProcessManagerViewModelTests
         await _vm.EndTaskCommand.Execute().FirstAsync();
 
         (IReadOnlyList<int> pids, ProcessSignal signal) = _service.Signals.Single();
-        CollectionAssert.AreEqual(new[] { 100 }, pids.ToArray());
+        Assert.AreSequenceEqual([100], [.. pids]);
         Assert.AreEqual(ProcessSignal.Terminate, signal);
     }
 
@@ -167,7 +167,7 @@ public class ProcessManagerViewModelTests
 
         await _vm.EndTaskTreeCommand.Execute().FirstAsync();
 
-        CollectionAssert.AreEqual(new[] { 300, 200, 100 }, _service.Signals.Single().Pids.ToArray());
+        Assert.AreSequenceEqual([300, 200, 100], [.. _service.Signals.Single().Pids]);
     }
 
     [TestMethod]
@@ -237,13 +237,11 @@ public class ProcessManagerViewModelTests
         await _vm.RefreshAsync();
         _vm.ShowTree = true;
 
-        CollectionAssert.AreEqual(
-            new[] { 1, 100, 200, 300 },
-            _vm.Processes.Select(row => row.Pid).ToArray()
+        Assert.AreSequenceEqual(
+            [1, 100, 200, 300], [.. _vm.Processes.Select(row => row.Pid)]
         );
-        CollectionAssert.AreEqual(
-            new[] { 0, 1, 2, 3 },
-            _vm.Processes.Select(row => row.Depth).ToArray()
+        Assert.AreSequenceEqual(
+            [0, 1, 2, 3], [.. _vm.Processes.Select(row => row.Depth)]
         );
         Assert.IsTrue(_vm.Processes.Single(row => row.Pid == 200).HasChildren);
         Assert.IsFalse(_vm.Processes.Single(row => row.Pid == 300).HasChildren);
@@ -263,11 +261,11 @@ public class ProcessManagerViewModelTests
         ProcessRowViewModel parent = _vm.Processes.Single(row => row.Pid == 100);
         _vm.ToggleExpandCommand.Execute(parent).Subscribe();
 
-        CollectionAssert.AreEqual(new[] { 1, 100 }, _vm.Processes.Select(row => row.Pid).ToArray());
+        Assert.AreSequenceEqual([1, 100], [.. _vm.Processes.Select(row => row.Pid)]);
 
         // 折叠状态挂在复用的行对象上,刷新之后仍然保持。
         await _vm.RefreshAsync();
-        CollectionAssert.AreEqual(new[] { 1, 100 }, _vm.Processes.Select(row => row.Pid).ToArray());
+        Assert.AreSequenceEqual([1, 100], [.. _vm.Processes.Select(row => row.Pid)]);
     }
 
     [TestMethod]
@@ -283,7 +281,7 @@ public class ProcessManagerViewModelTests
         _vm.ShowTree = true;
         _vm.SearchText = "needle";
 
-        CollectionAssert.AreEqual(new[] { 1, 100, 200 }, _vm.Processes.Select(row => row.Pid).ToArray());
+        Assert.AreSequenceEqual([1, 100, 200], [.. _vm.Processes.Select(row => row.Pid)]);
         Assert.AreEqual(2, _vm.Processes.Single(row => row.Pid == 200).Depth);
     }
 
@@ -298,7 +296,7 @@ public class ProcessManagerViewModelTests
         await _vm.RefreshAsync();
         _vm.ShowTree = true;
 
-        CollectionAssert.AreEqual(new[] { 500 }, _vm.Processes.Select(row => row.Pid).ToArray());
+        Assert.AreSequenceEqual([500], [.. _vm.Processes.Select(row => row.Pid)]);
         Assert.AreEqual(0, _vm.Processes[0].Depth);
     }
 

--- a/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
@@ -1,0 +1,272 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using ReactiveUI.Primitives;
+using NSubstitute;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+using VelaShell.Localization;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 远端文件浏览器的框选(双栏 SFTP 右栏 与 终端模式下方浏览器共用同一个控件)。
+/// <para>
+/// 这里守的是那条与拖放的分界:双栏模式(<c>IsDragEnabled</c>)下"按住行拖"要留给
+/// 跨栏拖放,只能从空白处起框;终端模式没有行拖拽,才放开从行上起框。
+/// </para>
+/// <para>
+/// body 必须同步 + <c>return Task.CompletedTask</c> —— 传 async lambda 会绑到
+/// <c>Dispatch(Func&lt;TResult&gt;)</c>,断言一条都不会跑却全绿。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("MarqueeUI")]
+public sealed class FileBrowserMarqueeUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(FileBrowserMarqueeUiTests).Assembly);
+        LocalizedStrings.Instance.Attach(new LocalizationService());
+    }
+
+    [TestMethod]
+    public void TerminalMode_DraggingFromARow_MarqueeSelectsTheSweptRows()
+    {
+        // 终端模式(IsDragEnabled=false):没有行拖拽,允许从行上起框。
+        RunWithBrowser(dragEnabled: false, (window, list, vm) =>
+        {
+            Drag(window, list, fromRow: 1, toRow: 3);
+
+            Assert.AreSequenceEqual(
+                ["f1.txt", "f2.txt", "f3.txt"], [.. vm.SelectedFiles.Select(f => f.Name)], SequenceOrder.InAnyOrder, "终端模式下从行上拖应框中划过的三行。"
+            );
+        });
+    }
+
+    [TestMethod]
+    public void DualPaneMode_DraggingFromARow_DoesNotMarquee_SoCrossPaneDragKeepsWorking()
+    {
+        // 双栏模式(IsDragEnabled=true):按住行拖是"拖去另一栏",不能被框选抢走。
+        RunWithBrowser(dragEnabled: true, (window, list, vm) =>
+        {
+            Border overlay = window.GetVisualDescendants().OfType<Border>().Single(b => b.Name == "MarqueeOverlay");
+            Drag(window, list, fromRow: 1, toRow: 3, midDrag: () =>
+                Assert.IsFalse(overlay.IsVisible, "双栏模式下按住行拖不该起框 —— 那是跨栏拖放的手势。"));
+
+            Assert.HasCount(1, vm.SelectedFiles, "只应保留按下那一行的普通选中。");
+        });
+    }
+
+    [TestMethod]
+    public void DualPaneMode_DraggingFromTheEmptyAreaBelowTheRows_StillMarquees()
+    {
+        // 资源管理器的惯例:空白处起框依然可用,拖上去把行框进来。
+        RunWithBrowser(dragEnabled: true, (window, list, vm) =>
+        {
+            Control lastRow = list.ContainerFromIndex(list.ItemCount - 1)!;
+            Point below = lastRow.TranslatePoint(new(20, lastRow.Bounds.Height + 30), window)!.Value;
+            Point up = RowCenter(window, list, 2);
+
+            window.MouseDown(below, MouseButton.Left);
+            Pump(window);
+            for (int step = 1; step <= 4; step++)
+            {
+                window.MouseMove(new(
+                    below.X + ((up.X - below.X) * step / 4),
+                    below.Y + ((up.Y - below.Y) * step / 4)
+                ));
+                Pump(window);
+            }
+            window.MouseUp(up, MouseButton.Left);
+            Pump(window);
+
+            Assert.AreSequenceEqual(
+                ["f2.txt", "f3.txt", "f4.txt"], [.. vm.SelectedFiles.Select(f => f.Name)], SequenceOrder.InAnyOrder, "从末行下方的空白往上拖,应框中 f2..f4。"
+            );
+        });
+    }
+
+    [TestMethod]
+    public void DualPaneMode_DraggingFromRowWhitespace_Marquees()
+    {
+        RunWithBrowser(dragEnabled: true, (window, list, vm) =>
+        {
+            Control row = list.ContainerFromIndex(2)!;
+            Point start = row.TranslatePoint(new(150, row.Bounds.Height / 2), window)!.Value;
+            Point end = RowCenter(window, list, 4);
+
+            window.MouseDown(start, MouseButton.Left);
+            Pump(window);
+            window.MouseMove(end);
+            Pump(window);
+            window.MouseUp(end, MouseButton.Left);
+            Pump(window);
+
+            Assert.AreSequenceEqual(
+                ["f2.txt", "f3.txt", "f4.txt"], [.. vm.SelectedFiles.Select(file => file.Name)], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+        });
+    }
+
+    [TestMethod]
+    public void DualPaneMode_DraggingSelectedItem_KeepsTheWholeBatchVisiblySelected()
+    {
+        RunWithBrowser(dragEnabled: true, (window, list, vm) =>
+        {
+            RemoteFileInfoViewModel[] batch = [vm.Files[1], vm.Files[2], vm.Files[3]];
+            Assert.IsNotNull(list.SelectedItems);
+            foreach (RemoteFileInfoViewModel file in batch)
+            {
+                list.SelectedItems.Add(file);
+            }
+            Pump(window);
+            Assert.AreEqual(3, list.SelectedItems.Count, "测试必须先建立真实的三项控件选区。");
+            Assert.AreEqual(3, vm.SelectedFiles.Count, "控件选区应同步到视图模型。");
+
+            Drag(window, list, fromRow: 2, toRow: 3, midDrag: () =>
+                Assert.AreSequenceEqual(
+                    [.. batch.Select(file => file.Name)],
+                    [.. vm.SelectedFiles.Select(file => file.Name)],
+                    Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder,
+                    "批量拖拽期间应持续高亮全部待传输项目。"));
+        });
+    }
+
+    [TestMethod]
+    public void DualPaneMode_ClickingSelectedItemWithoutDragging_CollapsesToThatItem()
+    {
+        RunWithBrowser(dragEnabled: true, (window, list, vm) =>
+        {
+            Assert.IsNotNull(list.SelectedItems);
+            foreach (RemoteFileInfoViewModel file in vm.Files.Skip(1).Take(3))
+            {
+                list.SelectedItems.Add(file);
+            }
+            Pump(window);
+
+            Point point = RowCenter(window, list, 2);
+            window.MouseDown(point, MouseButton.Left);
+            Pump(window);
+            window.MouseUp(point, MouseButton.Left);
+            Pump(window);
+
+            Assert.AreSequenceEqual(["f2.txt"], [.. vm.SelectedFiles.Select(file => file.Name)]);
+        });
+    }
+
+    private static void Drag(Window window, ListBox list, int fromRow, int toRow, Action? midDrag = null)
+    {
+        Point start = RowCenter(window, list, fromRow);
+        Point end = RowCenter(window, list, toRow);
+
+        window.MouseDown(start, MouseButton.Left);
+        Pump(window);
+        for (int step = 1; step <= 4; step++)
+        {
+            window.MouseMove(new(
+                start.X + ((end.X - start.X) * step / 4),
+                start.Y + ((end.Y - start.Y) * step / 4)
+            ));
+            Pump(window);
+        }
+        midDrag?.Invoke();
+        window.MouseUp(end, MouseButton.Left);
+        Pump(window);
+    }
+
+    private static Point RowCenter(Window window, ListBox list, int index)
+    {
+        Control container = list.ContainerFromIndex(index)
+                            ?? throw new InvalidOperationException($"第 {index} 行没有实现出容器。");
+        return container.TranslatePoint(new(20, container.Bounds.Height / 2), window)
+               ?? throw new InvalidOperationException("坐标换算失败。");
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    private static void RunWithBrowser(bool dragEnabled, Action<Window, ListBox, FileBrowserViewModel> body) =>
+        OnUi(() =>
+        {
+            ISftpService sftp = Substitute.For<ISftpService>();
+            var sessionId = Guid.NewGuid();
+            List<RemoteFileInfo> files =
+            [
+                .. Enumerable.Range(1, 4).Select(i => new RemoteFileInfo
+                {
+                    Name = $"f{i}.txt",
+                    FullPath = $"/home/user/f{i}.txt",
+                    Size = i * 10,
+                    Permissions = "-rw-r--r--",
+                    IsDirectory = false,
+                    LastModified = DateTime.UtcNow,
+                    Owner = "user",
+                    Group = "user",
+                }),
+            ];
+            sftp.ListDirectoryAsync(sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(files));
+
+            var vm = new FileBrowserViewModel(sftp, sessionId)
+            {
+                IsVisible = true,
+                IsDragEnabled = dragEnabled,
+                TransferOptions = new(),
+                CurrentPath = "/home/user",
+            };
+            vm.RefreshCommand.Execute().Subscribe();
+            PumpUntil(() => vm.Files.Count > 0);
+
+            var view = new FileBrowserView { DataContext = vm };
+            var window = new Window { Width = 900, Height = 600, Content = view };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+
+                ListBox list = view.GetVisualDescendants().OfType<ListBox>().Single(l => l.Name == "FileList");
+                Assert.AreEqual(5, list.ItemCount, "应为 \"..\" 加 4 个文件。");
+                Assert.IsTrue(vm.Files[0].IsParentEntry, "首行应是合成的 \"..\"。");
+                vm.SelectedFiles.Clear();
+
+                body(window, list, vm);
+            }
+            finally
+            {
+                // 不关窗整个 headless 套件会永久卡死。
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        });
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>在 UI 线程上把异步的目录列举跑完(body 必须保持同步,不能 await)。</summary>
+    private static void PumpUntil(Func<bool> done)
+    {
+        for (int i = 0; i < 2000 && !done(); i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(1);
+        }
+        Assert.IsTrue(done(), "目录列举没能在预期时间内完成。");
+    }
+}

--- a/tests/VelaShell.Tests/Views/FileTransferPanelUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileTransferPanelUiTests.cs
@@ -88,7 +88,7 @@ public sealed class FileTransferPanelUiTests
             ScrollViewer viewport = fixture.Viewport;
             double rows = fixture.RealizedRows().Sum(row => row.Bounds.Height);
 
-            Assert.AreEqual(2, fixture.RealizedRows().Count, "两条都应当实现出来。");
+            Assert.HasCount(2, fixture.RealizedRows(), "两条都应当实现出来。");
             Assert.AreEqual(
                 rows,
                 viewport.Bounds.Height,
@@ -126,7 +126,7 @@ public sealed class FileTransferPanelUiTests
 
         public static Fixture Show(int transferCount)
         {
-            var manager = Substitute.For<ITransferManager>();
+            ITransferManager manager = Substitute.For<ITransferManager>();
             manager.ActiveTransfers.Returns([]);
             manager.QueuedTransfers.Returns([]);
 

--- a/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using VelaShell.Core.Models;
@@ -56,6 +58,85 @@ public sealed class LocalFilePaneViewUiTests
                 window.Close();
             }
         }, CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task DraggingFromRowWhitespace_MarqueesAcrossLocalRows()
+    {
+        await _session.Dispatch(async () =>
+        {
+            using var root = new TempDirectory();
+            for (int i = 0; i < 5; i++)
+            {
+                File.WriteAllText(Path.Combine(root.Path, $"f{i}.txt"), $"file {i}");
+            }
+
+            var accessible = new LocalRootEntry("~", root.Path, true, root.Path);
+            var viewModel = new LocalFilePaneViewModel(
+                new TransferOptions { LocalDownloadDirectory = root.Path },
+                rootProvider: new TestRootProvider(accessible));
+            await viewModel.LoadInitialAsync();
+
+            var view = new LocalFilePaneView { DataContext = viewModel };
+            var window = new Window { Width = 700, Height = 450, Content = view };
+            try
+            {
+                window.Show();
+                Pump(window);
+
+                ListBox list = view.GetVisualDescendants().OfType<ListBox>().Single(l => l.Name == "FileList");
+                Assert.IsGreaterThanOrEqualTo(4, list.ItemCount);
+                viewModel.SelectedEntries.Clear();
+
+                const int firstRow = 1;
+                const int lastRow = 3;
+                Control first = list.ContainerFromIndex(firstRow)!;
+                Control last = list.ContainerFromIndex(lastRow)!;
+                Point start = first.TranslatePoint(FindWhitespacePoint(first), window)!.Value;
+                Point end = last.TranslatePoint(FindWhitespacePoint(last), window)!.Value;
+                Border overlay = view.GetVisualDescendants().OfType<Border>()
+                    .Single(border => border.Name == "MarqueeOverlay");
+
+                window.MouseDown(start, MouseButton.Left);
+                Pump(window);
+                window.MouseMove(end);
+                Pump(window);
+
+                Assert.IsTrue(overlay.IsVisible, "本地栏行内空白拖动应显示框选矩形。");
+
+                window.MouseUp(end, MouseButton.Left);
+                Pump(window);
+
+                Assert.AreSequenceEqual(
+                    [.. viewModel.Entries.Skip(firstRow).Take(lastRow - firstRow + 1).Select(entry => entry.Name)], [.. viewModel.SelectedEntries.Select(entry => entry.Name)], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+            }
+            finally
+            {
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }, CancellationToken.None);
+    }
+
+    private static Point FindWhitespacePoint(Control row)
+    {
+        double y = row.Bounds.Height / 2;
+        for (double x = 40; x < row.Bounds.Width - 10; x += 10)
+        {
+            var point = new Point(x, y);
+            if (!MarqueeSelection.IsDndSurface(row, row, point))
+            {
+                return point;
+            }
+        }
+
+        throw new InvalidOperationException("本地文件行中没有找到可用于框选的视觉空白区域。");
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
     }
 
     private sealed class TestRootProvider(params LocalRootEntry[] roots) : ILocalRootProvider

--- a/tests/VelaShell.Tests/Views/LocalPathPickerMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/LocalPathPickerMarqueeUiTests.cs
@@ -51,10 +51,8 @@ public sealed class LocalPathPickerMarqueeUiTests
             // 从第 1 行(".." 之后的头一个真实条目)拖到第 3 行。
             Drag(dialog, list, fromRow: 1, toRow: 3);
 
-            CollectionAssert.AreEquivalent(
-                new[] { "a0.txt", "a1.txt", "a2.txt" },
-                Names(vm),
-                "框选划过的三行都该选中。"
+            Assert.AreSequenceEqual(
+                ["a0.txt", "a1.txt", "a2.txt"], Names(vm), SequenceOrder.InAnyOrder, "框选划过的三行都该选中。"
             );
         });
     }
@@ -84,10 +82,8 @@ public sealed class LocalPathPickerMarqueeUiTests
         {
             Drag(dialog, list, fromRow: 3, toRow: 1);
 
-            CollectionAssert.AreEquivalent(
-                new[] { "a0.txt", "a1.txt", "a2.txt" },
-                Names(vm),
-                "向上拖应与向下拖选中同一批行。"
+            Assert.AreSequenceEqual(
+                ["a0.txt", "a1.txt", "a2.txt"], Names(vm), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "向上拖应与向下拖选中同一批行。"
             );
         });
     }
@@ -100,11 +96,11 @@ public sealed class LocalPathPickerMarqueeUiTests
             // 从 ".." 那一行(下标 0)往下拖:".." 不是真实条目,不能被框进来。
             Drag(dialog, list, fromRow: 0, toRow: 2);
 
-            Assert.IsFalse(
-                vm.SelectedEntries.Any(entry => entry.IsParentEntry),
+            Assert.DoesNotContain(
+                entry => entry.IsParentEntry, vm.SelectedEntries,
                 "合成的 \"..\" 行不该被框选选中。"
             );
-            CollectionAssert.AreEquivalent(new[] { "a0.txt", "a1.txt" }, Names(vm));
+            Assert.AreSequenceEqual(["a0.txt", "a1.txt"], Names(vm), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         });
     }
 
@@ -119,7 +115,7 @@ public sealed class LocalPathPickerMarqueeUiTests
             dialog.MouseUp(point, MouseButton.Left);
             Pump(dialog);
 
-            CollectionAssert.AreEquivalent(new[] { "a1.txt" }, Names(vm));
+            Assert.AreSequenceEqual(["a1.txt"], Names(vm), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         });
     }
 
@@ -187,7 +183,7 @@ public sealed class LocalPathPickerMarqueeUiTests
                 dialog.UpdateLayout();
 
                 ListBox list = dialog.GetVisualDescendants().OfType<ListBox>().Single();
-                Assert.AreEqual(7, vm.Entries.Count, "应为 \"..\" 加 6 个文件。");
+                Assert.HasCount(7, vm.Entries, "应为 \"..\" 加 6 个文件。");
                 Assert.IsTrue(vm.Entries[0].IsParentEntry, "首行应是合成的 \"..\"。");
                 vm.SelectedEntries.Clear();
 

--- a/tests/VelaShell.Tests/Views/MarqueeSelectionMathTests.cs
+++ b/tests/VelaShell.Tests/Views/MarqueeSelectionMathTests.cs
@@ -14,6 +14,125 @@ public class MarqueeSelectionMathTests
     private const double RowHeight = 28;
 
     [TestMethod]
+    public void CtrlMarquee_MergesTheMouseDownSnapshotWithSweptRows()
+    {
+        IReadOnlyList<string> result = MarqueeSelectionMath.MergeSelection(
+            ["already-selected.txt"],
+            ["already-selected.txt", "swept.txt"]);
+
+        Assert.AreSequenceEqual(
+            ["already-selected.txt", "swept.txt"], [.. result], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void DragPayload_WhenSourceIsSelected_ContainsAllSelectedNonParentItems()
+    {
+        string parent = "..";
+        string source = "b.txt";
+        string[] selected = [parent, source, "a.txt"];
+
+        IReadOnlyList<string> result = DragSelectionResolver.Resolve(
+            selected,
+            source,
+            item => item == parent);
+
+        Assert.AreSequenceEqual(["a.txt", "b.txt"], [.. result], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void DragPayload_WhenSourceIsNotSelected_ContainsOnlyTheSource()
+    {
+        string parent = "..";
+        string source = "c.txt";
+        string[] selected = [parent, "a.txt", "b.txt"];
+
+        IReadOnlyList<string> result = DragSelectionResolver.Resolve(
+            selected,
+            source,
+            item => item == parent);
+
+        Assert.AreSequenceEqual([source], [.. result]);
+    }
+
+    [TestMethod]
+    public void DragPayload_WhenSourceIsParent_IsEmpty()
+    {
+        IReadOnlyList<string> result = DragSelectionResolver.Resolve(
+            ["a.txt"],
+            "..",
+            item => item == "..");
+
+        Assert.IsEmpty(result);
+    }
+
+    [TestMethod]
+    public void DragPayload_UsesPressSnapshotWhenSourceWasSelectedBeforeListBoxMutation()
+    {
+        IReadOnlyList<string> result = DragSelectionResolver.ResolveAtDragStart(
+            ["a.txt", "b.txt"],
+            ["b.txt"],
+            "b.txt",
+            item => item == "..");
+
+        Assert.AreSequenceEqual(["a.txt", "b.txt"], [.. result], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void DragPayload_UsesCurrentSelectionWhenPressSnapshotDidNotContainSource()
+    {
+        IReadOnlyList<string> result = DragSelectionResolver.ResolveAtDragStart(
+            ["a.txt", "b.txt"],
+            ["c.txt"],
+            "c.txt",
+            item => item == "..");
+
+        Assert.AreSequenceEqual(["c.txt"], [.. result]);
+    }
+
+    [TestMethod]
+    public void DragSelectionSynchronization_RestoresEveryPayloadItemToTheVisibleSelection()
+    {
+        List<string> visibleSelection = ["b.txt"];
+        string[] dragItems = ["a.txt", "b.txt", "folder"];
+
+        DragSelectionResolver.SynchronizeSelection(visibleSelection, dragItems);
+
+        Assert.AreSequenceEqual(
+            dragItems,
+            [.. visibleSelection],
+            Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void ModifierDrag_DoesNotRestoreAStalePressSnapshot()
+    {
+        IReadOnlyList<string> result = DragSelectionResolver.ResolveAtDragStart(
+            ["a.txt", "b.txt"],
+            ["a.txt"],
+            "b.txt",
+            item => item == "..",
+            usePressSnapshot: false);
+
+        Assert.AreSequenceEqual(["b.txt"], [.. result]);
+    }
+
+    [TestMethod]
+    public void ModifierDrag_UsesTheCurrentRangeSelection()
+    {
+        IReadOnlyList<string> result = DragSelectionResolver.ResolveAtDragStart(
+            ["a.txt", "b.txt"],
+            ["b.txt", "c.txt"],
+            "b.txt",
+            item => item == "..",
+            usePressSnapshot: false);
+
+        Assert.AreSequenceEqual(
+            ["b.txt", "c.txt"],
+            [.. result],
+            Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
     public void BandCoveringTwoRows_SelectsBothInclusive()
     {
         // 第 1 行中间拖到第 3 行中间:1、2、3 三行都该选中。

--- a/tests/VelaShell.Tests/Views/ProcessManagerUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ProcessManagerUiTests.cs
@@ -218,7 +218,7 @@ public sealed class ProcessManagerUiTests
             using var fixture = Fixture.Show();
 
             // 内核线程默认不显示,所以 4 个样本里只出 3 行。
-            Assert.AreEqual(3, fixture.ViewModel.Processes.Count);
+            Assert.HasCount(3, fixture.ViewModel.Processes);
             SaveFrame(fixture.Window, "process-manager-tree.png");
 
             fixture.ViewModel.ShowTree = false;


### PR DESCRIPTION
本次提交实现文件/目录列表的框选（Marquee Selection）功能，支持鼠标拖动矩形批量选择文件，自动滚动、跨栏拖放与框选手势分离。新增 MarqueeSelection.cs 封装框选逻辑，DragSelectionResolver.cs 统一拖拽与选区同步。各列表视图接入框选，按模式区分拖放与框选手势。批量移动/复制操作优化为多选时仅询问一次目标目录，失败时汇总错误。多语言资源补充批量操作提示。大量 UI/单元测试覆盖框选、拖放、批量操作等场景，部分测试断言采用更现代风格。