### PR TITLE
支持 Ctrl+Backspace 删除前一个单词(#127)

### DIFF
--- a/docs/交互与界面规格.md
+++ b/docs/交互与界面规格.md
@@ -436,6 +436,7 @@ VelaShell 是一款面向运维/开发的现代化 SSH/SFTP 终端客户端。�
 | `Ctrl+Shift+T` | 打开隧道管理 | ✅ |
 | `Ctrl+F` | 终端内搜索 | ✅ |
 | `Ctrl+Shift+C` / `Ctrl+Shift+V` | 终端复制 / 粘贴 | ✅ |
+| `Ctrl+Backspace` | 终端内删除光标前一个单词（等价 `Alt+Backspace`） | ✅ |
 | `Alt+Enter` | 弹出命令补全 | ✅ |
 | `Enter` / `Ctrl+R` | 断线后重新连接 | ✅ |
 | `Ctrl+S` | 远程编辑器内保存 | ✅ |

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2610,6 +2610,9 @@
   <data name="SetVm_ShortcutCompletionPopup" xml:space="preserve">
     <value>コマンド補完を表示</value>
   </data>
+  <data name="SetVm_ShortcutDeleteWord" xml:space="preserve">
+    <value>前の単語を削除</value>
+  </data>
   <data name="SetVm_ShortcutNewTabAlias" xml:space="preserve">
     <value>新しいタブ(新規接続と同じ)</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2610,6 +2610,9 @@
   <data name="SetVm_ShortcutCompletionPopup" xml:space="preserve">
     <value>명령 자동 완성 표시</value>
   </data>
+  <data name="SetVm_ShortcutDeleteWord" xml:space="preserve">
+    <value>이전 단어 삭제</value>
+  </data>
   <data name="SetVm_ShortcutNewTabAlias" xml:space="preserve">
     <value>새 탭(새 연결과 동일)</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2713,6 +2713,9 @@ Paste anyway?</value>
   <data name="SetVm_ShortcutCompletionPopup" xml:space="preserve">
     <value>Show Command Completion</value>
   </data>
+  <data name="SetVm_ShortcutDeleteWord" xml:space="preserve">
+    <value>Delete Previous Word</value>
+  </data>
   <data name="SetVm_ShortcutNewTabAlias" xml:space="preserve">
     <value>New Tab (same as New Connection)</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2804,6 +2804,9 @@
   <data name="SetVm_ShortcutCompletionPopup" xml:space="preserve">
     <value>弹出命令补全</value>
   </data>
+  <data name="SetVm_ShortcutDeleteWord" xml:space="preserve">
+    <value>删除前一个单词</value>
+  </data>
   <data name="SetVm_ShortcutNewTabAlias" xml:space="preserve">
     <value>新建标签(同新建连接)</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2610,6 +2610,9 @@
   <data name="SetVm_ShortcutCompletionPopup" xml:space="preserve">
     <value>顯示命令補全</value>
   </data>
+  <data name="SetVm_ShortcutDeleteWord" xml:space="preserve">
+    <value>刪除前一個單字</value>
+  </data>
   <data name="SetVm_ShortcutNewTabAlias" xml:space="preserve">
     <value>新增標籤(同新增連線)</value>
   </data>

--- a/src/VelaShell.Terminal/Emulation/InputEncoder.cs
+++ b/src/VelaShell.Terminal/Emulation/InputEncoder.cs
@@ -50,7 +50,11 @@ public static class InputEncoder
             Key.PageDown => Tilde(6, mod, alt),
             Key.Enter => WithAlt(modes.NewLineMode ? "\r\n"u8.ToArray() : "\r"u8.ToArray(), alt),
             Key.Tab => shift ? Esc("[Z") : WithAlt([0x09], alt),
-            Key.Back => WithAlt([ctrl ? (byte)0x08 : (byte)0x7F], alt),
+            // Ctrl+Backspace = 删除光标前一个单词(#127,与 Tabby 一致):发 ESC+DEL,
+            // 即 readline 的 M-DEL(backward-kill-word)与 zsh 的 backward-kill-word 默认绑定,
+            // 也与 Alt+Backspace 同序列。原先发的 0x08(^H)在 readline 里等价于退一格,
+            // 与普通 Backspace 毫无区别,达不到删词效果。
+            Key.Back => ctrl ? [0x1B, 0x7F] : WithAlt([0x7F], alt),
             Key.Escape => WithAlt([0x1B], alt),
             Key.F1 => Function(1, 'P', mod, alt, vt52),
             Key.F2 => Function(2, 'Q', mod, alt, vt52),

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -778,6 +778,7 @@ public class SettingsViewModel : ReactiveObject
                     new(Strings.Get("Copy"), ["Ctrl", "Shift", "C"]),
                     new(Strings.Get("Cmd_Paste"), ["Ctrl", "Shift", "V"]),
                     new(Strings.Get("SetVm_ShortcutSendInterrupt"), ["Ctrl", "C"]),
+                    new(Strings.Get("SetVm_ShortcutDeleteWord"), ["Ctrl", "Backspace"]),
                     new(Strings.Get("SetVm_ShortcutSearchTerminal"), ["Ctrl", "F"]),
                     new(Strings.Get("SetVm_ShortcutCompletionPopup"), ["Alt", "Enter"]),
                     new(Strings.Get("SetVm_ShortcutReconnect"), ["Enter"]),

--- a/tests/VelaShell.Terminal.Tests/Input/TerminalInputTrackerTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Input/TerminalInputTrackerTests.cs
@@ -88,6 +88,27 @@ public class TerminalInputTrackerTests
     }
 
     [TestMethod]
+    public void CtrlBackspace_KillWord_MarksUnknownButKeepsTrackingNewTyping()
+    {
+        // Ctrl+Backspace 发的 ESC+DEL(#127)删掉多少字符由 shell 的词边界规则决定
+        // (readline 只认字母数字,zsh 的 WORDCHARS 还含 /-_. 等),本地推演必然会与
+        // 真实行内容分叉 —— 分叉的缓冲会喂出错误的整行建议。故一律进未知态,
+        // 之后键入的字符仍以试探段暴露,降级为追加式词补全。
+        var tracker = new TerminalInputTracker();
+        tracker.Process(Bytes("git checkout"));
+        tracker.Process([0x1B, 0x7F]);
+        Assert.IsNull(tracker.CurrentInput);
+        Assert.AreEqual(string.Empty, tracker.TentativeRun, "ESC 序列的尾字节 DEL 不得漏进试探段");
+
+        tracker.Process(Bytes("st"));
+        Assert.AreEqual("st", tracker.TentativeRun);
+
+        // 回车把行交给 shell,状态复位为确定的空行(未知态不粘死)。
+        tracker.Process([0x0D]);
+        Assert.AreEqual(string.Empty, tracker.CurrentInput);
+    }
+
+    [TestMethod]
     public void EnterOnUnknownState_DoesNotSubmit()
     {
         var tracker = new TerminalInputTracker();

--- a/tests/VelaShell.Terminal.Tests/Input/TerminalKeyRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Input/TerminalKeyRouterTests.cs
@@ -107,6 +107,33 @@ public class TerminalKeyRouterTests
     }
 
     [TestMethod]
+    public void Backspace_EncodesDelete()
+    {
+        TerminalKeyAction action = Classify(Key.Back, KeyModifiers.None);
+        Assert.AreEqual(TerminalKeyActionKind.SendBytes, action.Kind);
+        Assert.AreSequenceEqual(new byte[] { 0x7F }, action.Bytes);
+    }
+
+    [TestMethod]
+    public void CtrlBackspace_SendsEscDelete_SoReadlineKillsAWord()
+    {
+        // #127:ESC+DEL 命中 readline 的 backward-kill-word(zsh 同名绑定);
+        // 老行为 0x08(^H)只等价于退一格,与普通 Backspace 无异。
+        TerminalKeyAction action = Classify(Key.Back, KeyModifiers.Control);
+        Assert.AreEqual(TerminalKeyActionKind.SendBytes, action.Kind);
+        Assert.AreSequenceEqual(new byte[] { 0x1B, 0x7F }, action.Bytes);
+    }
+
+    [TestMethod]
+    public void AltBackspace_SendsTheSameKillWordSequence()
+    {
+        // 两种习惯(Tabby 的 Ctrl+Backspace 与 xterm 的 Alt+Backspace)必须等价。
+        Assert.AreSequenceEqual(
+            Classify(Key.Back, KeyModifiers.Control).Bytes,
+            Classify(Key.Back, KeyModifiers.Alt).Bytes);
+    }
+
+    [TestMethod]
     public void Enter_EncodesCarriageReturn()
     {
         TerminalKeyAction action = Classify(Key.Enter, KeyModifiers.None);


### PR DESCRIPTION
为终端增加 Ctrl+Backspace（等价于 Alt+Backspace）快捷键，发送 ESC+DEL（[0x1B, 0x7F]），与主流终端一致。调整 InputEncoder，区分普通 Backspace 和 Ctrl/Alt 组合键。SettingsViewModel 展示新快捷键。补充界面规格文档和多语言资源。新增单元测试，确保行为一致并验证输入跟踪。