### PR TITLE
新增关闭按钮及相关测试用例

### DIFF
--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -221,8 +221,10 @@
                              Data="{StaticResource Icon.refresh-cw}"
                              Foreground="{DynamicResource VelaTextTertiary}" />
             </Button>
-            <Button Classes="toolbar-btn" Width="24" Height="24" Padding="0"
+            <Button x:Name="RemotePaneCloseButton"
+                    Classes="toolbar-btn" Width="24" Height="24" Padding="0"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    IsVisible="{Binding !IsDragEnabled}"
                     Command="{Binding ToggleVisibilityCommand}"
                     ToolTip.Tip="{loc:Localize Close}">
               <pc:LucideIcon Width="13" Height="13"

--- a/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
@@ -54,6 +54,30 @@ public sealed class FileBrowserMarqueeUiTests
     }
 
     [TestMethod]
+    public void DualPaneMode_HidesTheRemotePaneCloseButton()
+    {
+        RunWithBrowser(dragEnabled: true, (window, _, _) =>
+        {
+            Button closeButton = window.GetVisualDescendants().OfType<Button>()
+                .Single(button => button.Name == "RemotePaneCloseButton");
+
+            Assert.IsFalse(closeButton.IsVisible, "独立 SFTP 双栏模式不能关闭远端栏。");
+        });
+    }
+
+    [TestMethod]
+    public void TerminalMode_KeepsTheFileBrowserCloseButton()
+    {
+        RunWithBrowser(dragEnabled: false, (window, _, _) =>
+        {
+            Button closeButton = window.GetVisualDescendants().OfType<Button>()
+                .Single(button => button.Name == "RemotePaneCloseButton");
+
+            Assert.IsTrue(closeButton.IsVisible, "终端内嵌文件浏览器仍需保留关闭入口。");
+        });
+    }
+
+    [TestMethod]
     public void DualPaneMode_DraggingFromARow_DoesNotMarquee_SoCrossPaneDragKeepsWorking()
     {
         // 双栏模式(IsDragEnabled=true):按住行拖是"拖去另一栏",不能被框选抢走。


### PR DESCRIPTION
在 FileBrowserView.axaml 中新增 RemotePaneCloseButton，并通过 IsVisible 绑定 !IsDragEnabled，实现根据模式动态显示/隐藏关闭按钮。 在 FileBrowserMarqueeUiTests.cs 中新增 DualPaneMode_HidesTheRemotePaneCloseButton 和 TerminalMode_KeepsTheFileBrowserCloseButton 两个测试用例，分别验证双栏模式下关闭按钮不可见和终端模式下关闭按钮可见。