### PR TITLE
限制窗口缩放区仅响应鼠标左键按下(#116)

### DIFF
--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -56,9 +56,18 @@ public partial class MainWindow : Window
     private bool _standaloneSftpShutdownComplete;
     private bool _openedInitialized;
 
-    /// <summary>自绘缩放抓取区:普通状态按下即进入原生缩放;最大化时整层隐藏(见 OnPropertyChanged)。</summary>
+    /// <summary>
+    /// 自绘缩放抓取区:普通状态按下即进入原生缩放;最大化时整层隐藏(见 OnPropertyChanged)。
+    /// 只认左键:BeginResizeDrag 在 Win32 上是伪造一条 WM_NCLBUTTONDOWN 进系统 sizing 模态
+    /// 循环,而该循环只在左键弹起时退出。用右/中键起手会让循环永远等不到那次弹起,
+    /// 表现为松开按键后窗口仍一直跟着光标改尺寸(#116)。标题栏拖动同此守卫。
+    /// </summary>
     private void ResizeEdge_PointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
     {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
         if (WindowState == WindowState.Normal && sender is Border { Tag: string tag } && Enum.TryParse(tag, out WindowEdge edge)
         )
         {

--- a/src/VelaShell/Views/ProcessManagerView.axaml.cs
+++ b/src/VelaShell/Views/ProcessManagerView.axaml.cs
@@ -81,9 +81,16 @@ public partial class ProcessManagerView : Window
         BeginMoveDrag(e);
     }
 
-    /// <summary>自绘缩放抓取区:按下即进入原生缩放。最大化时整层已隐藏。</summary>
+    /// <summary>
+    /// 自绘缩放抓取区:按下即进入原生缩放。最大化时整层已隐藏。
+    /// 只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。
+    /// </summary>
     private void ResizeEdge_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
         if (WindowState == WindowState.Normal
             && sender is Border { Tag: string tag }
             && Enum.TryParse(tag, out WindowEdge edge))

--- a/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
+++ b/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
@@ -61,8 +61,13 @@ public partial class ResourceMonitorWindow : Window
         BeginMoveDrag(e);
     }
 
+    /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>
     private void ResizeEdge_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
         if (WindowState == WindowState.Normal
             && sender is Border { Tag: string tag }
             && Enum.TryParse(tag, out WindowEdge edge))

--- a/src/VelaShell/Views/TraceRouteWindow.axaml.cs
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml.cs
@@ -87,8 +87,13 @@ public partial class TraceRouteWindow : Window
         BeginMoveDrag(e);
     }
 
+    /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>
     private void ResizeEdge_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
         if (WindowState == WindowState.Normal
             && sender is Border { Tag: string tag }
             && Enum.TryParse(tag, out WindowEdge edge))


### PR DESCRIPTION
为 MainWindow、ProcessManagerView、ResourceMonitorWindow 和 TraceRouteWindow 的 ResizeEdge_PointerPressed 方法增加了 IsLeftButtonPressed 判断，防止右键或中键触发导致窗口调整模式异常（#116）。补充和完善了相关注释，详细说明了更改原因和背景。