### PR TITLE
统一目录解析逻辑，新增UserPathResolver及默认目录管理(#120)

### DIFF
--- a/src/VelaShell.Core/Models/UserPathResolver.cs
+++ b/src/VelaShell.Core/Models/UserPathResolver.cs
@@ -1,0 +1,81 @@
+namespace VelaShell.Core.Models;
+
+/// <summary>
+/// 设置里"目录/路径"类取值的唯一权威解析器(下载目录、传输日志目录等)。
+/// </summary>
+/// <remarks>
+/// 关键约定:<b>相对路径以用户主目录为基准,绝不落到进程工作目录上</b>。
+/// 工作目录是外部环境决定的 —— 开机自启(<c>HKCU\...\Run</c>)时 Explorer 会把它设成
+/// <c>C:\Windows\System32</c>,归一之后则是应用安装目录(商店版还是只读的 WindowsApps)——
+/// 两者都不是用户填 <c>downloads</c> 时想要的地方。历史上这里有四份各自为政的展开逻辑,
+/// 只处理 <c>~</c> 而把相对路径原样丢给 <c>Path.GetFullPath</c> / <c>Directory.CreateDirectory</c>,
+/// 于是同一个配置值在不同功能里落到不同地方(#120)。全部统一到这里。
+/// </remarks>
+public static class UserPathResolver
+{
+    /// <summary>用户主目录。</summary>
+    public static string Home => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    /// <summary>
+    /// 把设置里的目录/路径解析成绝对路径:
+    /// 空白 → <paramref name="fallback" />;<c>~</c> 开头 → 用户主目录下;
+    /// 相对路径 → 用户主目录下;绝对路径 → 规范化后原样返回。
+    /// </summary>
+    /// <param name="configured">设置里保存的原始取值,可为 null/空。</param>
+    /// <param name="fallback">取值为空时的回退路径(调用方各自的默认落点)。</param>
+    public static string Resolve(string? configured, string fallback)
+    {
+        string value = configured?.Trim() ?? string.Empty;
+        if (value.Length == 0)
+        {
+            return fallback;
+        }
+
+        string home = Home;
+        if (value == "~")
+        {
+            return home;
+        }
+
+        // 只认 "~/" 与 "~\":TrimStart('~','/','\\') 会把 "~~/a"、"~///a" 里的多个字符一起吃掉,
+        // 那是历史实现之间行为不一致的来源之一。
+        if (value.StartsWith("~/", StringComparison.Ordinal)
+            || value.StartsWith("~\\", StringComparison.Ordinal))
+        {
+            return Combine(home, value[2..]);
+        }
+
+        // Path.GetFullPath(单参) 对相对路径按【进程工作目录】解析 —— 这正是要避开的行为,
+        // 故相对路径显式给出用户主目录作为基准。
+        return Path.IsPathRooted(value) ? Normalize(value) : Combine(home, value);
+    }
+
+    /// <summary>
+    /// 同 <see cref="Resolve" />,但取值为空时回退到用户主目录。
+    /// </summary>
+    public static string ResolveOrHome(string? configured) => Resolve(configured, Home);
+
+    private static string Combine(string basePath, string relative) =>
+        Normalize(Path.Combine(basePath, relative.TrimStart('/', '\\')));
+
+    /// <summary>规范化路径;路径含非法字符等无法规范化时原样返回,由调用方的存在性检查兜底。</summary>
+    private static string Normalize(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (ArgumentException)
+        {
+            return path;
+        }
+        catch (NotSupportedException)
+        {
+            return path;
+        }
+        catch (PathTooLongException)
+        {
+            return path;
+        }
+    }
+}

--- a/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
+++ b/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
@@ -166,6 +166,13 @@ public sealed partial class ConPtyShellStream : IShellStreamWrapper
         columns = Math.Clamp(columns, 2, 500);
         rows = Math.Clamp(rows, 2, 500);
 
+        // 不指定工作目录时落到用户主目录,而不是让 CreateProcess 继承本进程的工作目录:
+        // 后者由外部环境决定(开机自启时曾是 C:\Windows\System32),绝不该成为 shell 的起点(#120)。
+        if (string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
         // 两对匿名管道:input(child ← us)、output(us ← child)。
         if (!NativeMethods.CreatePipe(out IntPtr inputRead, out IntPtr inputWrite, IntPtr.Zero, 0))
         {

--- a/src/VelaShell/Program.cs
+++ b/src/VelaShell/Program.cs
@@ -29,6 +29,8 @@ internal static partial class Program
             return;
         }
 
+        NormalizeWorkingDirectory();
+
         // 启用旧代码页(GBK、Big5、Shift_JIS 等)以支持终端编码选项。
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         InstallGlobalExceptionGuards();
@@ -57,6 +59,33 @@ internal static partial class Program
         finally
         {
             ReleaseSingleInstanceLock();
+        }
+    }
+
+    /// <summary>
+    /// 把进程的工作目录钉在应用自身目录上。
+    /// </summary>
+    /// <remarks>
+    /// 开机自启走的是 <c>HKCU\...\Run</c>,而 Explorer 拉起 Run 键里的程序时会把子进程的工作目录
+    /// 设成 <c>C:\Windows\System32</c>(继承它自己的 CWD)。应用本身从不依赖 CWD——所有持久化路径
+    /// 都以 <c>%LocalAppData%\VelaShell</c> 或 <see cref="Environment.ProcessPath" /> 为根——但
+    /// 系统层面仍有两处会踩到它:没指定起始目录的文件对话框会停在 CWD,设置里若填了相对路径也按
+    /// CWD 解析。二者都会让 System32 莫名其妙地冒出来(#120)。这里定死一次即可根除。
+    /// 外置换版进程不走这条路径(它在上面就返回了),其临时目录语义不受影响。
+    /// </remarks>
+    private static void NormalizeWorkingDirectory()
+    {
+        try
+        {
+            if (Path.GetDirectoryName(Environment.ProcessPath) is { Length: > 0 } appDirectory
+                && Directory.Exists(appDirectory))
+            {
+                Directory.SetCurrentDirectory(appDirectory);
+            }
+        }
+        catch
+        {
+            // 目录不可访问(受限环境/只读介质)时保持原样:CWD 不参与任何功能路径。
         }
     }
 

--- a/src/VelaShell/Services/ExternalEditSessionManager.cs
+++ b/src/VelaShell/Services/ExternalEditSessionManager.cs
@@ -180,7 +180,12 @@ internal sealed class ExternalEditSession : IDisposable
         startInfo = new()
         {
             FileName = editor,
-            UseShellExecute = OperatingSystem.IsWindows()
+            UseShellExecute = OperatingSystem.IsWindows(),
+            // 显式指定工作目录 = 被编辑文件所在的临时目录。不指定的话子进程继承 VelaShell 的
+            // 工作目录(应用安装目录),编辑器的相对路径操作、swap/备份文件就会落到那儿 ——
+            // 商店版的安装目录还是只读的,直接写失败(#120)。
+            WorkingDirectory = Path.GetDirectoryName(filePath)
+                               ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
         };
         startInfo.ArgumentList.Add(filePath);
         return startInfo;

--- a/src/VelaShell/Services/TransferLogService.cs
+++ b/src/VelaShell/Services/TransferLogService.cs
@@ -11,21 +11,12 @@ public static class TransferLogService
 {
     private static readonly Lock Gate = new();
 
-    /// <summary>展开配置的日志目录("~" = 用户目录);空则退回默认 %LocalAppData%\VelaShell\logs。</summary>
-    private static string ResolveDirectory(string? configured)
-    {
-        string? dir = configured?.Trim();
-        if (string.IsNullOrEmpty(dir))
-        {
-            return SessionLogService.LogDirectory;
-        }
-        if (dir.StartsWith('~'))
-        {
-            dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                dir.TrimStart('~', '/', '\\'));
-        }
-        return dir;
-    }
+    /// <summary>
+    /// 解析配置的日志目录("~" 与相对路径均以用户目录为基准,见 <see cref="UserPathResolver" />);
+    /// 空则退回默认 %LocalAppData%\VelaShell\logs。
+    /// </summary>
+    private static string ResolveDirectory(string? configured) =>
+        UserPathResolver.Resolve(configured, SessionLogService.LogDirectory);
 
     /// <summary>向当天的 transfer 日志追加一条传输记录(写入失败静默忽略)。</summary>
     public static void Append(string? configuredDirectory, TransferType type, string localPath, string remotePath, TransferStatus status)

--- a/src/VelaShell/Services/ZModem/FolderZModemFileSink.cs
+++ b/src/VelaShell/Services/ZModem/FolderZModemFileSink.cs
@@ -167,20 +167,11 @@ internal sealed class FolderZModemFileSink(
         _streams.Clear();
     }
 
-    /// <summary>把以 <c>~</c> 开头的路径展开为用户主目录下的绝对路径。</summary>
-    private static string ExpandHome(string path)
-    {
-        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (string.IsNullOrWhiteSpace(path) || path == "~")
-        {
-            return home;
-        }
-        if (path.StartsWith("~/", StringComparison.Ordinal) || path.StartsWith("~\\", StringComparison.Ordinal))
-        {
-            return Path.Combine(home, path[2..]);
-        }
-        return path;
-    }
+    /// <summary>
+    /// 把配置的下载目录解析成绝对路径:<c>~</c> 与相对路径一律以用户主目录为基准,
+    /// 空值回退到用户主目录(见 <see cref="UserPathResolver" />)。
+    /// </summary>
+    private static string ExpandHome(string path) => UserPathResolver.ResolveOrHome(path);
 
     /// <summary>把远端文件名归一为安全的纯文件名:剥离任何目录成分并替换非法字符。</summary>
     private static string SanitizeFileName(string remoteFileName)

--- a/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
+++ b/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
@@ -227,19 +227,7 @@ public sealed class LocalFilePaneViewModel : ReactiveObject
     public async Task LoadInitialAsync(CancellationToken cancellationToken = default)
     {
         await RefreshRootsAsync(cancellationToken);
-        string configured;
-        try
-        {
-            configured = ExpandConfiguredPath(_transferOptions.LocalDownloadDirectory);
-        }
-        catch (ArgumentException)
-        {
-            configured = string.Empty;
-        }
-        catch (NotSupportedException)
-        {
-            configured = string.Empty;
-        }
+        string configured = ExpandConfiguredPath(_transferOptions.LocalDownloadDirectory);
         string home = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
         foreach (string candidate in new[] { configured, home }.Distinct(StringComparer.Ordinal))
         {
@@ -571,18 +559,12 @@ public sealed class LocalFilePaneViewModel : ReactiveObject
         }
     }
 
-    private static string ExpandConfiguredPath(string configured)
-    {
-        string value = configured?.Trim() ?? string.Empty;
-        if (value == "~" || value.StartsWith("~/", StringComparison.Ordinal) || value.StartsWith("~\\", StringComparison.Ordinal))
-        {
-            value = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                value[1..].TrimStart('/', '\\')
-            );
-        }
-        return string.IsNullOrWhiteSpace(value) ? string.Empty : Path.GetFullPath(value);
-    }
+    /// <summary>
+    /// 解析配置的下载目录:"~" 与相对路径一律以用户主目录为基准(见 <see cref="UserPathResolver" />),
+    /// 空值返回空串,交给调用方回退到用户主目录。
+    /// </summary>
+    private static string ExpandConfiguredPath(string configured) =>
+        UserPathResolver.Resolve(configured, string.Empty);
 
     private static bool DirectoryIsAccessible(string path)
     {

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
@@ -68,7 +68,8 @@ public partial class AuthenticationDialogView : Window
         IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new()
         {
             Title = Strings.Get("Profile_SelectKeyFile"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.SshAsync(this)
         });
         if (files.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path)
         {

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
@@ -63,6 +63,7 @@ public partial class ConnectionDiagnosticsView : Window
         {
             Title = Strings.Get("Diag_ExportReport"),
             SuggestedFileName = viewModel.SuggestedReportFileName,
+            SuggestedStartLocation = await StorageDefaults.DownloadsAsync(this),
             DefaultExtension = "txt",
             FileTypeChoices =
             [

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -184,7 +184,8 @@ public partial class ConnectionProfileView : Window
         IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new()
         {
             Title = Strings.Get("Profile_SelectKeyFile"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.SshAsync(this)
         });
         if (files.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path)
         {

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI.Primitives;
 using VelaShell.Controls.Controls;
+using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;
 using VelaShell.ViewModels;
@@ -366,28 +367,13 @@ public partial class FileBrowserView : UserControl
         {
             return null;
         }
-        string configured = vm.TransferOptions.LocalDownloadDirectory.Trim();
-        if (string.IsNullOrEmpty(configured))
-        {
-            return null;
-        }
-        if (configured.StartsWith('~'))
-        {
-            configured = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                configured.TrimStart('~', '/', '\\')
-            );
-        }
-        try
-        {
-            return Directory.Exists(configured)
-                ? await top.StorageProvider.TryGetFolderFromPathAsync(configured)
-                : null;
-        }
-        catch
-        {
-            return null;
-        }
+        // "~" 与相对路径一律以用户主目录为基准(见 UserPathResolver);目录不存在时退回主目录,
+        // 绝不落回进程工作目录 —— 那是外部环境决定的,不是用户想要的落点(#120)。
+        return await StorageDefaults.FolderAsync(
+                   top,
+                   UserPathResolver.ResolveOrHome(vm.TransferOptions.LocalDownloadDirectory)
+               )
+               ?? await StorageDefaults.HomeAsync(top);
     }
 
     private void OnFileListDragOver(object? sender, DragEventArgs e)

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -1144,6 +1144,7 @@ public partial class MainWindow : Window
             {
                 Title = Strings.Get("Main_ExportTerminalTitle"),
                 SuggestedFileName = suggestedName,
+                SuggestedStartLocation = await StorageDefaults.DownloadsAsync(this),
                 DefaultExtension = "txt",
                 FileTypeChoices =
                 [
@@ -1242,7 +1243,8 @@ public partial class MainWindow : Window
                 Title = isRetryAfterCancel
                     ? Strings.Get("ZModem_ChooseUploadFilesRetry")
                     : Strings.Get("ZModem_ChooseUploadFiles"),
-                AllowMultiple = true
+                AllowMultiple = true,
+                SuggestedStartLocation = await StorageDefaults.DownloadsAsync(top)
             });
             List<string> paths = [];
             foreach (IStorageFile file in files)

--- a/src/VelaShell/Views/RecordingPlayerView.axaml.cs
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml.cs
@@ -110,6 +110,7 @@ public partial class RecordingPlayerView : Window
         {
             Title = Strings.Get("Recorder_Export"),
             SuggestedFileName = $"velashell-recording-{DateTime.Now:yyyyMMdd-HHmmss}.cast",
+            SuggestedStartLocation = await StorageDefaults.DownloadsAsync(this),
             DefaultExtension = "cast"
         });
         if (file?.TryGetLocalPath() is { Length: > 0 } path)

--- a/src/VelaShell/Views/SessionImportView.axaml.cs
+++ b/src/VelaShell/Views/SessionImportView.axaml.cs
@@ -83,9 +83,10 @@ public partial class SessionImportView : Window
         IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(new()
         {
             Title = Strings.Get("XImport_Browse"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.HomeAsync(this)
         });
-        return folders.FirstOrDefault()?.TryGetLocalPath();
+        return folders.AsParallel().FirstOrDefault()?.TryGetLocalPath();
     }
 
     private async Task<string?> PickFileAsync()
@@ -93,8 +94,9 @@ public partial class SessionImportView : Window
         IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new()
         {
             Title = Strings.Get("XImport_Browse"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.HomeAsync(this)
         });
-        return files.FirstOrDefault()?.TryGetLocalPath();
+        return files.AsParallel().FirstOrDefault()?.TryGetLocalPath();
     }
 }

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
@@ -26,6 +26,7 @@ public partial class AppearanceSettingsPage : UserControl
         {
             Title = Strings.Get("SetAppear_BackgroundImage"),
             AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.PicturesAsync(TopLevel.GetTopLevel(this)),
             FileTypeFilter =
             [
                 new("Images") { Patterns = ["*.png", "*.jpg", "*.jpeg", "*.bmp", "*.gif", "*.webp"] }

--- a/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
@@ -26,6 +26,7 @@ public partial class GeneralSettingsPage : UserControl
         {
             Title = Strings.Get("SetGeneral_ExportDialogTitle"),
             SuggestedFileName = "velashell-settings.json",
+            SuggestedStartLocation = await StorageDefaults.DownloadsAsync(top),
             DefaultExtension = "json"
         });
         if (file?.TryGetLocalPath() is { Length: > 0 } path)
@@ -43,7 +44,8 @@ public partial class GeneralSettingsPage : UserControl
         IReadOnlyList<IStorageFile> files = await top.StorageProvider.OpenFilePickerAsync(new()
         {
             Title = Strings.Get("SetGeneral_ImportDialogTitle"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.DownloadsAsync(top)
         });
         if (files.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path && File.Exists(path))
         {

--- a/src/VelaShell/Views/Settings/KeyManagementPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/KeyManagementPage.axaml.cs
@@ -26,7 +26,8 @@ public partial class KeyManagementPage : UserControl
         IReadOnlyList<IStorageFile> files = await top.StorageProvider.OpenFilePickerAsync(new()
         {
             Title = Strings.Get("SetKeys_ImportDialogTitle"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.SshAsync(top)
         });
         if (files.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path)
         {

--- a/src/VelaShell/Views/Settings/TransferSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/TransferSettingsPage.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 
@@ -24,7 +25,12 @@ public partial class TransferSettingsPage : UserControl
         IReadOnlyList<IStorageFolder> folders = await top.StorageProvider.OpenFolderPickerAsync(new()
         {
             Title = Strings.Get("SelectDownloadFolder"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            // 起点用当前已配置的下载目录:改目录时从旧值出发比从头翻更顺手。
+            SuggestedStartLocation = await StorageDefaults.FolderAsync(
+                top,
+                UserPathResolver.ResolveOrHome(DownloadDirBox.Text)
+            ) ?? await StorageDefaults.HomeAsync(top)
         });
         if (folders.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path)
         {
@@ -44,7 +50,13 @@ public partial class TransferSettingsPage : UserControl
         var options = new FilePickerOpenOptions
         {
             Title = Strings.Get("SetTransfer_SelectEditorTitle"),
-            AllowMultiple = false
+            AllowMultiple = false,
+            // 挑的是编辑器可执行文件:已填过就从它所在目录出发,否则从程序安装目录出发。
+            SuggestedStartLocation = await StorageDefaults.FolderAsync(top, Path.GetDirectoryName(EditorPathBox.Text))
+                                     ?? await StorageDefaults.FolderAsync(
+                                         top,
+                                         Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                                     )
         };
         if (OperatingSystem.IsWindows())
         {

--- a/src/VelaShell/Views/StorageDefaults.cs
+++ b/src/VelaShell/Views/StorageDefaults.cs
@@ -1,0 +1,78 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Views;
+
+/// <summary>
+/// 文件/文件夹对话框的默认起始目录。
+/// </summary>
+/// <remarks>
+/// 不指定 <c>SuggestedStartLocation</c> 时,Windows 通用对话框的回落顺序是
+/// per-app MRU → 进程工作目录 → 系统默认库。进程工作目录由外部环境决定:开机自启
+/// (<c>HKCU\...\Run</c>)时 Explorer 会把它设成 <c>C:\Windows\System32</c>,归一之后是应用
+/// 安装目录(商店版的 WindowsApps 还是只读的)—— 两者都不是用户想要的落点(#120)。
+/// 因此每个对话框都显式给出起点,统一由本类提供。
+/// 取不到目录时一律返回 null(等同于不指定,交回系统默认),绝不因此让对话框打不开。
+/// </remarks>
+internal static class StorageDefaults
+{
+    /// <summary>把一个绝对路径转成对话框起始位置;路径为空/不存在/不可访问时返回 null。</summary>
+    public static async Task<IStorageFolder?> FolderAsync(TopLevel? top, string? path)
+    {
+        if (top is null || string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+        try
+        {
+            return Directory.Exists(path)
+                ? await top.StorageProvider.TryGetFolderFromPathAsync(path)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>用户主目录。</summary>
+    public static Task<IStorageFolder?> HomeAsync(TopLevel? top) =>
+        FolderAsync(top, UserPathResolver.Home);
+
+    /// <summary>设置 → 文件传输里配置的下载目录;未配置或不存在时退回用户主目录。</summary>
+    public static async Task<IStorageFolder?> DownloadsAsync(TopLevel? top) =>
+        await FolderAsync(top, UserPathResolver.ResolveOrHome(await ConfiguredDownloadDirectoryAsync()))
+        ?? await HomeAsync(top);
+
+    /// <summary>密钥目录 <c>~/.ssh</c>;不存在时退回用户主目录。</summary>
+    public static async Task<IStorageFolder?> SshAsync(TopLevel? top) =>
+        await FolderAsync(top, Path.Combine(UserPathResolver.Home, ".ssh")) ?? await HomeAsync(top);
+
+    /// <summary>系统图片库;不存在时退回用户主目录。</summary>
+    public static async Task<IStorageFolder?> PicturesAsync(TopLevel? top) =>
+        await FolderAsync(top, Environment.GetFolderPath(Environment.SpecialFolder.MyPictures))
+        ?? await HomeAsync(top);
+
+    /// <summary>从设置服务读下载目录的原始配置值;读不出来返回 null(调用方回退到主目录)。</summary>
+    private static async Task<string?> ConfiguredDownloadDirectoryAsync()
+    {
+        try
+        {
+            if (Application.Current is App { Services: { } services }
+                && services.GetService<ISettingsService>() is { } settingsService)
+            {
+                AppSettings settings = await settingsService.GetSettingsAsync();
+                return settings.Transfer.LocalDownloadDirectory;
+            }
+        }
+        catch
+        {
+            // 设置读不出来就退回主目录:起始目录不值得让对话框弹不出来。
+        }
+        return null;
+    }
+}

--- a/src/VelaShell/Views/TraceRouteWindow.axaml.cs
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml.cs
@@ -56,6 +56,7 @@ public partial class TraceRouteWindow : Window
         {
             Title = Strings.Get("Trace_GeoPick"),
             AllowMultiple = false,
+            SuggestedStartLocation = await StorageDefaults.DownloadsAsync(this),
             FileTypeFilter =
             [
                 new(Strings.Get("Trace_GeoFileType")) { Patterns = ["*.mmdb", "*.gz"] }

--- a/src/VelaShell/app.manifest
+++ b/src/VelaShell/app.manifest
@@ -5,6 +5,17 @@
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
   <assemblyIdentity version="1.0.0.0" name="VelaShell.Desktop"/>
 
+  <!-- 永不提权。VelaShell 的全部写入都在 %LocalAppData%\VelaShell、%TEMP% 与应用自身目录内,
+       从不碰 System32 之类的受保护位置(#120)。显式声明 asInvoker 的意义:一是把"不请求管理员"
+       写进二进制、将来误加提权会在 diff 里显形;二是关掉 UAC 对未声明程序的安装程序检测启发式。 -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on

--- a/tests/VelaShell.Core.Tests/Models/UserPathResolverTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/UserPathResolverTests.cs
@@ -1,0 +1,82 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Tests.Models;
+
+/// <summary>
+/// 设置里目录取值的解析规则(<see cref="UserPathResolver" />)。核心不变式:
+/// <b>相对路径以用户主目录为基准,绝不落到进程工作目录上</b> —— 工作目录由外部环境决定
+/// (开机自启时曾是 C:\Windows\System32,归一后是只读的安装目录),两者都不是用户想要的落点(#120)。
+/// </summary>
+[TestClass]
+[TestCategory("DataStore")]
+public class UserPathResolverTests
+{
+    private static string Home => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    [TestMethod]
+    public void Empty_ReturnsFallback() =>
+        Assert.AreEqual("fallback", UserPathResolver.Resolve("   ", "fallback"));
+
+    [TestMethod]
+    public void Null_ReturnsFallback() =>
+        Assert.AreEqual("fallback", UserPathResolver.Resolve(null, "fallback"));
+
+    [TestMethod]
+    public void Tilde_ReturnsHome() => Assert.AreEqual(Home, UserPathResolver.Resolve("~", "fallback"));
+
+    [TestMethod]
+    public void TildeSlash_ExpandsUnderHome() =>
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine(Home, "Downloads")),
+            UserPathResolver.Resolve("~/Downloads", "fallback")
+        );
+
+    [TestMethod]
+    public void TildeBackslash_ExpandsUnderHome() =>
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine(Home, "Downloads")),
+            UserPathResolver.Resolve("~\\Downloads", "fallback")
+        );
+
+    [TestMethod]
+    public void RelativePath_IsBasedOnHome_NotCurrentDirectory()
+    {
+        // 这条是本类的存在理由:历史实现把相对路径交给 Path.GetFullPath(单参),
+        // 于是按进程工作目录解析 —— 开机自启时那就是 C:\Windows\System32。
+        string resolved = UserPathResolver.Resolve("downloads", "fallback");
+
+        Assert.AreEqual(Path.GetFullPath(Path.Combine(Home, "downloads")), resolved);
+        Assert.AreNotEqual(Path.GetFullPath("downloads"), resolved);
+    }
+
+    [TestMethod]
+    public void NestedRelativePath_IsBasedOnHome() =>
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine(Home, "a", "b")),
+            UserPathResolver.Resolve(Path.Combine("a", "b"), "fallback")
+        );
+
+    [TestMethod]
+    public void AbsolutePath_IsPreserved()
+    {
+        string absolute = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "vela-abs"));
+        Assert.AreEqual(absolute, UserPathResolver.Resolve(absolute, "fallback"));
+    }
+
+    [TestMethod]
+    public void SurroundingWhitespace_IsTrimmed() =>
+        Assert.AreEqual(Home, UserPathResolver.Resolve("  ~  ", "fallback"));
+
+    [TestMethod]
+    public void DoubleTilde_IsTreatedAsRelative_NotTrimmedAway() =>
+        // 历史实现用 TrimStart('~','/','\\') 会把 "~~/a" 的前缀整段吃掉,得到 Home/a;
+        // 现在 "~~" 不是主目录记号,应按普通相对路径处理。
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine(Home, "~~", "a")),
+            UserPathResolver.Resolve("~~/a", "fallback")
+        );
+
+    [TestMethod]
+    public void ResolveOrHome_FallsBackToHome() =>
+        Assert.AreEqual(Home, UserPathResolver.ResolveOrHome(null));
+}


### PR DESCRIPTION
统一应用内目录/路径配置项的解析逻辑，新增UserPathResolver类，所有相对路径和~均以用户主目录为基准，避免落到System32或只读目录。所有目录解析调用UserPathResolver，删除重复代码。新增StorageDefaults集中管理文件/文件夹对话框默认起始目录，UI选择对话框统一指定合理起点。启动时显式设定工作目录为应用自身目录，规避依赖CWD。Windows manifest声明asInvoker，防止请求管理员权限。增加UserPathResolverTests单元测试，相关注释补充设计原因和历史问题。