### PR TITLE
feat: 支持从 Xshell / WinSCP 一键迁移会话

### DIFF
--- a/src/VelaShell.Core/Import/ISessionImportService.cs
+++ b/src/VelaShell.Core/Import/ISessionImportService.cs
@@ -1,0 +1,49 @@
+namespace VelaShell.Core.Import;
+
+/// <summary>「浏览来源」时对话框应弹出的选择器类型。</summary>
+public enum ImportBrowseKind
+{
+    /// <summary>不支持手动浏览(来源固定,如注册表)。</summary>
+    None,
+
+    /// <summary>选择一个文件夹(如 Xshell 的 Sessions 目录)。</summary>
+    Folder,
+
+    /// <summary>选择一个文件(如 WinSCP.ini)。</summary>
+    File
+}
+
+/// <summary>
+/// 会话一键迁移服务:从某个外部工具(Xshell、WinSCP 等)定位来源、解析会话
+/// (含以当前 Windows 用户身份尝试还原保存的密码),并把选中的会话写入 VelaShell 仓储。
+/// </summary>
+public interface ISessionImportService
+{
+    /// <summary>来源名称(如 <c>Xshell</c>、<c>WinSCP</c>),用于对话框标题与默认分组名。</summary>
+    string SourceKey { get; }
+
+    /// <summary>手动浏览来源时应弹出的选择器类型。</summary>
+    ImportBrowseKind BrowseKind { get; }
+
+    /// <summary>
+    /// 探测默认来源并返回其可读描述(目录/文件路径或注册表键);探测不到时返回 <c>null</c>。
+    /// 该值仅用于展示,扫描时传 <c>null</c> 即让服务自动定位。
+    /// </summary>
+    string? DetectDefaultSource();
+
+    /// <summary>
+    /// 扫描来源并生成导入预览。<paramref name="source" /> 为 <c>null</c> 时由服务自动定位
+    /// (Xshell 用注册表定位 Sessions 目录;WinSCP 优先读注册表,其次默认 INI)。
+    /// </summary>
+    /// <param name="source">显式来源(目录或文件路径);<c>null</c> 表示自动定位。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    Task<SessionImportScan> ScanAsync(string? source, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 将选中的会话导入 VelaShell:新建一个分组承载它们,并逐条持久化(密码由仓储 AES 重新加密落盘)。
+    /// </summary>
+    /// <param name="items">用户勾选要导入的会话。</param>
+    /// <param name="groupName">新建承载分组的名称。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    Task<SessionImportOutcome> ImportAsync(IReadOnlyList<ImportedSession> items, string groupName, CancellationToken cancellationToken = default);
+}

--- a/src/VelaShell.Core/Import/ImportedSession.cs
+++ b/src/VelaShell.Core/Import/ImportedSession.cs
@@ -1,0 +1,43 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Import;
+
+/// <summary>从外部工具(Xshell、WinSCP 等)解析出的一条可导入会话,携带导入预览所需的元数据与状态。</summary>
+public sealed class ImportedSession
+{
+    /// <summary>会话显示名称。</summary>
+    public required string Name { get; init; }
+
+    /// <summary>目标主机地址(主机名或 IP)。</summary>
+    public required string Host { get; init; }
+
+    /// <summary>连接端口。</summary>
+    public int Port { get; init; } = 22;
+
+    /// <summary>登录用户名;来源未填写时为空串。</summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>映射后的连接协议类型(仅支持 SSH / SFTP)。</summary>
+    public ConnectionType ConnectionType { get; init; } = ConnectionType.SSH;
+
+    /// <summary>原文件中的协议字段原值(如 SSH、SFTP、SCP、FTP),用于预览展示与不支持判定。</summary>
+    public string Protocol { get; init; } = "SSH";
+
+    /// <summary>该协议是否可被 VelaShell 导入(仅 SSH / SFTP 支持)。</summary>
+    public bool IsSupported { get; init; } = true;
+
+    /// <summary>来源是否包含非空的加密密码字段。</summary>
+    public bool HasEncryptedPassword { get; init; }
+
+    /// <summary>成功解密并通过校验的明文密码;未启用密码、解密失败或校验不过时为 <c>null</c>。</summary>
+    public string? Password { get; init; }
+
+    /// <summary>是否成功还原出密码明文(即 <see cref="Password" /> 非空)。</summary>
+    public bool PasswordRecovered => Password is { Length: > 0 };
+
+    /// <summary>VelaShell 中是否已存在同主机/端口/用户名的会话(用于提示重复)。</summary>
+    public bool AlreadyExists { get; init; }
+
+    /// <summary>来源标识(文件路径或注册表键),用于诊断。</summary>
+    public string Source { get; init; } = string.Empty;
+}

--- a/src/VelaShell.Core/Import/SessionImportOutcome.cs
+++ b/src/VelaShell.Core/Import/SessionImportOutcome.cs
@@ -1,0 +1,14 @@
+namespace VelaShell.Core.Import;
+
+/// <summary>执行导入后的结果统计。</summary>
+public sealed class SessionImportOutcome
+{
+    /// <summary>成功写入 VelaShell 的会话数量。</summary>
+    public int Imported { get; init; }
+
+    /// <summary>其中成功还原了密码明文的会话数量。</summary>
+    public int PasswordsRecovered { get; init; }
+
+    /// <summary>新建承载分组的标识;未创建分组(导入数为 0)时为 <c>null</c>。</summary>
+    public Guid? GroupId { get; init; }
+}

--- a/src/VelaShell.Core/Import/SessionImportScan.cs
+++ b/src/VelaShell.Core/Import/SessionImportScan.cs
@@ -1,0 +1,17 @@
+namespace VelaShell.Core.Import;
+
+/// <summary>扫描一个导入来源后的结果:发现的会话列表与整体状态。</summary>
+public sealed class SessionImportScan
+{
+    /// <summary>实际读取的来源(目录路径、配置文件路径或注册表键)的可读描述。</summary>
+    public required string Source { get; init; }
+
+    /// <summary>解析出的可预览会话集合(含不受支持的协议,由各项自身的标记区分)。</summary>
+    public required IReadOnlyList<ImportedSession> Items { get; init; }
+
+    /// <summary>
+    /// 来源是否启用了主密码;为 <c>true</c> 时无法在不知主密码的情况下解密任何密码,
+    /// 所有会话将以「不含密码」方式导入。
+    /// </summary>
+    public bool MasterPasswordEnabled { get; init; }
+}

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3178,4 +3178,79 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Trace_GeoAttribution" xml:space="preserve">
     <value>IP 位置データ提供: DB-IP.com (CC BY 4.0)</value>
   </data>
+  <data name="XImport_MenuItem" xml:space="preserve">
+    <value>Xshell からインポート…</value>
+  </data>
+  <data name="XImport_Title" xml:space="preserve">
+    <value>Xshell セッションをインポート</value>
+  </data>
+  <data name="XImport_SessionsDir" xml:space="preserve">
+    <value>Xshell セッションフォルダー</value>
+  </data>
+  <data name="XImport_Browse" xml:space="preserve">
+    <value>参照…</value>
+  </data>
+  <data name="XImport_Rescan" xml:space="preserve">
+    <value>スキャン</value>
+  </data>
+  <data name="XImport_MasterPwWarn" xml:space="preserve">
+    <value>このツールはマスターパスワードが有効なため、保存されたパスワードを復元できません。セッションはパスワードなしでインポートされます。</value>
+  </data>
+  <data name="XImport_WinScpMenuItem" xml:space="preserve">
+    <value>WinSCP からインポート…</value>
+  </data>
+  <data name="XImport_TitleFmt" xml:space="preserve">
+    <value>{0} からセッションをインポート</value>
+  </data>
+  <data name="XImport_GroupFmt" xml:space="preserve">
+    <value>{0} インポート</value>
+  </data>
+  <data name="XImport_SourceFolder" xml:space="preserve">
+    <value>セッションフォルダー</value>
+  </data>
+  <data name="XImport_SourceFile" xml:space="preserve">
+    <value>設定ファイル</value>
+  </data>
+  <data name="XImport_SelectAll" xml:space="preserve">
+    <value>すべて選択</value>
+  </data>
+  <data name="XImport_SelectNone" xml:space="preserve">
+    <value>すべて解除</value>
+  </data>
+  <data name="XImport_ImportButton" xml:space="preserve">
+    <value>インポート</value>
+  </data>
+  <data name="XImport_DefaultGroup" xml:space="preserve">
+    <value>Xshell インポート</value>
+  </data>
+  <data name="XImport_NotDetected" xml:space="preserve">
+    <value>インポート元を自動検出できませんでした。手動で選択してください。</value>
+  </data>
+  <data name="XImport_NoSessions" xml:space="preserve">
+    <value>このフォルダーにセッションが見つかりません。</value>
+  </data>
+  <data name="XImport_Found" xml:space="preserve">
+    <value>{0} 件のセッションが見つかりました。</value>
+  </data>
+  <data name="XImport_DirNotFound" xml:space="preserve">
+    <value>フォルダーが見つかりません。</value>
+  </data>
+  <data name="XImport_SelectedCount" xml:space="preserve">
+    <value>{0} 件選択 · {1} 件パスワードあり</value>
+  </data>
+  <data name="XImport_Unsupported" xml:space="preserve">
+    <value>未対応のプロトコル</value>
+  </data>
+  <data name="XImport_PwRecovered" xml:space="preserve">
+    <value>パスワード復元済み</value>
+  </data>
+  <data name="XImport_PwFailed" xml:space="preserve">
+    <value>パスワード入力が必要</value>
+  </data>
+  <data name="XImport_PwNone" xml:space="preserve">
+    <value>パスワードなし</value>
+  </data>
+  <data name="XImport_Duplicate" xml:space="preserve">
+    <value>既に存在します</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3178,4 +3178,79 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Trace_GeoAttribution" xml:space="preserve">
     <value>IP 위치 데이터 제공: DB-IP.com (CC BY 4.0)</value>
   </data>
+  <data name="XImport_MenuItem" xml:space="preserve">
+    <value>Xshell에서 가져오기…</value>
+  </data>
+  <data name="XImport_Title" xml:space="preserve">
+    <value>Xshell 세션 가져오기</value>
+  </data>
+  <data name="XImport_SessionsDir" xml:space="preserve">
+    <value>Xshell 세션 폴더</value>
+  </data>
+  <data name="XImport_Browse" xml:space="preserve">
+    <value>찾아보기…</value>
+  </data>
+  <data name="XImport_Rescan" xml:space="preserve">
+    <value>검색</value>
+  </data>
+  <data name="XImport_MasterPwWarn" xml:space="preserve">
+    <value>이 도구는 마스터 암호가 설정되어 있어 저장된 암호를 복구할 수 없습니다. 세션은 암호 없이 가져옵니다.</value>
+  </data>
+  <data name="XImport_WinScpMenuItem" xml:space="preserve">
+    <value>WinSCP에서 가져오기…</value>
+  </data>
+  <data name="XImport_TitleFmt" xml:space="preserve">
+    <value>{0}에서 세션 가져오기</value>
+  </data>
+  <data name="XImport_GroupFmt" xml:space="preserve">
+    <value>{0} 가져오기</value>
+  </data>
+  <data name="XImport_SourceFolder" xml:space="preserve">
+    <value>세션 폴더</value>
+  </data>
+  <data name="XImport_SourceFile" xml:space="preserve">
+    <value>구성 파일</value>
+  </data>
+  <data name="XImport_SelectAll" xml:space="preserve">
+    <value>모두 선택</value>
+  </data>
+  <data name="XImport_SelectNone" xml:space="preserve">
+    <value>모두 해제</value>
+  </data>
+  <data name="XImport_ImportButton" xml:space="preserve">
+    <value>가져오기</value>
+  </data>
+  <data name="XImport_DefaultGroup" xml:space="preserve">
+    <value>Xshell 가져오기</value>
+  </data>
+  <data name="XImport_NotDetected" xml:space="preserve">
+    <value>가져올 원본을 자동으로 감지하지 못했습니다. 수동으로 선택하세요.</value>
+  </data>
+  <data name="XImport_NoSessions" xml:space="preserve">
+    <value>이 폴더에서 세션을 찾을 수 없습니다.</value>
+  </data>
+  <data name="XImport_Found" xml:space="preserve">
+    <value>세션 {0}개를 찾았습니다.</value>
+  </data>
+  <data name="XImport_DirNotFound" xml:space="preserve">
+    <value>폴더를 찾을 수 없습니다.</value>
+  </data>
+  <data name="XImport_SelectedCount" xml:space="preserve">
+    <value>{0}개 선택 · 암호 {1}개</value>
+  </data>
+  <data name="XImport_Unsupported" xml:space="preserve">
+    <value>지원되지 않는 프로토콜</value>
+  </data>
+  <data name="XImport_PwRecovered" xml:space="preserve">
+    <value>암호 복구됨</value>
+  </data>
+  <data name="XImport_PwFailed" xml:space="preserve">
+    <value>암호 입력 필요</value>
+  </data>
+  <data name="XImport_PwNone" xml:space="preserve">
+    <value>암호 없음</value>
+  </data>
+  <data name="XImport_Duplicate" xml:space="preserve">
+    <value>이미 있음</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3179,4 +3179,79 @@ Overwrite it?</value>
   <data name="Trace_GeoAttribution" xml:space="preserve">
     <value>IP location data by DB-IP.com (CC BY 4.0)</value>
   </data>
+  <data name="XImport_MenuItem" xml:space="preserve">
+    <value>Import from Xshell…</value>
+  </data>
+  <data name="XImport_Title" xml:space="preserve">
+    <value>Import Xshell Sessions</value>
+  </data>
+  <data name="XImport_SessionsDir" xml:space="preserve">
+    <value>Xshell sessions folder</value>
+  </data>
+  <data name="XImport_Browse" xml:space="preserve">
+    <value>Browse…</value>
+  </data>
+  <data name="XImport_Rescan" xml:space="preserve">
+    <value>Scan</value>
+  </data>
+  <data name="XImport_MasterPwWarn" xml:space="preserve">
+    <value>This tool has a master password enabled, so saved passwords can't be recovered. Sessions will be imported without passwords.</value>
+  </data>
+  <data name="XImport_WinScpMenuItem" xml:space="preserve">
+    <value>Import from WinSCP…</value>
+  </data>
+  <data name="XImport_TitleFmt" xml:space="preserve">
+    <value>Import Sessions from {0}</value>
+  </data>
+  <data name="XImport_GroupFmt" xml:space="preserve">
+    <value>{0} Import</value>
+  </data>
+  <data name="XImport_SourceFolder" xml:space="preserve">
+    <value>Sessions folder</value>
+  </data>
+  <data name="XImport_SourceFile" xml:space="preserve">
+    <value>Config file</value>
+  </data>
+  <data name="XImport_SelectAll" xml:space="preserve">
+    <value>Select all</value>
+  </data>
+  <data name="XImport_SelectNone" xml:space="preserve">
+    <value>Select none</value>
+  </data>
+  <data name="XImport_ImportButton" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="XImport_DefaultGroup" xml:space="preserve">
+    <value>Xshell Import</value>
+  </data>
+  <data name="XImport_NotDetected" xml:space="preserve">
+    <value>Couldn't auto-detect the source. Choose it manually.</value>
+  </data>
+  <data name="XImport_NoSessions" xml:space="preserve">
+    <value>No sessions found in this folder.</value>
+  </data>
+  <data name="XImport_Found" xml:space="preserve">
+    <value>Found {0} session(s).</value>
+  </data>
+  <data name="XImport_DirNotFound" xml:space="preserve">
+    <value>Folder not found.</value>
+  </data>
+  <data name="XImport_SelectedCount" xml:space="preserve">
+    <value>{0} selected · {1} with password</value>
+  </data>
+  <data name="XImport_Unsupported" xml:space="preserve">
+    <value>Unsupported protocol</value>
+  </data>
+  <data name="XImport_PwRecovered" xml:space="preserve">
+    <value>Password recovered</value>
+  </data>
+  <data name="XImport_PwFailed" xml:space="preserve">
+    <value>Password needed</value>
+  </data>
+  <data name="XImport_PwNone" xml:space="preserve">
+    <value>No password</value>
+  </data>
+  <data name="XImport_Duplicate" xml:space="preserve">
+    <value>Already exists</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3270,4 +3270,79 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Trace_GeoAttribution" xml:space="preserve">
     <value>IP 归属地数据由 DB-IP.com 提供 (CC BY 4.0)</value>
   </data>
+  <data name="XImport_MenuItem" xml:space="preserve">
+    <value>从 Xshell 导入…</value>
+  </data>
+  <data name="XImport_Title" xml:space="preserve">
+    <value>从 Xshell 导入会话</value>
+  </data>
+  <data name="XImport_SessionsDir" xml:space="preserve">
+    <value>Xshell 会话目录</value>
+  </data>
+  <data name="XImport_Browse" xml:space="preserve">
+    <value>浏览…</value>
+  </data>
+  <data name="XImport_Rescan" xml:space="preserve">
+    <value>扫描</value>
+  </data>
+  <data name="XImport_MasterPwWarn" xml:space="preserve">
+    <value>该工具启用了主密码，无法还原已保存的密码；会话将以不含密码的方式导入。</value>
+  </data>
+  <data name="XImport_WinScpMenuItem" xml:space="preserve">
+    <value>从 WinSCP 导入…</value>
+  </data>
+  <data name="XImport_TitleFmt" xml:space="preserve">
+    <value>从 {0} 导入会话</value>
+  </data>
+  <data name="XImport_GroupFmt" xml:space="preserve">
+    <value>{0} 导入</value>
+  </data>
+  <data name="XImport_SourceFolder" xml:space="preserve">
+    <value>会话目录</value>
+  </data>
+  <data name="XImport_SourceFile" xml:space="preserve">
+    <value>配置文件</value>
+  </data>
+  <data name="XImport_SelectAll" xml:space="preserve">
+    <value>全选</value>
+  </data>
+  <data name="XImport_SelectNone" xml:space="preserve">
+    <value>全不选</value>
+  </data>
+  <data name="XImport_ImportButton" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="XImport_DefaultGroup" xml:space="preserve">
+    <value>Xshell 导入</value>
+  </data>
+  <data name="XImport_NotDetected" xml:space="preserve">
+    <value>未能自动检测到来源，请手动选择。</value>
+  </data>
+  <data name="XImport_NoSessions" xml:space="preserve">
+    <value>该目录下未找到会话。</value>
+  </data>
+  <data name="XImport_Found" xml:space="preserve">
+    <value>发现 {0} 个会话。</value>
+  </data>
+  <data name="XImport_DirNotFound" xml:space="preserve">
+    <value>目录不存在。</value>
+  </data>
+  <data name="XImport_SelectedCount" xml:space="preserve">
+    <value>已选 {0} 项 · {1} 个含密码</value>
+  </data>
+  <data name="XImport_Unsupported" xml:space="preserve">
+    <value>协议不支持</value>
+  </data>
+  <data name="XImport_PwRecovered" xml:space="preserve">
+    <value>密码已还原</value>
+  </data>
+  <data name="XImport_PwFailed" xml:space="preserve">
+    <value>需手动填写密码</value>
+  </data>
+  <data name="XImport_PwNone" xml:space="preserve">
+    <value>无密码</value>
+  </data>
+  <data name="XImport_Duplicate" xml:space="preserve">
+    <value>已存在</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3178,4 +3178,79 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Trace_GeoAttribution" xml:space="preserve">
     <value>IP 歸屬地資料由 DB-IP.com 提供 (CC BY 4.0)</value>
   </data>
+  <data name="XImport_MenuItem" xml:space="preserve">
+    <value>從 Xshell 匯入…</value>
+  </data>
+  <data name="XImport_Title" xml:space="preserve">
+    <value>從 Xshell 匯入工作階段</value>
+  </data>
+  <data name="XImport_SessionsDir" xml:space="preserve">
+    <value>Xshell 工作階段目錄</value>
+  </data>
+  <data name="XImport_Browse" xml:space="preserve">
+    <value>瀏覽…</value>
+  </data>
+  <data name="XImport_Rescan" xml:space="preserve">
+    <value>掃描</value>
+  </data>
+  <data name="XImport_MasterPwWarn" xml:space="preserve">
+    <value>此工具已啟用主密碼，無法還原已儲存的密碼；工作階段將以不含密碼的方式匯入。</value>
+  </data>
+  <data name="XImport_WinScpMenuItem" xml:space="preserve">
+    <value>從 WinSCP 匯入…</value>
+  </data>
+  <data name="XImport_TitleFmt" xml:space="preserve">
+    <value>從 {0} 匯入工作階段</value>
+  </data>
+  <data name="XImport_GroupFmt" xml:space="preserve">
+    <value>{0} 匯入</value>
+  </data>
+  <data name="XImport_SourceFolder" xml:space="preserve">
+    <value>工作階段目錄</value>
+  </data>
+  <data name="XImport_SourceFile" xml:space="preserve">
+    <value>設定檔</value>
+  </data>
+  <data name="XImport_SelectAll" xml:space="preserve">
+    <value>全選</value>
+  </data>
+  <data name="XImport_SelectNone" xml:space="preserve">
+    <value>全不選</value>
+  </data>
+  <data name="XImport_ImportButton" xml:space="preserve">
+    <value>匯入</value>
+  </data>
+  <data name="XImport_DefaultGroup" xml:space="preserve">
+    <value>Xshell 匯入</value>
+  </data>
+  <data name="XImport_NotDetected" xml:space="preserve">
+    <value>未能自動偵測到來源，請手動選擇。</value>
+  </data>
+  <data name="XImport_NoSessions" xml:space="preserve">
+    <value>此目錄下找不到工作階段。</value>
+  </data>
+  <data name="XImport_Found" xml:space="preserve">
+    <value>找到 {0} 個工作階段。</value>
+  </data>
+  <data name="XImport_DirNotFound" xml:space="preserve">
+    <value>目錄不存在。</value>
+  </data>
+  <data name="XImport_SelectedCount" xml:space="preserve">
+    <value>已選 {0} 項 · {1} 個含密碼</value>
+  </data>
+  <data name="XImport_Unsupported" xml:space="preserve">
+    <value>通訊協定不支援</value>
+  </data>
+  <data name="XImport_PwRecovered" xml:space="preserve">
+    <value>密碼已還原</value>
+  </data>
+  <data name="XImport_PwFailed" xml:space="preserve">
+    <value>需手動填寫密碼</value>
+  </data>
+  <data name="XImport_PwNone" xml:space="preserve">
+    <value>無密碼</value>
+  </data>
+  <data name="XImport_Duplicate" xml:space="preserve">
+    <value>已存在</value>
+  </data>
 </root>

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Tmds.Ssh;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
+using VelaShell.Core.Import;
 using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Recording;
@@ -11,6 +12,7 @@ using VelaShell.Core.Sftp;
 using VelaShell.Core.Ssh;
 using VelaShell.Core.Sync;
 using VelaShell.Core.Tunnels;
+using VelaShell.Infrastructure.Import;
 using VelaShell.Infrastructure.Persistence;
 using VelaShell.Infrastructure.Ssh;
 using VelaShell.Infrastructure.Tunnels;
@@ -49,6 +51,11 @@ public static class InfrastructureServiceCollectionExtensions
             return new SonnetDbSettingsService(sp.GetRequiredService<SonnetDbEngine>(),
                 [paths.RootDirectory, paths.LegacyDotDirectory]);
         });
+        // 会话一键迁移:各来源(Xshell / WinSCP)解析 + 还原密码 + 写入会话仓储。
+        services.AddSingleton<XshellImportService>(sp =>
+            new(sp.GetRequiredService<ISessionRepository>()));
+        services.AddSingleton<WinScpImportService>(sp =>
+            new(sp.GetRequiredService<ISessionRepository>()));
         services.AddSingleton<IHostKeyService>(sp =>
         {
             VelaShellStoragePaths paths = sp.GetRequiredService<VelaShellStoragePaths>();

--- a/src/VelaShell.Infrastructure/Import/Rc4.cs
+++ b/src/VelaShell.Infrastructure/Import/Rc4.cs
@@ -1,0 +1,37 @@
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>RC4 流密码(对称:加密与解密同一变换)。仅供 Xshell 密码还原使用。</summary>
+internal static class Rc4
+{
+    /// <summary>用 <paramref name="key" /> 对 <paramref name="data" /> 做 RC4 变换并返回结果。</summary>
+    public static byte[] Transform(byte[] key, byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(data);
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("RC4 key must not be empty.", nameof(key));
+        }
+        var s = new int[256];
+        for (var i = 0; i < 256; i++)
+        {
+            s[i] = i;
+        }
+        var j = 0;
+        for (var i = 0; i < 256; i++)
+        {
+            j = (j + s[i] + key[i % key.Length]) % 256;
+            (s[i], s[j]) = (s[j], s[i]);
+        }
+        var output = new byte[data.Length];
+        int a = 0, b = 0;
+        for (var i = 0; i < data.Length; i++)
+        {
+            a = (a + 1) % 256;
+            b = (b + s[a]) % 256;
+            (s[a], s[b]) = (s[b], s[a]);
+            output[i] = (byte)(data[i] ^ s[(s[a] + s[b]) % 256]);
+        }
+        return output;
+    }
+}

--- a/src/VelaShell.Infrastructure/Import/SessionImportWriter.cs
+++ b/src/VelaShell.Infrastructure/Import/SessionImportWriter.cs
@@ -1,0 +1,69 @@
+using VelaShell.Core.Data;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>把一批 <see cref="ImportedSession" /> 写入仓储的共享逻辑(各来源的导入服务复用)。</summary>
+internal static class SessionImportWriter
+{
+    /// <summary>
+    /// 新建一个分组承载选中的受支持会话并逐条持久化;密码由仓储 AES 重新加密落盘,
+    /// 仅当密码成功还原时才设 <see cref="SessionProfile.RememberPassword" />。
+    /// </summary>
+    public static async Task<SessionImportOutcome> WriteAsync(
+        ISessionRepository repository,
+        IReadOnlyList<ImportedSession> items,
+        string groupName,
+        string tag,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        var toImport = items.Where(static i => i.IsSupported).ToList();
+        if (toImport.Count == 0)
+        {
+            return new SessionImportOutcome { Imported = 0, PasswordsRecovered = 0, GroupId = null };
+        }
+
+        List<ServerGroup> groups = await repository.GetAllGroupsAsync().ConfigureAwait(false);
+        int nextSort = groups.Count == 0 ? 0 : groups.Max(static g => g.SortOrder) + 1;
+        var group = new ServerGroup
+        {
+            Name = string.IsNullOrWhiteSpace(groupName) ? tag : groupName,
+            SortOrder = nextSort
+        };
+
+        var recovered = 0;
+        foreach (ImportedSession item in toImport)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var profile = new SessionProfile
+            {
+                ConnectionType = item.ConnectionType,
+                Name = item.Name,
+                Host = item.Host,
+                Port = item.Port,
+                Username = item.Username,
+                AuthMethod = AuthMethod.Password,
+                Password = item.Password,
+                RememberPassword = item.PasswordRecovered,
+                GroupId = group.Id,
+                Tags = [tag.ToLowerInvariant()]
+            };
+            await repository.SaveSessionAsync(profile).ConfigureAwait(false);
+            group.Sessions.Add(profile.Id);
+            if (item.PasswordRecovered)
+            {
+                recovered++;
+            }
+        }
+        await repository.SaveGroupAsync(group).ConfigureAwait(false);
+
+        return new SessionImportOutcome
+        {
+            Imported = toImport.Count,
+            PasswordsRecovered = recovered,
+            GroupId = group.Id
+        };
+    }
+}

--- a/src/VelaShell.Infrastructure/Import/WinScpCrypto.cs
+++ b/src/VelaShell.Infrastructure/Import/WinScpCrypto.cs
@@ -1,0 +1,107 @@
+using System.Text;
+
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>
+/// WinSCP 保存密码的解码算法(可逆混淆,非真正加密):以 <c>0xA3</c> 取反异或,种子为
+/// <c>用户名 + 主机名</c>。不绑定机器,任何账户/机器均可解 —— 除非 WinSCP 启用了主密码。
+/// 算法与公开实现(anoopengineer/winscppasswd 等)一致。
+/// </summary>
+internal static class WinScpCrypto
+{
+    private const int PwMagic = 0xA3;
+    private const int PwFlag = 0xFF;
+
+    /// <summary>解码一条 WinSCP 密码;输入非法或数据不足时返回 <c>null</c>。</summary>
+    /// <param name="host">会话的 HostName(与用户名一起构成种子/校验前缀)。</param>
+    /// <param name="username">会话的 UserName。</param>
+    /// <param name="encrypted">注册表/INI 中 <c>Password</c> 的十六进制字符串原值。</param>
+    public static string? Decrypt(string host, string username, string? encrypted)
+    {
+        if (string.IsNullOrEmpty(encrypted))
+        {
+            return null;
+        }
+        var nibbles = new int[encrypted.Length];
+        for (var i = 0; i < encrypted.Length; i++)
+        {
+            int v = HexValue(encrypted[i]);
+            if (v < 0)
+            {
+                return null;
+            }
+            nibbles[i] = v;
+        }
+
+        var index = 0;
+        int Next()
+        {
+            if (index + 1 >= nibbles.Length)
+            {
+                return -1;
+            }
+            int a = nibbles[index];
+            int b = nibbles[index + 1];
+            index += 2;
+            return ~(((a << 4) + b) ^ PwMagic) & 0xFF;
+        }
+
+        int flag = Next();
+        if (flag < 0)
+        {
+            return null;
+        }
+        int length;
+        if (flag == PwFlag)
+        {
+            _ = Next(); // 版本/占位字节,忽略。
+            length = Next();
+        }
+        else
+        {
+            length = flag;
+        }
+        if (length < 0)
+        {
+            return null;
+        }
+        int skip = Next();
+        if (skip < 0)
+        {
+            return null;
+        }
+        index += skip * 2; // 跳过前导填充。
+
+        var builder = new StringBuilder(length);
+        for (var i = 0; i < length; i++)
+        {
+            int value = Next();
+            if (value < 0)
+            {
+                return null;
+            }
+            builder.Append((char)value);
+        }
+        string clear = builder.ToString();
+
+        // 新版格式:明文以 用户名+主机名 作前缀,校验后剥离。
+        if (flag == PwFlag)
+        {
+            string key = username + host;
+            if (clear.Length < key.Length)
+            {
+                return null;
+            }
+            clear = clear[key.Length..];
+        }
+        return clear;
+    }
+
+    private static int HexValue(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        >= 'A' and <= 'F' => c - 'A' + 10,
+        _ => -1
+    };
+}

--- a/src/VelaShell.Infrastructure/Import/WinScpImportService.cs
+++ b/src/VelaShell.Infrastructure/Import/WinScpImportService.cs
@@ -1,0 +1,338 @@
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+using VelaShell.Core.Data;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>
+/// WinSCP 的 <see cref="ISessionImportService" /> 实现:从注册表
+/// <c>HKCU\Software\Martin Prikryl\WinSCP 2\Sessions</c> 或 <c>WinSCP.ini</c> 读取会话,
+/// 解码保存的密码(<see cref="WinScpCrypto" />),写入 <see cref="ISessionRepository" />。
+/// </summary>
+public sealed class WinScpImportService(ISessionRepository repository) : ISessionImportService
+{
+    private const string RegRoot = @"Software\Martin Prikryl\WinSCP 2";
+    private const string SessionsSubKey = RegRoot + @"\Sessions";
+    private const string SecuritySubKey = RegRoot + @"\Configuration\Security";
+    private const string DefaultSessionName = "Default Settings";
+
+    private readonly ISessionRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    /// <inheritdoc />
+    public string SourceKey => "WinSCP";
+
+    /// <inheritdoc />
+    public ImportBrowseKind BrowseKind => ImportBrowseKind.File;
+
+    /// <inheritdoc />
+    public string? DetectDefaultSource()
+    {
+        if (OperatingSystem.IsWindows() && RegistryHasSessions())
+        {
+            return @"HKCU\" + SessionsSubKey;
+        }
+        return FindIniFile();
+    }
+
+    /// <inheritdoc />
+    public async Task<SessionImportScan> ScanAsync(string? source, CancellationToken cancellationToken = default)
+    {
+        // 显式指向一个存在的文件 → 按 INI 解析;否则自动(优先注册表,其次默认 INI)。
+        string? autoIni = FindIniFile();
+        var (rawSessions, masterPassword, sourceLabel) =
+            !string.IsNullOrWhiteSpace(source) && File.Exists(source)
+                ? ReadFromIni(source)
+                : OperatingSystem.IsWindows() && RegistryHasSessions()
+                    ? ReadFromRegistry()
+                    : autoIni is not null
+                        ? ReadFromIni(autoIni)
+                        : ([], false, source ?? string.Empty);
+
+        List<SessionProfile> existing = await _repository.GetAllSessionsAsync().ConfigureAwait(false);
+        var existingKeys = existing
+            .Select(static s => DedupKey(s.Host, s.Port, s.Username))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var items = new List<ImportedSession>();
+        foreach (WinScpRawSession raw in rawSessions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(raw.Host))
+            {
+                continue;
+            }
+            (ConnectionType type, bool supported, string protocol) = MapProtocol(raw.FsProtocol);
+            bool hasEncrypted = !string.IsNullOrWhiteSpace(raw.Password);
+            string? password = hasEncrypted && !masterPassword
+                ? WinScpCrypto.Decrypt(raw.Host, raw.Username, raw.Password)
+                : null;
+            int port = raw.Port is int p and > 0 ? p : 22;
+
+            items.Add(new ImportedSession
+            {
+                Name = raw.Name,
+                Host = raw.Host.Trim(),
+                Port = port,
+                Username = raw.Username.Trim(),
+                ConnectionType = type,
+                Protocol = protocol,
+                IsSupported = supported,
+                HasEncryptedPassword = hasEncrypted,
+                Password = password,
+                AlreadyExists = existingKeys.Contains(DedupKey(raw.Host, port, raw.Username)),
+                Source = sourceLabel
+            });
+        }
+
+        return new SessionImportScan
+        {
+            Source = sourceLabel,
+            Items = [.. items.OrderBy(static i => i.Name, StringComparer.OrdinalIgnoreCase)],
+            MasterPasswordEnabled = masterPassword
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<SessionImportOutcome> ImportAsync(IReadOnlyList<ImportedSession> items, string groupName, CancellationToken cancellationToken = default) =>
+        await SessionImportWriter.WriteAsync(_repository, items, groupName, "WinSCP", cancellationToken).ConfigureAwait(false);
+
+    /// <summary>按优先级探测 <c>WinSCP.ini</c>:漫游目录 → 安装目录(卸载信息)→ 常见 Program Files。</summary>
+    private static string? FindIniFile()
+    {
+        foreach (string candidate in IniCandidates())
+        {
+            if (!string.IsNullOrEmpty(candidate) && File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> IniCandidates()
+    {
+        // 漫游配置(WinSCP 选“INI 文件”存储时的默认位置)。
+        yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WinSCP.ini");
+
+        // 便携/自定义安装:INI 与 WinSCP.exe 同目录,安装目录取自卸载信息 InstallLocation。
+        foreach (string dir in InstallLocations())
+        {
+            yield return Path.Combine(dir, "WinSCP.ini");
+        }
+
+        // 常见安装目录兜底。
+        foreach (string env in (string[])["ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"])
+        {
+            string? root = Environment.GetEnvironmentVariable(env);
+            if (!string.IsNullOrEmpty(root))
+            {
+                yield return Path.Combine(root, "WinSCP", "WinSCP.ini");
+            }
+        }
+    }
+
+    private static IEnumerable<string> InstallLocations()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            yield break;
+        }
+        foreach (string location in ReadInstallLocations())
+        {
+            yield return location;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static List<string> ReadInstallLocations()
+    {
+        var result = new List<string>();
+        // Inno Setup 卸载键(32/64 位视图)。
+        (RegistryKey Root, string Path)[] keys =
+        [
+            (Registry.LocalMachine, @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\winscp3_is1"),
+            (Registry.LocalMachine, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\winscp3_is1"),
+            (Registry.CurrentUser, @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\winscp3_is1")
+        ];
+        foreach ((RegistryKey root, string path) in keys)
+        {
+            try
+            {
+                using RegistryKey? key = root.OpenSubKey(path);
+                if (key?.GetValue("InstallLocation") is string location && location.Length > 0)
+                {
+                    result.Add(location);
+                }
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+            {
+                // 忽略读不到的键。
+            }
+        }
+        return result;
+    }
+
+    /// <summary>把 WinSCP 的 FSProtocol 数值映射为 VelaShell 连接类型;仅 SSH 系(SCP/SFTP)受支持。</summary>
+    private static (ConnectionType Type, bool Supported, string Protocol) MapProtocol(int? fsProtocol) =>
+        fsProtocol switch
+        {
+            0 => (ConnectionType.SSH, true, "SCP"),
+            1 or 2 or null => (ConnectionType.SSH, true, "SFTP"),
+            5 => (ConnectionType.SSH, false, "FTP"),
+            6 => (ConnectionType.SSH, false, "WebDAV"),
+            7 => (ConnectionType.SSH, false, "S3"),
+            _ => (ConnectionType.SSH, false, "?")
+        };
+
+    private static string DedupKey(string host, int port, string user) => $"{host.Trim()}|{port}|{user.Trim()}";
+
+    // ---- 注册表来源 --------------------------------------------------------
+
+    [SupportedOSPlatform("windows")]
+    private static bool RegistryHasSessions()
+    {
+        try
+        {
+            using RegistryKey? sessions = Registry.CurrentUser.OpenSubKey(SessionsSubKey);
+            return sessions is not null && sessions.GetSubKeyNames().Length > 0;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+        {
+            return false;
+        }
+    }
+
+    private static (List<WinScpRawSession> Sessions, bool MasterPassword, string Source) ReadFromRegistry()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return ([], false, string.Empty);
+        }
+        return ReadFromRegistryWindows();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static (List<WinScpRawSession> Sessions, bool MasterPassword, string Source) ReadFromRegistryWindows()
+    {
+        var result = new List<WinScpRawSession>();
+        bool master = false;
+        try
+        {
+            using (RegistryKey? security = Registry.CurrentUser.OpenSubKey(SecuritySubKey))
+            {
+                master = security?.GetValue("UseMasterPassword") is int i && i == 1;
+            }
+            using RegistryKey? sessions = Registry.CurrentUser.OpenSubKey(SessionsSubKey);
+            if (sessions is not null)
+            {
+                foreach (string subName in sessions.GetSubKeyNames())
+                {
+                    string decoded = CleanName(Uri.UnescapeDataString(subName));
+                    if (decoded.Equals(DefaultSessionName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    using RegistryKey? session = sessions.OpenSubKey(subName);
+                    if (session?.GetValue("HostName") is not string host || host.Length == 0)
+                    {
+                        continue;
+                    }
+                    result.Add(new WinScpRawSession(
+                        decoded,
+                        host,
+                        session.GetValue("UserName") as string ?? string.Empty,
+                        session.GetValue("Password") as string,
+                        session.GetValue("PortNumber") as int?,
+                        session.GetValue("FSProtocol") as int?));
+                }
+            }
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+        {
+            // 读不全就返回已读到的部分。
+        }
+        return (result, master, @"HKCU\" + SessionsSubKey);
+    }
+
+    // ---- INI 来源 ----------------------------------------------------------
+
+    private static (List<WinScpRawSession> Sessions, bool MasterPassword, string Source) ReadFromIni(string path)
+    {
+        var result = new List<WinScpRawSession>();
+        bool master = false;
+        try
+        {
+            string currentSection = string.Empty;
+            var current = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string? sessionName = null;
+
+            void Flush()
+            {
+                if (sessionName is not null &&
+                    current.TryGetValue("HostName", out string? host) && host.Length > 0 &&
+                    !sessionName.Equals(DefaultSessionName, StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(new WinScpRawSession(
+                        sessionName,
+                        host,
+                        current.GetValueOrDefault("UserName", string.Empty),
+                        current.GetValueOrDefault("Password"),
+                        ParseInt(current.GetValueOrDefault("PortNumber")),
+                        ParseInt(current.GetValueOrDefault("FSProtocol"))));
+                }
+                current.Clear();
+                sessionName = null;
+            }
+
+            foreach (string raw in File.ReadLines(path))
+            {
+                string line = raw.Trim();
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+                if (line[0] == '[' && line[^1] == ']')
+                {
+                    Flush();
+                    currentSection = line[1..^1];
+                    if (currentSection.StartsWith("Sessions\\", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sessionName = CleanName(Uri.UnescapeDataString(currentSection["Sessions\\".Length..]));
+                    }
+                    continue;
+                }
+                int eq = line.IndexOf('=');
+                if (eq < 0)
+                {
+                    continue;
+                }
+                string key = line[..eq].Trim();
+                string value = line[(eq + 1)..].Trim();
+                if (sessionName is not null)
+                {
+                    current[key] = value;
+                }
+                else if (currentSection.Equals(@"Configuration\Security", StringComparison.OrdinalIgnoreCase) &&
+                         key.Equals("UseMasterPassword", StringComparison.OrdinalIgnoreCase))
+                {
+                    master = value.Trim() == "1";
+                }
+            }
+            Flush();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // 读失败返回已解析部分。
+        }
+        return (result, master, path);
+    }
+
+    private static int? ParseInt(string? value) => int.TryParse(value, out int i) ? i : null;
+
+    /// <summary>去除会话名中的 BOM 与首尾空白(WinSCP.ini 偶有残留 BOM 混入名称)。</summary>
+    private static string CleanName(string raw) => raw.Trim('﻿', ' ', '\t', '\r', '\n');
+
+    private sealed record WinScpRawSession(string Name, string Host, string Username, string? Password, int? Port, int? FsProtocol);
+}

--- a/src/VelaShell.Infrastructure/Import/XshellCrypto.cs
+++ b/src/VelaShell.Infrastructure/Import/XshellCrypto.cs
@@ -1,0 +1,76 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>
+/// Xshell 会话密码的解密算法。密钥由当前 Windows 用户的用户名 + SID 派生,故只有以
+/// 「创建这些会话的同一 Windows 账户」运行时才能还原明文,且仅在 Xshell 未启用主密码时适用。
+/// 不同 Xshell 版本使用不同的密钥派生方式(见公开工具 SharpXDecrypt 与 Xpass);由于密文尾部
+/// 带 32 字节 SHA-256(明文) 校验,这里依次尝试所有已知派生方式、取校验通过者 —— 从而无需依赖
+/// <c>.xsh</c> 里可能不准确的 <c>Version</c> 字段即可兼容 5/6/7/8 及以后版本。
+/// </summary>
+internal static class XshellCrypto
+{
+    // 早期版本(2/3/4/5.0)使用的固定口令,MD5 后作为 RC4 密钥。
+    private const string LegacySalt = "!X@s#h$e%l^l&";
+
+    /// <summary>
+    /// 尝试还原一条 Xshell 加密密码;逐一试探已知密钥方案,尾部校验通过即返回明文,全部失败返回 <c>null</c>。
+    /// </summary>
+    /// <param name="encryptedBase64">会话文件中的 <c>Password=</c> 原值(Base64)。</param>
+    /// <param name="userName">当前 Windows 用户名(不含域前缀)。</param>
+    /// <param name="sid">当前 Windows 用户 SID 字符串。</param>
+    public static string? TryDecryptPassword(string? encryptedBase64, string userName, string sid)
+    {
+        if (string.IsNullOrWhiteSpace(encryptedBase64))
+        {
+            return null;
+        }
+        byte[] data;
+        try
+        {
+            data = Convert.FromBase64String(encryptedBase64.Trim());
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        // 布局:RC4(明文) ‖ SHA256(明文);尾部 32 字节是明文校验哈希,不参与 RC4。
+        if (data.Length <= 0x20)
+        {
+            return null;
+        }
+        int bodyLength = data.Length - 0x20;
+        ReadOnlySpan<byte> trailer = data.AsSpan(bodyLength, 0x20);
+
+        foreach (byte[] key in CandidateKeys(userName, sid))
+        {
+            var body = new byte[bodyLength];
+            Array.Copy(data, 0, body, 0, bodyLength);
+            byte[] plain = Rc4.Transform(key, body);
+
+            if (SHA256.HashData(plain).AsSpan().SequenceEqual(trailer))
+            {
+                // 明文按 UTF-8 还原(与 ASCII 口令完全一致;非 ASCII 口令依赖原始编码,属少数情形)。
+                return Encoding.UTF8.GetString(plain);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>按「最常见优先」的顺序产出各版本的候选 RC4 密钥。</summary>
+    private static IEnumerable<byte[]> CandidateKeys(string userName, string sid)
+    {
+        // Xshell 5 / 6 / 7.0。
+        yield return SHA256.HashData(Encoding.UTF8.GetBytes(userName + sid));
+        // Xshell 7.x / 8.x:SHA256(reverse(sid) + userName)。
+        yield return SHA256.HashData(Encoding.UTF8.GetBytes(Reverse(sid) + userName));
+        // Xshell 5.1 / 5.2。
+        yield return SHA256.HashData(Encoding.UTF8.GetBytes(sid));
+        // 早期(2/3/4/5.0)固定口令。
+        yield return MD5.HashData(Encoding.ASCII.GetBytes(LegacySalt));
+    }
+
+    private static string Reverse(string value) => new([.. value.Reverse()]);
+}

--- a/src/VelaShell.Infrastructure/Import/XshellImportService.cs
+++ b/src/VelaShell.Infrastructure/Import/XshellImportService.cs
@@ -1,0 +1,233 @@
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using System.Text;
+using Microsoft.Win32;
+using VelaShell.Core.Data;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>
+/// Xshell 的 <see cref="ISessionImportService" /> 实现:定位 <c>Sessions</c> 目录、解析 <c>.xsh</c>
+/// 会话(并尝试以当前 Windows 用户身份还原密码),将选中的会话写入 <see cref="ISessionRepository" />。
+/// </summary>
+public sealed class XshellImportService(ISessionRepository repository) : ISessionImportService
+{
+    private readonly ISessionRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    /// <inheritdoc />
+    public string SourceKey => "Xshell";
+
+    /// <inheritdoc />
+    public ImportBrowseKind BrowseKind => ImportBrowseKind.Folder;
+
+    /// <inheritdoc />
+    public string? DetectDefaultSource() => DetectSessionsDirectory();
+
+    /// <inheritdoc />
+    public async Task<SessionImportScan> ScanAsync(string? source, CancellationToken cancellationToken = default)
+    {
+        string? directory = string.IsNullOrWhiteSpace(source) ? DetectSessionsDirectory() : source;
+        if (directory is null || !Directory.Exists(directory))
+        {
+            return new SessionImportScan { Source = directory ?? string.Empty, Items = [] };
+        }
+
+        bool masterPasswordEnabled = IsMasterPasswordEnabled(directory);
+        (string userName, string sid) = GetCurrentUser();
+
+        // 以已存在会话的 主机|端口|用户名 作为重复判据。
+        List<SessionProfile> existing = await _repository.GetAllSessionsAsync().ConfigureAwait(false);
+        var existingKeys = existing
+            .Select(static s => DedupKey(s.Host, s.Port, s.Username))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var items = new List<ImportedSession>();
+        foreach (string file in Directory.EnumerateFiles(directory, "*.xsh", SearchOption.AllDirectories))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            XshellSessionFile parsed;
+            try
+            {
+                parsed = XshellIniParser.Parse(ReadLines(file));
+            }
+            catch (IOException)
+            {
+                continue; // 单个文件读失败不阻断整体扫描。
+            }
+            if (string.IsNullOrWhiteSpace(parsed.Host))
+            {
+                continue;
+            }
+
+            (ConnectionType type, bool supported) = MapProtocol(parsed.Protocol);
+            bool hasEncrypted = !string.IsNullOrWhiteSpace(parsed.EncryptedPassword);
+            string? password = null;
+            if (hasEncrypted && !masterPasswordEnabled && userName.Length > 0)
+            {
+                password = XshellCrypto.TryDecryptPassword(parsed.EncryptedPassword, userName, sid);
+            }
+
+            int port = parsed.Port > 0 ? parsed.Port : 22;
+            items.Add(new ImportedSession
+            {
+                Name = Path.GetFileNameWithoutExtension(file),
+                Host = parsed.Host!.Trim(),
+                Port = port,
+                Username = parsed.UserName?.Trim() ?? string.Empty,
+                ConnectionType = type,
+                Protocol = string.IsNullOrWhiteSpace(parsed.Protocol) ? "SSH" : parsed.Protocol!.Trim(),
+                IsSupported = supported,
+                HasEncryptedPassword = hasEncrypted,
+                Password = password,
+                AlreadyExists = existingKeys.Contains(DedupKey(parsed.Host!, port, parsed.UserName ?? string.Empty)),
+                Source = file
+            });
+        }
+
+        return new SessionImportScan
+        {
+            Source = directory,
+            Items = [.. items.OrderBy(static i => i.Name, StringComparer.OrdinalIgnoreCase)],
+            MasterPasswordEnabled = masterPasswordEnabled
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<SessionImportOutcome> ImportAsync(IReadOnlyList<ImportedSession> items, string groupName, CancellationToken cancellationToken = default) =>
+        await SessionImportWriter.WriteAsync(_repository, items, groupName, "Xshell", cancellationToken).ConfigureAwait(false);
+
+    /// <summary>把 Xshell 协议字段映射为 VelaShell 连接类型;仅 SSH / SFTP 受支持。</summary>
+    private static (ConnectionType Type, bool Supported) MapProtocol(string? protocol) =>
+        protocol?.Trim().ToUpperInvariant() switch
+        {
+            "SFTP" => (ConnectionType.SFTP, true),
+            "SSH" or null or "" => (ConnectionType.SSH, true),
+            _ => (ConnectionType.SSH, false)
+        };
+
+    private static string DedupKey(string host, int port, string user) => $"{host.Trim()}|{port}|{user.Trim()}";
+
+    /// <summary>按 BOM 自动识别编码(Xshell 为 UTF-16 LE)读入全部行。</summary>
+    private static IReadOnlyList<string> ReadLines(string path)
+    {
+        using var reader = new StreamReader(path, Encoding.Unicode, detectEncodingFromByteOrderMarks: true);
+        var lines = new List<string>();
+        while (reader.ReadLine() is { } line)
+        {
+            lines.Add(line);
+        }
+        return lines;
+    }
+
+    private static string? DetectSessionsDirectory()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+        string? userDataPath = ReadUserDataPathFromRegistry();
+        if (userDataPath is { Length: > 0 })
+        {
+            string sessions = Path.Combine(userDataPath, "Xshell", "Sessions");
+            if (Directory.Exists(sessions))
+            {
+                return sessions;
+            }
+        }
+        // 便携/自定义安装读不到注册表时,回退到默认文档位置(Xshell 5/6/7/8)。
+        string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        foreach (string version in (string[])["8", "7", "6", "5"])
+        {
+            string candidate = Path.Combine(documents, "NetSarang Computer", version, "Xshell", "Sessions");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>检测该会话目录对应的 Xshell 是否启用主密码;无法判定时按未启用处理。</summary>
+    private static bool IsMasterPasswordEnabled(string sessionsDirectory)
+    {
+        // Sessions 目录布局:&lt;UserData&gt;\Xshell\Sessions;主密码文件在 &lt;UserData&gt;\common\MasterPassword.mpw。
+        try
+        {
+            DirectoryInfo? xshell = Directory.GetParent(sessionsDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            DirectoryInfo? userData = xshell?.Parent;
+            if (userData is null)
+            {
+                return false;
+            }
+            string mpw = Path.Combine(userData.FullName, "common", "MasterPassword.mpw");
+            if (!File.Exists(mpw))
+            {
+                return false;
+            }
+            foreach (string raw in ReadLines(mpw))
+            {
+                string line = raw.Trim();
+                if (line.StartsWith("EnblMasterPasswd=", StringComparison.OrdinalIgnoreCase))
+                {
+                    return line["EnblMasterPasswd=".Length..].Trim() == "1";
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // 读不到就按未启用处理:大不了解密失败,会话仍以「不含密码」导入。
+        }
+        return false;
+    }
+
+    private static (string UserName, string Sid) GetCurrentUser() =>
+        OperatingSystem.IsWindows() ? GetWindowsUser() : (string.Empty, string.Empty);
+
+    [SupportedOSPlatform("windows")]
+    private static (string UserName, string Sid) GetWindowsUser()
+    {
+        try
+        {
+            using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            string fullName = identity.Name; // DOMAIN\user 或 machine\user
+            int slash = fullName.LastIndexOf('\\');
+            string name = slash >= 0 ? fullName[(slash + 1)..] : fullName;
+            string sid = identity.User?.Value ?? string.Empty;
+            return (name, sid);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            return (string.Empty, string.Empty);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? ReadUserDataPathFromRegistry()
+    {
+        try
+        {
+            using RegistryKey? common = Registry.CurrentUser.OpenSubKey(@"Software\NetSarang\Common");
+            if (common is null)
+            {
+                return null;
+            }
+            // 取版本号最高、且以 5/6/7/8 起始的子键。
+            string? bestVersion = common.GetSubKeyNames()
+                .Where(static v => v.StartsWith('5') || v.StartsWith('6') || v.StartsWith('7') || v.StartsWith('8'))
+                .OrderByDescending(static v => v, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (bestVersion is null)
+            {
+                return null;
+            }
+            using RegistryKey? userData = common.OpenSubKey($@"{bestVersion}\UserData");
+            return userData?.GetValue("UserDataPath") as string;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or System.Security.SecurityException or IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/VelaShell.Infrastructure/Import/XshellIniParser.cs
+++ b/src/VelaShell.Infrastructure/Import/XshellIniParser.cs
@@ -1,0 +1,71 @@
+namespace VelaShell.Infrastructure.Import;
+
+/// <summary>从 Xshell <c>.xsh</c>(UTF-16 INI)中解析出的、导入所需的原始字段。</summary>
+internal sealed record XshellSessionFile(
+    string? Version,
+    string? Host,
+    int Port,
+    string? Protocol,
+    string? UserName,
+    string? EncryptedPassword,
+    string? UserKey);
+
+/// <summary>Xshell 会话文件的分节 INI 解析器(只取导入需要的少量字段)。</summary>
+internal static class XshellIniParser
+{
+    /// <summary>解析已按行读入的会话文件内容。</summary>
+    public static XshellSessionFile Parse(IEnumerable<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        string section = string.Empty;
+        string? version = null, host = null, protocol = null, userName = null, password = null, userKey = null;
+        var port = 0;
+
+        foreach (string raw in lines)
+        {
+            string line = raw.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+            if (line[0] == '[' && line[^1] == ']')
+            {
+                section = line[1..^1];
+                continue;
+            }
+            int eq = line.IndexOf('=');
+            if (eq < 0)
+            {
+                continue;
+            }
+            string key = line[..eq].Trim();
+            string value = line[(eq + 1)..].Trim();
+
+            switch (section)
+            {
+                case "SessionInfo" when key.Equals("Version", StringComparison.OrdinalIgnoreCase):
+                    version = value;
+                    break;
+                case "CONNECTION" when key.Equals("Host", StringComparison.OrdinalIgnoreCase):
+                    host = value;
+                    break;
+                case "CONNECTION" when key.Equals("Port", StringComparison.OrdinalIgnoreCase):
+                    _ = int.TryParse(value, out port);
+                    break;
+                case "CONNECTION" when key.Equals("Protocol", StringComparison.OrdinalIgnoreCase):
+                    protocol = value;
+                    break;
+                case "CONNECTION:AUTHENTICATION" when key.Equals("UserName", StringComparison.OrdinalIgnoreCase):
+                    userName = value;
+                    break;
+                case "CONNECTION:AUTHENTICATION" when key.Equals("Password", StringComparison.OrdinalIgnoreCase):
+                    password = value;
+                    break;
+                case "CONNECTION:AUTHENTICATION" when key.Equals("UserKey", StringComparison.OrdinalIgnoreCase):
+                    userKey = value;
+                    break;
+            }
+        }
+        return new XshellSessionFile(version, host, port, protocol, userName, password, userKey);
+    }
+}

--- a/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
+++ b/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
@@ -20,6 +20,7 @@
        本项目的友元是 VelaShell.Core.Tests(Tmds.Ssh 包装类与异常翻译的白盒测试放在那边)。 -->
   <ItemGroup Condition="'$(SignAssembly)' != 'true'">
     <InternalsVisibleTo Include="VelaShell.Core.Tests" />
+    <InternalsVisibleTo Include="VelaShell.Infrastructure.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/VelaShell.Presentation/ViewModels/SessionImportItemViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionImportItemViewModel.cs
@@ -1,0 +1,54 @@
+using ReactiveUI;
+using VelaShell.Core.Import;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.Presentation.ViewModels;
+
+/// <summary>会话导入预览列表中的单行:包裹一条 <see cref="ImportedSession" /> 并提供勾选状态与展示文案。</summary>
+public sealed class SessionImportItemViewModel : ReactiveObject
+{
+    /// <summary>用一条已解析的会话构造预览行;不受支持的协议默认不勾选。</summary>
+    public SessionImportItemViewModel(ImportedSession source)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        IsSelected = source.IsSupported;
+    }
+
+    /// <summary>底层已解析的会话数据。</summary>
+    public ImportedSession Source { get; }
+
+    /// <summary>是否勾选导入。</summary>
+    public bool IsSelected
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>会话显示名称。</summary>
+    public string Name => Source.Name;
+
+    /// <summary>连接目标(<c>user@host:port</c> 或 <c>host:port</c>)。</summary>
+    public string Endpoint =>
+        Source.Username.Length > 0
+            ? $"{Source.Username}@{Source.Host}:{Source.Port}"
+            : $"{Source.Host}:{Source.Port}";
+
+    /// <summary>协议标签(SSH / SFTP,或不支持时的原始协议名)。</summary>
+    public string Protocol => Source.Protocol.ToUpperInvariant();
+
+    /// <summary>该行是否可被勾选(不支持的协议禁用勾选)。</summary>
+    public bool CanSelect => Source.IsSupported;
+
+    /// <summary>密码状态文案:已还原 / 未还原(需手填) / 无密码。</summary>
+    public string PasswordStatus =>
+        !Source.IsSupported ? Strings.Get("XImport_Unsupported") :
+        Source.PasswordRecovered ? Strings.Get("XImport_PwRecovered") :
+        Source.HasEncryptedPassword ? Strings.Get("XImport_PwFailed") :
+        Strings.Get("XImport_PwNone");
+
+    /// <summary>是否在 VelaShell 中已存在同目标会话(用于提示重复)。</summary>
+    public bool AlreadyExists => Source.AlreadyExists;
+
+    /// <summary>已存在提示文案(仅在 <see cref="AlreadyExists" /> 时非空)。</summary>
+    public string ExistsHint => Source.AlreadyExists ? Strings.Get("XImport_Duplicate") : string.Empty;
+}

--- a/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
@@ -1,0 +1,242 @@
+using System.Collections.ObjectModel;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Import;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.Presentation.ViewModels;
+
+/// <summary>
+/// 会话导入对话框的视图模型:扫描某个来源(Xshell / WinSCP …)生成勾选预览,并把选中的会话
+/// 经 <see cref="ISessionImportService" /> 一键写入 VelaShell。同一 VM 适配所有来源。
+/// </summary>
+public sealed class SessionImportViewModel : ReactiveObject
+{
+    private readonly ISessionImportService _service;
+    private readonly List<IDisposable> _itemSubscriptions = [];
+
+    /// <summary>用某个来源的导入服务构造视图模型,并初始化扫描/勾选/导入命令。</summary>
+    public SessionImportViewModel(ISessionImportService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+        Items = [];
+        Title = Strings.Format("XImport_TitleFmt", _service.SourceKey);
+        GroupName = Strings.Format("XImport_GroupFmt", _service.SourceKey);
+        SourceLabel = _service.BrowseKind == ImportBrowseKind.File
+            ? Strings.Get("XImport_SourceFile")
+            : Strings.Get("XImport_SourceFolder");
+
+        IObservable<bool> notBusy = this.WhenAnyValue(x => x.IsScanning).Select(static busy => !busy);
+        ScanCommand = ReactiveCommand.CreateFromTask(ScanAsync, notBusy);
+
+        IObservable<bool> canImport = this.WhenAnyValue(x => x.SelectedCount, x => x.IsScanning)
+            .Select(static t => t.Item1 > 0 && !t.Item2);
+        ImportCommand = ReactiveCommand.CreateFromTask(ImportAsync, canImport);
+
+        SelectAllCommand = ReactiveCommand.Create(() => SetAllSelected(true));
+        SelectNoneCommand = ReactiveCommand.Create(() => SetAllSelected(false));
+    }
+
+    /// <summary>对话框标题(含来源名)。</summary>
+    public string Title { get; }
+
+    /// <summary>来源输入框的标签(会话目录 / 配置文件)。</summary>
+    public string SourceLabel { get; }
+
+    /// <summary>是否允许手动浏览来源。</summary>
+    public bool CanBrowse => _service.BrowseKind != ImportBrowseKind.None;
+
+    /// <summary>浏览来源时应弹出的选择器类型。</summary>
+    public ImportBrowseKind BrowseKind => _service.BrowseKind;
+
+    /// <summary>当前来源(目录/文件路径或来源描述)。</summary>
+    public string SourceText
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = string.Empty;
+
+    /// <summary>新建承载分组的名称。</summary>
+    public string GroupName
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>导入预览行集合。</summary>
+    public ObservableCollection<SessionImportItemViewModel> Items { get; }
+
+    /// <summary>是否正在扫描来源。</summary>
+    public bool IsScanning
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>已勾选(且受支持)的会话数量。</summary>
+    public int SelectedCount
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>其中可自动还原密码的数量。</summary>
+    public int RecoveredCount
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>底部选择汇总文案(已选数量 · 含密码数量)。</summary>
+    public string SelectionSummary => Strings.Format("XImport_SelectedCount", SelectedCount, RecoveredCount);
+
+    /// <summary>扫描到的会话总数是否为 0(驱动空状态提示)。</summary>
+    public bool HasNoItems
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = true;
+
+    /// <summary>来源是否启用主密码(启用时无法还原任何密码,给出提示)。</summary>
+    public bool MasterPasswordEnabled
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>面向用户的状态/结果文案。</summary>
+    public string StatusMessage
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = string.Empty;
+
+    /// <summary>扫描当前来源并重建预览列表。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> ScanCommand { get; }
+
+    /// <summary>执行导入,返回结果统计(取消或无选中时为 <c>null</c>)。</summary>
+    public ReactiveCommand<RxVoid, SessionImportOutcome?> ImportCommand { get; }
+
+    /// <summary>勾选全部受支持的会话。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> SelectAllCommand { get; }
+
+    /// <summary>取消勾选全部会话。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> SelectNoneCommand { get; }
+
+    /// <summary>对话框打开时调用:自动探测来源并立即扫描;探测不到则提示手动选择。</summary>
+    public async Task InitializeAsync()
+    {
+        string? detected = _service.DetectDefaultSource();
+        SourceText = detected ?? string.Empty;
+        if (detected is { Length: > 0 } || !CanBrowse)
+        {
+            await ScanAsync().ConfigureAwait(true);
+        }
+        else
+        {
+            StatusMessage = Strings.Get("XImport_NotDetected");
+        }
+    }
+
+    private async Task ScanAsync()
+    {
+        IsScanning = true;
+        StatusMessage = string.Empty;
+        try
+        {
+            SessionImportScan result = await _service
+                .ScanAsync(string.IsNullOrWhiteSpace(SourceText) ? null : SourceText)
+                .ConfigureAwait(true);
+            ClearItems();
+            foreach (ImportedSession item in result.Items)
+            {
+                var vm = new SessionImportItemViewModel(item);
+                _itemSubscriptions.Add(vm.WhenAnyValue(static x => x.IsSelected).Subscribe(_ => RecomputeCounts()));
+                Items.Add(vm);
+            }
+            MasterPasswordEnabled = result.MasterPasswordEnabled;
+            HasNoItems = Items.Count == 0;
+            if (result.Source is { Length: > 0 })
+            {
+                SourceText = result.Source;
+            }
+            RecomputeCounts();
+            StatusMessage = Items.Count == 0
+                ? Strings.Get("XImport_NoSessions")
+                : Strings.Format("XImport_Found", Items.Count);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            ClearItems();
+            HasNoItems = true;
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsScanning = false;
+        }
+    }
+
+    private async Task<SessionImportOutcome?> ImportAsync()
+    {
+        var selected = Items
+            .Where(static i => i.IsSelected && i.CanSelect)
+            .Select(static i => i.Source)
+            .ToList();
+        if (selected.Count == 0)
+        {
+            return null;
+        }
+        IsScanning = true;
+        try
+        {
+            return await _service.ImportAsync(selected, GroupName).ConfigureAwait(true);
+        }
+        finally
+        {
+            IsScanning = false;
+        }
+    }
+
+    private void SetAllSelected(bool value)
+    {
+        foreach (SessionImportItemViewModel item in Items)
+        {
+            if (item.CanSelect)
+            {
+                item.IsSelected = value;
+            }
+        }
+    }
+
+    private void RecomputeCounts()
+    {
+        var selected = 0;
+        var recovered = 0;
+        foreach (SessionImportItemViewModel item in Items)
+        {
+            if (!item.IsSelected || !item.CanSelect)
+            {
+                continue;
+            }
+            selected++;
+            if (item.Source.PasswordRecovered)
+            {
+                recovered++;
+            }
+        }
+        SelectedCount = selected;
+        RecoveredCount = recovered;
+        this.RaisePropertyChanged(nameof(SelectionSummary));
+    }
+
+    private void ClearItems()
+    {
+        foreach (IDisposable subscription in _itemSubscriptions)
+        {
+            subscription.Dispose();
+        }
+        _itemSubscriptions.Clear();
+        Items.Clear();
+    }
+}

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -11,13 +11,16 @@ using ReactiveUI;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
+using VelaShell.Core.Import;
 using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Services;
 using VelaShell.Core.Ssh;
 using VelaShell.Docking;
+using VelaShell.Infrastructure.Import;
 using VelaShell.Presentation.Services;
+using VelaShell.Presentation.ViewModels;
 using VelaShell.Security;
 using VelaShell.Services;
 using VelaShell.Services.ZModem;
@@ -100,6 +103,8 @@ public partial class MainWindow : Window
             sidebar.OpenConnectionProfileRequested += OnOpenConnectionProfileRequested;
             sidebar.RecentConnectRequested += OnSidebarRecentConnectRequested;
             sidebar.SettingsRequested += (_, _) => _ = OpenSettingsAsync();
+            sidebar.ImportXshellRequested += (_, _) => _ = OpenSessionImportDialogAsync<XshellImportService>();
+            sidebar.ImportWinScpRequested += (_, _) => _ = OpenSessionImportDialogAsync<WinScpImportService>();
         }
         DataContextChanged += (_, _) => HookFileBrowserVisibility();
         // 主题(暗/亮)切换时,按新主题色重建背景令牌覆盖画刷。否则之前设的覆盖仍持旧主题色、
@@ -751,6 +756,25 @@ public partial class MainWindow : Window
     }
 
     private void OnOpenConnectionProfileRequested(object? sender, EventArgs e) => _ = OpenProfileDialogAsync(null);
+
+    /// <summary>打开「从外部工具导入会话」弹窗(按具体来源服务);导入成功后刷新资源管理器树。</summary>
+    private async Task OpenSessionImportDialogAsync<TService>() where TService : class, ISessionImportService
+    {
+        if (DataContext is not MainWindowViewModel mainWindowViewModel)
+        {
+            return;
+        }
+        if (Application.Current is not App app || app.Services?.GetService<TService>() is not { } importService)
+        {
+            return;
+        }
+        var dialog = new SessionImportView { DataContext = new SessionImportViewModel(importService) };
+        SessionImportOutcome? outcome = await dialog.ShowDialog<SessionImportOutcome?>(this);
+        if (outcome is { Imported: > 0 })
+        {
+            await mainWindowViewModel.RefreshSessionTreeAsync();
+        }
+    }
 
     /// <summary>打开“新建连接”弹窗;传入 existing 时为编辑既有配置。</summary>
     private async Task OpenProfileDialogAsync(SessionProfile? existing)

--- a/src/VelaShell/Views/SessionImportView.axaml
+++ b/src/VelaShell/Views/SessionImportView.axaml
@@ -1,0 +1,201 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:VelaShell.Presentation.ViewModels"
+        xmlns:loc="using:VelaShell.Localization"
+        mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="560"
+        x:Class="VelaShell.Views.SessionImportView"
+        x:DataType="vm:SessionImportViewModel"
+        Title="{Binding Title}"
+        Width="560" Height="600"
+        CanResize="False"
+        WindowDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <Style Selector="TextBlock.field-label">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontWeight" Value="Medium" />
+      <Setter Property="Margin" Value="0,0,0,5" />
+    </Style>
+    <Style Selector="TextBox">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.dlg-outline">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="Height" Value="32" />
+      <Setter Property="Padding" Value="14,0" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <Style Selector="Button.dlg-primary">
+      <Setter Property="Background" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccentForeground}" />
+      <Setter Property="Height" Value="32" />
+      <Setter Property="Padding" Value="16,0" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <Style Selector="Button.link">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+      <Setter Property="Padding" Value="6,2" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="FontSize" Value="11" />
+    </Style>
+  </Window.Styles>
+
+  <Border CornerRadius="8"
+          Background="{DynamicResource VelaBgSurface}"
+          BorderBrush="{DynamicResource VelaBorderSecondary}"
+          BorderThickness="1"
+          BoxShadow="0 8 32 0 #80000000"
+          Margin="12">
+    <Grid RowDefinitions="48,Auto,Auto,*,52">
+
+      <!-- Header -->
+      <Border Grid.Row="0" Height="48" Padding="20,0"
+              PointerPressed="Header_PointerPressed"
+              Background="Transparent"
+              BorderThickness="0,0,0,1"
+              BorderBrush="{DynamicResource VelaBorderPrimary}">
+        <Grid ColumnDefinitions="Auto,8,*,Auto">
+          <PathIcon Grid.Column="0" Width="16" Height="16"
+                    Data="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"
+                    Foreground="{DynamicResource VelaAccent}"
+                    VerticalAlignment="Center" />
+          <TextBlock Grid.Column="2" Text="{Binding Title}"
+                     Foreground="{DynamicResource VelaTextPrimary}"
+                     FontSize="14" FontWeight="SemiBold"
+                     VerticalAlignment="Center" />
+          <Button Grid.Column="3" Width="24" Height="24"
+                  Background="Transparent" Padding="0" CornerRadius="3"
+                  Cursor="Hand" Click="Cancel_Click">
+            <PathIcon Width="14" Height="14"
+                      Data="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      Foreground="{DynamicResource VelaTextTertiary}" />
+          </Button>
+        </Grid>
+      </Border>
+
+      <!-- 来源选择 -->
+      <StackPanel Grid.Row="1" Margin="20,16,20,8">
+        <TextBlock Classes="field-label" Text="{Binding SourceLabel}" />
+        <Grid ColumnDefinitions="*,8,Auto,8,Auto">
+          <TextBox Grid.Column="0" Text="{Binding SourceText}" />
+          <Button Grid.Column="2" Classes="dlg-outline"
+                  Content="{loc:Localize XImport_Browse}"
+                  IsVisible="{Binding CanBrowse}" Click="Browse_Click" />
+          <Button Grid.Column="4" Classes="dlg-outline"
+                  Content="{loc:Localize XImport_Rescan}"
+                  Command="{Binding ScanCommand}" />
+        </Grid>
+      </StackPanel>
+
+      <!-- 主密码警告 -->
+      <Border Grid.Row="2" Margin="20,0,20,8" Padding="12,8" CornerRadius="4"
+              Background="{DynamicResource VelaBgInput}"
+              BorderBrush="#66FFB020" BorderThickness="1"
+              IsVisible="{Binding MasterPasswordEnabled}">
+        <TextBlock Text="{loc:Localize XImport_MasterPwWarn}"
+                   Foreground="{DynamicResource VelaTextSecondary}"
+                   FontSize="11" TextWrapping="Wrap" />
+      </Border>
+
+      <!-- 会话列表 -->
+      <Border Grid.Row="3" Margin="20,0,20,0" CornerRadius="4"
+              Background="{DynamicResource VelaBgInput}"
+              BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="1">
+        <Grid>
+          <ScrollViewer>
+            <ItemsControl ItemsSource="{Binding Items}" Margin="2">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="vm:SessionImportItemViewModel">
+                  <Border Padding="10,7" Margin="1" CornerRadius="3">
+                    <Grid ColumnDefinitions="Auto,10,*,Auto">
+                      <CheckBox Grid.Column="0" IsChecked="{Binding IsSelected}"
+                                IsEnabled="{Binding CanSelect}"
+                                MinHeight="0" Padding="0" VerticalAlignment="Center" />
+                      <StackPanel Grid.Column="2" Spacing="2" VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                          <TextBlock Text="{Binding Name}"
+                                     Foreground="{DynamicResource VelaTextPrimary}"
+                                     FontSize="12" FontWeight="Medium" />
+                          <Border Background="{DynamicResource VelaBgHover}"
+                                  CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
+                            <TextBlock Text="{Binding Protocol}"
+                                       Foreground="{DynamicResource VelaTextTertiary}"
+                                       FontSize="9" FontFamily="{DynamicResource VelaTerminalFont}" />
+                          </Border>
+                          <TextBlock Text="{Binding ExistsHint}"
+                                     IsVisible="{Binding ExistsHint, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                     Foreground="{DynamicResource VelaTextMuted}"
+                                     FontSize="10" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding Endpoint}"
+                                   Foreground="{DynamicResource VelaTextTertiary}"
+                                   FontSize="10.5"
+                                   FontFamily="{DynamicResource VelaTerminalFont}" />
+                      </StackPanel>
+                      <TextBlock Grid.Column="3" Text="{Binding PasswordStatus}"
+                                 Foreground="{DynamicResource VelaTextMuted}"
+                                 FontSize="10" VerticalAlignment="Center" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+          <TextBlock Text="{Binding StatusMessage}"
+                     IsVisible="{Binding HasNoItems}"
+                     Foreground="{DynamicResource VelaTextMuted}"
+                     FontSize="11" TextWrapping="Wrap" TextAlignment="Center"
+                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                     Margin="24" />
+        </Grid>
+      </Border>
+
+      <!-- Footer -->
+      <Border Grid.Row="4" Height="52" Padding="20,0"
+              BorderThickness="0,1,0,0"
+              BorderBrush="{DynamicResource VelaBorderPrimary}">
+        <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+          <Button Grid.Column="0" Classes="link"
+                  Content="{loc:Localize XImport_SelectAll}"
+                  Command="{Binding SelectAllCommand}" VerticalAlignment="Center" />
+          <Button Grid.Column="1" Classes="link"
+                  Content="{loc:Localize XImport_SelectNone}"
+                  Command="{Binding SelectNoneCommand}" VerticalAlignment="Center" />
+          <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8"
+                      VerticalAlignment="Center">
+            <TextBlock Text="{Binding SelectionSummary}"
+                       Foreground="{DynamicResource VelaTextTertiary}"
+                       FontSize="11" VerticalAlignment="Center" Margin="0,0,4,0" />
+            <Button Classes="dlg-outline" Content="{loc:Localize Cancel}" Click="Cancel_Click" />
+            <Button Classes="dlg-primary" Content="{loc:Localize XImport_ImportButton}"
+                    Command="{Binding ImportCommand}" />
+          </StackPanel>
+        </Grid>
+      </Border>
+
+    </Grid>
+  </Border>
+</Window>

--- a/src/VelaShell/Views/SessionImportView.axaml.cs
+++ b/src/VelaShell/Views/SessionImportView.axaml.cs
@@ -1,0 +1,100 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Import;
+using VelaShell.Core.Resources;
+using VelaShell.Presentation.ViewModels;
+
+namespace VelaShell.Views;
+
+/// <summary>会话导入对话框:扫描来源(Xshell / WinSCP)、勾选预览并一键导入到 VelaShell。</summary>
+public partial class SessionImportView : Window
+{
+    /// <summary>初始化导入对话框并接线打开时的扫描与命令回调。</summary>
+    public SessionImportView()
+    {
+        InitializeComponent();
+        Opened += OnOpened;
+    }
+
+    private async void OnOpened(object? sender, EventArgs e)
+    {
+        if (DataContext is not SessionImportViewModel viewModel)
+        {
+            return;
+        }
+        // 导入成功后关闭并把结果回传给宿主(用于刷新会话树)。
+        viewModel.ImportCommand.Subscribe(outcome =>
+        {
+            if (outcome is not null)
+            {
+                this.PostClose(outcome);
+            }
+        });
+        await viewModel.InitializeAsync();
+    }
+
+    /// <summary>Esc 等价于取消。</summary>
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            this.PostClose(null);
+            e.Handled = true;
+            return;
+        }
+        base.OnKeyDown(e);
+    }
+
+    /// <summary>无系统标题栏 —— 按住头部拖动窗口。</summary>
+    private void Header_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            BeginMoveDrag(e);
+        }
+    }
+
+    private void Cancel_Click(object? sender, RoutedEventArgs e) => this.PostClose(null);
+
+    private async void Browse_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not SessionImportViewModel viewModel)
+        {
+            return;
+        }
+        string? picked = viewModel.BrowseKind switch
+        {
+            ImportBrowseKind.File => await PickFileAsync(),
+            ImportBrowseKind.Folder => await PickFolderAsync(),
+            _ => null
+        };
+        if (picked is { Length: > 0 })
+        {
+            viewModel.SourceText = picked;
+            viewModel.ScanCommand.Execute().Subscribe();
+        }
+    }
+
+    private async Task<string?> PickFolderAsync()
+    {
+        IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new()
+        {
+            Title = Strings.Get("XImport_Browse"),
+            AllowMultiple = false
+        });
+        return folders.FirstOrDefault()?.TryGetLocalPath();
+    }
+
+    private async Task<string?> PickFileAsync()
+    {
+        IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new()
+        {
+            Title = Strings.Get("XImport_Browse"),
+            AllowMultiple = false
+        });
+        return files.FirstOrDefault()?.TryGetLocalPath();
+    }
+}

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -35,9 +35,18 @@
                            Foreground="{DynamicResource VelaTextTertiary}" />
           </Button>
           <Button Background="Transparent" Padding="0" Width="24" Height="24"
-                  CornerRadius="3" Cursor="Hand">
+                  CornerRadius="3" Cursor="Hand"
+                  ToolTip.Tip="{loc:Localize XImport_MenuItem}">
             <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.ellipsis}"
                            Foreground="{DynamicResource VelaTextTertiary}" />
+            <Button.Flyout>
+              <MenuFlyout Placement="BottomEdgeAlignedRight">
+                <MenuItem Header="{loc:Localize XImport_MenuItem}"
+                          Click="ImportXshell_Click" />
+                <MenuItem Header="{loc:Localize XImport_WinScpMenuItem}"
+                          Click="ImportWinScp_Click" />
+              </MenuFlyout>
+            </Button.Flyout>
           </Button>
         </StackPanel>
       </Grid>

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -33,6 +33,12 @@ public partial class SidebarView : UserControl
     /// <summary>用户双击最近连接以重新连接时触发。</summary>
     public event EventHandler<RecentConnectionEntry>? RecentConnectRequested;
 
+    /// <summary>用户在资源管理器「更多」菜单中选择「从 Xshell 导入」时触发。</summary>
+    public event EventHandler? ImportXshellRequested;
+
+    /// <summary>用户在资源管理器「更多」菜单中选择「从 WinSCP 导入」时触发。</summary>
+    public event EventHandler? ImportWinScpRequested;
+
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         _viewModel?.PropertyChanged -= OnViewModelPropertyChanged;
@@ -71,6 +77,16 @@ public partial class SidebarView : UserControl
     private void OpenSettings_Click(object? sender, RoutedEventArgs e)
     {
         SettingsRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ImportXshell_Click(object? sender, RoutedEventArgs e)
+    {
+        ImportXshellRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ImportWinScp_Click(object? sender, RoutedEventArgs e)
+    {
+        ImportWinScpRequested?.Invoke(this, EventArgs.Empty);
     }
 
     private void ToggleQuickCommands_Click(object? sender, RoutedEventArgs e)

--- a/tests/VelaShell.Infrastructure.Tests/WinScpImportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/WinScpImportTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Import;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>WinSCP 会话导入:0xA3 密码编解码往返 + 本机真实数据验证。</summary>
+[TestClass]
+public class WinScpImportTests
+{
+    private const int PwMagic = 0xA3;
+    private const int PwFlag = 0xFF;
+
+    /// <summary>用 WinSCP 的编码方式(含 用户名+主机名 前缀)构造密文,<see cref="WinScpCrypto.Decrypt" /> 应还原明文。</summary>
+    [TestMethod]
+    [DataRow("root", "192.168.1.1", "hunter2")]
+    [DataRow("admin", "example.com", "p@ss W0rd!")]
+    [DataRow("u", "h", "x")]
+    public void Crypto_RoundTrip_Recovers(string user, string host, string password)
+    {
+        string encoded = Encode(user, host, password);
+        Assert.AreEqual(password, WinScpCrypto.Decrypt(host, user, encoded));
+    }
+
+    /// <summary>空/非法十六进制输入安全返回 null。</summary>
+    [TestMethod]
+    public void Crypto_HandlesEmptyAndGarbage()
+    {
+        Assert.IsNull(WinScpCrypto.Decrypt("h", "u", null));
+        Assert.IsNull(WinScpCrypto.Decrypt("h", "u", ""));
+        Assert.IsNull(WinScpCrypto.Decrypt("h", "u", "ZZZZ"));   // 非十六进制
+        Assert.IsNull(WinScpCrypto.Decrypt("h", "u", "A"));      // 数据不足
+    }
+
+    /// <summary>INI 中未启用主密码时,含密码会话应被解出;来源可为文件路径。</summary>
+    [TestMethod]
+    public async Task Scan_FromIni_DecodesPassword()
+    {
+        string host = "10.0.0.5";
+        string user = "deploy";
+        string password = "S3cr3t!";
+        string ini = Path.Combine(Path.GetTempPath(), $"winscp-test-{Guid.NewGuid():N}.ini");
+        await File.WriteAllTextAsync(ini,
+            $"""
+             [Configuration\Security]
+             UseMasterPassword=0
+             [Sessions\prod%20box]
+             HostName={host}
+             UserName={user}
+             PortNumber=2222
+             FSProtocol=5
+             Password={Encode(user, host, password)}
+             """);
+        try
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+            var service = new WinScpImportService(repository);
+
+            SessionImportScan scan = await service.ScanAsync(ini);
+
+            Assert.IsFalse(scan.MasterPasswordEnabled);
+            Assert.AreEqual(1, scan.Items.Count);
+            ImportedSession item = scan.Items[0];
+            Assert.AreEqual("prod box", item.Name);       // %20 已解码
+            Assert.AreEqual(host, item.Host);
+            Assert.AreEqual(2222, item.Port);
+            Assert.AreEqual(user, item.Username);
+            Assert.AreEqual(password, item.Password);
+            Assert.IsTrue(item.PasswordRecovered);
+        }
+        finally
+        {
+            File.Delete(ini);
+        }
+    }
+
+    /// <summary>启用主密码时,不尝试解密,密码留空。</summary>
+    [TestMethod]
+    public async Task Scan_FromIni_MasterPassword_SkipsDecryption()
+    {
+        string ini = Path.Combine(Path.GetTempPath(), $"winscp-mpw-{Guid.NewGuid():N}.ini");
+        await File.WriteAllTextAsync(ini,
+            """
+            [Configuration\Security]
+            UseMasterPassword=1
+            [Sessions\box]
+            HostName=host
+            UserName=user
+            Password=ABCDEF0123
+            """);
+        try
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+            var service = new WinScpImportService(repository);
+
+            SessionImportScan scan = await service.ScanAsync(ini);
+
+            Assert.IsTrue(scan.MasterPasswordEnabled);
+            Assert.AreEqual(1, scan.Items.Count);
+            Assert.IsFalse(scan.Items[0].PasswordRecovered);
+            Assert.IsTrue(scan.Items[0].HasEncryptedPassword);
+        }
+        finally
+        {
+            File.Delete(ini);
+        }
+    }
+
+    /// <summary>本机真实 WinSCP 数据的端到端验证:含密码会话应至少有一条被解出。未安装/主密码/无密码时 Inconclusive。</summary>
+    [TestMethod]
+    public async Task Scan_RealWinScp_RecoversAtLeastOnePassword()
+    {
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+        var service = new WinScpImportService(repository);
+
+        if (service.DetectDefaultSource() is null)
+        {
+            Assert.Inconclusive("本机未安装 WinSCP 或无保存的会话。");
+            return;
+        }
+
+        SessionImportScan scan = await service.ScanAsync(null);
+        if (scan.MasterPasswordEnabled)
+        {
+            Assert.Inconclusive("WinSCP 启用了主密码,无法验证解密。");
+            return;
+        }
+
+        var withPassword = scan.Items.Where(i => i is { IsSupported: true, HasEncryptedPassword: true }).ToList();
+        if (withPassword.Count == 0)
+        {
+            Assert.Inconclusive("没有含已保存密码的 WinSCP 会话可供验证。");
+            return;
+        }
+
+        Assert.IsTrue(
+            withPassword.Any(i => i.PasswordRecovered),
+            "含密码的 WinSCP 会话应至少有一条被成功解出;若全部失败,说明 0xA3 解码或字段读取与真实 WinSCP 不符。");
+    }
+
+    /// <summary>WinSCP 0xA3 编码(flag=FF 新格式,无随机填充):明文 = 用户名+主机名+密码。</summary>
+    private static string Encode(string user, string host, string password)
+    {
+        string clear = user + host + password;
+        var bytes = new List<byte> { PwFlag, 0x00, (byte)clear.Length, 0x00 };
+        bytes.AddRange(clear.Select(static c => (byte)c));
+
+        var sb = new StringBuilder(bytes.Count * 2);
+        foreach (byte value in bytes)
+        {
+            int x = (~value & 0xFF) ^ PwMagic;
+            sb.Append("0123456789ABCDEF"[(x >> 4) & 0xF]);
+            sb.Append("0123456789ABCDEF"[x & 0xF]);
+        }
+        return sb.ToString();
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/XshellImportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/XshellImportTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using System.Text;
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Import;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>Xshell 会话导入:INI 解析、RC4、密码还原(多版本密钥 + 本机真实数据验证)。</summary>
+[TestClass]
+public class XshellImportTests
+{
+    /// <summary>分节解析:各字段只在其所属节内取值,错误节里的同名键不得覆盖。</summary>
+    [TestMethod]
+    public void IniParser_ReadsSectionScopedFields()
+    {
+        string[] lines =
+        [
+            "[SessionInfo]", "Version=6.0",
+            "[CONNECTION]", "Host=192.168.1.10", "Port=2222", "Protocol=SSH",
+            "[CONNECTION:AUTHENTICATION]", "UserName=root", "Password=QUJDQQ==", "Method=0", "UserKey=",
+            "[TERMINAL]", "Host=ignore-me", "Rows=24"
+        ];
+
+        XshellSessionFile result = XshellIniParser.Parse(lines);
+
+        Assert.AreEqual("6.0", result.Version);
+        Assert.AreEqual("192.168.1.10", result.Host);
+        Assert.AreEqual(2222, result.Port);
+        Assert.AreEqual("SSH", result.Protocol);
+        Assert.AreEqual("root", result.UserName);
+        Assert.AreEqual("QUJDQQ==", result.EncryptedPassword);
+    }
+
+    /// <summary>RC4 是对称变换:同密钥两次变换还原原文。</summary>
+    [TestMethod]
+    public void Rc4_IsSymmetric()
+    {
+        byte[] key = SHA256.HashData(Encoding.UTF8.GetBytes("unit-test-key"));
+        byte[] plain = Encoding.UTF8.GetBytes("hunter2!§你好");
+
+        byte[] cipher = Rc4.Transform(key, plain);
+        byte[] round = Rc4.Transform(key, cipher);
+
+        CollectionAssert.AreEqual(plain, round);
+    }
+
+    /// <summary>
+    /// 多版本密钥:分别用 v5/6/7.0 方案(name+sid)与 v7/8 方案(reverse(sid)+name)构造 blob,
+    /// TryDecryptPassword 都应还原 —— 证明依次试探密钥可兼容 6/7/8。
+    /// </summary>
+    [TestMethod]
+    [DataRow(false, DisplayName = "Xshell 5/6/7.0 key = SHA256(name+sid)")]
+    [DataRow(true, DisplayName = "Xshell 7/8 key = SHA256(reverse(sid)+name)")]
+    public void Crypto_RoundTrip_AcrossVersions(bool reverseScheme)
+    {
+        const string user = "tester";
+        const string sid = "S-1-5-21-11-22-33-1001";
+        const string password = "P@ssw0rd-9";
+
+        byte[] key = reverseScheme
+            ? SHA256.HashData(Encoding.UTF8.GetBytes(new string([.. sid.Reverse()]) + user))
+            : SHA256.HashData(Encoding.UTF8.GetBytes(user + sid));
+        byte[] plain = Encoding.UTF8.GetBytes(password);
+        byte[] blob = [.. Rc4.Transform(key, plain), .. SHA256.HashData(plain)];
+
+        Assert.AreEqual(password, XshellCrypto.TryDecryptPassword(Convert.ToBase64String(blob), user, sid));
+    }
+
+    /// <summary>校验被破坏或 SID 不符时拒绝(不返回可能是垃圾的明文);空/损坏输入安全返回 null。</summary>
+    [TestMethod]
+    public void Crypto_RejectsTamperedAndGarbage()
+    {
+        const string user = "tester";
+        const string sid = "S-1-5-21-11-22-33-1001";
+        byte[] key = SHA256.HashData(Encoding.UTF8.GetBytes(user + sid));
+        byte[] plain = Encoding.UTF8.GetBytes("secret");
+        byte[] body = Rc4.Transform(key, plain);
+
+        byte[] broken = [.. body, .. new byte[32]];
+        Assert.IsNull(XshellCrypto.TryDecryptPassword(Convert.ToBase64String(broken), user, sid));
+
+        byte[] valid = [.. body, .. SHA256.HashData(plain)];
+        Assert.IsNull(XshellCrypto.TryDecryptPassword(Convert.ToBase64String(valid), user, "S-1-5-21-9-9-9-9"));
+
+        Assert.IsNull(XshellCrypto.TryDecryptPassword(null, "u", "s"));
+        Assert.IsNull(XshellCrypto.TryDecryptPassword("", "u", "s"));
+        Assert.IsNull(XshellCrypto.TryDecryptPassword("not-base64!!!", "u", "s"));
+        Assert.IsNull(XshellCrypto.TryDecryptPassword("QUJD", "u", "s")); // 太短(<32B)
+    }
+
+    /// <summary>
+    /// 针对本机真实 Xshell 数据的端到端验证:含加密密码的会话应至少有一条被成功还原。
+    /// 无 Xshell / 启用主密码 / 无带密码会话时置为 Inconclusive(绝不把凭据写入仓库)。
+    /// </summary>
+    [TestMethod]
+    public async Task Scan_RealXshellSessions_RecoversAtLeastOnePassword()
+    {
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+        var service = new XshellImportService(repository);
+
+        string? source = service.DetectDefaultSource();
+        if (source is null)
+        {
+            Assert.Inconclusive("本机未安装 Xshell 或无法定位 Sessions 目录。");
+            return;
+        }
+
+        SessionImportScan scan = await service.ScanAsync(null);
+        if (scan.MasterPasswordEnabled)
+        {
+            Assert.Inconclusive("Xshell 启用了主密码,无法在无主密码时验证解密。");
+            return;
+        }
+
+        var withPassword = scan.Items.Where(i => i is { IsSupported: true, HasEncryptedPassword: true }).ToList();
+        if (withPassword.Count == 0)
+        {
+            Assert.Inconclusive("没有含已保存密码的会话可供验证。");
+            return;
+        }
+
+        Assert.IsTrue(
+            withPassword.Any(i => i.PasswordRecovered),
+            "含加密密码的会话应至少有一条被成功还原;若全部失败,说明密钥派生或尾部校验假设与真实 Xshell 不符。");
+    }
+}


### PR DESCRIPTION
## 概述

新增「会话导入」功能,可从外部工具一键迁移会话到 VelaShell:自动定位来源、解析会话、还原保存的密码,并写入会话仓储。侧边栏「资源管理器 → 更多(…)」菜单新增两个入口:**从 Xshell 导入…** / **从 WinSCP 导入…**。

## 支持的来源

### Xshell(5 / 6 / 7 / 8)
- 通过注册表 `HKCU\Software\NetSarang\Common\<ver>\UserData\UserDataPath` 定位 `Sessions` 目录,读不到时回退到默认文档位置。
- 解析 `.xsh`(UTF-16 分节 INI)。
- 密码还原:密文尾部带 `SHA256(明文)` 校验,故**依次试探多版本密钥**并取校验通过者 —— `SHA256(用户名+SID)`(5/6/7.0)、`SHA256(reverse(SID)+用户名)`(7/8)、`SHA256(SID)`(5.1/5.2)、旧版固定口令 MD5。无需依赖不一定准确的 `Version` 字段即可兼容各版本。
- 检测主密码(`MasterPassword.mpw`),启用时降级为「不含密码」导入。

### WinSCP
- 读注册表 `HKCU\Software\Martin Prikryl\WinSCP 2\Sessions`,或 `WinSCP.ini`;自动探测漫游目录、卸载信息 `InstallLocation`(覆盖便携版)、常见安装目录。
- 密码解码:`0xA3` 可逆混淆(种子 = 用户名+主机名),不绑定机器。
- 检测主密码(`UseMasterPassword`);`FSProtocol` 映射:SCP/SFTP → 支持,FTP/WebDAV/S3 → 标为不支持。

## 设计

- 抽象为 `ISessionImportService`,Xshell 与 WinSCP 两个实现共用同一预览对话框(`SessionImportView` / `SessionImportViewModel`):自动探测来源、勾选预览、显示密码还原状态与重复项提示、可编辑目标分组。
- 仅将**成功还原密码**的会话设为「记住密码」,其余以不含密码方式导入到新建分组。
- 密钥派生仅在当前 Windows 用户身份下有效;Windows 专有调用(注册表 / WindowsIdentity)均加平台守卫,非 Windows 下安全降级。
- 五语言本地化(en / zh-Hans / zh-Hant / ja / ko)。

## 测试

`VelaShell.Infrastructure.Tests` 新增:INI 分节解析、RC4 对称性、Xshell 多版本密钥往返、篡改/损坏输入拒绝、WinSCP `0xA3` 编解码往返、WinSCP INI 解析与主密码跳过,以及针对**本机真实 Xshell / WinSCP 数据**的端到端还原验证(无数据时置为 Inconclusive,不写入任何凭据)。全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
