### PR TITLE
修正终端 CSI/DECRQSS/DECSCUSR 兼容性问题

### DIFF
--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -280,19 +280,43 @@ public sealed class TerminalEmulator : IVtActions
     /// <summary>分发 CSI 序列(光标移动、擦除、插入/删除、SGR、模式设置/重置、报告等)。</summary>
     public void CsiDispatch(char prefix, IReadOnlyList<int> p, string intermediates, char final)
     {
-        if (prefix == '?')
+        // 带中间字节的 CSI 自成一套文法,末字节与无中间字节的同名序列毫无关系:
+        // 认识的在这里消费,其余一律忽略 —— 绝不能落到下面按 final 分派的分支去。
+        // (vim 启动时的 xterm 兼容性探针 "CSI 0 % m" 曾被当成 SGR 0 执行。)
+        if (intermediates.Length > 0)
         {
-            HandlePrivateMode(p, final);
+            if (prefix == '\0')
+            {
+                switch (intermediates)
+                {
+                    case "!" when final == 'p':
+                        SoftReset(); // DECSTR 软复位
+                        break;
+                    case " " when final == 'q':
+                        // DECSCUSR:渲染按用户设置,这里只记形状供 DECRQSS 回报。
+                        // 钳到 0..6(合法取值),回报必须是单个数字,否则 vim 解析不了会把整段应答当键入。
+                        Modes.CursorStyle = Math.Clamp(P0(0), 0, 6);
+                        break;
+                }
+            }
             return;
         }
-        switch (intermediates)
+        // 私有前缀(? > = <)与无前缀同样是彼此独立的文法:vim 启动时的
+        // "CSI > 4 ; 2 m"(modifyOtherKeys)不是 SGR,"CSI = 0 ; 1 u"(kitty 键盘协议)
+        // 也不是恢复光标 —— 早期按 final 裸分派会让终端凭空变色、光标乱跳。
+        switch (prefix)
         {
-            // 中间字节 '!' + 'p' => DECSTR 软复位。
-            case "!" when final == 'p':
-                SoftReset();
+            case '?':
+                HandlePrivateMode(p, final);
                 return;
-            case " " when final == 'q':
-                return; // DECSCUSR 光标样式(已接受,样式在 UI 中处理)
+            case '>':
+            case '=':
+            case '<':
+                if (final == 'c')
+                {
+                    DeviceAttributes(prefix); // DA2(CSI > c);DA3(CSI = c)未实现,静默
+                }
+                return;
         }
         switch (final)
         {
@@ -498,6 +522,14 @@ public sealed class TerminalEmulator : IVtActions
                 break;
             case "r": // DECSTBM:回报当前滚动区域(1 基)
                 Send($"\eP1$r{Screen.ScrollTop + 1};{Screen.ScrollBottom + 1}r\e\\");
+                break;
+            case " q":
+                // DECSCUSR 光标形状。vim 启动时必问这一句(t_RS),而且它只认
+                // "DCS 1 $ r <一位数字> SP q ST" 这一种形状 —— 我们过去回 "DCS 0 $ r ST"
+                // (无效请求),vim 的 handle_dcs() 匹配失败后会把整段应答当成键入吞进去:
+                // ESC P 0 $ r ESC \ 依次变成 Esc、P(粘贴 → E353 报错并响铃)、0、$(跳到行尾)、r…
+                // 也就是 issue #112 里"打开 vim 自动输入奇怪字符 + 光标乱跳 + 响一声"的全部现象。
+                Send($"\eP1$r{Modes.CursorStyle} q\e\\");
                 break;
             default:
                 Send("\eP0$r\e\\");

--- a/src/VelaShell.Terminal/Emulation/TerminalModes.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalModes.cs
@@ -17,6 +17,12 @@ public sealed class TerminalModes
     public bool BracketedPaste;        // ?2004
     /// <summary>光标闪烁(?12):是否让光标闪烁,默认开启。</summary>
     public bool CursorBlink = true;    // ?12
+    /// <summary>
+    /// 光标形状(DECSCUSR <c>CSI Ps SP q</c>):0/1=闪烁块、2=稳定块、3=闪烁下划线、
+    /// 4=稳定下划线、5=闪烁竖线、6=稳定竖线。渲染仍按用户设置(见 VelaTerminalControl.CursorStyle),
+    /// 这里只保留远端设过的值,以便 DECRQSS " q" 能如实回报 —— vim 会用它决定退出时恢复成什么形状。
+    /// </summary>
+    public int CursorStyle;            // DECSCUSR (CSI Ps SP q)
     /// <summary>光标可见(DECTCEM ?25):是否显示光标,默认可见。</summary>
     public bool CursorVisible = true;  // DECTCEM ?25
 
@@ -55,6 +61,7 @@ public sealed class TerminalModes
         CursorVisible = true;
         BracketedPaste = false;
         CursorBlink = true;
+        CursorStyle = 0;
         Mouse = MouseTracking.None;
         MouseEncoding = MouseEncoding.Default;
         InsertMode = false;

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
@@ -328,7 +328,100 @@ public class TerminalEmulatorTests
         TerminalEmulator e = New();
         string? reply = null;
         e.Response += b => reply = Encoding.ASCII.GetString(b);
-        Feed(e, "\x1bP$q q\x1b\\"); // DECSCUSR:未实现
+        Feed(e, "\x1bP$q\"p\x1b\\"); // DECSCL:未实现
         Assert.AreEqual("\x1bP0$r\x1b\\", reply);
+    }
+
+    // ---- 回归:issue #112「打开 vim 会自动输入奇怪字符」 ----
+
+    [TestMethod]
+    public void Decrqss_Decscusr_ReportsCursorStyle()
+    {
+        // vim 启动时必发 t_RS = DCS $ q SP q ST,且只认 "DCS 1 $ r <一位数字> SP q ST"。
+        // 曾经回 "DCS 0 $ r ST"(无效请求),vim 匹配失败后把整段当键入:
+        // Esc P 0 $ r … → E353 报错 + 响铃 + 光标跳到行尾。
+        TerminalEmulator e = New();
+        string? reply = null;
+        e.Response += b => reply = Encoding.ASCII.GetString(b);
+        Feed(e, "\x1bP$q q\x1b\\");
+        Assert.AreEqual("\x1bP1$r0 q\x1b\\", reply);
+    }
+
+    [TestMethod]
+    public void Decscusr_SetStyle_IsEchoedByDecrqss()
+    {
+        TerminalEmulator e = New();
+        string? reply = null;
+        e.Response += b => reply = Encoding.ASCII.GetString(b);
+        Feed(e, "\x1b[4 q");       // DECSCUSR:稳定下划线
+        Feed(e, "\x1bP$q q\x1b\\");
+        Assert.AreEqual("\x1bP1$r4 q\x1b\\", reply);
+    }
+
+    [TestMethod]
+    public void Decscusr_OutOfRangeStyle_IsClampedToOneDigit()
+    {
+        // 应答必须是单个数字,否则 vim 又会解析失败并把应答当键入。
+        TerminalEmulator e = New();
+        string? reply = null;
+        e.Response += b => reply = Encoding.ASCII.GetString(b);
+        Feed(e, "\x1b[42 q");
+        Feed(e, "\x1bP$q q\x1b\\");
+        Assert.AreEqual("\x1bP1$r6 q\x1b\\", reply);
+    }
+
+    [TestMethod]
+    public void ModifyOtherKeys_IsNotTreatedAsSgr()
+    {
+        // vim 启动/退出时发 "CSI > 4 ; 2 m" / "CSI > 4 ; m":私有前缀的序列不是 SGR,
+        // 曾被裸分派成 SGR 4;2(下划线 + 变暗),整屏跟着变样。
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[>4;2mX");
+        Assert.AreEqual(CellFlags.None, e.Screen.GetCell(0, 0).Flags);
+    }
+
+    [TestMethod]
+    public void CsiWithIntermediate_IsNotTreatedAsPlainFinal()
+    {
+        // vim 的 xterm 兼容性探针:未知 DCS 与带中间字节的 CSI 都应被静默忽略,
+        // 光标不许动、屏幕不许出字符(vim 靠随后的 CPR 判定终端是否 xterm 兼容)。
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[3;5H");
+        Feed(e, "\x1bPzz\x1b\\\x1b[0%m");
+        Assert.AreEqual(4, e.CursorX);
+        Assert.AreEqual(2, e.CursorY);
+        Assert.AreEqual(string.Empty, Line(e, 2));
+    }
+
+    [TestMethod]
+    public void VimStartupHandshake_OnlyRepliesWithSequencesVimCanParse()
+    {
+        // vim 启动时的整套探询(我们回报为 xterm 补丁级 360,于是 vim 会问光标形状)。
+        // 每一条应答都必须是 vim 认得的形状:任何一条对不上,vim 都会把它当键入吞进去。
+        TerminalEmulator e = New();
+        var replies = new List<string>();
+        e.Response += b => replies.Add(Encoding.ASCII.GetString(b));
+        Feed(e, "\x1b[>4;2m");           // modifyOtherKeys:不应答
+        Feed(e, "\x1b[>c");              // DA2
+        Feed(e, "\x1bP+q544e\x1b\\");    // XTGETTCAP:不应答
+        Feed(e, "\x1b[?12$p");           // DECRQM 光标闪烁:不应答
+        Feed(e, "\x1bP$q q\x1b\\");      // DECRQSS 光标形状
+        Feed(e, "\x1b]11;?\x1b\\");      // OSC 11 背景色:不应答
+        Feed(e, "\x1bPzz\x1b\\\x1b[0%m"); // xterm 兼容性探针:不应答、不动光标
+        Feed(e, "\x1b[6n");              // CPR
+        CollectionAssert.AreEqual(new[] { "\x1b[>41;360;0c", "\x1bP1$r0 q\x1b\\", "\x1b[1;1R" }, replies);
+    }
+
+    [TestMethod]
+    public void KittyKeyboardProtocol_DoesNotRestoreCursor()
+    {
+        // "CSI = 0 ; 1 u" / "CSI > 1 u" 是 kitty 键盘协议,不是 ANSI.SYS 的恢复光标;
+        // 裸按 final 分派会让光标跳回上次保存的位置。
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[1;1H\x1b[s");  // 在 (0,0) 保存
+        Feed(e, "\x1b[5;7H");        // 移到别处
+        Feed(e, "\x1b[=0;1u\x1b[>1u");
+        Assert.AreEqual(6, e.CursorX);
+        Assert.AreEqual(4, e.CursorY);
     }
 }


### PR DESCRIPTION
修复 vim 启动时探测终端能力的兼容性，避免误将带中间字节的 CSI 序列当作标准序列处理，防止屏幕变色和光标异常（修复 issue #112）。严格区分 CSI 序列，仅处理明确支持的类型。完善 DECSCUSR 实现，支持光标形状设置与回报，新增 TerminalModes.CursorStyle 字段。补充多项单元测试，确保应答符合 vim 预期。