### PR TITLE
升级 Avalonia 与 ReactiveUI 相关依赖包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,18 +4,18 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Avalonia UI -->
-    <PackageVersion Include="Avalonia" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.1" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Wayland" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Wayland" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
     <!-- Microsoft.Extensions -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26359.118" />
     <!-- 其它 -->
-    <PackageVersion Include="ReactiveUI" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI" Version="24.1.0" />
     <!-- MMDB 读取器(Apache 2.0)。只是格式读取库,不绑定 MaxMind 的数据 ——
          我们配的是 DB-IP Lite City(CC BY 4.0),同一格式。 -->
     <PackageVersion Include="MaxMind.Db" Version="5.1.0" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -10,9 +10,9 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <!-- 测试辅助 -->
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-    <PackageVersion Include="ReactiveUI.Testing" Version="24.0.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="ReactiveUI.Testing" Version="24.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
升级 Avalonia 及其相关组件（Avalonia、Avalonia.Desktop、Avalonia.Themes.Fluent、Avalonia.Fonts.Inter、Avalonia.Wayland、Avalonia.Headless）和 ReactiveUI 及其测试包（ReactiveUI、ReactiveUI.Testing），版本从 12.1.0/24.0.0 升级至 12.1.1/24.1.0。