### PR TITLE
优化幽灵文本显示逻辑，避免与zsh内容重叠

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -899,6 +899,18 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             return null;
         }
         string line = Emulator.Screen.ActiveLine(Emulator.CursorY).GetText();
+
+        // 光标右侧同一行还有非空白内容时一律不显示:幽灵是叠画层,画上去会与既有文字
+        // 重影,且"补全在行尾"的语义此时并不成立。典型场景是 zsh-autosuggestions ——
+        // shell 自己把建议写进了光标右侧的缓冲(#115),还有行中编辑与右提示符 RPROMPT。
+        // 判定必须落在渲染时钟上:宿主侧只在输入变化那一刻判过一次(HasTextRightOfCursor),
+        // 而 shell 自带的建议要等 PTY 往返之后才回显,那时幽灵早已设好、宿主不会再复核,
+        // 只有每帧按屏上真实状态现判才拦得住。GetText 已裁掉尾部空格,故行尾留白不误判。
+        if (line.Length > col && !string.IsNullOrWhiteSpace(line[col..]))
+        {
+            return null;
+        }
+
         // 光标左侧已回显文本(1 单元格≈1 字符,与 HasTextRightOfCursor 等既有假设一致)。
         int before = Math.Min(col, line.Length);
         // 最长 k:line 的末 k 字符 == full 的前 k 字符。先求最长(含 k==full.Length),

--- a/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
@@ -22,6 +22,9 @@ public sealed class GhostTextRemainderTests
     [ClassCleanup]
     public static void Cleanup() => _session.Dispose();
 
+    /// <summary>CSI CUB:把光标左移 n 格,用来构造"光标右侧还有内容"的屏幕状态。</summary>
+    private static string CursorBack(int n) => $"\u001b[{n}D";
+
     private static string? RemainderAfter(string echoed, string full)
     {
         string? result = null;
@@ -67,6 +70,23 @@ public sealed class GhostTextRemainderTests
     [TestMethod]
     public void PromptPrefixedLine_MatchesOnlyTrailingInput() =>
         Assert.AreEqual("kout", RemainderAfter("user@host:~$ git chec", "git checkout"));
+
+    [TestMethod]
+    public void ShellOwnSuggestionRightOfCursor_ReturnsNull() =>
+        // zsh-autosuggestions:shell 自己把建议("kout -b")写进了光标右侧的缓冲区。
+        // 再叠画幽灵就会与之重影(#115),故整体不显示。喂入 "git checkout -b" 后
+        // 左移 7 格,光标停在 "git chec" 之后 —— 若无守卫,这里会算出 "kout"。
+        Assert.IsNull(RemainderAfter($"git checkout -b{CursorBack(7)}", "git checkout"));
+
+    [TestMethod]
+    public void MidLineEditing_ReturnsNull() =>
+        // 行中编辑同理:光标右侧还有内容时,"补全在行尾"的语义不成立。
+        Assert.IsNull(RemainderAfter($"git chec --all{CursorBack(6)}", "git checkout"));
+
+    [TestMethod]
+    public void TrailingBlanksRightOfCursor_StillShowsRemainder() =>
+        // 行尾留白不是内容:GetText 已裁掉尾部空格,守卫不得因此误伤正常的行尾补全。
+        Assert.AreEqual("kout", RemainderAfter($"git chec    {CursorBack(4)}", "git checkout"));
 
     [TestMethod]
     public void EmptyLine_ReturnsNull() =>


### PR DESCRIPTION
在 VelaTerminalControl.cs 增加判断，光标右侧同一行有非空白内容时不显示幽灵文本，防止与 shell 建议或 RPROMPT 重影，并补充详细注释说明设计原因。GhostTextRemainderTests.cs 新增多组单元测试，覆盖 shell 建议、行中编辑、行尾留白等场景，确保补全文本仅在右侧无内容时显示，提升健壮性和正确性。