### PR TITLE
统一对话框按钮主题，完善视觉规范与测试

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@ VelaShell is a keyboard-first, high-density SSH/SFTP terminal client for ops and
 - **Platform**: .NET 11 + Avalonia 12.1, cross-platform desktop (Windows/Linux/macOS)
 - **Window**: Self-drawn frameless (`WindowDecorations="None"`), 36px custom title bar via `TitleBarView`
 - **Icon set**: Lucide (stroke weight 2, round caps, 24x24 viewBox scaled to 11-16px)
-- **Fonts**: JetBrains Mono (terminal, data, paths, keys) + Inter (UI chrome, buttons, settings)
+- **Fonts**: Cascadia Mono (terminal, data, paths, keys) + Inter (UI chrome, buttons, settings); both interface faces follow Settings → Appearance → UI Font
 - **Theme switching**: Runtime dark/light/system, driven entirely by `DynamicResource` token swaps
 
 ---
@@ -189,7 +189,41 @@ StatusBar (24px, bg-sidebar)
 
 ## 5. Components & States
 
-### 5.1 Reusable Primitives
+### 5.1 Action Buttons (`Themes/ButtonThemes.axaml`)
+
+Every window and dialog draws its action buttons from **two shared control themes**. They are
+registered application-wide in `App.axaml`, so any view can reference them with no local setup.
+Do **not** use the Fluent default button appearance, and do **not** re-declare an equivalent
+button style inside a view — that is exactly how the same action ends up looking different in
+two places (the upload dialog's Cancel button was a bare Fluent button while the file browser's
+Upload button was an accent pill).
+
+| Role | Theme | Appearance |
+|---|---|---|
+| Primary action — upload, create, confirm | `VelaAccentPillButtonTheme` | `VelaAccentDim` fill (translucent), `VelaAccent` foreground for icon *and* label, `CornerRadius:3`, no border until focused |
+| Secondary action — cancel, close, browse | `VelaOutlineButtonTheme` | `Transparent` fill, 1px `VelaBorderPrimary`, `VelaTextSecondary` foreground, `CornerRadius:3`, `Height:28`, `Padding:[14,0]` |
+| Destructive action | `VelaOutlineButtonTheme` + `VelaError` foreground/border | Never a solid red fill |
+
+Rules:
+
+- **Primary is a translucent pill, not a solid fill.** `VelaAccentDim` is semi-transparent so it
+  blends with a user background image; a solid `VelaAccent` block reads as too loud and sits on
+  the image like a sticker.
+- **Both fills are transparent-friendly.** A row must not mix one button that blends into the
+  background with another that sits on an opaque slab.
+- **Foreground comes from the theme.** The pill theme sets `Foreground` to `VelaAccent`; content
+  inherits it. Only bind `Foreground="{Binding $parent[Button].Foreground}"` on a `LucideIcon`,
+  which does not inherit text foreground.
+- **Same action, same icon.** If an action has an icon anywhere (e.g. `Icon.upload` on the file
+  browser toolbar), the dialog that performs the same action carries that icon too.
+- **Buttons in one action row share a height.** Set it on the primary; the outline theme already
+  defaults to 28.
+- Toolbar icon buttons are a separate role — see `.toolbar-btn` below — and may override
+  `Height`/`Padding` to fit a 24px toolbar.
+
+Guarded by `DialogButtonStyleTests`.
+
+### 5.2 Reusable Primitives
 
 #### LucideIcon (`pc:LucideIcon`)
 - Custom Avalonia control rendering Lucide path data
@@ -213,7 +247,7 @@ StatusBar (24px, bg-sidebar)
 - Class: `.crumb` -- transparent bg, no border, `FontFamily:VelaUiMonoFont`, `FontSize:11`, `FontWeight:Medium`
 - Hover: `VelaBgHover` background, `VelaAccent` foreground
 
-### 5.2 File Browser (`FileBrowserView.axaml`)
+### 5.3 File Browser (`FileBrowserView.axaml`)
 
 The existing SFTP file browser is the primary reusable component for the dual-pane SFTP document.
 
@@ -238,14 +272,14 @@ The existing SFTP file browser is the primary reusable component for the dual-pa
 
 **Error banner:** `VelaBgActive` background, `VelaAccent` text, shown above column header
 
-### 5.3 Session Tree (`SessionTreeView.axaml`)
+### 5.4 Session Tree (`SessionTreeView.axaml`)
 
 - Group row (30px): chevron + folder icon (color rotates: `VelaWarning`/`VelaInfo`/`VelaAccent`) + name (`VelaTextPrimary` 12px Medium) + count (`VelaTextTertiary` 10px)
 - Session row (28px): status dot + name + optional status tag
 - Selected: `VelaBgActive` background, name switches to `VelaAccent` Medium
 - Hover: `VelaBgHover`
 
-### 5.4 Context Menus (global style in `DockStyles.axaml`)
+### 5.5 Context Menus (global style in `DockStyles.axaml`)
 
 - `VelaBgSurface` background, `VelaBorderSecondary` 1px border, `CornerRadius:6`, `Padding:4`
 - Item: `VelaUiMonoFont` 11px, `VelaTextSecondary`, `Padding:[10,5]`, `CornerRadius:4`
@@ -255,12 +289,12 @@ The existing SFTP file browser is the primary reusable component for the dual-pa
 - Danger items: `VelaError` foreground + icon
 - Primary action items: `VelaTextPrimary` Medium + `VelaAccent` icon
 
-### 5.5 Tooltips (global style in `DockStyles.axaml`)
+### 5.6 Tooltips (global style in `DockStyles.axaml`)
 
 - `VelaBgSurface` background, `VelaBorderSecondary` 1px border, `CornerRadius:6`, `Padding:[8,4]`
 - `VelaTextSecondary` foreground, 11px
 
-### 5.6 Tab Navigation Buttons (`.tab-nav` in `DockStyles.axaml`)
+### 5.7 Tab Navigation Buttons (`.tab-nav` in `DockStyles.axaml`)
 
 - 24x24, `CornerRadius:3`, transparent background
 - Hover: `VelaBgHover`

--- a/src/VelaShell/Themes/ButtonThemes.axaml
+++ b/src/VelaShell/Themes/ButtonThemes.axaml
@@ -1,11 +1,23 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+  <!-- ============================== 按钮方案(全应用统一) ==============================
+       任何窗口/对话框的动作按钮都从这两个主题里挑,不要用 Fluent 默认按钮外观,也不要在
+       各自视图里另起一套(那正是"同一个动作在不同窗口长得不一样"的来源):
+
+         主操作 → VelaAccentPillButtonTheme  强调药丸(SFTP 上传、隧道创建、对话框确认…)
+         次操作 → VelaOutlineButtonTheme     描边按钮(取消、关闭、浏览…)
+
+       危险操作在次操作基础上把前景/描边换成 VelaError 即可,不另立主题。
+       两者尺寸默认按对话框动作条给(Height 28);工具条里的小号按钮自行压 Height/Padding。
+       详见 DESIGN.md §5.1 Action Buttons。 -->
+
   <!-- 强调色「药丸」按钮(SFTP 上传、隧道创建等主操作):半透明强调底 VelaAccentDim + 强调色描边/图标/文字。
        比实心 VelaAccent 更柔和;且 VelaAccentDim 为半透明,能与背景图自然融合,不突兀。
-       图标/文字请自行用 VelaAccent 前景(见各调用处)。 -->
+       前景默认就是 VelaAccent,内容里的图标/文字不写 Foreground 也能拿到正确颜色。 -->
   <ControlTheme x:Key="VelaAccentPillButtonTheme" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
     <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="CornerRadius" Value="3" />
@@ -55,6 +67,60 @@
     </Style>
     <Style Selector="^:disabled">
       <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+  </ControlTheme>
+
+  <!-- 描边按钮(取消/关闭/浏览等次操作):透明底 + 1px 边框,与强调药丸配对出现。
+       透明底同样是为了背景图能透上来 —— 与药丸一致,一排按钮不会一个融进背景一个糊着实底。 -->
+  <ControlTheme x:Key="VelaOutlineButtonTheme" TargetType="Button">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="3" />
+    <Setter Property="Padding" Value="14,0" />
+    <Setter Property="Height" Value="28" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+    <Setter Property="FontWeight" Value="Medium" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="PART_OutlineRoot"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <ContentPresenter x:Name="PART_ContentPresenter"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Foreground="{TemplateBinding Foreground}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+    </Style>
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+    </Style>
+    <!-- 键盘焦点:描边换成强调色。次操作不抢视觉重心,故只动描边、不动底色。 -->
+    <Style Selector="^:focus">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
     </Style>

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml
@@ -103,13 +103,23 @@
                      Foreground="{DynamicResource VelaTextMuted}"
                      FontFamily="{DynamicResource VelaUiMonoFont}"
                      FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center" />
+          <!-- 动作按钮走全应用统一的两个按钮主题(见 Themes/ButtonThemes.axaml):
+               取消 = 描边次操作,上传 = 强调药丸 + upload 图标,与 SFTP 文件浏览器工具条上的
+               「上传」按钮同一套视觉语言 —— 同一个动作在两处不该长成两个样子。 -->
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-            <Button Height="26" Padding="14,0" Cursor="Hand" Click="OnCancelClick"
-                    Content="{x:Static res:Strings.Cancel}" FontSize="{DynamicResource VelaFontSize11}" />
-            <Button Name="ConfirmButton" Height="26" Padding="14,0" Cursor="Hand"
+            <Button Theme="{DynamicResource VelaOutlineButtonTheme}"
+                    Click="OnCancelClick" Content="{x:Static res:Strings.Cancel}" />
+            <Button Name="ConfirmButton" Height="28" Padding="14,0"
                     Theme="{DynamicResource VelaAccentPillButtonTheme}"
-                    Click="OnConfirmClick" IsDefault="True"
-                    Content="{x:Static res:Strings.Upload}" FontSize="{DynamicResource VelaFontSize11}" />
+                    Click="OnConfirmClick" IsDefault="True">
+              <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <pc:LucideIcon Width="12" Height="12" VerticalAlignment="Center"
+                               Data="{StaticResource Icon.upload}"
+                               Foreground="{Binding $parent[Button].Foreground}" />
+                <TextBlock Text="{x:Static res:Strings.Upload}" VerticalAlignment="Center"
+                           FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+              </StackPanel>
+            </Button>
           </StackPanel>
         </Grid>
       </Border>

--- a/tests/VelaShell.Core.Tests/Ssh/SshConnectionServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/SshConnectionServiceTests.cs
@@ -136,7 +136,7 @@ public class SshConnectionServiceTests
         Assert.IsNotNull(session1);
         Assert.IsNotNull(session2);
         Assert.AreNotEqual(session2.SessionId, session1.SessionId);
-        Assert.AreEqual(2, service.Sessions.Count);
+        Assert.HasCount(2, service.Sessions);
     }
 
     [TestMethod]
@@ -262,7 +262,7 @@ public class SshConnectionServiceTests
         };
         var service = new SshConnectionService(_ => mockClientWrapper);
         await Assert.ThrowsExactlyAsync<VelaSshConnectionException>(async () => await service.ConnectAsync(connectionInfo));
-        Assert.AreEqual(0, service.Sessions.Count);
+        Assert.IsEmpty(service.Sessions);
     }
 
     [TestMethod]
@@ -318,7 +318,7 @@ public class SshConnectionServiceTests
         TimeoutException ex = await Assert.ThrowsExactlyAsync<TimeoutException>(async () => await service.ConnectAsync(connectionInfo));
         Assert.Contains("slow.example.com", ex.Message);
         Assert.Contains("timed out", ex.Message);
-        Assert.AreEqual(0, service.Sessions.Count);
+        Assert.IsEmpty(service.Sessions);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -472,7 +472,7 @@ public class TerminalBridgeTests
 
         lock (written)
         {
-            Assert.IsFalse(written.Contains((byte)'q'), "ZMODEM 会话期间的击键不得写入传输流。");
+            Assert.DoesNotContain((byte)'q', written, "ZMODEM 会话期间的击键不得写入传输流。");
         }
         router.CancelActiveSession();
     }

--- a/tests/VelaShell.Tests/Views/DialogButtonStyleTests.cs
+++ b/tests/VelaShell.Tests/Views/DialogButtonStyleTests.cs
@@ -1,0 +1,152 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Core.Models;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 对话框动作按钮的统一视觉方案:主操作 = 强调药丸(VelaAccentPillButtonTheme),
+/// 次操作 = 描边按钮(VelaOutlineButtonTheme)。见 DESIGN.md 的 Buttons 一节。
+/// </summary>
+/// <remarks>
+/// 起因是"选择要上传的文件与文件夹"对话框:确认按钮虽然挂了药丸主题却没拿到强调色前景,
+/// 取消按钮干脆是 Fluent 默认外观 —— 同一个「上传」动作在文件浏览器工具条和这个对话框里
+/// 长成了两个样子。这里钉住的是【方案本身】(挂对主题、拿到对的前景),不钉具体像素:
+/// 尺寸是照观感调的,该由眼睛拍板。
+/// </remarks>
+[TestClass]
+[TestCategory("DialogButtonStyle")]
+public class DialogButtonStyleTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App。
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(DialogButtonStyleTests).Assembly);
+
+    [TestMethod]
+    public void AccentPillTheme_PaintsItsContentInAccent()
+    {
+        OnUi(() =>
+        {
+            // 药丸主题自带强调色前景,调用处不必逐个元素重复写 Foreground ——
+            // 少写一处就少一处漏写(上传对话框的确认按钮当初漏的就是它)。
+            var button = new Button { Theme = Theme("VelaAccentPillButtonTheme") };
+            var label = new TextBlock { Text = "上传" };
+            button.Content = new StackPanel { Children = { label } };
+            var window = new Window { Content = button };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Assert.AreEqual(Brush("VelaAccent"), button.Foreground);
+                // 内容里的文字靠继承拿到同一支画刷,不写 Foreground 也不会退回默认文字色。
+                Assert.AreEqual(Brush("VelaAccent"), label.Foreground);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [TestMethod]
+    public void UploadDialog_UsesSharedActionButtonThemes()
+    {
+        OnUi(() =>
+        {
+            // loadInitial: false —— 不去真读磁盘,本组只关心按钮长什么样。
+            var window = new LocalPathPickerDialog(new LocalFilePaneViewModel(new TransferOptions()), loadInitial: false);
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Button confirm = ButtonNamed(window, "ConfirmButton");
+                Assert.AreEqual(Theme("VelaAccentPillButtonTheme"), confirm.Theme, "上传按钮没走强调药丸方案");
+
+                // 没选中任何条目时确认按钮是禁用的(前景走 VelaTextMuted),放开才看得到强调色。
+                confirm.IsEnabled = true;
+                Dispatcher.UIThread.RunJobs();
+                Assert.AreEqual(Brush("VelaAccent"), confirm.Foreground);
+
+                // 取消:与确认同处一条动作条,必须是描边次操作,而不是 Fluent 默认按钮
+                // (默认按钮是实底灰,和旁边透明的药丸完全不是一套东西)。
+                Button cancel = SiblingButtons(confirm).Single(b => b != confirm);
+                Assert.AreEqual(Theme("VelaOutlineButtonTheme"), cancel.Theme, "取消按钮没走描边方案");
+
+                // 两个按钮等高,否则一条动作条上高低不齐。
+                Assert.AreEqual(confirm.Bounds.Height, cancel.Bounds.Height);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>确认按钮带 upload 图标:与文件浏览器工具条上的「上传」是同一个图标。</summary>
+    [TestMethod]
+    public void UploadDialog_ConfirmButtonCarriesUploadIcon()
+    {
+        OnUi(() =>
+        {
+            // loadInitial: false —— 不去真读磁盘,本组只关心按钮长什么样。
+            var window = new LocalPathPickerDialog(new LocalFilePaneViewModel(new TransferOptions()), loadInitial: false);
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Assert.IsNotEmpty(
+                    ButtonNamed(window, "ConfirmButton").GetVisualDescendants()
+                        .OfType<Control>()
+                        .Where(c => c.GetType().Name == "LucideIcon")
+                        .ToList(),
+                    "上传按钮少了 upload 图标"
+                );
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    private static Button ButtonNamed(Window window, string name) =>
+        window.GetVisualDescendants().OfType<Button>().Single(b => b.Name == name);
+
+    private static IEnumerable<Button> SiblingButtons(Button button) =>
+        button.GetVisualAncestors()
+              .OfType<StackPanel>()
+              .First()
+              .GetVisualDescendants()
+              .OfType<Button>();
+
+    private static ControlTheme Theme(string key) =>
+        Application.Current!.TryGetResource(key, null, out object? value) && value is ControlTheme theme
+            ? theme
+            : throw new AssertFailedException($"按钮主题 {key} 不存在");
+
+    private static IBrush Brush(string key) =>
+        Application.Current!.TryGetResource(key, ThemeVariant.Dark, out object? value) && value is IBrush brush
+            ? brush
+            : throw new AssertFailedException($"画刷令牌 {key} 不存在");
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(
+            () =>
+            {
+                body();
+                return Task.CompletedTask;
+            },
+            CancellationToken.None
+        ).GetAwaiter().GetResult();
+}

--- a/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/FileBrowserMarqueeUiTests.cs
@@ -153,8 +153,8 @@ public sealed class FileBrowserMarqueeUiTests
                 list.SelectedItems.Add(file);
             }
             Pump(window);
-            Assert.AreEqual(3, list.SelectedItems.Count, "测试必须先建立真实的三项控件选区。");
-            Assert.AreEqual(3, vm.SelectedFiles.Count, "控件选区应同步到视图模型。");
+            Assert.HasCount(3, list.SelectedItems, "测试必须先建立真实的三项控件选区。");
+            Assert.HasCount(3, vm.SelectedFiles, "控件选区应同步到视图模型。");
 
             Drag(window, list, fromRow: 2, toRow: 3, midDrag: () =>
                 Assert.AreSequenceEqual(

--- a/tests/VelaShell.Tests/Views/UiFontSettingsTests.cs
+++ b/tests/VelaShell.Tests/Views/UiFontSettingsTests.cs
@@ -203,8 +203,8 @@ public class UiFontSettingsTests
                     Assert.AreEqual(TextWrapping.Wrap, desc.TextWrapping, $"说明「{desc.Text}」不会换行");
                 }
                 // 并且要真的折起来了 —— 只断言属性值的话,换行在布局上被别的容器挡掉也发现不了。
-                Assert.IsTrue(
-                    descriptions.Any(d => d.Bounds.Height > d.FontSize * 1.6),
+                Assert.Contains(
+                    d => d.Bounds.Height > d.FontSize * 1.6, descriptions,
                     "最大字号下没有任何一条说明折行,这条断言就是空的"
                 );
             }

--- a/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
+++ b/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
@@ -30,6 +30,7 @@ public class VelaHeadlessApp : Application
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaTokens.axaml"));
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaShellTokens.axaml"));
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Icons.axaml"));
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell/Themes/ButtonThemes.axaml"));
         Styles.Add(LoadStyles("avares://VelaShell/Themes/DockStyles.axaml"));
         Styles.Add(LoadStyles("avares://VelaShell/Themes/InputStyles.axaml"));
         // 与 App.axaml 末尾那条同源:设置 → 外观 → 界面字体/字号靠它下发到每个窗口,


### PR DESCRIPTION
本次提交统一了对话框主/次操作按钮的视觉风格：主操作采用强调色药丸按钮（VelaAccentPillButtonTheme），次操作采用描边按钮（VelaOutlineButtonTheme），并在 DESIGN.md 详细规范了按钮主题的使用规则。新增 ButtonThemes.axaml 集中定义按钮主题，LocalPathPickerDialog.axaml 实际应用，确保“上传”“取消”按钮风格一致。补充 DialogButtonStyleTests，自动化验证按钮主题、前景色继承和图标一致性，防止回归。部分测试断言优化为更语义化方法。VelaHeadlessApp 合并按钮主题资源，保证测试环境一致性，整体提升 UI 一致性和可维护性。