### PR TITLE
重构界面字体/字号令牌体系，支持全局生效

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -93,14 +93,21 @@ All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds vi
 
 ## 3. Typography
 
-Two font families, both loaded as Avalonia resources.
+Two font families, both loaded as Avalonia resources. Both are *interface* fonts: they
+follow Settings → Appearance → UI Font, which overrides both at runtime. Terminal content
+is not a token — `VelaTerminalControl` takes its font straight from Settings → Terminal.
 
-| Token | Stack | Usage |
+| Token | Default stack | Usage |
 |---|---|---|
-| `VelaTerminalFont` | JetBrains Mono, Cascadia Mono, Consolas, monospace | Terminal content, hostnames, IPs, ports, paths, keybindings, values, tab names, file browser cells |
+| `VelaUiMonoFont` | Cascadia Mono, JetBrains Mono, Consolas, monospace | Column-aligned interface text: hostnames, IPs, ports, paths, keybindings, values, tab names, file browser cells |
 | `VelaUiFont` | Inter, Segoe UI, Microsoft YaHei, sans-serif | Menus, buttons, settings labels, descriptive text, group headings |
 
-### Size Scale (by context, not tokenized)
+### Size Scale (tokenized: `VelaFontSize<n>`)
+
+Every size below is a resource token whose name is its pt value at the default UI font size
+(13). Settings → Appearance → UI Font Size rescales the whole ladder by `base / 13`
+(rounded, floor 6), so the hierarchy holds at any base. Never write `FontSize="11"` in a
+view — a literal does not follow the setting.
 
 | Size | Weight | Context |
 |---|---|---|
@@ -203,7 +210,7 @@ StatusBar (24px, bg-sidebar)
 - Sizing: 24x24 for icon-only, auto for pill buttons
 
 #### BreadcrumbSegment (`Button`)
-- Class: `.crumb` -- transparent bg, no border, `FontFamily:VelaTerminalFont`, `FontSize:11`, `FontWeight:Medium`
+- Class: `.crumb` -- transparent bg, no border, `FontFamily:VelaUiMonoFont`, `FontSize:11`, `FontWeight:Medium`
 - Hover: `VelaBgHover` background, `VelaAccent` foreground
 
 ### 5.2 File Browser (`FileBrowserView.axaml`)
@@ -218,8 +225,8 @@ The existing SFTP file browser is the primary reusable component for the dual-pa
 
 **Row anatomy (28px):**
 - Icon (13px): `VelaFileFolderIcon` for directories, `VelaTextTertiary` for files, `VelaTextTertiary` corner-left-up for `..`
-- Name: `VelaTerminalFont` 11px, `VelaFileDirName` for dirs, `VelaTextSecondary` for files, `VelaTextSecondary` for parent
-- Metadata columns: `VelaTerminalFont` 11px, `VelaTextTertiary`
+- Name: `VelaUiMonoFont` 11px, `VelaFileDirName` for dirs, `VelaTextSecondary` for files, `VelaTextSecondary` for parent
+- Metadata columns: `VelaUiMonoFont` 11px, `VelaTextTertiary`
 
 **Selection:** `VelaBgHover` replaces default theme blue (style on `ListBoxItem:selected`)
 
@@ -241,7 +248,7 @@ The existing SFTP file browser is the primary reusable component for the dual-pa
 ### 5.4 Context Menus (global style in `DockStyles.axaml`)
 
 - `VelaBgSurface` background, `VelaBorderSecondary` 1px border, `CornerRadius:6`, `Padding:4`
-- Item: `VelaTerminalFont` 11px, `VelaTextSecondary`, `Padding:[10,5]`, `CornerRadius:4`
+- Item: `VelaUiMonoFont` 11px, `VelaTextSecondary`, `Padding:[10,5]`, `CornerRadius:4`
 - Selected/hover: `VelaBgHover` background, `VelaTextPrimary` foreground
 - Disabled: `VelaTextMuted` foreground, 0.6 opacity
 - Separator: `VelaBorderPrimary` 1px, `Margin:[6,4]`
@@ -370,7 +377,7 @@ A standalone dock document hosting a side-by-side local + remote file browser fo
 
 #### Header (36px, `VelaBgSidebar`)
 
-- **Left pane header**: `hard-drive` icon (14px, `VelaTextTertiary`) + root selector + full current path (`VelaTerminalFont` 11px Medium `VelaTextPrimary`) + Go Up and local refresh buttons
+- **Left pane header**: `hard-drive` icon (14px, `VelaTextTertiary`) + root selector + full current path (`VelaUiMonoFont` 11px Medium `VelaTextPrimary`) + Go Up and local refresh buttons
 - **Right pane header**: Reuses existing `FileBrowserView` header exactly (session badge + `folder-open` accent + remote breadcrumb + upload pill + toolbar)
 - **Shared header** (top bar): Session identity (if applicable) and distinct local/remote refresh actions with accessible names
 
@@ -491,7 +498,7 @@ All tokens used in the SFTP dual-pane document. Source files: `VelaTokens.axaml`
 
 **File-specific**: `VelaFileFolderIcon`, `VelaFileDirName`
 
-**Fonts**: `VelaTerminalFont`, `VelaUiFont`
+**Fonts**: `VelaUiMonoFont`, `VelaUiFont`
 
 ---
 

--- a/src/VelaShell.Controls/Themes/VelaTokens.axaml
+++ b/src/VelaShell.Controls/Themes/VelaTokens.axaml
@@ -1,5 +1,41 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="using:System">
+
+  <!-- ============================ 字体令牌(与主题无关) ============================
+       界面上的每一处文字都归【设置 → 外观 → 界面字体】管,只是分成两支,别再往 axaml
+       里写死字体名:
+         VelaUiFont      普通界面文字。默认 Inter(比例字体)。
+         VelaUiMonoFont  界面里【按列对齐】的部分(文件列表的大小/时间列、端口、路径、
+                         徽标数字等)。默认与终端同款 Cascadia Mono,故默认外观与从前一致;
+                         但它同样跟随【界面字体】—— 它属于"界面",不属于终端。
+       两者都由 MainWindow.ApplyWindowAppearance 在运行时覆盖。
+       终端画面自身的字体不走令牌:VelaTerminalControl 直接吃【设置 → 终端 → 字体】。 -->
+  <FontFamily x:Key="VelaUiFont">fonts:Inter#Inter, Segoe UI, Microsoft YaHei, sans-serif</FontFamily>
+  <!-- 内置 Cascadia Mono 打头(三平台一致、无连字、含制表/框线字形);CJK 走系统回退。 -->
+  <FontFamily x:Key="VelaUiMonoFont">fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace</FontFamily>
+
+  <!-- ===================== 界面字号阶梯(设置 → 外观 → 界面字号) =====================
+       令牌名里的数字 = 基准字号(13)下的磅值,所以默认状态与从前逐像素一致。
+       用户改基准字号后,整套阶梯按 基准/13 等比缩放并四舍五入(见
+       MainWindow.ApplyWindowAppearance),界面的层级关系不会走形。
+       界面 axaml 里【不要】再写 FontSize="11" 这类字面量 —— 写死的字号不跟随设置,
+       正是"界面字号设了没反应"的老毛病。终端画面自身的字号不在此列(走终端设置)。 -->
+  <sys:Double x:Key="VelaUiFontSize">13</sys:Double>
+  <sys:Double x:Key="VelaFontSize8">8</sys:Double>
+  <sys:Double x:Key="VelaFontSize9">9</sys:Double>
+  <sys:Double x:Key="VelaFontSize10">10</sys:Double>
+  <sys:Double x:Key="VelaFontSize11">11</sys:Double>
+  <sys:Double x:Key="VelaFontSize12">12</sys:Double>
+  <sys:Double x:Key="VelaFontSize13">13</sys:Double>
+  <sys:Double x:Key="VelaFontSize14">14</sys:Double>
+  <sys:Double x:Key="VelaFontSize15">15</sys:Double>
+  <sys:Double x:Key="VelaFontSize16">16</sys:Double>
+  <sys:Double x:Key="VelaFontSize18">18</sys:Double>
+  <sys:Double x:Key="VelaFontSize20">20</sys:Double>
+  <!-- 设置页说明文字:固定为界面字号的 85%(默认 13 → 11)。 -->
+  <sys:Double x:Key="VelaFontSizeDesc">11</sys:Double>
+
   <ResourceDictionary.ThemeDictionaries>
     <!-- Dracula 暗色:accent=紫 #BD93F9,弱文字取官方 comment #6272A4,
          边框用 #44475A(selection)家族。 -->
@@ -37,10 +73,6 @@
       <SolidColorBrush x:Key="VelaTraceBorder" Color="#5C6488" />
       <!-- 标注底片:压在陆地上也要读得清,故用半透明深色垫底。 -->
       <SolidColorBrush x:Key="VelaTraceLabelBg" Color="#D2151A28" />
-      <!-- 终端字体:内置 Cascadia Mono 打头(三平台一致、无连字、含制表/框线字形),
-           系统装了 JetBrains Mono 的用户仍可在设置里切回;CJK 走系统回退。 -->
-      <FontFamily x:Key="VelaTerminalFont">fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace</FontFamily>
-      <FontFamily x:Key="VelaUiFont">fonts:Inter#Inter, Segoe UI, Microsoft YaHei, sans-serif</FontFamily>
     </ResourceDictionary>
     <!-- Alucard 亮色:accent=紫 #644AC9,弱文字取 Alucard comment #6C664B。 -->
     <ResourceDictionary x:Key="Light">
@@ -72,10 +104,6 @@
       <SolidColorBrush x:Key="VelaTraceLand" Color="#EFE9D2" />
       <SolidColorBrush x:Key="VelaTraceBorder" Color="#BDB392" />
       <SolidColorBrush x:Key="VelaTraceLabelBg" Color="#E6FFFBEB" />
-      <!-- 终端字体:内置 Cascadia Mono 打头(三平台一致、无连字、含制表/框线字形),
-           系统装了 JetBrains Mono 的用户仍可在设置里切回;CJK 走系统回退。 -->
-      <FontFamily x:Key="VelaTerminalFont">fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace</FontFamily>
-      <FontFamily x:Key="VelaUiFont">fonts:Inter#Inter, Segoe UI, Microsoft YaHei, sans-serif</FontFamily>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/VelaShell/App.axaml
+++ b/src/VelaShell/App.axaml
@@ -1,6 +1,5 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:sys="using:System"
              x:Class="VelaShell.App"
              RequestedThemeVariant="Dark">
 
@@ -29,8 +28,8 @@
                 <ResourceInclude Source="avares://VelaShell/Themes/ButtonThemes.axaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- 界面字号默认值(设计 font-ui 13);运行时被 ApplyWindowAppearance 覆盖。 -->
-            <sys:Double x:Key="VelaUiFontSize">13</sys:Double>
+            <!-- 界面字体/字号令牌(含整套字号阶梯)在 VelaTokens.axaml 里定义,
+                 运行时由 MainWindow.ApplyWindowAppearance 覆盖。 -->
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
                     <ResourceDictionary.MergedDictionaries>

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml
@@ -119,8 +119,8 @@
                    Text="{loc:Localize Dock_DropTabHere}"
                    HorizontalAlignment="Center"
                    VerticalAlignment="Center"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="11"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize11}"
                    Foreground="{DynamicResource VelaTextMuted}"
                    IsVisible="False" />
         <controls:ReparentingHost x:Name="ContentHost">

--- a/src/VelaShell/Docking/Controls/DockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/DockTabItem.axaml
@@ -10,7 +10,7 @@
              xmlns:loc="using:VelaShell.Localization"
              x:Class="VelaShell.Docking.Controls.DockTabItem"
              x:DataType="docking:TerminalDocument"
-             FontSize="11"
+             FontSize="{DynamicResource VelaFontSize11}"
              VerticalAlignment="Stretch">
 
   <!-- 单个终端标签(设计 nunbT):32px 高、padding [0,14],状态点 7px + 连接标识色条
@@ -19,7 +19,7 @@
   <UserControl.Styles>
     <Style Selector="local|DockTabItem">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="Transitions">
         <Transitions>
           <BrushTransition Property="Foreground" Duration="0:0:0.12" Easing="CubicEaseOut" />

--- a/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
@@ -7,12 +7,12 @@
              xmlns:loc="using:VelaShell.Localization"
              x:Class="VelaShell.Docking.Controls.SftpDockTabItem"
              x:DataType="docking:SftpDocument"
-             FontSize="11"
+             FontSize="{DynamicResource VelaFontSize11}"
              VerticalAlignment="Stretch">
   <UserControl.Styles>
     <Style Selector="local|SftpDockTabItem">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="Transitions">
         <Transitions>
           <BrushTransition Property="Foreground" Duration="0:0:0.12" Easing="CubicEaseOut" />

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -41,7 +41,7 @@
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="8,4" />
         <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
 
     <!-- 右键菜单(设计稿会话右键菜单样式):所有右键菜单统一外观 ——
@@ -57,8 +57,8 @@
 
     <Style Selector="ContextMenu MenuItem">
         <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-        <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
         <Setter Property="Padding" Value="10,5" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
@@ -136,8 +136,8 @@
     </Style>
     <Style Selector="MenuFlyoutPresenter MenuItem">
         <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-        <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
         <Setter Property="Padding" Value="10,5" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml
@@ -20,7 +20,7 @@
   <Window.Styles>
     <Style Selector="TextBlock.field-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
       <Setter Property="Margin" Value="0,0,0,5" />
     </Style>
@@ -30,8 +30,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="34" />
-      <Setter Property="FontSize" Value="12" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="Button.dlg-outline">
@@ -43,7 +43,7 @@
       <Setter Property="Padding" Value="16,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-primary">
@@ -53,7 +53,7 @@
       <Setter Property="Padding" Value="20,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <!-- 认证方式分段选择 -->
@@ -64,7 +64,7 @@
       <Setter Property="Height" Value="28" />
       <Setter Property="HorizontalAlignment" Value="Stretch" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="Cursor" Value="Hand" />
     </Style>
     <Style Selector="Button.seg-tab.active">
@@ -95,7 +95,7 @@
                     VerticalAlignment="Center" />
           <TextBlock Grid.Column="2" Text="{Binding HeaderTitle}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="14" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize14}" FontWeight="SemiBold"
                      VerticalAlignment="Center" />
           <Button Grid.Column="3" Width="24" Height="24"
                   Background="Transparent" Padding="0" CornerRadius="3"
@@ -116,18 +116,18 @@
           <StackPanel Grid.Column="2" Spacing="2" VerticalAlignment="Center">
             <TextBlock Text="{Binding TargetText}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11" FontWeight="Medium" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
             <TextBlock Text="{Binding FingerprintText}"
                        IsVisible="{Binding IsStep1}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="10" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}" />
             <TextBlock Text="{Binding UsernameLine}"
                        IsVisible="{Binding IsStep2}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="10" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}" />
           </StackPanel>
         </Grid>
       </Border>
@@ -142,7 +142,7 @@
                   Background="{DynamicResource VelaAccent}">
             <Panel>
               <TextBlock Text="1" IsVisible="{Binding IsStep1}"
-                         Foreground="{DynamicResource VelaAccentForeground}" FontSize="10" FontWeight="SemiBold"
+                         Foreground="{DynamicResource VelaAccentForeground}" FontSize="{DynamicResource VelaFontSize10}" FontWeight="SemiBold"
                          HorizontalAlignment="Center" VerticalAlignment="Center" />
               <PathIcon Width="10" Height="10" IsVisible="{Binding IsStep2}"
                         Data="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
@@ -167,7 +167,7 @@
             <Panel>
               <Border CornerRadius="10" Background="{DynamicResource VelaAccent}"
                       IsVisible="{Binding IsStep2}" Margin="-1" />
-              <TextBlock Text="2" FontSize="10" FontWeight="SemiBold"
+              <TextBlock Text="2" FontSize="{DynamicResource VelaFontSize10}" FontWeight="SemiBold"
                          HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock.Styles>
                   <Style Selector="TextBlock">
@@ -184,10 +184,10 @@
             </Panel>
           </Border>
           <TextBlock Text="{loc:Localize Auth_EnterUsername}" IsVisible="{Binding IsStep1}"
-                     Foreground="{DynamicResource VelaTextMuted}" FontSize="11"
+                     Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}"
                      VerticalAlignment="Center" />
           <TextBlock Text="{loc:Localize Auth_SelectMethod}" IsVisible="{Binding IsStep2}"
-                     Foreground="{DynamicResource VelaTextMuted}" FontSize="11"
+                     Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}"
                      VerticalAlignment="Center" />
         </StackPanel>
 
@@ -261,7 +261,7 @@
                   <TextBlock Text="{loc:Localize Profile_RememberPassword}"
                              Margin="6,0,0,0"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontSize="11" />
+                             FontSize="{DynamicResource VelaFontSize11}" />
                 </CheckBox>
               </StackPanel>
               <Border Grid.Column="1" Background="{DynamicResource VelaAccentDim}"
@@ -272,8 +272,8 @@
                             Foreground="{DynamicResource VelaAccent}" />
                   <TextBlock Text="{loc:Localize Auth_AesBadge}"
                              Foreground="{DynamicResource VelaAccent}"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="9" FontWeight="Medium"
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium"
                              VerticalAlignment="Center" />
                 </StackPanel>
               </Border>

--- a/src/VelaShell/Views/CommandPaletteView.axaml
+++ b/src/VelaShell/Views/CommandPaletteView.axaml
@@ -21,7 +21,7 @@
     </Style>
     <Style Selector="TextBlock.cat">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="FontWeight" Value="Medium" />
       <Setter Property="Margin" Value="16,6,0,2" />
     </Style>
@@ -38,7 +38,7 @@
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
     <Style Selector="Border.kbd > TextBlock">
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
       <Setter Property="HorizontalAlignment" Value="Center" />
       <Setter Property="VerticalAlignment" Value="Center" />
@@ -91,12 +91,12 @@
                    Background="Transparent"
                    Foreground="{DynamicResource VelaTextPrimary}"
                    CaretBrush="{DynamicResource VelaAccent}"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="14"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize14}"
                    VerticalContentAlignment="Center"
                    PlaceholderText="{loc:Localize Palette_SearchPlaceholder}" />
           <Border Grid.Column="2" Classes="kbd">
-            <TextBlock Text="Ctrl+K" FontFamily="{DynamicResource VelaTerminalFont}" />
+            <TextBlock Text="Ctrl+K" FontFamily="{DynamicResource VelaUiMonoFont}" />
           </Border>
         </Grid>
       </Border>
@@ -116,27 +116,27 @@
               <Border Classes="kbd">
                 <TextBlock Text="↑↓" />
               </Border>
-              <TextBlock Text="{loc:Localize Palette_Navigate}" FontSize="10" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
+              <TextBlock Text="{loc:Localize Palette_Navigate}" FontSize="{DynamicResource VelaFontSize10}" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="4">
               <Border Classes="kbd">
                 <TextBlock Text="↵" />
               </Border>
-              <TextBlock Text="{loc:Localize Palette_Confirm}" FontSize="10" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
+              <TextBlock Text="{loc:Localize Palette_Confirm}" FontSize="{DynamicResource VelaFontSize10}" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="4">
               <Border Classes="kbd">
                 <TextBlock Text="Esc" />
               </Border>
-              <TextBlock Text="{loc:Localize Palette_Close}" FontSize="10" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
+              <TextBlock Text="{loc:Localize Palette_Close}" FontSize="{DynamicResource VelaFontSize10}" Foreground="{DynamicResource VelaTextMuted}" VerticalAlignment="Center" />
             </StackPanel>
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="3">
             <TextBlock Text="{Binding ResultCount}"
-                       FontSize="10"
+                       FontSize="{DynamicResource VelaFontSize10}"
                        Foreground="{DynamicResource VelaTextMuted}" />
             <TextBlock Text="{loc:Localize Palette_ResultsSuffix}"
-                       FontSize="10"
+                       FontSize="{DynamicResource VelaFontSize10}"
                        Foreground="{DynamicResource VelaTextMuted}" />
           </StackPanel>
         </Grid>
@@ -165,23 +165,23 @@
                                      Fill="{DynamicResource VelaStatusConnected}" />
                             <TextBlock Text="{Binding Title}"
                                        Foreground="{DynamicResource VelaTextPrimary}"
-                                       FontFamily="{DynamicResource VelaTerminalFont}"
-                                       FontSize="12"
+                                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                                       FontSize="{DynamicResource VelaFontSize12}"
                                        VerticalAlignment="Center" />
                             <Border IsVisible="{Binding Tag, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                     Background="{DynamicResource VelaAccentDim}"
                                     CornerRadius="2" Padding="6,1" VerticalAlignment="Center">
                               <TextBlock Text="{Binding Tag}"
                                          Foreground="{DynamicResource VelaAccent}"
-                                         FontFamily="{DynamicResource VelaTerminalFont}"
-                                         FontSize="9" />
+                                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                                         FontSize="{DynamicResource VelaFontSize9}" />
                             </Border>
                           </StackPanel>
                           <TextBlock Grid.Column="1"
                                      Text="{Binding Hint}"
                                      Foreground="{DynamicResource VelaTextMuted}"
-                                     FontFamily="{DynamicResource VelaTerminalFont}"
-                                     FontSize="10"
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize10}"
                                      VerticalAlignment="Center" />
                         </Grid>
                       </Border>

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml
@@ -29,7 +29,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-primary">
@@ -39,13 +39,13 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <!-- 步骤行状态配色 -->
     <Style Selector="TextBlock.step-status">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
   </Window.Styles>
 
@@ -71,12 +71,12 @@
                              Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
               <TextBlock Text="{loc:Localize Diag_Header}"
                          Foreground="{DynamicResource VelaTextPrimary}"
-                         FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center" />
+                         FontSize="{DynamicResource VelaFontSize15}" FontWeight="SemiBold" VerticalAlignment="Center" />
             </StackPanel>
             <TextBlock Text="{Binding TargetSummary}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="10" TextTrimming="CharacterEllipsis" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}" TextTrimming="CharacterEllipsis" />
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
             <Button Classes="dlg-outline" Click="ExportReport_Click"
@@ -121,7 +121,7 @@
                     BorderBrush="{DynamicResource VelaBorderPrimary}">
               <TextBlock Text="{loc:Localize Diag_Steps}"
                          Foreground="{DynamicResource VelaTextSecondary}"
-                         FontSize="12" FontWeight="Medium" VerticalAlignment="Center" />
+                         FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center" />
             </Border>
             <ItemsControl ItemsSource="{Binding Steps}" Margin="12,10">
               <ItemsControl.ItemTemplate>
@@ -162,8 +162,8 @@
                     <TextBlock Text="{Binding Detail}"
                                IsVisible="{Binding HasDetail}"
                                Foreground="{DynamicResource VelaTextMuted}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="10" TextWrapping="Wrap"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize10}" TextWrapping="Wrap"
                                Margin="14,0,0,0" />
                   </StackPanel>
                 </DataTemplate>
@@ -184,7 +184,7 @@
             <TextBlock Text="{loc:Localize Diag_Running}"
                        IsVisible="{Binding IsBusy}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" />
 
             <!-- 未发现问题 -->
             <Border Background="{DynamicResource VelaBgSurface}"
@@ -196,7 +196,7 @@
                                Foreground="{DynamicResource VelaStatusConnected}" VerticalAlignment="Center" />
                 <TextBlock Text="{loc:Localize Diag_AllPassed}"
                            Foreground="{DynamicResource VelaStatusConnected}"
-                           FontSize="12" FontWeight="Medium" VerticalAlignment="Center" />
+                           FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center" />
               </StackPanel>
             </Border>
 
@@ -210,13 +210,13 @@
                                  Data="{StaticResource Icon.triangle-alert}"
                                  Foreground="{DynamicResource VelaWarning}" VerticalAlignment="Center" />
                   <TextBlock Foreground="{DynamicResource VelaWarning}"
-                             FontSize="12" FontWeight="SemiBold" VerticalAlignment="Center">
+                             FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" VerticalAlignment="Center">
                     <Run Text="{loc:Localize Diag_IssueFound}" /><Run Text="{Binding IssueTitle}" />
                   </TextBlock>
                 </StackPanel>
                 <TextBlock Text="{Binding IssueDescription}"
                            Foreground="{DynamicResource VelaTextSecondary}"
-                           FontSize="11" TextWrapping="Wrap" />
+                           FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" />
               </StackPanel>
             </Border>
 
@@ -232,7 +232,7 @@
                                    VerticalAlignment="Top" Margin="0,2,0,0" />
                     <TextBlock Text="{Binding}"
                                Foreground="{DynamicResource VelaTextPrimary}"
-                               FontSize="11" TextWrapping="Wrap"
+                               FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap"
                                MaxWidth="330" />
                   </StackPanel>
                 </DataTemplate>

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -24,7 +24,7 @@
     <!-- 表单标签 -->
     <Style Selector="TextBlock.field-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
       <Setter Property="Margin" Value="0,0,0,5" />
     </Style>
@@ -34,8 +34,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="32" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="ComboBox">
@@ -44,7 +44,7 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="32" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="HorizontalAlignment" Value="Stretch" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
@@ -54,8 +54,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="32" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
     </Style>
     <!-- 底部按钮:描边(测试/保存)与主色(连接) -->
     <Style Selector="Button.dlg-outline">
@@ -67,7 +67,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-primary">
@@ -77,7 +77,7 @@
       <Setter Property="Padding" Value="16,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <!-- 协议标签页 -->
@@ -87,8 +87,8 @@
       <Setter Property="VerticalAlignment" Value="Bottom" />
     </Style>
     <Style Selector="TextBlock.proto-label">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
     <Style Selector="Button.proto-tab">
@@ -159,7 +159,7 @@
                     VerticalAlignment="Center" />
           <TextBlock Grid.Column="2" Text="{loc:Localize Profile_Title}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="14" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize14}" FontWeight="SemiBold"
                      VerticalAlignment="Center" />
           <Button Grid.Column="3" Width="24" Height="24"
                   Background="Transparent" Padding="0" CornerRadius="3"
@@ -298,12 +298,12 @@
             <TextBlock Text="{loc:Localize Profile_RememberPassword}"
                        Margin="6,0,0,0"
                        Foreground="{DynamicResource VelaTextSecondary}"
-                       FontSize="11" FontWeight="Medium" />
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
           </CheckBox>
           <TextBlock Text="{loc:Localize Profile_AesNote}"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10"
+                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}"
                      VerticalAlignment="Center" />
         </StackPanel>
 
@@ -333,16 +333,16 @@
                     ItemsSource="{Binding JumpHostOptions}"
                     SelectedItem="{Binding SelectedJumpHost}" />
           <TextBlock Text="{loc:Localize Profile_JumpHostHint}"
-                     Foreground="{DynamicResource VelaTextMuted}" FontSize="10" TextWrapping="Wrap" />
+                     Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize10}" TextWrapping="Wrap" />
         </StackPanel>
 
         <!-- 测试/保存反馈 -->
         <TextBlock Text="{Binding ErrorMessage}"
                    IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                   Foreground="#FF6B6B" FontSize="11" TextWrapping="Wrap" />
+                   Foreground="#FF6B6B" FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" />
         <TextBlock Text="{loc:Localize Profile_TestSuccess}"
                    IsVisible="{Binding ShowTestSuccess}"
-                   Foreground="{DynamicResource VelaAccent}" FontSize="11" />
+                   Foreground="{DynamicResource VelaAccent}" FontSize="{DynamicResource VelaFontSize11}" />
       </StackPanel>
 
       <!-- Footer -->
@@ -360,7 +360,7 @@
                         Foreground="{DynamicResource VelaTextTertiary}" />
               <TextBlock Text="{loc:Localize Profile_AdvancedOptions}"
                          Foreground="{DynamicResource VelaTextTertiary}"
-                         FontSize="11" VerticalAlignment="Center" />
+                         FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
             </StackPanel>
           </Button>
 

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -67,8 +67,8 @@
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.crumb:pointerover /template/ ContentPresenter">
@@ -107,14 +107,14 @@
                     IsVisible="{Binding ServerDisplayName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             <TextBlock Text="{Binding ServerDisplayName}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11" FontWeight="SemiBold"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold"
                        VerticalAlignment="Center"
                        IsVisible="{Binding ServerDisplayName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             <TextBlock Text="·"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11" VerticalAlignment="Center"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center"
                        IsVisible="{Binding ServerDisplayName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             <pc:LucideIcon Width="14" Height="14"
                            Data="{StaticResource Icon.folder-open}"
@@ -138,8 +138,8 @@
                               CommandParameter="{Binding Path}" />
                       <TextBlock Text="/"
                                  Foreground="{DynamicResource VelaTextMuted}"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
-                                 FontSize="11" VerticalAlignment="Center" />
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
                     </StackPanel>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -164,8 +164,8 @@
                                Foreground="{DynamicResource VelaAccent}" />
                 <TextBlock Text="{x:Static res:Strings.Upload}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="10" FontWeight="Medium"
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
                            VerticalAlignment="Center" />
               </StackPanel>
             </Button>
@@ -241,7 +241,7 @@
               Padding="8,4">
         <TextBlock Text="{Binding ErrorMessage}"
                    Foreground="{DynamicResource VelaAccent}"
-                   FontSize="11" />
+                   FontSize="{DynamicResource VelaFontSize11}" />
       </Border>
 
       <Grid RowDefinitions="26,*">
@@ -290,10 +290,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize FileName}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding NameSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="1"
@@ -308,10 +308,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize Size}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding SizeSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="3"
@@ -327,10 +327,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize Permissions}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding PermissionsSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="5"
@@ -346,10 +346,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize PermissionOwner}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding OwnerSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="7"
@@ -365,10 +365,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize PermissionGroup}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding GroupSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="9"
@@ -384,10 +384,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize FileType}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding TypeSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
             <Border Grid.Column="11"
@@ -403,10 +403,10 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                 <TextBlock Text="{loc:Localize Modified}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" LetterSpacing="1" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" />
                 <TextBlock Text="{Binding ModifiedSortGlyph}"
                            Foreground="{DynamicResource VelaAccent}"
-                           FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}" />
               </StackPanel>
             </Button>
           </Grid>
@@ -666,8 +666,8 @@
                       <TextBlock Classes="dnd-surface" Grid.Column="1"
                                  Text="{Binding DisplayName}"
                                  Foreground="{DynamicResource VelaTextSecondary}"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
-                                 FontSize="11"
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize11}"
                                  VerticalAlignment="Center"
                                  HorizontalAlignment="Left"
                                  TextTrimming="CharacterEllipsis"
@@ -684,24 +684,24 @@
                                Text="{Binding FormattedSize}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowSizeColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left" />
                     <TextBlock Classes="dnd-surface" Grid.Column="4"
                                Text="{Binding Permissions}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowPermissionsColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left" />
                     <TextBlock Classes="dnd-surface" Grid.Column="6"
                                Text="{Binding Owner}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowOwnerColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
@@ -709,8 +709,8 @@
                                Text="{Binding Group}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowGroupColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
@@ -718,8 +718,8 @@
                                Text="{Binding FileTypeDisplay}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowTypeColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
@@ -727,8 +727,8 @@
                                Text="{Binding FormattedModifiedTime}"
                                IsVisible="{Binding $parent[ListBox].((vm:FileBrowserViewModel)DataContext).ShowModifiedColumn}"
                                Foreground="{DynamicResource VelaTextTertiary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left"
                                TextTrimming="CharacterEllipsis" />
@@ -764,7 +764,7 @@
                Foreground="{DynamicResource VelaTextSecondary}"
                HorizontalAlignment="Center"
                TextAlignment="Center"
-               FontSize="13" />
+               FontSize="{DynamicResource VelaFontSize13}" />
           <ProgressBar IsVisible="{Binding IsDeleteProgressVisible}"
                  IsIndeterminate="{Binding IsDeleteProgressIndeterminate}"
                  Minimum="0"

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -43,11 +43,12 @@ public partial class FileBrowserView : UserControl
     /// <summary>表头/行的左右内边距合计(axaml 里 Padding="14,0")。</summary>
     private const double HorizontalPadding = 28;
 
-    // 必须与 axaml 里渲染用的 VelaTerminalFont 令牌(内置 Cascadia Mono 打头)一致:
-    // 列宽是用这个字体度量的,若度量字体与实际渲染字体不同(旧值以 JetBrains Mono 打头,
-    // 且不含内置 Cascadia),字形步进不一致会导致列自适应/截断错位。
-    private static readonly FontFamily TerminalFont = new("fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace");
-    private static readonly Typeface TerminalTypeface = new(TerminalFont);
+    // 列宽靠度量文字算出来,度量字体必须与实际渲染字体一致 —— 不一致(旧值以 JetBrains Mono
+    // 打头、且不含内置 Cascadia)字形步进就对不上,列自适应/截断会错位。渲染用的是
+    // VelaUiMonoFont 令牌(跟随设置 → 外观 → 界面字体),故运行时现取(见 ResolveMonoTypeface);
+    // 这里只留取不到令牌时的兜底。
+    private static readonly FontFamily DefaultMonoFont = new("fonts:VelaShell#Cascadia Mono, JetBrains Mono, Consolas, monospace");
+    private static readonly Typeface DefaultMonoTypeface = new(DefaultMonoFont);
     private string? _activeSplitter;
     private double _dragStartX;
 
@@ -212,7 +213,7 @@ public partial class FileBrowserView : UserControl
     /// 双击拖拽条的自适应宽度:取表头与所有行里最宽的那条文本。“文件名”列还要
     /// 额外让出前导图标区(14px 图标 + 6px 间距)。上限防止一个超长名字把列撑爆。
     /// </summary>
-    private static double EstimateAutoWidth(FileBrowserViewModel vm, string columnKey)
+    private double EstimateAutoWidth(FileBrowserViewModel vm, string columnKey)
     {
         (
             string Header,
@@ -228,9 +229,12 @@ public partial class FileBrowserView : UserControl
             "type" => (Strings.FileType, f => f.FileTypeDisplay, 8d, 300d),
             _ => (Strings.FileName, f => f.DisplayName, 34d, 760d),
         };
-        double headerWidth = MeasureTextWidth(spec.Header, 10);
+        // 度量必须用【当前生效的】字体与字号:两者都跟随设置 → 外观 → 界面字体/字号,
+        // 写死就会在用户改过设置后把列算窄一截(文字被截断)。
+        Typeface typeface = ResolveMonoTypeface();
+        double headerWidth = MeasureTextWidth(spec.Header, ResolveFontSize("VelaFontSize10", 10), typeface);
         double rowsWidth = vm.Files.Any()
-            ? vm.Files.Max(f => MeasureTextWidth(spec.Cell(f), 11))
+            ? vm.Files.Max(f => MeasureTextWidth(spec.Cell(f), ResolveFontSize("VelaFontSize11", 11), typeface))
             : 0;
         return Math.Clamp(
             Math.Max(headerWidth, rowsWidth) + spec.Padding,
@@ -257,13 +261,23 @@ public partial class FileBrowserView : UserControl
         );
     }
 
-    private static double MeasureTextWidth(string text, double fontSize)
+    /// <summary>列表实际渲染用的等宽字体(VelaUiMonoFont 令牌);取不到时退回内置默认。</summary>
+    private Typeface ResolveMonoTypeface() =>
+        this.TryFindResource("VelaUiMonoFont", out object? value) && value is FontFamily family
+            ? new Typeface(family)
+            : DefaultMonoTypeface;
+
+    /// <summary>取字号令牌的当前值;取不到时退回默认基准下的磅值。</summary>
+    private double ResolveFontSize(string key, double fallback) =>
+        this.TryFindResource(key, out object? value) && value is double size ? size : fallback;
+
+    private static double MeasureTextWidth(string text, double fontSize, Typeface typeface)
     {
         var ft = new FormattedText(
             text,
             CultureInfo.CurrentCulture,
             FlowDirection.LeftToRight,
-            TerminalTypeface,
+            typeface,
             fontSize,
             Brushes.White
         );

--- a/src/VelaShell/Views/FileTransferView.axaml
+++ b/src/VelaShell/Views/FileTransferView.axaml
@@ -45,8 +45,8 @@
                            Foreground="{DynamicResource VelaAccent}" />
             <TextBlock Text="{loc:Localize Transfer_Title}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11" FontWeight="Medium"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium"
                        VerticalAlignment="Center" />
             <Border Background="{DynamicResource VelaAccent}"
                     CornerRadius="8" Padding="6,1"
@@ -54,8 +54,8 @@
                     IsVisible="{Binding PendingCount}">
               <TextBlock Text="{Binding PendingCount}"
                          Foreground="{DynamicResource VelaAccentText}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="9" FontWeight="Medium" />
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
             </Border>
           </StackPanel>
           <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
@@ -66,8 +66,8 @@
                     ToolTip.Tip="{loc:Localize Transfer_CancelRemainingTip}">
               <TextBlock Text="{loc:Localize Cancel}"
                          Foreground="{DynamicResource VelaError}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="10" FontWeight="Medium" />
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
             </Button>
             <!-- 清除已完成/已取消的历史行(进行中与失败行保留:失败行还带着"重试"入口)。 -->
             <Button Background="Transparent" Padding="4,1" Cursor="Hand"
@@ -75,8 +75,8 @@
                     ToolTip.Tip="{loc:Localize Transfer_ClearCompleted}">
               <TextBlock Text="{loc:Localize Transfer_ClearCompleted}"
                          Foreground="{DynamicResource VelaTextTertiary}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="10" />
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize10}" />
             </Button>
             <Button Background="Transparent" Padding="2" Cursor="Hand"
                     Command="{Binding HidePanelCommand}"
@@ -96,8 +96,8 @@
               IsVisible="{Binding IsPreparing}">
         <TextBlock Text="{Binding PreparingText}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="10" />
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize10}" />
       </Border>
 
       <!-- 传输行:限制面板高度(约 5 行)并对溢出内容滚动。
@@ -122,8 +122,8 @@
                     <TextBlock Grid.Column="0"
                                Text="{Binding FileName}"
                                Foreground="{DynamicResource VelaTextPrimary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="10" FontWeight="Medium"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
                                TextTrimming="CharacterEllipsis" />
                     <!-- 失败且原会话仍在时可重试:重新探测续传起点后单文件重跑(断点续传收尾)。 -->
                     <Button Grid.Column="1" Background="Transparent" Padding="4,0" Margin="0,0,6,0" Cursor="Hand"
@@ -133,13 +133,13 @@
                             ToolTip.Tip="{loc:Localize Transfer_Retry}">
                       <TextBlock Text="{loc:Localize Transfer_Retry}"
                                  Foreground="{DynamicResource VelaAccent}"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
-                                 FontSize="10" FontWeight="Medium" />
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
                     </Button>
                     <TextBlock Grid.Column="2"
                                Text="{Binding ProgressText}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="10" FontWeight="Medium"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
                                Classes.done="{Binding IsCompleted}"
                                Classes.failed="{Binding IsFailed}">
                       <TextBlock.Styles>
@@ -167,8 +167,8 @@
                   <!-- 明细行 -->
                   <TextBlock Text="{Binding InfoLine}"
                              Foreground="{DynamicResource VelaTextMuted}"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="9" />
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize9}" />
                 </StackPanel>
               </Border>
             </DataTemplate>

--- a/src/VelaShell/Views/HostKeyPromptView.axaml
+++ b/src/VelaShell/Views/HostKeyPromptView.axaml
@@ -24,18 +24,18 @@
 
   <Window.Styles>
     <Style Selector="TextBlock.mono">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaAccentText}" />
     </Style>
     <Style Selector="TextBlock.info-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
       <Setter Property="Margin" Value="0,0,12,0" />
     </Style>
     <Style Selector="TextBlock.info-value">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
     </Style>
     <Style Selector="Button.trust">
       <Setter Property="Background" Value="{DynamicResource VelaAccent}" />
@@ -44,7 +44,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.reject">
@@ -56,7 +56,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="Button.trust-once">
       <Setter Property="Background" Value="Transparent" />
@@ -67,7 +67,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
   </Window.Styles>
 
@@ -94,7 +94,7 @@
           <TextBlock Grid.Column="1"
                      Text="{x:Static res:Strings.HostKeyVerification}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="13" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold"
                      VerticalAlignment="Center" />
           <Button Grid.Column="2" Width="24" Height="24"
                   Background="Transparent" Padding="0" CornerRadius="3"
@@ -121,7 +121,7 @@
                            Foreground="{DynamicResource VelaWarning}" />
             <TextBlock Text="{Binding WarningText}"
                        Foreground="{DynamicResource VelaWarning}"
-                       FontSize="12"
+                       FontSize="{DynamicResource VelaFontSize12}"
                        FontWeight="SemiBold"
                        TextWrapping="Wrap"
                        MaxWidth="360"
@@ -129,7 +129,7 @@
                        IsVisible="{Binding !IsChanged}" />
             <TextBlock Text="{Binding WarningText}"
                        Foreground="{DynamicResource VelaError}"
-                       FontSize="12"
+                       FontSize="{DynamicResource VelaFontSize12}"
                        FontWeight="SemiBold"
                        TextWrapping="Wrap"
                        MaxWidth="360"

--- a/src/VelaShell/Views/LocalFilePaneView.axaml
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml
@@ -44,8 +44,8 @@
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.crumb:pointerover /template/ ContentPresenter">
@@ -84,8 +84,8 @@
                                 CommandParameter="{Binding Path}" />
                 <TextBlock Text="{Binding $parent[ItemsControl].((vm:LocalFilePaneViewModel)DataContext).PathSeparator}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" VerticalAlignment="Center" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
                       </StackPanel>
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
@@ -98,14 +98,14 @@
                          IsVisible="{Binding IsDirectoryLoading}" />
           </Grid>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="11"
+            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize11}"
                       ItemsSource="{Binding Roots}" SelectedItem="{Binding SelectedRoot, Mode=OneWay}"
                       SelectionChanged="OnRootSelectionChanged"
                       VerticalContentAlignment="Center" MaxDropDownHeight="320">
               <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="vm:LocalRootEntry">
                   <TextBlock Text="{Binding DisplayName}" ToolTip.Tip="{Binding Tooltip}"
-                             TextTrimming="CharacterEllipsis" FontSize="11" Padding="2,1" />
+                             TextTrimming="CharacterEllipsis" FontSize="{DynamicResource VelaFontSize11}" Padding="2,1" />
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
@@ -131,20 +131,20 @@
               Background="{DynamicResource VelaBgContentHeader}"
               BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
         <Grid ColumnDefinitions="*,90,130">
-          <TextBlock Text="{x:Static res:Strings.FileName}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Text="{x:Static res:Strings.FileName}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
-          <TextBlock Grid.Column="1" Text="{x:Static res:Strings.Size}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Grid.Column="1" Text="{x:Static res:Strings.Size}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
-          <TextBlock Grid.Column="2" Text="{x:Static res:Strings.Modified}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Grid.Column="2" Text="{x:Static res:Strings.Modified}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
         </Grid>
       </Border>
       <Border DockPanel.Dock="Top" IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
               Background="{DynamicResource VelaBgActive}" Padding="8,4">
-        <TextBlock Text="{Binding ErrorMessage}" Foreground="{DynamicResource VelaAccent}" FontSize="11" />
+        <TextBlock Text="{Binding ErrorMessage}" Foreground="{DynamicResource VelaAccent}" FontSize="{DynamicResource VelaFontSize11}" />
       </Border>
       <!-- 列表外面套一层 Panel,是为了在它上面叠一个框选矩形(见 MarqueeOverlay)。 -->
       <Panel>
@@ -193,16 +193,16 @@
                   <pc:LucideIcon Classes="dnd-surface" Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.corner-left-up}" Foreground="{DynamicResource VelaTextTertiary}"
                                  IsVisible="{Binding IsParentEntry}" />
-                  <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="11" Foreground="{DynamicResource VelaTextSecondary}"
+                  <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextSecondary}"
                              VerticalAlignment="Center" HorizontalAlignment="Left"
                              TextTrimming="CharacterEllipsis" />
                 </Grid>
-                <TextBlock Classes="local-size-cell dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
+                <TextBlock Classes="local-size-cell dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
                            HorizontalAlignment="Left" />
-                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
+                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center"
                            HorizontalAlignment="Left" />
               </Grid>
             </Border>

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml
@@ -47,8 +47,8 @@
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.crumb:pointerover /template/ ContentPresenter">
@@ -83,7 +83,7 @@
                            Foreground="{DynamicResource VelaAccent}" />
             <TextBlock Text="{loc:Localize Sftp_PickUploadTitle}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontSize="12" FontWeight="SemiBold" VerticalAlignment="Center" />
+                       FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" VerticalAlignment="Center" />
           </StackPanel>
           <Button Grid.Column="2" Classes="toolbar-btn" Width="24" Height="24" Padding="0"
                   Click="OnCancelClick"
@@ -101,15 +101,15 @@
         <Grid ColumnDefinitions="*,Auto">
           <TextBlock Name="SelectionSummary"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" VerticalAlignment="Center" />
+                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
             <Button Height="26" Padding="14,0" Cursor="Hand" Click="OnCancelClick"
-                    Content="{x:Static res:Strings.Cancel}" FontSize="11" />
+                    Content="{x:Static res:Strings.Cancel}" FontSize="{DynamicResource VelaFontSize11}" />
             <Button Name="ConfirmButton" Height="26" Padding="14,0" Cursor="Hand"
                     Theme="{DynamicResource VelaAccentPillButtonTheme}"
                     Click="OnConfirmClick" IsDefault="True"
-                    Content="{x:Static res:Strings.Upload}" FontSize="11" />
+                    Content="{x:Static res:Strings.Upload}" FontSize="{DynamicResource VelaFontSize11}" />
           </StackPanel>
         </Grid>
       </Border>
@@ -139,8 +139,8 @@
                               CommandParameter="{Binding Path}" />
                       <TextBlock Text="{Binding $parent[ItemsControl].((vm:LocalFilePaneViewModel)DataContext).PathSeparator}"
                                  Foreground="{DynamicResource VelaTextMuted}"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
-                                 FontSize="11" VerticalAlignment="Center" />
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
                     </StackPanel>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -148,14 +148,14 @@
             </StackPanel>
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="11"
+            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize11}"
                       ItemsSource="{Binding Roots}" SelectedItem="{Binding SelectedRoot, Mode=OneWay}"
                       SelectionChanged="OnRootSelectionChanged"
                       VerticalContentAlignment="Center" MaxDropDownHeight="320">
               <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="vm:LocalRootEntry">
                   <TextBlock Text="{Binding DisplayName}" ToolTip.Tip="{Binding Tooltip}"
-                             TextTrimming="CharacterEllipsis" FontSize="11" Padding="2,1" />
+                             TextTrimming="CharacterEllipsis" FontSize="{DynamicResource VelaFontSize11}" Padding="2,1" />
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
@@ -180,14 +180,14 @@
               Background="{DynamicResource VelaBgContentHeader}"
               BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
         <Grid ColumnDefinitions="*,90,130">
-          <TextBlock Text="{x:Static res:Strings.FileName}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Text="{x:Static res:Strings.FileName}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
-          <TextBlock Grid.Column="1" Text="{x:Static res:Strings.Size}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Grid.Column="1" Text="{x:Static res:Strings.Size}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
-          <TextBlock Grid.Column="2" Text="{x:Static res:Strings.Modified}" FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
+          <TextBlock Grid.Column="2" Text="{x:Static res:Strings.Modified}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center" />
         </Grid>
       </Border>
@@ -195,7 +195,7 @@
       <Border DockPanel.Dock="Top"
               IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
               Background="{DynamicResource VelaBgActive}" Padding="10,4">
-        <TextBlock Text="{Binding ErrorMessage}" Foreground="{DynamicResource VelaError}" FontSize="11" />
+        <TextBlock Text="{Binding ErrorMessage}" Foreground="{DynamicResource VelaError}" FontSize="{DynamicResource VelaFontSize11}" />
       </Border>
 
       <!-- 文件与文件夹同列表混选:这正是系统对话框做不到、也是拆成两个菜单项的原因。
@@ -219,14 +219,14 @@
                   <pc:LucideIcon Width="13" Height="13" Margin="0,0,7,0"
                                  Data="{StaticResource Icon.corner-left-up}" Foreground="{DynamicResource VelaTextTertiary}"
                                  IsVisible="{Binding IsParentEntry}" />
-                  <TextBlock Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="11" Foreground="{DynamicResource VelaTextSecondary}"
+                  <TextBlock Grid.Column="1" Text="{Binding DisplayName}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextSecondary}"
                              VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
                 </Grid>
-                <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
-                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="11" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
+                <TextBlock Classes="dnd-surface" Grid.Column="1" Text="{Binding FormattedSize}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
+                <TextBlock Classes="dnd-surface" Grid.Column="2" Text="{Binding FormattedModifiedTime}" FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize11}" Foreground="{DynamicResource VelaTextTertiary}" VerticalAlignment="Center" />
               </Grid>
             </Border>
           </DataTemplate>

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -342,28 +342,68 @@ public partial class MainWindow : Window
         ApplyWindowOpacity(a.WindowOpacityPercent);
         ApplySidebarPosition(a.SidebarPosition == "right");
         ApplyBackgroundImage(a);
-        if (Application.Current is not { } app)
+        if (Application.Current is { } app)
         {
-            return;
+            ApplyUiFontTokens(app, a);
         }
-        // 界面字体:覆盖 VelaUiFont 令牌(空或默认 Inter 时还原主题字体);
-        // App 级 :is(Window) 样式让所有窗口继承,未显式指定 FontFamily 的文本统一换字体。
+    }
+
+    /// <summary>
+    /// 把设置 → 外观 → 界面字体/字号下发成应用级令牌。界面上的字体与字号【只】经由令牌
+    /// 取值(axaml 里不写字面量),所以这一处覆盖就是"界面字体/字号"这两个选项的全部实现。
+    /// </summary>
+    internal static void ApplyUiFontTokens(Application app, AppearanceOptions a)
+    {
+        // 界面字体:覆盖 VelaUiFont(比例)与 VelaUiMonoFont(界面里按列对齐的等宽部分)
+        // 两个令牌 —— 界面上的文字要么用前者要么用后者,一起换才谈得上"界面字体"生效。
+        // 空或默认 Inter 时移除覆盖,还原令牌默认值(比例 Inter + 等宽 Cascadia Mono)。
+        // App 级 :is(Window) 样式让所有窗口继承,终端画面自身不受影响(它吃终端设置)。
         string uiFont = a.UiFont.Trim();
         if (string.IsNullOrEmpty(uiFont) || string.Equals(uiFont, "Inter", StringComparison.OrdinalIgnoreCase))
         {
             app.Resources.Remove("VelaUiFont");
+            app.Resources.Remove("VelaUiMonoFont");
         }
         else
         {
-            app.Resources["VelaUiFont"] = new FontFamily($"{uiFont}, Segoe UI, Microsoft YaHei, sans-serif");
+            var family = new FontFamily($"{uiFont}, Segoe UI, Microsoft YaHei, sans-serif");
+            app.Resources["VelaUiFont"] = family;
+            app.Resources["VelaUiMonoFont"] = family;
         }
 
         // 界面字号:覆盖 VelaUiFontSize 令牌(同上,全窗口继承);同时覆盖 Fluent 的
         // ControlContentThemeFontSize,让内置控件(按钮/输入框/下拉等)一起缩放。
-        double uiFontSize = Math.Clamp(a.UiFontSize, 9, 24);
+        double uiFontSize = Math.Clamp((double)a.UiFontSize, MinUiFontSize, MaxUiFontSize);
         app.Resources["VelaUiFontSize"] = uiFontSize;
         app.Resources["ControlContentThemeFontSize"] = uiFontSize;
+
+        // 整套字号阶梯按 基准/13 等比缩放:界面各处不再写死字号,层级关系也不会因缩放走形。
+        foreach (double step in FontSizeSteps)
+        {
+            app.Resources[$"VelaFontSize{step:0}"] = ScaleFontSize(step, uiFontSize);
+        }
+        // 说明文字固定为基准字号的 85%(不参与等比阶梯,见 SettingsView 的 row-desc)。
+        app.Resources["VelaFontSizeDesc"] = ScaleFontSize(BaseUiFontSize * DescFontSizeRatio, uiFontSize);
     }
+
+    /// <summary>界面字号的取值范围(与设置页 NumericUpDown 的 Minimum/Maximum 一致)。</summary>
+    private const double MinUiFontSize = 9, MaxUiFontSize = 24;
+
+    /// <summary>设计基准字号:字号阶梯令牌名里的数字就是这个基准下的磅值。</summary>
+    private const double BaseUiFontSize = 13;
+
+    /// <summary>设置页说明文字相对基准字号的比例。</summary>
+    private const double DescFontSizeRatio = 0.85;
+
+    /// <summary>缩放后的字号下限:再小就糊了,基准取最小值时给小号字兜个底。</summary>
+    private const double MinScaledFontSize = 6;
+
+    /// <summary>VelaTokens.axaml 里定义的字号阶梯(= 基准 13 下的磅值)。</summary>
+    private static readonly double[] FontSizeSteps = [8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20];
+
+    /// <summary>把基准 13 下的设计字号换算到用户设定的基准上,取整以免落在半像素上。</summary>
+    private static double ScaleFontSize(double designSize, double uiFontSize) =>
+        Math.Max(MinScaledFontSize, Math.Round(designSize * uiFontSize / BaseUiFontSize));
 
     private Bitmap? _backgroundBitmap;
     private string? _loadedBackgroundPath;

--- a/src/VelaShell/Views/MessageDialog.axaml
+++ b/src/VelaShell/Views/MessageDialog.axaml
@@ -40,18 +40,18 @@
     <!-- 自定义内容区(属性表/权限矩阵等)默认文字样式:调用方只挂类名,不在代码里取画刷。 -->
     <Style Selector="ContentControl#BodyHost TextBlock">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
     </Style>
     <Style Selector="ContentControl#BodyHost TextBlock.dim">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
     </Style>
     <Style Selector="ContentControl#BodyHost TextBlock.mono">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
     </Style>
     <Style Selector="ContentControl#BodyHost TextBlock.mono-accent">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaAccentText}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="ContentControl#BodyHost pc|LucideIcon.folder">
       <Setter Property="Foreground" Value="{DynamicResource VelaFileFolderIcon}" />
@@ -65,8 +65,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="28" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
     </Style>
 
     <Style Selector="Button.dlg-outline">
@@ -78,7 +78,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="Button.dlg-primary">
       <Setter Property="Background" Value="{DynamicResource VelaAccent}" />
@@ -87,7 +87,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-danger">
@@ -97,7 +97,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
   </Window.Styles>
@@ -122,7 +122,7 @@
                          VerticalAlignment="Center" Margin="0,0,10,0" />
           <TextBlock Grid.Column="1" Name="TitleText"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="13" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold"
                      VerticalAlignment="Center"
                      TextTrimming="CharacterEllipsis" />
           <Button Grid.Column="2" Width="24" Height="24"
@@ -140,14 +140,14 @@
       <StackPanel Grid.Row="1" Margin="20,16" Spacing="12">
         <TextBlock Name="MessageText"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontSize="12" LineHeight="19"
+                   FontSize="{DynamicResource VelaFontSize12}" LineHeight="19"
                    TextWrapping="Wrap" />
         <TextBox Name="InputBox" IsVisible="False"
                  Background="{DynamicResource VelaBgInput}"
                  Foreground="{DynamicResource VelaTextPrimary}"
                  BorderBrush="{DynamicResource VelaBorderPrimary}"
-                 CornerRadius="4" MinHeight="30" FontSize="11"
-                 FontFamily="{DynamicResource VelaTerminalFont}" />
+                 CornerRadius="4" MinHeight="30" FontSize="{DynamicResource VelaFontSize11}"
+                 FontFamily="{DynamicResource VelaUiMonoFont}" />
         <ContentControl Name="BodyHost" IsVisible="False" />
       </StackPanel>
 

--- a/src/VelaShell/Views/ProcessManagerView.axaml
+++ b/src/VelaShell/Views/ProcessManagerView.axaml
@@ -70,7 +70,7 @@
     </Style>
     <Style Selector="Button.col-header TextBlock">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="LetterSpacing" Value="1" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
@@ -84,7 +84,7 @@
       <Setter Property="Height" Value="28" />
       <Setter Property="MinHeight" Value="28" />
       <Setter Property="Padding" Value="10,0" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
@@ -132,13 +132,13 @@
     <!-- 概览条上的文字:标签与数值共用一套,字号字族一致,基线才对得齐。 -->
     <Style Selector="TextBlock.gauge-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
     <Style Selector="TextBlock.gauge-value">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="TextAlignment" Value="Right" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
@@ -146,12 +146,12 @@
     <!-- 数据行文本 -->
     <Style Selector="TextBlock.cell">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="TextTrimming" Value="CharacterEllipsis" />
     </Style>
     <Style Selector="TextBlock.num">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="TextAlignment" Value="Right" />
     </Style>
   </Window.Styles>
@@ -184,7 +184,7 @@
                          VerticalAlignment="Center" />
           <TextBlock Text="{Binding HostLabel}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="12" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
                      VerticalAlignment="Center" />
         </StackPanel>
         <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Top">
@@ -214,20 +214,20 @@
         <TextBox Grid.Column="0"
                  Text="{Binding SearchText}"
                  PlaceholderText="{loc:Localize Proc_SearchPlaceholder}"
-                 Height="28" MinHeight="28" FontSize="11" Padding="8,0"
+                 Height="28" MinHeight="28" FontSize="{DynamicResource VelaFontSize11}" Padding="8,0"
                  VerticalAlignment="Center"
                  VerticalContentAlignment="Center" />
 
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
           <CheckBox IsChecked="{Binding ShowTree}"
                     Content="{loc:Localize Proc_TreeView}"
-                    FontSize="11"
+                    FontSize="{DynamicResource VelaFontSize11}"
                     Foreground="{DynamicResource VelaTextSecondary}"
                     VerticalAlignment="Center" />
 
           <CheckBox IsChecked="{Binding ShowKernelThreads}"
                     Content="{loc:Localize Proc_ShowKernelThreads}"
-                    FontSize="11"
+                    FontSize="{DynamicResource VelaFontSize11}"
                     Foreground="{DynamicResource VelaTextSecondary}"
                     VerticalAlignment="Center" />
 
@@ -384,7 +384,7 @@
           </Button>
           <TextBlock Grid.Column="8" Text="{loc:Localize Proc_ColCommand}"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontSize="10" LetterSpacing="1" VerticalAlignment="Center" />
+                     FontSize="{DynamicResource VelaFontSize10}" LetterSpacing="1" VerticalAlignment="Center" />
         </Grid>
       </Border>
 
@@ -439,7 +439,7 @@
                           IsVisible="{Binding HasChildren}"
                           Command="{Binding $parent[ListBox].((vm:ProcessManagerViewModel)DataContext).ToggleExpandCommand}"
                           CommandParameter="{Binding}">
-                    <TextBlock Text="{Binding ExpanderGlyph}" FontSize="9"
+                    <TextBlock Text="{Binding ExpanderGlyph}" FontSize="{DynamicResource VelaFontSize9}"
                                Foreground="{DynamicResource VelaTextMuted}"
                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                   </Button>
@@ -470,11 +470,11 @@
                   IsVisible="{Binding IsUnavailable}">
         <TextBlock Text="{loc:Localize Proc_Unavailable}"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontSize="12" FontWeight="SemiBold"
+                   FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
                    TextAlignment="Center" HorizontalAlignment="Center" />
         <TextBlock Text="{loc:Localize Proc_UnavailableHint}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontSize="11" TextWrapping="Wrap" TextAlignment="Center" />
+                   FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" TextAlignment="Center" />
       </StackPanel>
     </Grid>
 
@@ -488,16 +488,16 @@
       <Grid ColumnDefinitions="Auto,*,Auto">
         <TextBlock Grid.Column="0" Text="{Binding CountSummary}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontSize="10" VerticalAlignment="Center" />
+                   FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
         <TextBlock Grid.Column="1" Text="{Binding StatusMessage}"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontSize="10" Margin="16,0"
+                   FontSize="{DynamicResource VelaFontSize10}" Margin="16,0"
                    TextTrimming="CharacterEllipsis"
                    VerticalAlignment="Center"
                    IsVisible="{Binding StatusMessage, Converter={x:Static conv:StringNotEmptyConverter.Instance}}" />
         <TextBlock Grid.Column="2" Text="{Binding CoresSummary}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontSize="10" VerticalAlignment="Center" />
+                   FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
       </Grid>
     </Border>
   </Grid>

--- a/src/VelaShell/Views/QuickCommandsView.axaml
+++ b/src/VelaShell/Views/QuickCommandsView.axaml
@@ -15,7 +15,7 @@
       <Setter Property="Padding" Value="7,0" />
       <Setter Property="CornerRadius" Value="3" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
     </Style>
 
     <!-- 分组头:压掉 Fluent ToggleButton 的强调色选中态,展开与否都保持侧栏的
@@ -97,7 +97,7 @@
               <Grid ColumnDefinitions="*,Auto,8,Auto">
                 <TextBlock Text="{loc:Localize QuickCmd_SelectTargets}"
                            Foreground="{DynamicResource VelaTextPrimary}"
-                           FontSize="11" FontWeight="SemiBold"
+                           FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold"
                            VerticalAlignment="Center" />
                 <Button Grid.Column="1" Classes="quick-action"
                         Content="{loc:Localize QuickCmd_SelectAll}"
@@ -107,7 +107,7 @@
                         Command="{Binding ClearSelectionCommand}" />
               </Grid>
               <TextBlock Text="{loc:Localize QuickCmd_NoConnectedTerminals}"
-                         Foreground="{DynamicResource VelaTextMuted}" FontSize="10"
+                         Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize10}"
                          IsVisible="{Binding !HasTargets}" />
               <ScrollViewer MaxHeight="220" VerticalScrollBarVisibility="Auto"
                             IsVisible="{Binding HasTargets}">
@@ -117,8 +117,8 @@
                       <CheckBox IsChecked="{Binding IsSelected}"
                                 Content="{Binding DisplayName}"
                                 Foreground="{DynamicResource VelaTextSecondary}"
-                                FontFamily="{DynamicResource VelaTerminalFont}"
-                                FontSize="11" Margin="2,3" />
+                                FontFamily="{DynamicResource VelaUiMonoFont}"
+                                FontSize="{DynamicResource VelaFontSize11}" Margin="2,3" />
                     </DataTemplate>
                   </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -132,15 +132,15 @@
                        Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
         <TextBlock Grid.Column="2" Text="{loc:Localize QuickCmd_CurrentTerminal}"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontSize="10" VerticalAlignment="Center"
+                   FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
                    IsVisible="{Binding !HasSelectedTargets}" />
         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
                     IsVisible="{Binding HasSelectedTargets}">
           <TextBlock Text="{Binding SelectedTargetCount}"
-                     Foreground="{DynamicResource VelaAccent}" FontSize="10"
+                     Foreground="{DynamicResource VelaAccent}" FontSize="{DynamicResource VelaFontSize10}"
                      FontWeight="SemiBold" VerticalAlignment="Center" />
           <TextBlock Text="{loc:Localize QuickCmd_SelectedTerminals}"
-                     Foreground="{DynamicResource VelaTextSecondary}" FontSize="10"
+                     Foreground="{DynamicResource VelaTextSecondary}" FontSize="{DynamicResource VelaFontSize10}"
                      VerticalAlignment="Center" />
         </StackPanel>
         <pc:LucideIcon Grid.Column="3" Width="11" Height="11"
@@ -152,7 +152,7 @@
     <TextBox Grid.Row="1" Margin="8,0,8,5" Height="26"
              Text="{Binding Library.SearchQuery}"
              PlaceholderText="{loc:Localize QuickCmd_Search}"
-             FontSize="10" Padding="7,3" />
+             FontSize="{DynamicResource VelaFontSize10}" Padding="7,3" />
 
     <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled">
@@ -175,12 +175,12 @@
                   </Panel>
                   <TextBlock Grid.Column="2" Text="{Binding Name}"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontSize="10" FontWeight="SemiBold"
+                             FontSize="{DynamicResource VelaFontSize10}" FontWeight="SemiBold"
                              TextTrimming="CharacterEllipsis" />
                   <Border Grid.Column="3" Padding="5,1" CornerRadius="7"
                           Background="{DynamicResource VelaBgInput}">
                     <TextBlock Text="{Binding FilteredCommands.Count}"
-                               Foreground="{DynamicResource VelaTextMuted}" FontSize="9" />
+                               Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize9}" />
                   </Border>
                 </Grid>
               </ToggleButton>
@@ -198,12 +198,12 @@
                         <StackPanel Spacing="2">
                           <TextBlock Text="{Binding Name}"
                                      Foreground="{DynamicResource VelaTextPrimary}"
-                                     FontSize="11" FontWeight="SemiBold"
+                                     FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold"
                                      TextTrimming="CharacterEllipsis" />
                           <TextBlock Text="{Binding CommandText}"
                                      Foreground="{DynamicResource VelaAccentText}"
-                                     FontFamily="{DynamicResource VelaTerminalFont}"
-                                     FontSize="9" TextTrimming="CharacterEllipsis" />
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize9}" TextTrimming="CharacterEllipsis" />
                         </StackPanel>
                         <pc:LucideIcon Grid.Column="2" Classes="send-hint"
                                        Width="12" Height="12"

--- a/src/VelaShell/Views/RecordingPlayerView.axaml
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml
@@ -25,7 +25,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="Button.dlg-accent">
       <Setter Property="Background" Value="{DynamicResource VelaAccent}" />
@@ -34,7 +34,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-danger">
@@ -44,7 +44,7 @@
       <Setter Property="Padding" Value="6,2" />
       <Setter Property="CornerRadius" Value="3" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
     </Style>
     <!-- 录制列表:选中/悬停用主题令牌(与设置导航一致),替换 Fluent 默认的
          低对比蓝色选中背景;选中项标题以强调色突出。 -->
@@ -90,11 +90,11 @@
           <StackPanel Spacing="2" VerticalAlignment="Center">
             <TextBlock Text="{loc:Localize Recorder_Title}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontSize="15" FontWeight="SemiBold" />
+                       FontSize="{DynamicResource VelaFontSize15}" FontWeight="SemiBold" />
             <TextBlock Text="{loc:Localize Recorder_Subtitle}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="10" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}" />
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
             <Button Classes="dlg-outline" Content="{loc:Localize Recorder_Export}"
@@ -108,13 +108,13 @@
             <Button Width="26" Height="26" Background="Transparent" Padding="0"
                     CornerRadius="3" Cursor="Hand" Click="Maximize_Click"
                     VerticalAlignment="Center" ToolTip.Tip="{loc:Localize Recorder_MaximizeTip}">
-              <TextBlock Text="▢" FontSize="12" HorizontalAlignment="Center"
+              <TextBlock Text="▢" FontSize="{DynamicResource VelaFontSize12}" HorizontalAlignment="Center"
                          Foreground="{DynamicResource VelaTextTertiary}" />
             </Button>
             <Button Width="26" Height="26" Background="Transparent" Padding="0"
                     CornerRadius="3" Cursor="Hand" Click="Close_Click"
                     VerticalAlignment="Center">
-              <TextBlock Text="✕" FontSize="13" HorizontalAlignment="Center"
+              <TextBlock Text="✕" FontSize="{DynamicResource VelaFontSize13}" HorizontalAlignment="Center"
                          Foreground="{DynamicResource VelaTextTertiary}" />
             </Button>
           </StackPanel>
@@ -131,10 +131,10 @@
           <Grid RowDefinitions="34,*">
             <Border Grid.Row="0" Padding="12,0"
                     BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
-              <TextBlock Text="{loc:Localize Recorder_ListTitle}" FontSize="12" FontWeight="Medium"
+              <TextBlock Text="{loc:Localize Recorder_ListTitle}" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                          Foreground="{DynamicResource VelaTextSecondary}" VerticalAlignment="Center" />
             </Border>
-            <TextBlock Grid.Row="1" Margin="12" TextWrapping="Wrap" FontSize="11"
+            <TextBlock Grid.Row="1" Margin="12" TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize11}"
                        Foreground="{DynamicResource VelaTextMuted}"
                        Text="{loc:Localize Recorder_Empty}"
                        IsVisible="{Binding !HasRecordings}" />
@@ -146,11 +146,11 @@
                 <DataTemplate x:DataType="vm:RecordingItemViewModel">
                   <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Spacing="2">
-                      <TextBlock Classes="rec-label" FontSize="12" FontWeight="Medium"
+                      <TextBlock Classes="rec-label" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                                  Foreground="{DynamicResource VelaTextPrimary}"
                                  Text="{Binding Label}" />
-                      <TextBlock FontSize="10"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
+                      <TextBlock FontSize="{DynamicResource VelaFontSize10}"
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
                                  Foreground="{DynamicResource VelaTextMuted}">
                         <Run Text="{Binding StartText, Mode=OneWay}" />
                         <Run Text=" • " /><Run Text="{Binding DurationText, Mode=OneWay}" />
@@ -175,7 +175,7 @@
           <Grid RowDefinitions="34,*,Auto,Auto">
             <Border Grid.Row="0" Padding="12,0"
                     BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
-              <TextBlock FontSize="12" FontWeight="Medium"
+              <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                          Foreground="{DynamicResource VelaTextSecondary}" VerticalAlignment="Center"
                          Text="{Binding PlaybackTitle}" />
             </Border>
@@ -185,15 +185,15 @@
 
             <!-- 时间轴 -->
             <Grid Grid.Row="2" Margin="12,4" ColumnDefinitions="Auto,8,*,8,Auto">
-              <TextBlock Grid.Column="0" FontSize="10" VerticalAlignment="Center"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
+              <TextBlock Grid.Column="0" FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
                          Foreground="{DynamicResource VelaTextMuted}"
                          Text="{Binding PositionText}" />
               <Slider Grid.Column="2" Minimum="0" VerticalAlignment="Center"
                       Maximum="{Binding DurationMs}"
                       Value="{Binding PositionMs}" />
-              <TextBlock Grid.Column="4" FontSize="10" VerticalAlignment="Center"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
+              <TextBlock Grid.Column="4" FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
                          Foreground="{DynamicResource VelaTextMuted}"
                          Text="{Binding DurationText}" />
             </Grid>
@@ -210,10 +210,10 @@
               <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                 <ToggleSwitch IsChecked="{Binding SkipIdle}" Padding="0" MinWidth="0"
                               OnContent="" OffContent="" />
-                <TextBlock Text="{loc:Localize Recorder_SkipIdle}" FontSize="11" VerticalAlignment="Center"
+                <TextBlock Text="{loc:Localize Recorder_SkipIdle}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center"
                            Foreground="{DynamicResource VelaTextSecondary}" />
               </StackPanel>
-              <TextBlock Grid.Column="6" FontSize="10" VerticalAlignment="Center"
+              <TextBlock Grid.Column="6" FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
                          Foreground="{DynamicResource VelaTextMuted}"
                          TextWrapping="Wrap" MaxWidth="320"
                          Text="{Binding Status}" />

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml
@@ -37,7 +37,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
   </Window.Styles>
@@ -66,12 +66,12 @@
           <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
             <TextBlock Name="TitleText"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontSize="13" FontWeight="SemiBold"
+                       FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold"
                        TextTrimming="CharacterEllipsis" />
             <TextBlock Name="PathText"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="10"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}"
                        TextTrimming="CharacterEllipsis" />
           </StackPanel>
           <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -100,8 +100,8 @@
       <!-- 编辑器 -->
       <Border Grid.Row="1" Background="{DynamicResource VelaBgSftpPanel}">
         <ae:TextEditor Name="Editor"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="13"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize13}"
                        ShowLineNumbers="True"
                        Background="Transparent"
                        Foreground="{DynamicResource VelaTextPrimary}"
@@ -118,8 +118,8 @@
         <Grid ColumnDefinitions="*,Auto">
           <TextBlock Name="StatusText"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="10"
+                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize10}"
                      VerticalAlignment="Center"
                      TextTrimming="CharacterEllipsis" />
           <Border Grid.Column="1" Width="18" Height="18"

--- a/src/VelaShell/Views/ResourceMonitorView.axaml
+++ b/src/VelaShell/Views/ResourceMonitorView.axaml
@@ -16,12 +16,12 @@
     <Style Selector="TextBlock.row-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
       <Setter Property="FontFamily" Value="{DynamicResource VelaUiFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="TextBlock.row-value">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
       <Setter Property="FontFamily" Value="{DynamicResource VelaUiFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="ProgressBar">
       <Setter Property="Height" Value="6" />
@@ -40,12 +40,12 @@
     <Style Selector="TextBlock.info-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
       <Setter Property="FontFamily" Value="{DynamicResource VelaUiFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
     </Style>
     <Style Selector="TextBlock.info-value">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
       <Setter Property="FontFamily" Value="{DynamicResource VelaUiFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
     </Style>
   </UserControl.Styles>
 
@@ -56,13 +56,13 @@
       <TextBlock Text="{Binding HostName}"
                  Foreground="{DynamicResource VelaTextPrimary}"
                  FontFamily="{DynamicResource VelaUiFont}"
-                 FontSize="13" FontWeight="Bold" />
+                 FontSize="{DynamicResource VelaFontSize13}" FontWeight="Bold" />
     </Grid>
 
     <!-- 不可用占位(§11:若该会话已断开，显示数据不可用) -->
     <TextBlock Text="{loc:Localize Monitor_Unavailable}"
                Foreground="{DynamicResource VelaTextMuted}"
-               FontFamily="{DynamicResource VelaUiFont}" FontSize="11"
+               FontFamily="{DynamicResource VelaUiFont}" FontSize="{DynamicResource VelaFontSize11}"
                IsVisible="{Binding !IsAvailable}" />
 
     <StackPanel Spacing="8" IsVisible="{Binding IsAvailable}">

--- a/src/VelaShell/Views/SessionImportView.axaml
+++ b/src/VelaShell/Views/SessionImportView.axaml
@@ -17,7 +17,7 @@
   <Window.Styles>
     <Style Selector="TextBlock.field-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
       <Setter Property="Margin" Value="0,0,0,5" />
     </Style>
@@ -27,8 +27,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="32" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="Button.dlg-outline">
@@ -40,7 +40,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-primary">
@@ -50,7 +50,7 @@
       <Setter Property="Padding" Value="16,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.link">
@@ -59,7 +59,7 @@
       <Setter Property="Padding" Value="6,2" />
       <Setter Property="CornerRadius" Value="3" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
   </Window.Styles>
 
@@ -84,7 +84,7 @@
                     VerticalAlignment="Center" />
           <TextBlock Grid.Column="2" Text="{Binding Title}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="14" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize14}" FontWeight="SemiBold"
                      VerticalAlignment="Center" />
           <Button Grid.Column="3" Width="24" Height="24"
                   Background="Transparent" Padding="0" CornerRadius="3"
@@ -117,7 +117,7 @@
               IsVisible="{Binding MasterPasswordEnabled}">
         <TextBlock Text="{loc:Localize XImport_MasterPwWarn}"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontSize="11" TextWrapping="Wrap" />
+                   FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" />
       </Border>
 
       <!-- 会话列表 -->
@@ -138,26 +138,26 @@
                         <StackPanel Orientation="Horizontal" Spacing="8">
                           <TextBlock Text="{Binding Name}"
                                      Foreground="{DynamicResource VelaTextPrimary}"
-                                     FontSize="12" FontWeight="Medium" />
+                                     FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" />
                           <Border Background="{DynamicResource VelaBgHover}"
                                   CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
                             <TextBlock Text="{Binding Protocol}"
                                        Foreground="{DynamicResource VelaTextTertiary}"
-                                       FontSize="9" FontFamily="{DynamicResource VelaTerminalFont}" />
+                                       FontSize="{DynamicResource VelaFontSize9}" FontFamily="{DynamicResource VelaUiMonoFont}" />
                           </Border>
                           <TextBlock Text="{Binding ExistsHint}"
                                      IsVisible="{Binding ExistsHint, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                      Foreground="{DynamicResource VelaTextMuted}"
-                                     FontSize="10" VerticalAlignment="Center" />
+                                     FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
                         </StackPanel>
                         <TextBlock Text="{Binding Endpoint}"
                                    Foreground="{DynamicResource VelaTextTertiary}"
-                                   FontSize="10.5"
-                                   FontFamily="{DynamicResource VelaTerminalFont}" />
+                                   FontSize="{DynamicResource VelaFontSize10}"
+                                   FontFamily="{DynamicResource VelaUiMonoFont}" />
                       </StackPanel>
                       <TextBlock Grid.Column="3" Text="{Binding PasswordStatus}"
                                  Foreground="{DynamicResource VelaTextMuted}"
-                                 FontSize="10" VerticalAlignment="Center" />
+                                 FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
                     </Grid>
                   </Border>
                 </DataTemplate>
@@ -167,7 +167,7 @@
           <TextBlock Text="{Binding StatusMessage}"
                      IsVisible="{Binding HasNoItems}"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontSize="11" TextWrapping="Wrap" TextAlignment="Center"
+                     FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" TextAlignment="Center"
                      HorizontalAlignment="Center" VerticalAlignment="Center"
                      Margin="24" />
         </Grid>
@@ -188,7 +188,7 @@
                       VerticalAlignment="Center">
             <TextBlock Text="{Binding SelectionSummary}"
                        Foreground="{DynamicResource VelaTextTertiary}"
-                       FontSize="11" VerticalAlignment="Center" Margin="0,0,4,0" />
+                       FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" Margin="0,0,4,0" />
             <Button Classes="dlg-outline" Content="{loc:Localize Cancel}" Click="Cancel_Click" />
             <Button Classes="dlg-primary" Content="{loc:Localize XImport_ImportButton}"
                     Command="{Binding ImportCommand}" />

--- a/src/VelaShell/Views/SessionTreeView.axaml
+++ b/src/VelaShell/Views/SessionTreeView.axaml
@@ -161,16 +161,16 @@
               <!-- 分组名 -->
               <TextBlock Text="{Binding Name}"
                          Foreground="{DynamicResource VelaTextPrimary}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="12"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize12}"
                          FontWeight="Medium"
                          VerticalAlignment="Center" />
 
               <!-- 子项数量 -->
               <TextBlock Text="{Binding Children.Count}"
                          Foreground="{DynamicResource VelaTextTertiary}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="10"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize10}"
                          VerticalAlignment="Center" />
 
             </StackPanel>
@@ -306,8 +306,8 @@
               <TextBlock Text="{Binding SyncChannelLetter}"
                          IsVisible="{Binding HasSyncChannel}"
                          Foreground="{Binding SyncChannelLetter, Converter={x:Static conv:SyncChannelLetterToBrushConverter.Instance}}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="11"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize11}"
                          FontWeight="Bold"
                          VerticalAlignment="Center" />
 
@@ -319,8 +319,8 @@
 
               <TextBlock Classes="sessionName"
                          Text="{Binding Name}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="11"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize11}"
                          VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" />
 
@@ -332,8 +332,8 @@
                       Padding="6,1"
                       VerticalAlignment="Center">
                 <TextBlock Text="{Binding StatusTagText}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="9"
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize9}"
                            FontWeight="Medium"
                            VerticalAlignment="Center" />
               </Border>

--- a/src/VelaShell/Views/Settings/AboutPage.axaml
+++ b/src/VelaShell/Views/Settings/AboutPage.axaml
@@ -13,7 +13,7 @@
       <Setter Property="Padding" Value="0" />
       <Setter Property="MinHeight" Value="0" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
     </Style>
     <Style Selector="Button.link /template/ ContentPresenter">
       <Setter Property="Background" Value="Transparent" />
@@ -50,17 +50,17 @@
       <StackPanel Spacing="4" VerticalAlignment="Center">
         <TextBlock Text="VelaShell"
                    Foreground="{DynamicResource VelaTextPrimary}"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="20" FontWeight="SemiBold" />
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize20}" FontWeight="SemiBold" />
         <StackPanel Orientation="Horizontal" Spacing="8">
           <TextBlock Text="{Binding AppVersion}"
                      Foreground="{DynamicResource VelaAccent}"
-                     FontFamily="{DynamicResource VelaTerminalFont}"
-                     FontSize="12" VerticalAlignment="Center" />
+                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                     FontSize="{DynamicResource VelaFontSize12}" VerticalAlignment="Center" />
           <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="6,2">
             <TextBlock Text="{loc:Localize SetAbout_InDevelopment}"
                        Foreground="{DynamicResource VelaAccent}"
-                       FontSize="9" />
+                       FontSize="{DynamicResource VelaFontSize9}" />
           </Border>
         </StackPanel>
       </StackPanel>
@@ -72,32 +72,32 @@
       <StackPanel>
         <Border Height="32" Padding="12,0" BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
           <Grid ColumnDefinitions="120,*">
-            <TextBlock Classes="row-desc" FontSize="11" Text="{loc:Localize SetAbout_Framework}" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{Binding AboutFramework}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" VerticalAlignment="Center" />
+            <TextBlock Classes="row-desc" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetAbout_Framework}" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding AboutFramework}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
           </Grid>
         </Border>
         <Border Height="32" Padding="12,0" BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
           <Grid ColumnDefinitions="120,*">
-            <TextBlock Classes="row-desc" FontSize="11" Text="{loc:Localize SetAbout_Runtime}" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{Binding AboutRuntime}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" VerticalAlignment="Center" />
+            <TextBlock Classes="row-desc" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetAbout_Runtime}" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding AboutRuntime}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
           </Grid>
         </Border>
         <Border Height="32" Padding="12,0" BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
           <Grid ColumnDefinitions="120,*">
-            <TextBlock Classes="row-desc" FontSize="11" Text="{loc:Localize SetAbout_SshLibrary}" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{Binding AboutSshLibrary}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" VerticalAlignment="Center" />
+            <TextBlock Classes="row-desc" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetAbout_SshLibrary}" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding AboutSshLibrary}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" />
           </Grid>
         </Border>
         <Border Height="32" Padding="12,0" BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
           <Grid ColumnDefinitions="120,*">
-            <TextBlock Classes="row-desc" FontSize="11" Text="{loc:Localize SetAbout_OperatingSystem}" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{Binding AboutOs}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+            <TextBlock Classes="row-desc" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetAbout_OperatingSystem}" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding AboutOs}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
           </Grid>
         </Border>
         <Border Height="32" Padding="12,0">
           <Grid ColumnDefinitions="120,*">
-            <TextBlock Classes="row-desc" FontSize="11" Text="{loc:Localize SetAbout_ConfigPath}" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{Binding AboutConfigPath}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+            <TextBlock Classes="row-desc" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetAbout_ConfigPath}" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding AboutConfigPath}" Foreground="{DynamicResource VelaTextSecondary}" FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
           </Grid>
         </Border>
       </StackPanel>
@@ -146,8 +146,8 @@
                           ToolTip.Tip="{Binding Url}">
                     <TextBlock Text="{Binding Name}"
                                Foreground="{DynamicResource VelaTextPrimary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11" FontWeight="Medium" />
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
                   </Button>
                 </StackPanel>
                 <!-- 许可证:点击跳转许可证页面 -->
@@ -156,8 +156,8 @@
                         ToolTip.Tip="{loc:Localize SetAbout_ViewLicense}">
                   <TextBlock Text="{Binding License}"
                              Foreground="{DynamicResource VelaTextMuted}"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="10" />
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize10}" />
                 </Button>
               </Grid>
             </Border>
@@ -190,7 +190,7 @@
                 <Panel>
                   <!-- 头像未就绪/加载失败:首字母占位 -->
                   <TextBlock Text="{Binding Initial}"
-                             FontSize="15" FontWeight="SemiBold"
+                             FontSize="{DynamicResource VelaFontSize15}" FontWeight="SemiBold"
                              Foreground="{DynamicResource VelaAccent}"
                              HorizontalAlignment="Center" VerticalAlignment="Center"
                              IsVisible="{Binding !HasAvatar}" />
@@ -199,8 +199,8 @@
                 </Panel>
               </Border>
               <TextBlock Text="{Binding Display}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="10" FontWeight="Medium"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
                          Foreground="{DynamicResource VelaTextSecondary}"
                          HorizontalAlignment="Center" />
             </StackPanel>

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
@@ -77,7 +77,7 @@
         <Slider Width="120" Minimum="0" Maximum="100"
                 Value="{Binding Appearance.BackgroundImageOpacity}" VerticalAlignment="Center" />
         <TextBlock Width="40" TextAlignment="Right" VerticalAlignment="Center"
-                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="12"
+                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="{DynamicResource VelaFontSize12}"
                    Text="{Binding Appearance.BackgroundImageOpacity, StringFormat={}{0}%}" />
       </StackPanel>
     </Grid>
@@ -91,7 +91,7 @@
         <Slider Width="120" Minimum="20" Maximum="100"
                 Value="{Binding Appearance.ContentBackgroundOpacity}" VerticalAlignment="Center" />
         <TextBlock Width="40" TextAlignment="Right" VerticalAlignment="Center"
-                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="12"
+                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="{DynamicResource VelaFontSize12}"
                    Text="{Binding Appearance.ContentBackgroundOpacity, StringFormat={}{0}%}" />
       </StackPanel>
     </Grid>
@@ -141,7 +141,7 @@
                 Value="{Binding Appearance.WindowOpacityPercent}" VerticalAlignment="Center" />
         <!-- 只读指示器:数值仅由滑块驱动(手动输入无意义且易输入非法字符)。 -->
         <TextBlock Width="40" TextAlignment="Right" VerticalAlignment="Center"
-                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="12"
+                   Foreground="{DynamicResource VelaTextSecondary}" FontSize="{DynamicResource VelaFontSize12}"
                    Text="{Binding Appearance.WindowOpacityPercent, StringFormat={}{0}%}" />
       </StackPanel>
     </Grid>
@@ -244,7 +244,10 @@
       <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_Ansi16Desc}" />
     </StackPanel>
     <StackPanel Orientation="Horizontal" Spacing="8">
-      <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_AnsiNormal}" Width="30" VerticalAlignment="Center" />
+      <!-- 定宽 30 的色板行首标注:借用 row-desc 的字体字号,但不能跟着换行(30px 宽会把
+           "Normal" 拆成好几行),故单独关掉。 -->
+      <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_AnsiNormal}" Width="30"
+                 TextWrapping="NoWrap" VerticalAlignment="Center" />
       <ItemsControl ItemsSource="{Binding Appearance.AnsiNormal}">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
@@ -262,7 +265,8 @@
       </ItemsControl>
     </StackPanel>
     <StackPanel Orientation="Horizontal" Spacing="8">
-      <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_AnsiBright}" Width="30" VerticalAlignment="Center" />
+      <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_AnsiBright}" Width="30"
+                 TextWrapping="NoWrap" VerticalAlignment="Center" />
       <ItemsControl ItemsSource="{Binding Appearance.AnsiBright}">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>

--- a/src/VelaShell/Views/Settings/DonatePage.axaml
+++ b/src/VelaShell/Views/Settings/DonatePage.axaml
@@ -11,7 +11,7 @@
       <TextBlock Classes="page-subtitle" Text="{loc:Localize SetDonate_Subtitle}" />
     </StackPanel>
 
-    <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+    <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                Foreground="{DynamicResource VelaTextSecondary}"
                Text="{loc:Localize SetDonate_Intro}" />
 
@@ -19,10 +19,10 @@
     <Border Background="{DynamicResource VelaBgActive}"
             CornerRadius="6" Padding="16,12">
       <StackPanel Spacing="6">
-        <TextBlock FontSize="12" FontWeight="SemiBold"
+        <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
                    Foreground="{DynamicResource VelaAccent}"
                    Text="{loc:Localize SetDonate_ContributeTitle}" />
-        <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+        <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                    Foreground="{DynamicResource VelaTextSecondary}"
                    Text="{loc:Localize SetDonate_ContributeBody}" />
       </StackPanel>
@@ -48,7 +48,7 @@
                  MaxWidth="260" Stretch="Uniform"
                  HorizontalAlignment="Center" VerticalAlignment="Center" />
           <TextBlock Grid.Row="1" Margin="0,10,0,0"
-                     Text="{loc:Localize SetDonate_Alipay}" FontSize="12" FontWeight="Medium"
+                     Text="{loc:Localize SetDonate_Alipay}" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                      HorizontalAlignment="Center"
                      Foreground="{DynamicResource VelaTextPrimary}" />
         </Grid>
@@ -63,7 +63,7 @@
                  MaxWidth="260" Stretch="Uniform"
                  HorizontalAlignment="Center" VerticalAlignment="Center" />
           <TextBlock Grid.Row="1" Margin="0,10,0,0"
-                     Text="{loc:Localize SetDonate_WeChatPay}" FontSize="12" FontWeight="Medium"
+                     Text="{loc:Localize SetDonate_WeChatPay}" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                      HorizontalAlignment="Center"
                      Foreground="{DynamicResource VelaTextPrimary}" />
         </Grid>
@@ -84,16 +84,16 @@
         <StackPanel Grid.Column="0" Spacing="8">
           <Image Source="avares://VelaShell/Assets/donate-wise.png"
                  Width="180" Stretch="Uniform" />
-          <TextBlock Text="Wise" FontSize="12" FontWeight="Medium"
+          <TextBlock Text="Wise" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                      HorizontalAlignment="Center"
                      Foreground="{DynamicResource VelaTextPrimary}" />
         </StackPanel>
         <StackPanel Grid.Column="2" Spacing="8" VerticalAlignment="Center">
-          <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+          <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                      Foreground="{DynamicResource VelaTextSecondary}"
                      Text="{loc:Localize SetDonate_WiseHint}" />
           <!-- 可点击链接:点击在系统浏览器打开付款页。 -->
-          <TextBlock FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11"
+          <TextBlock FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}"
                      Foreground="{DynamicResource VelaAccentText}"
                      TextWrapping="Wrap"
                      TextDecorations="Underline"
@@ -108,7 +108,7 @@
       </Grid>
     </Border>
 
-    <TextBlock TextWrapping="Wrap" FontSize="11" LineHeight="18"
+    <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize11}" LineHeight="18"
                Foreground="{DynamicResource VelaTextMuted}"
                Text="{loc:Localize SetDonate_Thanks}" />
   </StackPanel>

--- a/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml
@@ -63,15 +63,15 @@
     <TextBlock Classes="section-title" Text="{loc:Localize SetGeneral_ConnectionDefaultsSection}" />
     <Grid ColumnDefinitions="*,12,*" RowDefinitions="Auto,12,Auto">
       <StackPanel Grid.Row="0" Grid.Column="0" Spacing="5">
-        <TextBlock Classes="row-label" FontSize="11" Text="{loc:Localize DefaultPort}" />
+        <TextBlock Classes="row-label" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize DefaultPort}" />
         <NumericUpDown Width="NaN" HorizontalAlignment="Stretch" Value="{Binding DefaultPort}" Minimum="1" Maximum="65535" Increment="1" FormatString="0" />
       </StackPanel>
       <StackPanel Grid.Row="0" Grid.Column="2" Spacing="5">
-        <TextBlock Classes="row-label" FontSize="11" Text="{loc:Localize SetGeneral_ConnectTimeout}" />
+        <TextBlock Classes="row-label" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetGeneral_ConnectTimeout}" />
         <NumericUpDown Width="NaN" HorizontalAlignment="Stretch" Value="{Binding General.ConnectTimeoutSeconds}" Minimum="1" Maximum="600" Increment="5" FormatString="0" />
       </StackPanel>
       <StackPanel Grid.Row="2" Grid.Column="0" Spacing="5">
-        <TextBlock Classes="row-label" FontSize="11" Text="{loc:Localize SetGeneral_KeepAliveInterval}" />
+        <TextBlock Classes="row-label" FontSize="{DynamicResource VelaFontSize11}" Text="{loc:Localize SetGeneral_KeepAliveInterval}" />
         <NumericUpDown Width="NaN" HorizontalAlignment="Stretch" Value="{Binding General.KeepAliveSeconds}" Minimum="0" Maximum="600" Increment="10" FormatString="0" />
       </StackPanel>
     </Grid>

--- a/src/VelaShell/Views/Settings/KeyManagementPage.axaml
+++ b/src/VelaShell/Views/Settings/KeyManagementPage.axaml
@@ -28,10 +28,10 @@
                 BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1"
                 Padding="12,0">
           <Grid ColumnDefinitions="130,80,*,60">
-            <TextBlock Text="{loc:Localize Name}" Foreground="{DynamicResource VelaTextMuted}" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="1" Text="{loc:Localize KeyType}" Foreground="{DynamicResource VelaTextMuted}" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="2" Text="{loc:Localize Fingerprint}" Foreground="{DynamicResource VelaTextMuted}" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" />
-            <TextBlock Grid.Column="3" Text="{loc:Localize SetSync_Actions}" Foreground="{DynamicResource VelaTextMuted}" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <TextBlock Text="{loc:Localize Name}" Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{loc:Localize KeyType}" Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="2" Text="{loc:Localize Fingerprint}" Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="3" Text="{loc:Localize SetSync_Actions}" Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold" VerticalAlignment="Center" />
           </Grid>
         </Border>
 
@@ -47,16 +47,16 @@
                               Foreground="{DynamicResource VelaAccent}" />
                     <TextBlock Text="{Binding Name}"
                                Foreground="{DynamicResource VelaTextPrimary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11"
+                               FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}"
                                TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
                   </StackPanel>
                   <TextBlock Grid.Column="1" Text="{Binding Type}"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10"
+                             FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}"
                              VerticalAlignment="Center" />
                   <TextBlock Grid.Column="2" Text="{Binding Fingerprint}"
                              Foreground="{DynamicResource VelaTextMuted}"
-                             FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10"
+                             FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}"
                              TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
                   <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                     <Button Width="24" Height="24" Padding="0" Background="Transparent"

--- a/src/VelaShell/Views/Settings/SecurityAuditPage.axaml
+++ b/src/VelaShell/Views/Settings/SecurityAuditPage.axaml
@@ -78,21 +78,21 @@
                   <StackPanel Orientation="Horizontal" Spacing="8">
                     <!-- 地址脱敏:掩码为固定长度,不暴露真实地址的位数;
                          按指纹区分各条目(指纹是服务器公钥哈希,非敏感信息)。 -->
-                    <TextBlock FontSize="12" FontWeight="Medium"
+                    <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                                Foreground="{DynamicResource VelaTextPrimary}"
                                IsVisible="{Binding !$parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}">
                       <Run Text="{Binding Host}" /><Run Text=":" /><Run Text="{Binding Port}" />
                     </TextBlock>
-                    <TextBlock FontSize="12" FontWeight="Medium"
+                    <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                                Foreground="{DynamicResource VelaTextPrimary}"
                                Text="••••••••••:•••"
                                IsVisible="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}" />
-                    <TextBlock FontSize="10" VerticalAlignment="Center"
+                    <TextBlock FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
                                Foreground="{DynamicResource VelaTextMuted}"
                                Text="{Binding KeyType}" />
                   </StackPanel>
-                  <TextBlock FontSize="10"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
+                  <TextBlock FontSize="{DynamicResource VelaFontSize10}"
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
                              Foreground="{DynamicResource VelaTextMuted}"
                              TextWrapping="Wrap"
                              Text="{Binding Fingerprint}" />
@@ -112,7 +112,7 @@
 
     <!-- 告警通道 -->
     <TextBlock Text="{loc:Localize SetSecurity_SectionAlerts}"
-               Foreground="#74B9FF" FontSize="12" FontWeight="SemiBold" />
+               Foreground="#74B9FF" FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" />
     <Grid ColumnDefinitions="*,Auto">
       <TextBlock Classes="row-label" Text="{loc:Localize SetSecurity_AlertInApp}" VerticalAlignment="Center" />
       <ToggleSwitch Grid.Column="1" IsChecked="{Binding Security.AlertInApp}" VerticalAlignment="Center" />

--- a/src/VelaShell/Views/Settings/ShortcutsPage.axaml
+++ b/src/VelaShell/Views/Settings/ShortcutsPage.axaml
@@ -31,7 +31,7 @@
                       <Grid ColumnDefinitions="*,Auto">
                         <TextBlock Text="{Binding Label}"
                                    Foreground="{DynamicResource VelaTextSecondary}"
-                                   FontSize="12" VerticalAlignment="Center" />
+                                   FontSize="{DynamicResource VelaFontSize12}" VerticalAlignment="Center" />
                         <ItemsControl Grid.Column="1" ItemsSource="{Binding Keys}"
                                       VerticalAlignment="Center">
                           <ItemsControl.ItemsPanel>
@@ -44,8 +44,8 @@
                               <Border Classes="keycap">
                                 <TextBlock Text="{Binding}"
                                            Foreground="{DynamicResource VelaTextSecondary}"
-                                           FontFamily="{DynamicResource VelaTerminalFont}"
-                                           FontSize="10" FontWeight="Medium" />
+                                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                                           FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
                               </Border>
                             </DataTemplate>
                           </ItemsControl.ItemTemplate>

--- a/src/VelaShell/Views/Settings/SnippetsPage.axaml
+++ b/src/VelaShell/Views/Settings/SnippetsPage.axaml
@@ -67,7 +67,7 @@
 
     <TextBlock Text="{loc:Localize SetSnippets_Intro}"
                Foreground="{DynamicResource VelaTextSecondary}"
-               FontSize="13" TextWrapping="Wrap" />
+               FontSize="{DynamicResource VelaFontSize13}" TextWrapping="Wrap" />
 
     <Grid ColumnDefinitions="*,Auto">
       <StackPanel Spacing="2">
@@ -104,14 +104,14 @@
                   </Panel>
                   <TextBlock Grid.Column="2" Text="{Binding Name}"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontSize="12" FontWeight="SemiBold"
+                             FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
                              VerticalAlignment="Center"
                              TextTrimming="CharacterEllipsis" />
                   <Border Grid.Column="3" Padding="6,1" CornerRadius="8"
                           Background="{DynamicResource VelaBgInput}"
                           VerticalAlignment="Center">
                     <TextBlock Text="{Binding FilteredCommands.Count}"
-                               Foreground="{DynamicResource VelaTextMuted}" FontSize="10" />
+                               Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize10}" />
                   </Border>
                 </Grid>
               </ToggleButton>
@@ -126,11 +126,11 @@
                         <StackPanel Spacing="3">
                           <TextBlock Text="{Binding Name}"
                                      Foreground="{DynamicResource VelaTextPrimary}"
-                                     FontSize="12" FontWeight="Medium" />
+                                     FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" />
                           <TextBlock Text="{Binding CommandText}"
                                      Foreground="{DynamicResource VelaAccentText}"
-                                     FontFamily="{DynamicResource VelaTerminalFont}"
-                                     FontSize="10" TextWrapping="Wrap" />
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize10}" TextWrapping="Wrap" />
                         </StackPanel>
                         <Button Grid.Column="2" Classes="icon-btn"
                                 ToolTip.Tip="{loc:Localize Edit}"

--- a/src/VelaShell/Views/Settings/SyncPage.axaml
+++ b/src/VelaShell/Views/Settings/SyncPage.axaml
@@ -17,7 +17,7 @@
     <StackPanel Spacing="14" DataContext="{Binding Sync}" IsVisible="{Binding Converter={x:Static ObjectConverters.IsNotNull}}"
                 x:DataType="vm:SyncViewModel">
 
-      <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+      <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                  Foreground="{DynamicResource VelaTextSecondary}"
                  Text="{loc:Localize SetSync_Intro}" />
 
@@ -27,38 +27,38 @@
       <!-- 令牌获取指引:链接经代码后置在系统浏览器打开(Tag = URL)。 -->
       <Border Background="{DynamicResource VelaBgActive}" CornerRadius="6" Padding="16,12">
         <StackPanel Spacing="6">
-          <TextBlock FontSize="12" FontWeight="SemiBold"
+          <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
                      Foreground="{DynamicResource VelaAccent}"
                      Text="{loc:Localize SetSync_TokenGuideTitle}" />
           <!-- XML 属性值中的换行会被规范化为空格,分步文案用逐条 TextBlock 排版。 -->
           <StackPanel Spacing="3">
-            <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                        Foreground="{DynamicResource VelaTextSecondary}"
                        Text="{loc:Localize SetSync_TokenGuideStep1}" />
-            <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                        Foreground="{DynamicResource VelaTextSecondary}"
                        Text="{loc:Localize SetSync_TokenGuideStep2}" />
-            <TextBlock TextWrapping="Wrap" FontSize="12" LineHeight="20"
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize12}" LineHeight="20"
                        Foreground="{DynamicResource VelaTextSecondary}"
                        Text="{loc:Localize SetSync_TokenGuideStep3}" />
-            <TextBlock TextWrapping="Wrap" FontSize="11" LineHeight="18"
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource VelaFontSize11}" LineHeight="18"
                        Foreground="{DynamicResource VelaTextMuted}"
                        Text="{loc:Localize SetSync_TokenLocalOnly}" />
           </StackPanel>
           <StackPanel Orientation="Horizontal" Spacing="16">
-            <TextBlock FontSize="12" TextDecorations="Underline" Cursor="Hand"
+            <TextBlock FontSize="{DynamicResource VelaFontSize12}" TextDecorations="Underline" Cursor="Hand"
                        Foreground="{DynamicResource VelaAccentText}"
                        Text="{loc:Localize SetSync_CreateTokenLink}"
                        ToolTip.Tip="https://github.com/settings/tokens/new?scopes=gist"
                        Tag="https://github.com/settings/tokens/new?scopes=gist&amp;description=VelaShell%20Cloud%20Sync"
                        PointerPressed="OpenLink_PointerPressed" />
-            <TextBlock FontSize="12" TextDecorations="Underline" Cursor="Hand"
+            <TextBlock FontSize="{DynamicResource VelaFontSize12}" TextDecorations="Underline" Cursor="Hand"
                        Foreground="{DynamicResource VelaAccentText}"
                        Text="{loc:Localize SetSync_WhatIsGist}"
                        ToolTip.Tip="https://docs.github.com/zh/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists"
                        Tag="https://docs.github.com/zh/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists"
                        PointerPressed="OpenLink_PointerPressed" />
-            <TextBlock FontSize="12" TextDecorations="Underline" Cursor="Hand"
+            <TextBlock FontSize="{DynamicResource VelaFontSize12}" TextDecorations="Underline" Cursor="Hand"
                        Foreground="{DynamicResource VelaAccentText}"
                        Text="{loc:Localize SetSync_TokenDocs}"
                        ToolTip.Tip="https://docs.github.com/zh/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -81,7 +81,7 @@
         <Grid ColumnDefinitions="*,8,Auto">
           <TextBox Grid.Column="0" PasswordChar="●" behaviors:EnglishInputLocale.Enabled="True" Text="{Binding TokenInput}"
                    PlaceholderText="{loc:Localize SetSync_TokenPlaceholder}" />
-          <TextBlock Grid.Column="2" FontSize="12" FontWeight="Medium" VerticalAlignment="Center"
+          <TextBlock Grid.Column="2" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center"
                      Foreground="{DynamicResource VelaAccent}"
                      Text="{loc:Localize SetSync_Saved}" IsVisible="{Binding HasSavedToken}" />
         </Grid>
@@ -110,7 +110,7 @@
         <Grid ColumnDefinitions="*,8,Auto">
           <TextBox Grid.Column="0" PasswordChar="●" behaviors:EnglishInputLocale.Enabled="True" Text="{Binding PassphraseInput}"
                    PlaceholderText="{loc:Localize SetSync_PassphrasePlaceholder}" />
-          <TextBlock Grid.Column="2" FontSize="12" FontWeight="Medium" VerticalAlignment="Center"
+          <TextBlock Grid.Column="2" FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center"
                      Foreground="{DynamicResource VelaAccent}"
                      Text="{loc:Localize SetSync_Saved}" IsVisible="{Binding HasSavedPassphrase}" />
         </Grid>
@@ -187,15 +187,15 @@
                   <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Spacing="2" VerticalAlignment="Center">
                       <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock FontSize="12" FontWeight="Medium"
+                        <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                                    Foreground="{DynamicResource VelaTextPrimary}"
                                    Text="{Binding DeviceName, Mode=OneWay, TargetNullValue=未知设备}" />
-                        <TextBlock FontSize="10" VerticalAlignment="Center"
-                                   FontFamily="{DynamicResource VelaTerminalFont}"
+                        <TextBlock FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
+                                   FontFamily="{DynamicResource VelaUiMonoFont}"
                                    Foreground="{DynamicResource VelaTextMuted}"
                                    Text="{Binding Version, Mode=OneWay, Converter={x:Static conv:ShortShaConverter.Instance}}" />
                       </StackPanel>
-                      <TextBlock FontSize="10" Foreground="{DynamicResource VelaTextMuted}">
+                      <TextBlock FontSize="{DynamicResource VelaFontSize10}" Foreground="{DynamicResource VelaTextMuted}">
                         <Run Text="{Binding CommittedAtUtc, Mode=OneWay, Converter={x:Static conv:UtcToLocalTextConverter.Instance}}" />
                         <Run Text="  +" /><Run Text="{Binding Additions, Mode=OneWay}" />
                         <Run Text=" -" /><Run Text="{Binding Deletions, Mode=OneWay}" />

--- a/src/VelaShell/Views/SettingsView.axaml
+++ b/src/VelaShell/Views/SettingsView.axaml
@@ -24,30 +24,36 @@
     <!-- 分节标题 -->
     <Style Selector="TextBlock.section-title">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontSize" Value="13" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     <!-- 设置行左侧标签/描述 -->
     <Style Selector="TextBlock.row-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
+    <!-- 说明文字固定为界面字号的 85%(VelaFontSizeDesc),不走等比阶梯:
+         说明是次要信息,字号跟着基准 1:1 放大反而会盖过它上面的标签。
+         默认换行:说明有长有短,不换行的话长句子会顶出设置行右边的控件、跑到可视区外
+         (窗口 CanResize=False,横向没有滚动条可以救)。放在【左列】的说明才会真的换行 ——
+         横向 StackPanel 里的短标注(如 "MB/s")按无限宽度量,这条设置对它们是空操作。 -->
     <Style Selector="TextBlock.row-desc">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSizeDesc}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
     <!-- 页面标题/副标题 -->
     <Style Selector="TextBlock.page-title">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontSize" Value="18" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize18}" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     <Style Selector="TextBlock.page-subtitle">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <!-- 节分隔线 -->
     <Style Selector="Border.sep">
@@ -62,8 +68,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="30" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="ComboBox">
@@ -72,7 +78,7 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="30" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="MinWidth" Value="140" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
@@ -82,8 +88,8 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="30" />
-      <Setter Property="FontSize" Value="11" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
       <Setter Property="Width" Value="110" />
       <Setter Property="ShowButtonSpinner" Value="False" />
     </Style>
@@ -103,7 +109,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <Style Selector="Button.dlg-primary">
       <Setter Property="Background" Value="{DynamicResource VelaAccent}" />
@@ -112,7 +118,7 @@
       <Setter Property="Padding" Value="14,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
     <Style Selector="Button.dlg-danger">
@@ -124,7 +130,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
     <!-- keycap(快捷键页) -->
     <Style Selector="Border.keycap">
@@ -204,7 +210,7 @@
                         Foreground="{DynamicResource VelaAccent}" />
               <TextBlock Text="{loc:Localize Settings}"
                          Foreground="{DynamicResource VelaTextPrimary}"
-                         FontSize="13" FontWeight="SemiBold" />
+                         FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold" />
             </StackPanel>
           </Border>
 
@@ -215,7 +221,7 @@
               <DataTemplate x:DataType="vm:SettingsSection">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                   <PathIcon Width="14" Height="14" Data="{Binding Icon}" />
-                  <TextBlock Text="{Binding Name}" FontSize="12" VerticalAlignment="Center" />
+                  <TextBlock Text="{Binding Name}" FontSize="{DynamicResource VelaFontSize12}" VerticalAlignment="Center" />
                 </StackPanel>
               </DataTemplate>
             </ListBox.ItemTemplate>

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -22,8 +22,8 @@
       <Grid ColumnDefinitions="*,Auto">
         <TextBlock Text="{loc:Localize Sidebar_Explorer}"
                    Foreground="{DynamicResource VelaTextSecondary}"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="11" FontWeight="Medium" LetterSpacing="1"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" LetterSpacing="1"
                    VerticalAlignment="Center" />
         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4"
                     VerticalAlignment="Center">
@@ -103,8 +103,8 @@
                   </Panel>
                   <TextBlock Grid.Column="2" Text="{loc:Localize QuickCommands}"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="11" FontWeight="Medium" LetterSpacing="1"
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" LetterSpacing="1"
                              VerticalAlignment="Center" />
                 </Grid>
               </Button>
@@ -145,8 +145,8 @@
                   </Panel>
                   <TextBlock Grid.Column="2" Text="{loc:Localize RecentConnections}"
                              Foreground="{DynamicResource VelaTextSecondary}"
-                             FontFamily="{DynamicResource VelaTerminalFont}"
-                             FontSize="11" FontWeight="Medium" LetterSpacing="1"
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" LetterSpacing="1"
                              VerticalAlignment="Center" />
                 </Grid>
               </Button>
@@ -181,12 +181,12 @@
                       <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
                         <TextBlock Text="{Binding DisplayName}"
                                    Foreground="{DynamicResource VelaTextSecondary}"
-                                   FontFamily="{DynamicResource VelaTerminalFont}"
-                                   FontSize="11" TextTrimming="CharacterEllipsis" />
+                                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                                   FontSize="{DynamicResource VelaFontSize11}" TextTrimming="CharacterEllipsis" />
                         <TextBlock Text="{Binding RelativeTime}"
                                    Foreground="{DynamicResource VelaTextMuted}"
-                                   FontFamily="{DynamicResource VelaTerminalFont}"
-                                   FontSize="9" />
+                                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                                   FontSize="{DynamicResource VelaFontSize9}" />
                       </StackPanel>
                     </Grid>
                   </Border>
@@ -210,7 +210,7 @@
                            HorizontalAlignment="Center" VerticalAlignment="Center" />
           </Border>
           <TextBlock Text="root" Foreground="{DynamicResource VelaTextSecondary}"
-                     FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11"
+                     FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}"
                      VerticalAlignment="Center" />
         </StackPanel>
         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"

--- a/src/VelaShell/Views/StatusBarView.axaml
+++ b/src/VelaShell/Views/StatusBarView.axaml
@@ -16,8 +16,8 @@
 
   <UserControl.Styles>
     <Style Selector="TextBlock">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
     <Style Selector="Border.divider">

--- a/src/VelaShell/Views/TerminalTabView.axaml
+++ b/src/VelaShell/Views/TerminalTabView.axaml
@@ -21,7 +21,7 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="CornerRadius" Value="3" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -44,19 +44,19 @@
           <Border Width="10" Height="10" CornerRadius="2"
                   Background="{Binding SyncChannelBrush}"
                   VerticalAlignment="Center" />
-          <TextBlock FontSize="11"
+          <TextBlock FontSize="{DynamicResource VelaFontSize11}"
                      Foreground="{DynamicResource VelaTextSecondary}"
                      VerticalAlignment="Center"
                      Text="{loc:Localize SyncInput_BannerPrefix}" />
-          <TextBlock FontSize="11" FontWeight="Bold"
+          <TextBlock FontSize="{DynamicResource VelaFontSize11}" FontWeight="Bold"
                      Foreground="{Binding SyncChannelBrush}"
                      VerticalAlignment="Center"
                      Text="{Binding SyncChannelLetter}" />
-          <TextBlock FontSize="11"
+          <TextBlock FontSize="{DynamicResource VelaFontSize11}"
                      Foreground="{DynamicResource VelaTextSecondary}"
                      VerticalAlignment="Center"
                      Text="{loc:Localize SyncInput_BannerSuffix}" />
-          <TextBlock FontSize="11"
+          <TextBlock FontSize="{DynamicResource VelaFontSize11}"
                      Foreground="{DynamicResource VelaTextMuted}"
                      VerticalAlignment="Center"
                      IsVisible="{Binding IsSyncPaused}"
@@ -116,14 +116,14 @@
                          VerticalAlignment="Center" />
           <TextBox x:Name="SearchBox" Grid.Column="2"
                    MinHeight="24" Padding="8,2" CornerRadius="3"
-                   FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11"
+                   FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}"
                    Background="{DynamicResource VelaBgInput}"
                    Foreground="{DynamicResource VelaTextPrimary}"
                    BorderBrush="{DynamicResource VelaBorderPrimary}"
                    PlaceholderText="{loc:Localize Term_SearchPlaceholder}" />
           <TextBlock x:Name="SearchCount" Grid.Column="4"
                      Foreground="{DynamicResource VelaTextMuted}"
-                     FontFamily="{DynamicResource VelaTerminalFont}" FontSize="10"
+                     FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize10}"
                      VerticalAlignment="Center" />
           <Button x:Name="SearchPrev" Grid.Column="6"
                   Width="22" Height="22" Padding="0" Background="Transparent" CornerRadius="3"
@@ -203,12 +203,12 @@
                 <Grid ColumnDefinitions="*,8,Auto">
                   <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
                     <TextBlock Text="{Binding Text}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="12"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize12}"
                                Foreground="{DynamicResource VelaTextPrimary}"
                                TextTrimming="CharacterEllipsis" />
                     <TextBlock Text="{Binding Detail}"
-                               FontSize="11"
+                               FontSize="{DynamicResource VelaFontSize11}"
                                Foreground="{DynamicResource VelaTextMuted}"
                                VerticalAlignment="Center"
                                TextTrimming="CharacterEllipsis"
@@ -220,7 +220,7 @@
                           Padding="5,1"
                           VerticalAlignment="Center">
                     <TextBlock Text="{Binding Source}"
-                               FontSize="10"
+                               FontSize="{DynamicResource VelaFontSize10}"
                                Foreground="{DynamicResource VelaTextTertiary}" />
                   </Border>
                 </Grid>
@@ -269,13 +269,13 @@
 
             <TextBlock Text="{Binding DisconnectOverlayTitle}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontSize="16" FontWeight="SemiBold"
+                       FontSize="{DynamicResource VelaFontSize16}" FontWeight="SemiBold"
                        HorizontalAlignment="Center" />
 
             <TextBlock Text="{Binding DisconnectOverlayDetail}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}"
                        MaxWidth="280"
                        TextWrapping="Wrap"
                        TextAlignment="Center"
@@ -291,7 +291,7 @@
                                  Data="{StaticResource Icon.refresh-cw}"
                                  Foreground="#FFFFFF" VerticalAlignment="Center" />
                   <TextBlock Text="{loc:Localize Reconnect}" Foreground="#FFFFFF"
-                             FontSize="12" FontWeight="SemiBold" VerticalAlignment="Center" />
+                             FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" VerticalAlignment="Center" />
                 </StackPanel>
               </Button>
               <Button Command="{Binding CloseTabCommand}"
@@ -301,14 +301,14 @@
                       CornerRadius="4" Padding="16,8">
                 <TextBlock Text="{loc:Localize CloseTab}"
                            Foreground="{DynamicResource VelaTextSecondary}"
-                           FontSize="12" FontWeight="Medium" VerticalAlignment="Center" />
+                           FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center" />
               </Button>
             </StackPanel>
 
             <!-- 键位提示:两个按钮各自都有等效快捷键,不写出来没人会去试。 -->
             <TextBlock Text="{loc:Localize Msg_DisconnectOverlayKeyHint}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontSize="11"
+                       FontSize="{DynamicResource VelaFontSize11}"
                        TextAlignment="Center"
                        HorizontalAlignment="Center" />
 

--- a/src/VelaShell/Views/TitleBarView.axaml
+++ b/src/VelaShell/Views/TitleBarView.axaml
@@ -104,7 +104,7 @@
         <Image Source="avares://VelaShell/Assets/velashell.png" Width="18" Height="18" />
         <TextBlock Text="{x:Static res:Strings.AppName}"
                    FontFamily="{DynamicResource VelaUiFont}"
-                   FontSize="12" FontWeight="Medium"
+                   FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                    Foreground="{DynamicResource VelaTextSecondary}"
                    VerticalAlignment="Center" />
       </StackPanel>

--- a/src/VelaShell/Views/TraceRouteWindow.axaml
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml
@@ -48,7 +48,7 @@
       <Setter Property="Height" Value="28" />
       <Setter Property="MinHeight" Value="28" />
       <Setter Property="Padding" Value="12,0" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="Cursor" Value="Hand" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
@@ -57,14 +57,14 @@
     </Style>
     <Style Selector="TextBlock.col">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="LetterSpacing" Value="1" />
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
     <Style Selector="TextBlock.cell">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="TextAlignment" Value="Right" />
     </Style>
@@ -97,7 +97,7 @@
                            Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
             <TextBlock Text="{Binding SessionLabel}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontSize="12" FontWeight="SemiBold" VerticalAlignment="Center" />
+                       FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" VerticalAlignment="Center" />
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Top">
             <Button Classes="caption" Click="Minimize_Click">
@@ -125,7 +125,7 @@
         <Grid ColumnDefinitions="Auto,240,Auto,Auto,Auto,*">
           <TextBlock Grid.Column="0" Classes="col" Text="{loc:Localize Trace_Target}" Margin="0,0,8,0" />
           <TextBox Grid.Column="1" Text="{Binding Target}"
-                   Height="28" MinHeight="28" FontSize="11" Padding="8,0"
+                   Height="28" MinHeight="28" FontSize="{DynamicResource VelaFontSize11}" Padding="8,0"
                    VerticalAlignment="Center" VerticalContentAlignment="Center" />
           <Button Grid.Column="2" Classes="tool" Margin="8,0,0,0"
                   Command="{Binding StartCommand}" Content="{loc:Localize Trace_Start}" />
@@ -134,7 +134,7 @@
           <CheckBox Grid.Column="4" Margin="12,0,0,0"
                     IsChecked="{Binding Continuous}"
                     Content="{loc:Localize Trace_Continuous}"
-                    FontSize="11"
+                    FontSize="{DynamicResource VelaFontSize11}"
                     Foreground="{DynamicResource VelaTextSecondary}"
                     VerticalAlignment="Center" />
         </Grid>
@@ -152,7 +152,7 @@
             <StackPanel Spacing="6">
               <TextBlock Text="{loc:Localize Trace_MapNeedsDatabase}"
                          Foreground="{DynamicResource VelaTextSecondary}"
-                         FontSize="10" TextWrapping="Wrap" />
+                         FontSize="{DynamicResource VelaFontSize10}" TextWrapping="Wrap" />
               <StackPanel Orientation="Horizontal" Spacing="8">
                 <Button Classes="tool" Height="24" MinHeight="24"
                         Command="{Binding OpenDatabaseUrlCommand}"
@@ -163,11 +163,11 @@
               </StackPanel>
               <TextBlock Text="{Binding GeoDatabaseUrl}"
                          Foreground="{DynamicResource VelaTextMuted}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="9" TextWrapping="Wrap" />
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize9}" TextWrapping="Wrap" />
               <TextBlock Text="{Binding GeoDatabaseStatus}"
                          Foreground="{DynamicResource VelaError}"
-                         FontSize="10" TextWrapping="Wrap"
+                         FontSize="{DynamicResource VelaFontSize10}" TextWrapping="Wrap"
                          IsVisible="{Binding GeoDatabaseStatus, Converter={x:Static conv:StringNotEmptyConverter.Instance}}" />
             </StackPanel>
           </Border>
@@ -176,7 +176,7 @@
                   Background="#80000000" Padding="6,3" Margin="0,0,6,6"
                   IsVisible="{Binding !GeoDatabaseMissing}">
             <TextBlock Text="{loc:Localize Trace_GeoAttribution}"
-                       Foreground="{DynamicResource VelaTextMuted}" FontSize="9" />
+                       Foreground="{DynamicResource VelaTextMuted}" FontSize="{DynamicResource VelaFontSize9}" />
           </Border>
         </Panel>
         <Border Grid.Column="1" Background="{DynamicResource VelaBorderPrimary}" />
@@ -222,7 +222,7 @@
                 <Border Background="{DynamicResource VelaBgHover}" CornerRadius="3" Padding="4,0"
                         VerticalAlignment="Center"
                         IsVisible="{Binding ExtraAddresses, Converter={x:Static conv:StringNotEmptyConverter.Instance}}">
-                  <TextBlock Text="{Binding ExtraAddresses}" FontSize="9"
+                  <TextBlock Text="{Binding ExtraAddresses}" FontSize="{DynamicResource VelaFontSize9}"
                              Foreground="{DynamicResource VelaTextMuted}" />
                 </Border>
               </StackPanel>
@@ -251,7 +251,7 @@
               Padding="12,0">
         <TextBlock Text="{Binding Status}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontSize="10" VerticalAlignment="Center"
+                   FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
                    TextTrimming="CharacterEllipsis" />
       </Border>
     </Grid>

--- a/src/VelaShell/Views/TunnelHelpDialog.axaml
+++ b/src/VelaShell/Views/TunnelHelpDialog.axaml
@@ -21,24 +21,24 @@
   <Window.Styles>
     <Style Selector="TextBlock.help-title">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-      <Setter Property="FontSize" Value="13" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
       <Setter Property="FontWeight" Value="SemiBold" />
       <Setter Property="Margin" Value="0,12,0,4" />
     </Style>
     <Style Selector="TextBlock.help-body">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="LineHeight" Value="17" />
       <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
     <Style Selector="TextBlock.help-mono">
       <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
     </Style>
     <Style Selector="TextBlock.help-note">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
-      <Setter Property="FontSize" Value="10" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
       <Setter Property="LineHeight" Value="16" />
       <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
@@ -51,7 +51,7 @@
       <Setter Property="Padding" Value="12,0" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     </Style>
   </Window.Styles>
 
@@ -77,7 +77,7 @@
                          VerticalAlignment="Center" Margin="0,0,10,0" />
           <TextBlock Grid.Column="1" Text="{loc:Localize TunnelHelp_Title}"
                      Foreground="{DynamicResource VelaTextPrimary}"
-                     FontSize="13" FontWeight="SemiBold"
+                     FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold"
                      VerticalAlignment="Center"
                      TextTrimming="CharacterEllipsis" />
           <Button Grid.Column="2" Width="24" Height="24"

--- a/src/VelaShell/Views/TunnelPanelView.axaml
+++ b/src/VelaShell/Views/TunnelPanelView.axaml
@@ -16,8 +16,8 @@
 
   <UserControl.Styles>
     <Style Selector="TextBox">
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="MinHeight" Value="26" />
       <Setter Property="Padding" Value="8,4" />
       <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
@@ -27,8 +27,8 @@
     </Style>
     <Style Selector="TextBlock.form-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
-      <Setter Property="FontFamily" Value="{DynamicResource VelaTerminalFont}" />
-      <Setter Property="FontSize" Value="9" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize9}" />
     </Style>
     <Style Selector="Button.row-action">
       <Setter Property="Width" Value="20" />
@@ -61,16 +61,16 @@
                            Foreground="{DynamicResource VelaAccent}" />
             <TextBlock Text="{loc:Localize Tunnel_Title}"
                        Foreground="{DynamicResource VelaTextPrimary}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="11" FontWeight="Medium"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium"
                        VerticalAlignment="Center" />
             <Border Background="{DynamicResource VelaAccent}"
                     CornerRadius="8" Padding="6,1" VerticalAlignment="Center"
                     IsVisible="{Binding Tunnels.Count}">
               <TextBlock Text="{Binding Tunnels.Count}"
                          Foreground="{DynamicResource VelaAccentText}"
-                         FontFamily="{DynamicResource VelaTerminalFont}"
-                         FontSize="9" FontWeight="Medium" />
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
             </Border>
           </StackPanel>
           <Button Grid.Column="2" Classes="row-action" Name="HelpButton"
@@ -96,15 +96,15 @@
               BorderThickness="0,0,0,1">
         <StackPanel Spacing="4">
           <TextBlock Classes="form-label" Text="{loc:Localize Tunnel_ServerLabel}" />
-          <ComboBox MinHeight="26" FontSize="11"
-                    FontFamily="{DynamicResource VelaTerminalFont}"
+          <ComboBox MinHeight="26" FontSize="{DynamicResource VelaFontSize11}"
+                    FontFamily="{DynamicResource VelaUiMonoFont}"
                     HorizontalAlignment="Stretch"
                     PlaceholderText="{loc:Localize Tunnel_SelectServerPlaceholder}"
                     ItemsSource="{Binding Servers}"
                     SelectedItem="{Binding SelectedServer}">
             <ComboBox.ItemTemplate>
               <DataTemplate x:DataType="models:SessionProfile">
-                <TextBlock FontFamily="{DynamicResource VelaTerminalFont}" FontSize="11">
+                <TextBlock FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize11}">
                   <TextBlock.Text>
                     <MultiBinding StringFormat="{}{0} ({1}@{2})">
                       <Binding Path="Name" />
@@ -130,8 +130,8 @@
             </Ellipse>
             <TextBlock Text="{Binding ServerStatusText}"
                        Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaTerminalFont}"
-                       FontSize="9" VerticalAlignment="Center" />
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize9}" VerticalAlignment="Center" />
           </StackPanel>
         </StackPanel>
       </Border>
@@ -143,8 +143,8 @@
               IsVisible="{Binding !Tunnels.Count}">
         <TextBlock Text="{loc:Localize Tunnel_EmptyHint}"
                    Foreground="{DynamicResource VelaTextMuted}"
-                   FontFamily="{DynamicResource VelaTerminalFont}"
-                   FontSize="10" />
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize10}" />
       </Border>
 
       <!-- 隧道行(设计 tunItem1/2):圆点 + 名称 + 类型徽标 | 编辑/启停/删除 -->
@@ -171,16 +171,16 @@
                     </Ellipse>
                     <TextBlock Text="{Binding Name}"
                                Foreground="{DynamicResource VelaTextPrimary}"
-                               FontFamily="{DynamicResource VelaTerminalFont}"
-                               FontSize="11" FontWeight="Medium"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
+                               FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium"
                                MaxWidth="130" TextTrimming="CharacterEllipsis"
                                VerticalAlignment="Center" />
                     <Border Background="{DynamicResource VelaAccentDim}"
                             CornerRadius="2" Padding="6,1" VerticalAlignment="Center">
                       <TextBlock Text="{Binding TypeBadge}"
                                  Foreground="{DynamicResource VelaAccent}"
-                                 FontFamily="{DynamicResource VelaTerminalFont}"
-                                 FontSize="8" FontWeight="Medium" />
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize8}" FontWeight="Medium" />
                     </Border>
                   </StackPanel>
                   <!-- 编辑:把配置填回表单,保存后按新配置重建 -->
@@ -224,24 +224,24 @@
                 </Grid>
                 <TextBlock Text="{Binding DisplayRoute}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="10" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize10}" />
                 <TextBlock Text="{Binding EndpointSummary}"
                            Foreground="{DynamicResource VelaTextMuted}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="9"
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize9}"
                            MaxWidth="320" TextTrimming="CharacterEllipsis"
                            ToolTip.Tip="{Binding EndpointSummary}" />
                 <TextBlock Text="{Binding StatusText}"
                            Foreground="{DynamicResource VelaTextTertiary}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="9" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize9}" />
                 <!-- 转发通道错误(如目标拒绝连接):隧道虽在运行,但连接会失败 -->
                 <TextBlock Text="{Binding LastError, StringFormat='⚠ {0}'}"
                            IsVisible="{Binding HasError}"
                            Foreground="{DynamicResource VelaWarning}"
-                           FontFamily="{DynamicResource VelaTerminalFont}"
-                           FontSize="9" TextWrapping="Wrap" />
+                           FontFamily="{DynamicResource VelaUiMonoFont}"
+                           FontSize="{DynamicResource VelaFontSize9}" TextWrapping="Wrap" />
               </StackPanel>
             </Border>
           </DataTemplate>
@@ -258,7 +258,7 @@
           <TextBlock Text="{Binding FormTitle}"
                      Foreground="{DynamicResource VelaAccent}"
                      FontFamily="{DynamicResource VelaUiFont}"
-                     FontSize="11" FontWeight="Medium" VerticalAlignment="Center" />
+                     FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" VerticalAlignment="Center" />
         </StackPanel>
 
         <Grid ColumnDefinitions="*,8,120" RowDefinitions="Auto,4,Auto">
@@ -266,8 +266,8 @@
           <TextBox   Grid.Row="2" Grid.Column="0" Text="{Binding NewTunnelName}" PlaceholderText="{loc:Localize Tunnel_AliasPlaceholder}" />
           <TextBlock Grid.Row="0" Grid.Column="2" Classes="form-label" Text="{loc:Localize Tunnel_TypeLabel}" />
           <ComboBox  Grid.Row="2" Grid.Column="2"
-                     MinHeight="26" FontSize="11"
-                     FontFamily="{DynamicResource VelaTerminalFont}"
+                     MinHeight="26" FontSize="{DynamicResource VelaFontSize11}"
+                     FontFamily="{DynamicResource VelaUiMonoFont}"
                      HorizontalAlignment="Stretch"
                      SelectedIndex="{Binding NewTunnelTypeIndex}">
             <ComboBoxItem Content="{loc:Localize LocalForward}" ToolTip.Tip="{loc:Localize Tunnel_LocalForwardTip}" />
@@ -299,12 +299,12 @@
                   Padding="0" MinHeight="0">
           <TextBlock Text="{loc:Localize Tunnel_ForwardToLoopback}"
                      Foreground="{DynamicResource VelaTextSecondary}"
-                     FontSize="10" Margin="6,0,0,0" />
+                     FontSize="{DynamicResource VelaFontSize10}" Margin="6,0,0,0" />
         </CheckBox>
 
         <TextBlock Text="{Binding ErrorMessage}"
                    Foreground="{DynamicResource VelaError}"
-                   FontFamily="{DynamicResource VelaTerminalFont}" FontSize="9"
+                   FontFamily="{DynamicResource VelaUiMonoFont}" FontSize="{DynamicResource VelaFontSize9}"
                    TextWrapping="Wrap"
                    IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
 
@@ -314,7 +314,7 @@
                   Command="{Binding ResetFormCommand}">
             <TextBlock Text="{loc:Localize Cancel}"
                        Foreground="{DynamicResource VelaTextSecondary}"
-                       FontFamily="{DynamicResource VelaUiFont}" FontSize="11" />
+                       FontFamily="{DynamicResource VelaUiFont}" FontSize="{DynamicResource VelaFontSize11}" />
           </Button>
           <!-- 主操作按钮沿用 SFTP「上传」的强调药丸方案:半透明 VelaAccentDim 底 + 强调色描边/图标/文字,
                而非实心 VelaAccent(过于突兀、且不与背景图融合)。Padding 保持 10,4 以与左侧取消按钮等高。 -->
@@ -327,7 +327,7 @@
                              Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
               <TextBlock Text="{Binding SubmitButtonText}"
                          Foreground="{DynamicResource VelaAccent}"
-                         FontFamily="{DynamicResource VelaUiFont}" FontSize="11" FontWeight="Medium" />
+                         FontFamily="{DynamicResource VelaUiFont}" FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
             </StackPanel>
           </Button>
         </StackPanel>

--- a/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
@@ -709,7 +709,7 @@ public class FileBrowserViewModelTests
         await _sftpService.Received(1).RenameAsync(
             _sessionId, files[2].FullPath, $"/srv/archive/{files[2].Name}", Arg.Any<CancellationToken>());
         Assert.IsNotNull(_vm.ErrorMessage);
-        StringAssert.Contains(_vm.ErrorMessage, "permission denied");
+        Assert.Contains("permission denied", _vm.ErrorMessage);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Tests/Views/UiFontSettingsTests.cs
+++ b/tests/VelaShell.Tests/Views/UiFontSettingsTests.cs
@@ -1,0 +1,283 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 设置 → 外观 → 界面字体/字号是否真的落到界面上。
+/// </summary>
+/// <remarks>
+/// 这两个选项曾经"设了没反应":令牌接线本身是通的,但界面 axaml 把字号写死了 ~350 处、
+/// 把字体钉死在等宽令牌上 ~150 处,用户改设置只影响到极少数文本,观感上等同没生效。
+/// 所以这里【不】只断言令牌值 —— 只断言令牌等于自证,写死字号的老毛病照样能全绿溜回来。
+/// 关键的几条都是拿真实视图里的真实 TextBlock 去量的。
+/// </remarks>
+[TestClass]
+[TestCategory("UiFontSettings")]
+public class UiFontSettingsTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App。
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(UiFontSettingsTests).Assembly);
+
+    /// <summary>设计基准字号:令牌名里的数字就是这个基准下的磅值。</summary>
+    private const double BaseUiFontSize = 13;
+
+    [TestCleanup]
+    public void RestoreDefaults() => OnUi(() => ApplyAppearance(new AppearanceOptions()));
+
+    [TestMethod]
+    public void DefaultUiFontSize_LeavesLadderAtDesignValues()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions());
+
+            // 默认基准 13 时整套阶梯必须逐值等于设计值,否则这次改动就是一次全局改版。
+            foreach (double design in (double[])[8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20])
+            {
+                Assert.AreEqual(design, Token($"VelaFontSize{design:0}"), $"VelaFontSize{design:0}");
+            }
+            Assert.AreEqual(13d, Token("VelaUiFontSize"));
+        });
+    }
+
+    [TestMethod]
+    public void LargerUiFontSize_ScalesWholeLadderProportionally()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions { UiFontSize = 20 });
+
+            Assert.AreEqual(20d, Token("VelaUiFontSize"));
+            // 20/13 ≈ 1.54:每一级都跟着放大,且保持严格递增(层级不走形)。
+            Assert.AreEqual(Math.Round(10 * 20 / BaseUiFontSize), Token("VelaFontSize10"));
+            Assert.AreEqual(Math.Round(11 * 20 / BaseUiFontSize), Token("VelaFontSize11"));
+            Assert.IsGreaterThan(Token("VelaFontSize10"), Token("VelaFontSize11"));
+            Assert.IsGreaterThan(Token("VelaFontSize12"), Token("VelaFontSize13"));
+            // Fluent 内置控件(按钮/输入框/下拉)也得一起缩放,否则控件里的字与周围字对不上。
+            Assert.AreEqual(20d, Token("ControlContentThemeFontSize"));
+        });
+    }
+
+    [TestMethod]
+    public void SmallestUiFontSize_KeepsEverySizeLegible()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions { UiFontSize = 9 });
+
+            foreach (double design in (double[])[8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20])
+            {
+                Assert.IsGreaterThanOrEqualTo(6d, Token($"VelaFontSize{design:0}"), $"VelaFontSize{design:0}");
+            }
+        });
+    }
+
+    /// <summary>说明文字相对基准字号的比例(与 MainWindow.DescFontSizeRatio 同源)。</summary>
+    private const double DescRatio = 0.85;
+
+    [TestMethod]
+    public void DescriptionSize_StaysAtFixedShareOfBase()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions());
+            Assert.AreEqual(Math.Round(DescRatio * 13), Token("VelaFontSizeDesc"));
+
+            ApplyAppearance(new AppearanceOptions { UiFontSize = 20 });
+            Assert.AreEqual(Math.Round(DescRatio * 20), Token("VelaFontSizeDesc"));
+        });
+    }
+
+    [TestMethod]
+    public void UiFont_OverridesBothProportionalAndMonospaceInterfaceText()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions { UiFont = "Comic Sans MS" });
+
+            // 界面上的文字要么走比例令牌要么走等宽令牌 —— 只换其中一个,用户看到的就是
+            // "改了字体但大部分界面没变",正是这次要修的症状。
+            foreach (string key in (string[])["VelaUiFont", "VelaUiMonoFont"])
+            {
+                Assert.IsTrue(
+                    Application.Current!.TryGetResource(key, null, out object? value),
+                    $"{key} 未定义"
+                );
+                Assert.Contains("Comic Sans MS", value!.ToString(), $"{key} 没跟随界面字体");
+            }
+        });
+    }
+
+    [TestMethod]
+    public void DefaultUiFont_RestoresProportionalUiAndMonospaceChrome()
+    {
+        OnUi(() =>
+        {
+            ApplyAppearance(new AppearanceOptions { UiFont = "Comic Sans MS" });
+            ApplyAppearance(new AppearanceOptions { UiFont = "  " });
+
+            // 还原后:普通界面文字回到 Inter,按列对齐的界面文字回到等宽 —— 两者默认值不同,
+            // 一起覆盖时也必须一起还原,不能把等宽区域留在 Inter 上。
+            Assert.Contains("Inter", Font("VelaUiFont"));
+            Assert.Contains("Cascadia Mono", Font("VelaUiMonoFont"));
+        });
+    }
+
+    /// <summary>
+    /// 真实设置窗口里的真实文本:标签跟着界面字号缩放,说明文字跟着走固定比例。
+    /// 这条是本组测试的重心 —— 令牌对了但 axaml 写死字号的话,只有它会红。
+    /// </summary>
+    [TestMethod]
+    public void SettingsWindowText_FollowsUiFontSize()
+    {
+        OnUi(() =>
+        {
+            var window = new SettingsView { DataContext = NewSettingsViewModel() };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                ApplyAppearance(new AppearanceOptions());
+                Dispatcher.UIThread.RunJobs();
+                double labelAtDefault = FirstTextSize(window, "row-label");
+                double descAtDefault = FirstTextSize(window, "row-desc");
+
+                ApplyAppearance(new AppearanceOptions { UiFontSize = 20 });
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.IsGreaterThan(labelAtDefault, FirstTextSize(window, "row-label"), "设置项标签没跟随界面字号");
+                Assert.IsGreaterThan(descAtDefault, FirstTextSize(window, "row-desc"), "设置项说明没跟随界面字号");
+                Assert.AreEqual(Math.Round(DescRatio * 20), FirstTextSize(window, "row-desc"));
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 设置项说明必须换行:窗口 CanResize=False 且没有横向滚动条,不换行的长说明会直接
+    /// 顶到可视区外面去 —— 字号越大越明显,所以这里拿最大字号来量。
+    /// </summary>
+    [TestMethod]
+    public void LongSettingDescriptions_WrapInsteadOfOverflowing()
+    {
+        OnUi(() =>
+        {
+            var window = new SettingsView { DataContext = NewSettingsViewModel() };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                ApplyAppearance(new AppearanceOptions { UiFontSize = 24 });
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+
+                TextBlock[] descriptions =
+                [
+                    .. window.GetVisualDescendants()
+                             .OfType<TextBlock>()
+                             .Where(t => t.Classes.Contains("row-desc") && t.IsVisible && t.Bounds.Width > 0),
+                ];
+                Assert.IsNotEmpty(descriptions);
+
+                // 定宽的行首标注(ANSI 色板的"普通/明亮")是有意关掉换行的,余下的都得能折行。
+                foreach (TextBlock desc in descriptions.Where(t => double.IsNaN(t.Width)))
+                {
+                    Assert.AreEqual(TextWrapping.Wrap, desc.TextWrapping, $"说明「{desc.Text}」不会换行");
+                }
+                // 并且要真的折起来了 —— 只断言属性值的话,换行在布局上被别的容器挡掉也发现不了。
+                Assert.IsTrue(
+                    descriptions.Any(d => d.Bounds.Height > d.FontSize * 1.6),
+                    "最大字号下没有任何一条说明折行,这条断言就是空的"
+                );
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>真实设置窗口里的真实文本跟着界面字体换族 —— 含钉在等宽上的说明文字。</summary>
+    [TestMethod]
+    public void SettingsWindowText_FollowsUiFont()
+    {
+        OnUi(() =>
+        {
+            var window = new SettingsView { DataContext = NewSettingsViewModel() };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                ApplyAppearance(new AppearanceOptions { UiFont = "Comic Sans MS" });
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Contains("Comic Sans MS", FirstText(window, "row-label").FontFamily.ToString());
+                Assert.Contains("Comic Sans MS", FirstText(window, "row-desc").FontFamily.ToString());
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    private static SettingsViewModel NewSettingsViewModel()
+    {
+        ISettingsService settings = Substitute.For<ISettingsService>();
+        settings.GetSettingsAsync().Returns(new AppSettings());
+        return new SettingsViewModel(settings, Substitute.For<IThemeService>());
+    }
+
+    private static double FirstTextSize(Window window, string styleClass) =>
+        FirstText(window, styleClass).FontSize;
+
+    private static TextBlock FirstText(Window window, string styleClass) =>
+        window.GetVisualDescendants()
+              .OfType<TextBlock>()
+              .First(t => t.Classes.Contains(styleClass) && t.IsVisible);
+
+    private static double Token(string key) =>
+        Application.Current!.TryGetResource(key, null, out object? value) && value is double d
+            ? d
+            : throw new AssertFailedException($"令牌 {key} 不存在或不是 double");
+
+    private static string Font(string key) =>
+        Application.Current!.TryGetResource(key, null, out object? value) && value is FontFamily family
+            ? family.ToString()
+            : throw new AssertFailedException($"令牌 {key} 不存在或不是 FontFamily");
+
+    /// <summary>走生产那条通路下发外观(MainWindow 保存/预览时调用的就是它)。</summary>
+    private static void ApplyAppearance(AppearanceOptions appearance)
+    {
+        MainWindow.ApplyUiFontTokens(Application.Current!, appearance);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(
+            () =>
+            {
+                body();
+                return Task.CompletedTask;
+            },
+            CancellationToken.None
+        ).GetAwaiter().GetResult();
+}

--- a/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
+++ b/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
@@ -1,5 +1,8 @@
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
@@ -29,6 +32,16 @@ public class VelaHeadlessApp : Application
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Icons.axaml"));
         Styles.Add(LoadStyles("avares://VelaShell/Themes/DockStyles.axaml"));
         Styles.Add(LoadStyles("avares://VelaShell/Themes/InputStyles.axaml"));
+        // 与 App.axaml 末尾那条同源:设置 → 外观 → 界面字体/字号靠它下发到每个窗口,
+        // 没有它,测试里的窗口用的是 Fluent 默认字体/字号,与生产不是一回事。
+        Styles.Add(new Style(x => x.Is<Window>())
+        {
+            Setters =
+            {
+                new Setter(TemplatedControl.FontFamilyProperty, new DynamicResourceExtension("VelaUiFont")),
+                new Setter(TemplatedControl.FontSizeProperty, new DynamicResourceExtension("VelaUiFontSize")),
+            },
+        });
     }
 
     public static AppBuilder BuildAvaloniaApp() =>


### PR DESCRIPTION
全面重构界面字体和字号资源令牌，新增 VelaUiFont/VelaUiMonoFont 及字号阶梯令牌，所有界面文本统一绑定令牌，彻底消除写死字体/字号问题。实现“设置 → 外观 → 界面字体/字号”对全局生效，支持等比缩放和还原。XAML 视图、样式、控件等全部切换为令牌引用，移除所有硬编码。文件浏览器等依赖字体度量逻辑改为动态获取令牌。新增 UiFontSettingsTests 覆盖全局生效、缩放、还原等场景，测试环境同步支持令牌样式注入。相关文档已更新，明确使用规范和设计原则。全面提升界面一致性、可访问性和用户体验。