### PR TITLE
新增 AI 助手插件：多模型对话与 Agent 支持

### DIFF
--- a/VelaShell.slnx
+++ b/VelaShell.slnx
@@ -34,6 +34,7 @@
     <File Path="plugins/Directory.Build.props" />
     <File Path="plugins/Directory.Build.targets" />
     <File Path="plugins/README.md" />
+    <Project Path="plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj" />
     <Project Path="plugins/VelaShell.Plugin.HelloWorld/VelaShell.Plugin.HelloWorld.csproj" />
   </Folder>
   <Folder Name="/src/">
@@ -53,6 +54,7 @@
     <Project Path="tests/VelaShell.Controls.Tests/VelaShell.Controls.Tests.csproj" />
     <Project Path="tests/VelaShell.Core.Tests/VelaShell.Core.Tests.csproj" />
     <Project Path="tests/VelaShell.Infrastructure.Tests/VelaShell.Infrastructure.Tests.csproj" />
+    <Project Path="tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj" />
     <Project Path="tests/VelaShell.Presentation.Tests/VelaShell.Presentation.Tests.csproj" />
     <Project Path="tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj" />
     <Project Path="tests/VelaShell.Tests/VelaShell.Tests.csproj" /> 

--- a/docs/plugins/STATUS.md
+++ b/docs/plugins/STATUS.md
@@ -1,6 +1,6 @@
 # 插件系统进度总览
 
-> 更新:2026-08-11(二)。本页是实现进度的**单一权威来源**:按蓝图分项列出 已完成 / 部分完成 /
+> 更新:2026-08-12。本页是实现进度的**单一权威来源**:按蓝图分项列出 已完成 / 部分完成 /
 > 未开始,并给出验收证据(测试)与建议的下一步。写插件请读 [dev-guide.md](dev-guide.md)。
 
 ## 一、总体状态
@@ -8,7 +8,12 @@
 **插件系统框架层已可投产**:双宿主模式、完整能力面(9 个能力域)、UI(完整 Avalonia,
 inProcess 停靠 / 隔离独立窗口)、可靠性(心跳/自愈/回收)、数据层(SonnetDB 隔离存储 +
 卸载清理)、管理页(启停/卸载/.vpx 安装)、SDK 测试替身与开发文档全部就绪。
-**尚未开始写真正的第一方业务插件**(AI / 容器管理)。
+**第一个第一方业务插件已落地:AI 助手插件**(`plugins/VelaShell.Plugin.Ai`,id `velashell.ai`):
+多提供商流式对话(OpenAI Responses / OpenAI Chat Completions 兼容 / Anthropic Messages 三种线协议,
+覆盖 OpenAI/Grok/Ollama/中转站,自填 Base URL + API Key,Key 走 Secrets 加密)+ Agent 模式
+(Microsoft.Extensions.AI `FunctionInvokingChatClient` 工具循环,工具桥接 sessions/terminal/remoteExec/remoteFs,
+危险操作面板内逐条审批)。onCommand 惰性激活,五语文案。验收:VelaShell.Plugin.Ai.Tests 14 项
+(工具箱审批闸门/能力桥接语义/设置与机密存取)。容器管理插件未开始。
 
 质量基线(每轮全量回归):全仓构建 0 警告 0 错误;测试 ~1280 项全绿,其中插件专项
 75+ 项(含真实双进程 e2e:跨进程激活、杀进程自愈、空闲回收再拉起、嵌入/流式/终端 RPC 链路、.vpx 装卸)。

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -9,10 +9,10 @@ SDK 契约见 [plugin-sdk/](../plugin-sdk/),开发文档见
 | 目录 | id | 说明 |
 | --- | --- | --- |
 | [VelaShell.Plugin.HelloWorld](VelaShell.Plugin.HelloWorld/) | `velashell.hello-world` | 官方示例:SDK 各能力的最小用法 |
+| [VelaShell.Plugin.Ai](VelaShell.Plugin.Ai/) | `velashell.ai` | AI 助手:多提供商流式对话 + Agent 模式(读终端/执行命令带审批) |
 
 ## 规划中(尚未创建)
 
-- **AI 插件**:AI 辅助命令生成/输出解释(能力网关设计见 docs/plugins/11-automation-and-ai.md)。
 - **容器管理插件**:基于远程执行能力封装 docker/podman 常用操作。
 
 ## 新建插件

--- a/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
@@ -1,0 +1,184 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.RemoteExec;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Agent;
+
+/// <summary>
+/// Agent 模式的工具箱:把插件能力(会话枚举/终端读取/远程执行/远程读文件/终端回写)
+/// 包装为 <see cref="AIFunction" />,由 FunctionInvokingChatClient 自动循环调用。
+/// 危险操作(run_command / write_terminal)先过 <see cref="ApprovalHandler" /> 审批;
+/// write_terminal 之上还有宿主自己的授权弹窗。
+/// 工具返回值一律是给模型看的文本;失败以文本描述而非异常(异常会中断整轮对话)。
+/// </summary>
+public sealed class AgentToolbox(IPluginContext context)
+{
+    private const int MaxFileBytes = 256 * 1024;
+
+    /// <summary>当前选中的目标会话 id(由聊天面板提供;null = 未选)。</summary>
+    public Func<string?>? SessionIdProvider { get; set; }
+
+    /// <summary>危险操作审批(参数为将执行的命令/输入文本,返回是否放行)。未设置视为拒绝。</summary>
+    public Func<string, Task<bool>>? ApprovalHandler { get; set; }
+
+    /// <summary>免审批开关(用户显式打开才生效)。</summary>
+    public bool AutoApprove { get; set; }
+
+    /// <summary>构建暴露给模型的工具列表。</summary>
+    public IList<AITool> CreateTools() =>
+    [
+        AIFunctionFactory.Create(ListSessionsAsync, "list_sessions",
+            "List the user's SSH sessions (id, host, port, username, state). Use it to discover what servers are available."),
+        AIFunctionFactory.Create(ReadTerminalAsync, "read_terminal",
+            "Read the tail of the terminal output (scrollback + screen) of the selected SSH session. Use it to see what the user sees."),
+        AIFunctionFactory.Create(RunCommandAsync, "run_command",
+            "Run a one-shot, non-interactive shell command on the selected SSH session over a separate exec channel (it does NOT type into the user's terminal). Requires user approval. Prefer read-only commands."),
+        AIFunctionFactory.Create(ReadRemoteFileAsync, "read_remote_file",
+            "Read a small text file from the selected SSH session via SFTP (up to 256 KB). Returns the file content as text."),
+        AIFunctionFactory.Create(WriteTerminalAsync, "write_terminal",
+            "Type text into the user's visible terminal of the selected SSH session, as if the user typed it. A trailing newline executes the command. The host will additionally ask the user for permission. Use only when the user explicitly wants something typed into their terminal.")
+    ];
+
+    private async Task<string> ListSessionsAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
+        if (sessions.Count == 0)
+        {
+            return "No sessions. Ask the user to connect to a server in VelaShell first.";
+        }
+        var sb = new StringBuilder();
+        foreach (SessionInfo s in sessions)
+        {
+            sb.AppendLine(JsonSerializer.Serialize(new
+            {
+                id = s.SessionId,
+                host = s.Host,
+                port = s.Port,
+                username = s.Username,
+                state = s.State.ToString()
+            }));
+        }
+        return sb.ToString();
+    }
+
+    private async Task<string> ReadTerminalAsync(
+        [Description("Maximum number of lines to read from the end of the buffer (default 200, max 2000).")] int lines = 200,
+        CancellationToken cancellationToken = default)
+    {
+        if (ResolveSessionId() is not { } sessionId)
+        {
+            return NoSessionMessage;
+        }
+        lines = Math.Clamp(lines, 1, 2000);
+        string output = await context.Terminal.GetOutputAsync(sessionId, lines, cancellationToken).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(output) ? "(terminal buffer is empty)" : output;
+    }
+
+    private async Task<string> RunCommandAsync(
+        [Description("The shell command to execute (non-interactive, one-shot).")] string command,
+        [Description("Timeout in seconds (default 30, max 600).")] int timeoutSeconds = 30,
+        CancellationToken cancellationToken = default)
+    {
+        if (ResolveSessionId() is not { } sessionId)
+        {
+            return NoSessionMessage;
+        }
+        if (!await ApproveAsync($"run_command: {command}", cancellationToken).ConfigureAwait(false))
+        {
+            return "The user DENIED execution of this command. Do not retry it; ask the user how to proceed.";
+        }
+        try
+        {
+            ExecResult result = await context.RemoteExec.RunAsync(sessionId, command,
+                new ExecOptions { Timeout = TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 1, 600)) },
+                cancellationToken).ConfigureAwait(false);
+            string output = result.Output;
+            if (output.Length > 32 * 1024)
+            {
+                output = output[..(32 * 1024)] + "\n…(output truncated)";
+            }
+            return output.Length == 0 ? "(command produced no output)" : output;
+        }
+        catch (TimeoutException)
+        {
+            return $"Command timed out after {timeoutSeconds}s.";
+        }
+        catch (Exception ex)
+        {
+            return $"Command failed: {ex.Message}";
+        }
+    }
+
+    private async Task<string> ReadRemoteFileAsync(
+        [Description("Absolute path of the remote file to read.")] string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (ResolveSessionId() is not { } sessionId)
+        {
+            return NoSessionMessage;
+        }
+        try
+        {
+            byte[] bytes = await context.RemoteFs.ReadAllBytesAsync(sessionId, path, MaxFileBytes, cancellationToken).ConfigureAwait(false);
+            return bytes.Length == 0 ? "(file is empty)" : Encoding.UTF8.GetString(bytes);
+        }
+        catch (InvalidOperationException)
+        {
+            return $"File is larger than {MaxFileBytes / 1024} KB; read a smaller file or use run_command with head/tail/grep instead.";
+        }
+        catch (Exception ex)
+        {
+            return $"Failed to read file: {ex.Message}";
+        }
+    }
+
+    private async Task<string> WriteTerminalAsync(
+        [Description("Text to type into the terminal. Include a trailing \\n to execute it as a command.")] string text,
+        CancellationToken cancellationToken = default)
+    {
+        if (ResolveSessionId() is not { } sessionId)
+        {
+            return NoSessionMessage;
+        }
+        if (!await ApproveAsync($"write_terminal: {text}", cancellationToken).ConfigureAwait(false))
+        {
+            return "The user DENIED typing into the terminal. Do not retry; ask the user how to proceed.";
+        }
+        try
+        {
+            await context.Terminal.WriteAsync(sessionId, text, cancellationToken).ConfigureAwait(false);
+            return "Text was typed into the terminal.";
+        }
+        catch (PluginPermissionDeniedException)
+        {
+            return "The host denied terminal write permission. Do not retry.";
+        }
+        catch (Exception ex)
+        {
+            return $"Failed to write terminal: {ex.Message}";
+        }
+    }
+
+    private const string NoSessionMessage =
+        "No SSH session is selected/connected. Ask the user to connect and select a session in the AI panel first.";
+
+    private string? ResolveSessionId() => SessionIdProvider?.Invoke();
+
+    private async Task<bool> ApproveAsync(string summary, CancellationToken cancellationToken)
+    {
+        if (AutoApprove)
+        {
+            return true;
+        }
+        if (ApprovalHandler is not { } handler)
+        {
+            return false;
+        }
+        // 用户点了停止时,不再傻等审批
+        return await handler(summary).WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
+++ b/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
@@ -1,0 +1,113 @@
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Commands;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Ui;
+
+namespace VelaShell.Plugin.Ai;
+
+/// <summary>
+/// AI 助手插件入口。经 manifest 的 <c>onCommand</c> 惰性激活:
+/// 用户第一次触发 AI 命令才装载本程序集。
+/// 命令:打开聊天(标签页/窗口)、解释当前终端输出。
+/// </summary>
+[VelaPlugin]
+public sealed class AiPlugin : IVelaPlugin
+{
+    private IPluginContext? _context;
+    private AiSettingsStore? _store;
+    private IPluginPanel? _panel;
+    private ChatPanelView? _view;
+    private readonly List<IDisposable> _commands = [];
+
+    /// <inheritdoc />
+    public Task ActivateAsync(IPluginContext context, CancellationToken cancellationToken)
+    {
+        _context = context;
+        _store = new AiSettingsStore(context);
+        RegisterCommands();
+        // 命令标题本地化:语言切换时按同 id 重注册替换
+        context.Events.LocaleChanged += _ => RegisterCommands();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DeactivateAsync(CancellationToken cancellationToken)
+    {
+        // 命令、事件订阅与面板由宿主自动清理;这里只拆自己的引用。
+        _view?.Detach();
+        _view = null;
+        _panel = null;
+        _commands.Clear();
+        _context = null;
+        return Task.CompletedTask;
+    }
+
+    private void RegisterCommands()
+    {
+        IPluginContext context = _context!;
+        var loc = new Loc(context.Host.Locale);
+        foreach (IDisposable command in _commands)
+        {
+            command.Dispose();
+        }
+        _commands.Clear();
+        _commands.Add(context.Commands.Register(new PluginCommandDescriptor(
+            $"{context.PluginId}.chat", loc["CmdChat"], "AI",
+            _ => OpenPanelAsync(PanelDisplayMode.Document))));
+        _commands.Add(context.Commands.Register(new PluginCommandDescriptor(
+            $"{context.PluginId}.chat-window", loc["CmdChatWindow"], "AI",
+            _ => OpenPanelAsync(PanelDisplayMode.Window))));
+        _commands.Add(context.Commands.Register(new PluginCommandDescriptor(
+            $"{context.PluginId}.explain-terminal", loc["CmdExplain"], "AI",
+            ExplainTerminalAsync)));
+    }
+
+    private async Task<ChatPanelView?> OpenPanelAsync(PanelDisplayMode mode)
+    {
+        IPluginContext context = _context!;
+        if (_panel is { IsOpen: true } && _view is not null)
+        {
+            return _view; // 已开着(面板是活控件)
+        }
+        ChatPanelView? view = null;
+        _panel = await context.Ui.ShowPanelAsync(
+            new PanelOptions
+            {
+                Title = new Loc(context.Host.Locale)["Title"],
+                DisplayMode = mode,
+                WindowWidth = 720,
+                WindowHeight = 560
+            },
+            () => view = new ChatPanelView(context, _store!));
+        _view = view;
+        _panel.Closed += () =>
+        {
+            _view?.Detach();
+            _view = null;
+            _panel = null;
+        };
+        return _view;
+    }
+
+    private async Task ExplainTerminalAsync(CancellationToken cancellationToken)
+    {
+        IPluginContext context = _context!;
+        var loc = new Loc(context.Host.Locale);
+        IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken);
+        if (sessions.FirstOrDefault(s => s.State == SessionState.Connected) is not { } session)
+        {
+            context.Log.Warn(loc["NoConnectedSession"]);
+            return;
+        }
+        string output = await context.Terminal.GetOutputAsync(session.SessionId, 200, cancellationToken);
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            context.Log.Warn("Terminal buffer is empty; nothing to explain.");
+            return;
+        }
+        ChatPanelView? view = await OpenPanelAsync(PanelDisplayMode.Document);
+        view?.SendExternal($"{loc["ExplainPrompt"]}```\n{output}\n```");
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Configuration/AiProviderConfig.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/AiProviderConfig.cs
@@ -1,0 +1,122 @@
+using System.Text.Json.Serialization;
+
+namespace VelaShell.Plugin.Ai.Configuration;
+
+/// <summary>模型接入使用的线协议。</summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ChatProtocol
+{
+    /// <summary>OpenAI Chat Completions 兼容协议(OpenAI / Grok / Ollama / 绝大多数中转站)。</summary>
+    OpenAiChatCompletions,
+
+    /// <summary>OpenAI Responses 流式协议(OpenAI 官方新 API 及兼容中转站)。</summary>
+    OpenAiResponses,
+
+    /// <summary>Anthropic Messages 协议(Claude 官方及 Anthropic 兼容中转站)。</summary>
+    AnthropicMessages
+}
+
+/// <summary>
+/// 一个模型接入配置。API Key 不在此结构里 —— 单独经
+/// <c>ISecretsApi</c> 加密存储(键 <c>apikey:&lt;Id&gt;</c>)。
+/// </summary>
+public sealed class AiProviderConfig
+{
+    /// <summary>稳定 id(创建时生成,作为机密键的一部分)。</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>显示名称。</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>线协议。</summary>
+    public ChatProtocol Protocol { get; set; } = ChatProtocol.OpenAiChatCompletions;
+
+    /// <summary>
+    /// 基地址。OpenAI 系协议习惯含 <c>/v1</c>(如 https://api.openai.com/v1);
+    /// Anthropic 协议写根地址即可(如 https://api.anthropic.com),误带 /v1 会被自动剥除。
+    /// </summary>
+    public string BaseUrl { get; set; } = "";
+
+    /// <summary>模型 id。</summary>
+    public string Model { get; set; } = "";
+
+    /// <summary>单轮最大输出 token(Anthropic 协议必需;OpenAI 系协议不发送)。</summary>
+    public int MaxTokens { get; set; } = 8192;
+}
+
+/// <summary>插件持久化设置(经 Storage 存 JSON)。</summary>
+public sealed class AiSettings
+{
+    /// <summary>全部接入配置。</summary>
+    public List<AiProviderConfig> Providers { get; set; } = [];
+
+    /// <summary>当前选中的接入 id。</summary>
+    public string? ActiveProviderId { get; set; }
+
+    /// <summary>Agent 模式(带工具循环)。</summary>
+    public bool AgentMode { get; set; }
+
+    /// <summary>Agent 模式下 run_command / write_terminal 免审批(有风险,默认关)。</summary>
+    public bool AutoApproveCommands { get; set; }
+
+    /// <summary>自定义系统提示词(空 = 用内置默认)。</summary>
+    public string? SystemPrompt { get; set; }
+}
+
+/// <summary>内置的接入预设(设置页"新增"下拉)。</summary>
+public static class ProviderPresets
+{
+    /// <summary>全部预设:显示标签 + 出厂配置工厂。</summary>
+    public static IReadOnlyList<(string Label, Func<AiProviderConfig> Create)> All { get; } =
+    [
+        ("OpenAI (Responses)", () => new AiProviderConfig
+        {
+            Name = "OpenAI",
+            Protocol = ChatProtocol.OpenAiResponses,
+            BaseUrl = "https://api.openai.com/v1",
+            Model = "gpt-5"
+        }),
+        ("OpenAI (Chat Completions)", () => new AiProviderConfig
+        {
+            Name = "OpenAI (CC)",
+            Protocol = ChatProtocol.OpenAiChatCompletions,
+            BaseUrl = "https://api.openai.com/v1",
+            Model = "gpt-5"
+        }),
+        ("Anthropic Claude", () => new AiProviderConfig
+        {
+            Name = "Claude",
+            Protocol = ChatProtocol.AnthropicMessages,
+            BaseUrl = "https://api.anthropic.com",
+            Model = "claude-opus-5"
+        }),
+        ("xAI Grok", () => new AiProviderConfig
+        {
+            Name = "Grok",
+            Protocol = ChatProtocol.OpenAiChatCompletions,
+            BaseUrl = "https://api.x.ai/v1",
+            Model = "grok-4"
+        }),
+        ("Ollama (local)", () => new AiProviderConfig
+        {
+            Name = "Ollama",
+            Protocol = ChatProtocol.OpenAiChatCompletions,
+            BaseUrl = "http://localhost:11434/v1",
+            Model = "llama3.1"
+        }),
+        ("Custom (OpenAI compatible)", () => new AiProviderConfig
+        {
+            Name = "Custom",
+            Protocol = ChatProtocol.OpenAiChatCompletions,
+            BaseUrl = "https://example.com/v1",
+            Model = ""
+        }),
+        ("Custom (Anthropic compatible)", () => new AiProviderConfig
+        {
+            Name = "Custom (Anthropic)",
+            Protocol = ChatProtocol.AnthropicMessages,
+            BaseUrl = "https://example.com",
+            Model = ""
+        })
+    ];
+}

--- a/plugins/VelaShell.Plugin.Ai/Configuration/AiSettingsStore.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/AiSettingsStore.cs
@@ -1,0 +1,93 @@
+using System.ClientModel;
+using Anthropic;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Configuration;
+
+/// <summary>
+/// 设置读写:配置走 Storage(JSON),API Key 走 Secrets(加密)。
+/// 同时充当 <see cref="IChatClient" /> 工厂:三种线协议分别由
+/// OpenAI 官方 SDK(Chat Completions / Responses)与 Anthropic 官方 SDK 承载,
+/// 统一到 Microsoft.Extensions.AI 抽象。
+/// </summary>
+public sealed class AiSettingsStore(IPluginContext context)
+{
+    private const string SettingsKey = "settings";
+
+    /// <summary>读取设置(不存在时返回带默认值的新实例)。</summary>
+    public async Task<AiSettings> LoadAsync(CancellationToken cancellationToken = default)
+        => await context.Storage.GetAsync<AiSettings>(SettingsKey, cancellationToken).ConfigureAwait(false) ?? new AiSettings();
+
+    /// <summary>持久化设置。</summary>
+    public Task SaveAsync(AiSettings settings, CancellationToken cancellationToken = default)
+        => context.Storage.SetAsync(SettingsKey, settings, cancellationToken);
+
+    /// <summary>读取某接入的 API Key(未配置返回 null)。</summary>
+    public Task<string?> GetApiKeyAsync(string providerId, CancellationToken cancellationToken = default)
+        => context.Secrets.GetAsync(SecretName(providerId), cancellationToken);
+
+    /// <summary>写入(或清除)某接入的 API Key。</summary>
+    public async Task SetApiKeyAsync(string providerId, string? apiKey, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            await context.Secrets.DeleteAsync(SecretName(providerId), cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await context.Secrets.SetAsync(SecretName(providerId), apiKey, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>删除接入时连带清除其机密。</summary>
+    public Task DeleteApiKeyAsync(string providerId, CancellationToken cancellationToken = default)
+        => context.Secrets.DeleteAsync(SecretName(providerId), cancellationToken);
+
+    /// <summary>
+    /// 为接入构造 <see cref="IChatClient" />(每次调用读取最新 API Key)。
+    /// 返回的是"裸"客户端;Agent 模式的函数调用循环由调用方经
+    /// <c>AsBuilder().UseFunctionInvocation()</c> 叠加。
+    /// </summary>
+    public async Task<IChatClient> CreateClientAsync(AiProviderConfig provider, string? apiKeyOverride = null, CancellationToken cancellationToken = default)
+    {
+        string? apiKey = apiKeyOverride ?? await GetApiKeyAsync(provider.Id, cancellationToken).ConfigureAwait(false);
+        switch (provider.Protocol)
+        {
+            case ChatProtocol.OpenAiChatCompletions:
+                return CreateOpenAiClient(provider, apiKey).GetChatClient(provider.Model).AsIChatClient();
+
+            case ChatProtocol.OpenAiResponses:
+#pragma warning disable OPENAI001 // Responses API 在 OpenAI SDK 中标记为实验性
+                return CreateOpenAiClient(provider, apiKey).GetResponsesClient().AsIChatClient(provider.Model);
+#pragma warning restore OPENAI001
+
+            case ChatProtocol.AnthropicMessages:
+                {
+                    string baseUrl = provider.BaseUrl.TrimEnd('/');
+                    // Anthropic SDK 自己追加 /v1 路径,用户误填时剥除
+                    if (baseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+                    {
+                        baseUrl = baseUrl[..^3].TrimEnd('/');
+                    }
+                    // 属性为 init-only,按有无 Key 分别构造(无 Key 时留给 SDK 的环境变量回退)
+                    AnthropicClient anthropic = string.IsNullOrWhiteSpace(apiKey)
+                        ? new AnthropicClient { BaseUrl = baseUrl }
+                        : new AnthropicClient { BaseUrl = baseUrl, ApiKey = apiKey };
+                    return anthropic.AsIChatClient(provider.Model, provider.MaxTokens);
+                }
+
+            default:
+                throw new InvalidOperationException($"Unknown protocol: {provider.Protocol}");
+        }
+    }
+
+    private static OpenAIClient CreateOpenAiClient(AiProviderConfig provider, string? apiKey)
+        => new(
+            // OpenAI SDK 要求凭据非空;Ollama 等本地服务无鉴权,给占位值即可
+            new ApiKeyCredential(string.IsNullOrWhiteSpace(apiKey) ? "not-needed" : apiKey),
+            new OpenAIClientOptions { Endpoint = new Uri(provider.BaseUrl.TrimEnd('/')) });
+
+    private static string SecretName(string providerId) => $"apikey:{providerId}";
+}

--- a/plugins/VelaShell.Plugin.Ai/README.md
+++ b/plugins/VelaShell.Plugin.Ai/README.md
@@ -1,0 +1,77 @@
+# VelaShell.Plugin.Ai —— AI 助手插件
+
+多提供商 AI 助手:在 VelaShell 内与大模型流式对话,并可开启 **Agent 模式**
+让模型经审批调用工具(读终端输出、执行远程命令、读远程文件、写终端)。
+
+## 支持的接入
+
+| 提供商 | 线协议 | 说明 |
+| --- | --- | --- |
+| OpenAI | Responses(流式)或 Chat Completions | 官方 API,二选一 |
+| Anthropic Claude | Anthropic Messages(流式) | 官方 API |
+| xAI Grok | OpenAI Chat Completions 兼容 | `https://api.x.ai/v1` |
+| Ollama(本地自部署) | OpenAI Chat Completions 兼容 | `http://localhost:11434/v1`,无需 Key |
+| 第三方中转站 | OpenAI 兼容 或 Anthropic 兼容 | 自填 Base URL + API Key |
+
+Base URL 与 API Key 全部用户自填;API Key 经宿主 **Secrets 能力加密存储**
+(Windows 上为 DPAPI 包裹的本地密钥),绝不明文落盘。
+
+## 数据存储位置
+
+插件不直连数据库 —— 一切持久化走 SDK 能力,宿主统一落 **SonnetDB** 的
+`plugin_data` 集合(按插件 id 命名空间隔离,卸载自动清除):
+
+| 数据 | 能力 | SonnetDB 文档主键 |
+| --- | --- | --- |
+| 接入配置/开关/系统提示词(`AiSettings` 整体 JSON) | `Storage` | `velashell.ai\|kv\|settings` |
+| 各接入的 API Key(DPAPI 加密后入库) | `Secrets` | `velashell.ai\|secret\|apikey:<providerId>` |
+
+## 界面
+
+视觉语言与宿主对齐(DESIGN.md §5.1):主操作用宿主的 `VelaAccentPillButtonTheme`
+强调药丸(发送/保存/批准),次操作用 `VelaOutlineButtonTheme` 描边(新会话/测试),
+危险操作描边换 `VelaError`(停止/删除/拒绝);输入区仿宿主 input-affix 容器
+(聚焦强调描边);图标复用宿主 `Icon.*` lucide 几何;Agent/设置为自带
+ControlTheme 的芯片开关(`Ui/AiTheme.axaml`,隔离进程下仅令牌也能退化可用)。
+顶栏右侧 **新会话** 按钮:终止当前请求并开始全新对话。
+
+回复以 **Markdown 渲染**(Markdig 解析 + `Ui/MarkdownRenderer` 映射为 Avalonia 控件):
+标题/粗斜体/删除线/行内代码/链接(可点击)/围栏代码块(语言标签 + 复制按钮)/
+列表(嵌套)/引用/分隔线/管道表格;未覆盖语法回退渲染原文。流式期间按 ≥200ms
+节流整段重渲染,收尾定稿。工具调用为**紧凑单行卡片**(状态图标 + 工具名 +
+参数摘要),点击展开完整参数与结果;思考过程同款折叠区。
+
+## 技术栈(用户决策 2026-08-10)
+
+统一到 **Microsoft.Extensions.AI** 的 `IChatClient` 抽象:
+
+- OpenAI 两种协议:`OpenAI` 官方 SDK + `Microsoft.Extensions.AI.OpenAI` 适配
+  (`GetChatClient().AsIChatClient()` / `GetResponsesClient().AsIChatClient()`);
+- Anthropic 协议:`Anthropic` 官方 SDK 内建的 `AsIChatClient()` 适配;
+- Agent 循环:`FunctionInvokingChatClient`(`UseFunctionInvocation()`,上限 25 轮);
+- 工具经 `AIFunctionFactory` 包装插件 SDK 能力(Sessions / Terminal / RemoteExec / RemoteFs)。
+
+依赖随插件目录分发,由插件 ALC 按 deps.json 隔离解析,与宿主互不干扰。
+
+## 命令(Ctrl+P / Ctrl+K)
+
+| 命令 | 说明 |
+| --- | --- |
+| AI: Open Chat (Tab) | 打开聊天面板(可停靠标签页) |
+| AI: Open Chat (Window) | 打开聊天窗口 |
+| AI: Explain Terminal Output | 抓取当前会话终端末尾 200 行送模型解释 |
+
+插件按 `onCommand` **惰性激活**:不触发 AI 命令就不装载程序集,启动零开销。
+
+## Agent 模式与安全
+
+- 工具 `run_command`(独立 exec 通道,不进用户终端)与 `write_terminal`
+  默认**逐条审批**(面板内 批准/拒绝 卡片);可勾选"自动批准"跳过(有风险)。
+- `write_terminal` 之上还有宿主自己的终端回写授权弹窗(四态)。
+- `read_terminal` / `list_sessions` / `read_remote_file`(≤256KB)为只读,不需审批。
+- 目标会话由面板顶部的会话下拉框选定。
+
+## 测试
+
+`tests/VelaShell.Plugin.Ai.Tests`:基于 `VelaShell.PluginSdk.Testing` 替身,
+覆盖工具箱审批闸门、能力桥接语义与设置/机密存取。

--- a/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
@@ -1,0 +1,57 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <!-- 芯片式开关(Agent / 设置等):对齐宿主 VelaOutlineButtonTheme 的描边语言,
+       选中态换 VelaAccentDim 半透明底 + 强调色描边(与宿主"强调药丸"同一配方)。
+       之所以自带 ControlTheme 而不是依赖宿主资源:隔离进程宿主只下发 Vela* 令牌,
+       不下发宿主的 ControlTheme;令牌缺失时属性回落默认值,依然可用。 -->
+  <ControlTheme x:Key="AiChipToggleTheme" TargetType="ToggleButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="3" />
+    <Setter Property="Padding" Value="8,0" />
+    <Setter Property="Height" Value="26" />
+    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+    <Setter Property="FontWeight" Value="Medium" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Foreground="{TemplateBinding Foreground}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+    </Style>
+    <Style Selector="^:checked">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:checked:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -1,0 +1,307 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="VelaShell.Plugin.Ai.Ui.ChatPanelView">
+
+  <!-- 视觉语言对齐宿主(DESIGN.md §5.1):主操作 = VelaAccentPillButtonTheme 强调药丸,
+       次操作 = VelaOutlineButtonTheme 描边;输入区仿宿主 input-affix 容器
+       (外层 Border 承担边框/焦点态,内部 TextBox 去壳);图标用宿主 Icon.* 几何
+       (lucide 24 视图框,Viewbox 等比缩放描边渲染)。配色/字体/字号全走 Vela* 令牌。 -->
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://VelaShell.Plugin.Ai/Ui/AiTheme.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <UserControl.Styles>
+    <Style Selector="TextBlock.dim">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+    <Style Selector="TextBlock.roleHeader">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+      <Setter Property="Margin" Value="0,0,0,4" />
+    </Style>
+    <Style Selector="SelectableTextBlock.body">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+      <Setter Property="LineSpacing" Value="4" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mono">
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
+    <!-- assistant 卡片:表面色 + 主描边;user 卡片:半透明强调底(与药丸同配方),无描边感 -->
+    <Style Selector="Border.msg">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="6" />
+      <Setter Property="Padding" Value="10,8" />
+    </Style>
+    <Style Selector="Border.userMsg">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+    </Style>
+    <Style Selector="Border.toolCard">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="8,6" />
+      <Setter Property="Margin" Value="0,4,0,0" />
+    </Style>
+
+    <!-- 输入容器:仿宿主 Border.input-affix(悬停换次描边、聚焦换强调描边) -->
+    <Style Selector="Border.inputWrap">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="MinHeight" Value="34" />
+    </Style>
+    <Style Selector="Border.inputWrap:pointerover">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+    </Style>
+    <Style Selector="Border.inputWrap:focus-within">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="Border.inputWrap TextBox">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="CornerRadius" Value="0" />
+      <Setter Property="MinHeight" Value="0" />
+      <Setter Property="Padding" Value="10,7" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+    </Style>
+    <Style Selector="Border.inputWrap TextBox /template/ Border#PART_BorderElement">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="Border.inputWrap TextBox:pointerover /template/ Border#PART_BorderElement">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="Border.inputWrap TextBox:focus /template/ Border#PART_BorderElement">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <!-- Markdown 渲染样式(MarkdownRenderer 生成的控件按类取样式) -->
+    <Style Selector="SelectableTextBlock.mdH1">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize16}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+      <Setter Property="Margin" Value="0,4,0,0" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mdH2">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize15}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+      <Setter Property="Margin" Value="0,4,0,0" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mdH3">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize14}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+      <Setter Property="Margin" Value="0,2,0,0" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mdH4">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+    <Style Selector="Border.mdCode">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="8,6" />
+    </Style>
+    <Style Selector="Button.mdCopy">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Padding" Value="6,1" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize9}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Button.mdCopy:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+    </Style>
+    <Style Selector="Border.mdQuote">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="2,0,0,0" />
+      <Setter Property="Padding" Value="8,2,0,2" />
+    </Style>
+    <Style Selector="Border.mdRule">
+      <Setter Property="Background" Value="{DynamicResource VelaBorderPrimary}" />
+    </Style>
+    <Style Selector="TextBlock.mdBullet">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+    <Style Selector="TextBlock.mdLink">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="TextDecorations" Value="Underline" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="Border.mdTableFrame">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1,1,0,0" />
+      <Setter Property="CornerRadius" Value="2" />
+    </Style>
+    <Style Selector="Border.mdTableCell">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="0,0,1,1" />
+      <Setter Property="Padding" Value="8,4" />
+    </Style>
+    <Style Selector="Border.mdTableHead">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="0,0,1,1" />
+      <Setter Property="Padding" Value="8,4" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mdTableText">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+    <Style Selector="SelectableTextBlock.mdTableHeadText">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
+    <!-- 紧凑工具卡(主流 Agent 风格:单行头 + 点击展开详情) -->
+    <Style Selector="TextBlock.toolName">
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="TextBlock.toolArgs">
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+      <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+      <Setter Property="TextWrapping" Value="NoWrap" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <!-- 顶栏下拉与勾选的统一尺寸 -->
+    <Style Selector="Grid#TopBar ComboBox">
+      <Setter Property="MinHeight" Value="26" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Grid#TopBar CheckBox">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="MinHeight" Value="26" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+  </UserControl.Styles>
+
+  <DockPanel Margin="10">
+    <!-- 顶栏:接入 / 会话 / Agent 开关 | 新会话 / 设置 -->
+    <Grid x:Name="TopBar" DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <ComboBox x:Name="ProviderCombo" MinWidth="150" MaxWidth="240" />
+        <ComboBox x:Name="SessionCombo" MinWidth="110" MaxWidth="200" />
+        <ToggleButton x:Name="AgentToggle" Theme="{StaticResource AiChipToggleTheme}">
+          <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+            <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+              <Path Width="24" Height="24" Data="{DynamicResource Icon.zap}"
+                    Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                    StrokeLineCap="Round" StrokeJoin="Round" />
+            </Viewbox>
+            <TextBlock x:Name="AgentText" VerticalAlignment="Center" />
+          </StackPanel>
+        </ToggleButton>
+        <CheckBox x:Name="AutoApproveCheck" IsVisible="False" />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
+        <Button x:Name="NewChatButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="8,0">
+          <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+            <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+              <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
+                    Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
+                    StrokeLineCap="Round" StrokeJoin="Round" />
+            </Viewbox>
+            <TextBlock x:Name="NewChatText" VerticalAlignment="Center" />
+          </StackPanel>
+        </Button>
+        <ToggleButton x:Name="SettingsToggle" Theme="{StaticResource AiChipToggleTheme}" Width="30" Padding="0">
+          <Viewbox Width="13" Height="13">
+            <Path Width="24" Height="24" Data="{DynamicResource Icon.settings}"
+                  Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                  StrokeLineCap="Round" StrokeJoin="Round" />
+          </Viewbox>
+        </ToggleButton>
+      </StackPanel>
+    </Grid>
+
+    <!-- 底部:输入容器(内嵌 发送/停止),状态行悬于其上 -->
+    <Border DockPanel.Dock="Bottom" Classes="inputWrap" Margin="0,8,0,0">
+      <Grid ColumnDefinitions="*,Auto">
+        <TextBox x:Name="InputBox" AcceptsReturn="True" TextWrapping="Wrap" MaxHeight="120" />
+        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,5,0" VerticalAlignment="Bottom" Height="34">
+          <Button x:Name="SendButton" Theme="{DynamicResource VelaAccentPillButtonTheme}"
+                  Height="24" Padding="10,0" VerticalAlignment="Center">
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.send}"
+                      Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="SendText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+            </StackPanel>
+          </Button>
+          <Button x:Name="StopButton" Theme="{DynamicResource VelaOutlineButtonTheme}"
+                  Height="24" Padding="10,0" VerticalAlignment="Center" IsVisible="False"
+                  Foreground="{DynamicResource VelaError}" BorderBrush="{DynamicResource VelaError}">
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="10" Height="10" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.square}"
+                      Stroke="{DynamicResource VelaError}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="StopText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+            </StackPanel>
+          </Button>
+        </StackPanel>
+      </Grid>
+    </Border>
+    <TextBlock x:Name="StatusText" DockPanel.Dock="Bottom" Classes="dim" Margin="2,6,2,0" TextWrapping="Wrap" />
+
+    <!-- 中部:消息流 / 设置页(二选一显示) -->
+    <Panel>
+      <ScrollViewer x:Name="ChatScroll" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel x:Name="MessagesPanel" Spacing="8" Margin="0,2,4,2" />
+      </ScrollViewer>
+      <ContentControl x:Name="SettingsHost" IsVisible="False" />
+    </Panel>
+  </DockPanel>
+</UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -1,0 +1,769 @@
+using System.Text;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// AI 聊天面板:回复以 Markdown 渲染(流式期间节流重渲染,收尾整段定稿),
+/// 工具调用为紧凑单行卡片(点击展开参数与结果),Agent 模式下危险操作带审批交互。
+/// 会话历史用 Microsoft.Extensions.AI 的 <see cref="ChatMessage" /> 维护,
+/// 每轮请求前临时前置 system 消息。
+/// </summary>
+public partial class ChatPanelView : UserControl
+{
+    private readonly IPluginContext _context;
+    private readonly AiSettingsStore _store;
+    private readonly Loc _loc;
+    private readonly AgentToolbox _toolbox;
+    private readonly MarkdownRenderer _markdown;
+    private readonly List<ChatMessage> _history = [];
+
+    private AiSettings _settings = new();
+    private SettingsView? _settingsView;
+    private List<AiProviderConfig> _providers = [];
+    private List<SessionInfo> _sessions = [];
+    private CancellationTokenSource? _cts;
+    private bool _busy;
+    private long _totalInputTokens;
+    private long _totalOutputTokens;
+
+    /// <summary>由插件构造(UI 线程,经 ShowPanelAsync 工厂)。</summary>
+    public ChatPanelView(IPluginContext context, AiSettingsStore store)
+    {
+        _context = context;
+        _store = store;
+        _loc = new Loc(context.Host.Locale);
+        _toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => SelectedSessionId,
+            ApprovalHandler = RequestApprovalAsync
+        };
+        InitializeComponent();
+        _markdown = new MarkdownRenderer(this, text => _context.Clipboard.SetTextAsync(text), _loc);
+        ApplyLoc();
+
+        SendButton.Click += (_, _) => _ = SendAsync(InputBox.Text ?? "");
+        StopButton.Click += (_, _) => _cts?.Cancel();
+        NewChatButton.Click += (_, _) => StartNewChat();
+        InputBox.AddHandler(KeyDownEvent, OnInputKeyDown, RoutingStrategies.Tunnel);
+        SettingsToggle.IsCheckedChanged += (_, _) =>
+        {
+            bool showSettings = SettingsToggle.IsChecked == true;
+            SettingsHost.IsVisible = showSettings;
+            ChatScroll.IsVisible = !showSettings;
+        };
+        AgentToggle.IsCheckedChanged += (_, _) =>
+        {
+            _settings.AgentMode = AgentToggle.IsChecked == true;
+            AutoApproveCheck.IsVisible = _settings.AgentMode;
+            _ = PersistSettingsAsync();
+        };
+        AutoApproveCheck.IsCheckedChanged += (_, _) =>
+        {
+            _settings.AutoApproveCommands = AutoApproveCheck.IsChecked == true;
+            _ = PersistSettingsAsync();
+        };
+        ProviderCombo.SelectionChanged += (_, _) =>
+        {
+            if (ProviderCombo.SelectedIndex >= 0 && ProviderCombo.SelectedIndex < _providers.Count)
+            {
+                _settings.ActiveProviderId = _providers[ProviderCombo.SelectedIndex].Id;
+                _ = PersistSettingsAsync();
+            }
+        };
+
+        _context.Events.SessionConnected += OnSessionEvent;
+        _context.Events.SessionDisconnected += OnSessionEvent;
+        _context.Events.LocaleChanged += OnLocaleChanged;
+
+        _ = InitAsync();
+    }
+
+    /// <summary>面板关闭时由插件调用,拆除宿主事件订阅并取消进行中的请求。</summary>
+    public void Detach()
+    {
+        _context.Events.SessionConnected -= OnSessionEvent;
+        _context.Events.SessionDisconnected -= OnSessionEvent;
+        _context.Events.LocaleChanged -= OnLocaleChanged;
+        try
+        {
+            _cts?.Cancel();
+        }
+        catch
+        {
+            // 已释放则忽略
+        }
+    }
+
+    /// <summary>从命令入口外部注入一条消息并直接发送(任意线程可调)。</summary>
+    public void SendExternal(string text) => Dispatcher.UIThread.Post(() => _ = SendAsync(text));
+
+    // ---------- 初始化与状态 ----------
+
+    private async Task InitAsync()
+    {
+        try
+        {
+            _settings = await _store.LoadAsync();
+            AgentToggle.IsChecked = _settings.AgentMode;
+            AutoApproveCheck.IsChecked = _settings.AutoApproveCommands;
+            AutoApproveCheck.IsVisible = _settings.AgentMode;
+            _settingsView = new SettingsView(_context, _store, _settings, _loc, OnProvidersChanged);
+            SettingsHost.Content = _settingsView;
+            ReloadProviderCombo();
+            await RefreshSessionsAsync();
+            if (_providers.Count == 0)
+            {
+                StatusText.Text = _loc["NoProvider"];
+                SettingsToggle.IsChecked = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("AI panel init failed.", ex);
+            StatusText.Text = $"{_loc["Error"]}: {ex.Message}";
+        }
+    }
+
+    private void ApplyLoc()
+    {
+        AgentText.Text = _loc["Agent"];
+        ToolTip.SetTip(AgentToggle, _loc["AgentTip"]);
+        AutoApproveCheck.Content = _loc["AutoApprove"];
+        ToolTip.SetTip(AutoApproveCheck, _loc["AutoApproveTip"]);
+        NewChatText.Text = _loc["NewChat"];
+        ToolTip.SetTip(NewChatButton, _loc["NewChatTip"]);
+        ToolTip.SetTip(SettingsToggle, _loc["Settings"]);
+        InputBox.PlaceholderText = _loc["InputPlaceholder"];
+        SendText.Text = _loc["Send"];
+        StopText.Text = _loc["Stop"];
+    }
+
+    private void OnLocaleChanged(string locale) => Dispatcher.UIThread.Post(() =>
+    {
+        _loc.Switch(locale);
+        ApplyLoc();
+        _settingsView?.ApplyLoc();
+    });
+
+    private void OnProvidersChanged()
+    {
+        ReloadProviderCombo();
+        if (_providers.Count > 0 && StatusText.Text == _loc["NoProvider"])
+        {
+            StatusText.Text = "";
+        }
+        _ = PersistSettingsAsync();
+    }
+
+    private void ReloadProviderCombo()
+    {
+        _providers = _settings.Providers.ToList();
+        ProviderCombo.ItemsSource = _providers
+            .Select(p => string.IsNullOrWhiteSpace(p.Model) ? p.Name : $"{p.Name} · {p.Model}")
+            .ToList();
+        int active = _providers.FindIndex(p => p.Id == _settings.ActiveProviderId);
+        ProviderCombo.SelectedIndex = active >= 0 ? active : (_providers.Count > 0 ? 0 : -1);
+    }
+
+    private AiProviderConfig? ActiveProvider
+        => ProviderCombo.SelectedIndex >= 0 && ProviderCombo.SelectedIndex < _providers.Count
+            ? _providers[ProviderCombo.SelectedIndex]
+            : null;
+
+    private string? SelectedSessionId
+        => _sessions.Count > 0 && SessionCombo.SelectedIndex >= 0 && SessionCombo.SelectedIndex < _sessions.Count
+            ? _sessions[SessionCombo.SelectedIndex].SessionId
+            : null;
+
+    private void OnSessionEvent(SessionInfo info) => Dispatcher.UIThread.Post(() => _ = RefreshSessionsAsync());
+
+    private async Task RefreshSessionsAsync()
+    {
+        try
+        {
+            IReadOnlyList<SessionInfo> all = await _context.Sessions.ListAsync();
+            string? previous = SelectedSessionId;
+            _sessions = all.Where(s => s.State == SessionState.Connected).ToList();
+            SessionCombo.ItemsSource = _sessions.Count == 0
+                ? [_loc["NoSession"]]
+                : _sessions.Select(s => $"{s.Username}@{s.Host}").ToList();
+            int keep = _sessions.FindIndex(s => s.SessionId == previous);
+            SessionCombo.SelectedIndex = keep >= 0 ? keep : 0;
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Refresh sessions failed.", ex);
+        }
+    }
+
+    private async Task PersistSettingsAsync()
+    {
+        try
+        {
+            await _store.SaveAsync(_settings);
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Persist AI settings failed.", ex);
+        }
+    }
+
+    // ---------- 发送与流式渲染 ----------
+
+    private void OnInputKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter && !e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            e.Handled = true;
+            _ = SendAsync(InputBox.Text ?? "");
+        }
+    }
+
+    private void SetBusy(bool busy)
+    {
+        _busy = busy;
+        SendButton.IsVisible = !busy;
+        StopButton.IsVisible = busy;
+    }
+
+    private async Task SendAsync(string text)
+    {
+        text = text.Trim();
+        if (text.Length == 0 || _busy)
+        {
+            return;
+        }
+        if (ActiveProvider is not { } provider)
+        {
+            StatusText.Text = _loc["NoProvider"];
+            SettingsToggle.IsChecked = true;
+            return;
+        }
+
+        SetBusy(true);
+        InputBox.Text = "";
+        SettingsToggle.IsChecked = false;
+
+        AddUserBubble(text);
+        _history.Add(new ChatMessage(ChatRole.User, text));
+        var bubble = new AssistantBubble(this);
+        MessagesPanel.Children.Add(bubble.Root);
+        ChatScroll.ScrollToEnd();
+
+        _cts = new CancellationTokenSource();
+        CancellationToken token = _cts.Token;
+        try
+        {
+            IChatClient client = await _store.CreateClientAsync(provider, cancellationToken: token);
+            var options = new ChatOptions();
+            bool agentMode = _settings.AgentMode;
+            if (agentMode)
+            {
+                _toolbox.AutoApprove = _settings.AutoApproveCommands;
+                options.Tools = _toolbox.CreateTools();
+                client = client.AsBuilder()
+                    .UseFunctionInvocation(configure: c => c.MaximumIterationsPerRequest = 25)
+                    .Build();
+            }
+
+            var requestMessages = new List<ChatMessage>(_history.Count + 1)
+            {
+                new(ChatRole.System, BuildSystemPrompt(agentMode))
+            };
+            requestMessages.AddRange(_history);
+
+            var updates = new List<ChatResponseUpdate>();
+            // 网络流在线程池上消费,增量封送回 UI 线程,避免 SSE 读循环占用 UI。
+            await Task.Run(async () =>
+            {
+                await foreach (ChatResponseUpdate update in client
+                                   .GetStreamingResponseAsync(requestMessages, options, token)
+                                   .ConfigureAwait(false))
+                {
+                    updates.Add(update);
+                    Dispatcher.UIThread.Post(() => RenderUpdate(bubble, update));
+                }
+            }, token);
+
+            var response = updates.ToChatResponse();
+            _history.AddMessages(response);
+            if (response.Usage is { } usage)
+            {
+                _totalInputTokens += usage.InputTokenCount ?? 0;
+                _totalOutputTokens += usage.OutputTokenCount ?? 0;
+            }
+            StatusText.Text = _loc.F("Usage", _totalInputTokens, _totalOutputTokens);
+        }
+        catch (OperationCanceledException)
+        {
+            StatusText.Text = _loc["Cancelled"];
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("AI request failed.", ex);
+            bubble.AppendText($"\n\n**[{_loc["Error"]}]** {ex.Message}");
+        }
+        finally
+        {
+            _cts?.Dispose();
+            _cts = null;
+            SetBusy(false);
+            bubble.FinishStreaming();
+            ChatScroll.ScrollToEnd();
+        }
+    }
+
+    private void RenderUpdate(AssistantBubble bubble, ChatResponseUpdate update)
+    {
+        foreach (AIContent content in update.Contents)
+        {
+            switch (content)
+            {
+                case TextReasoningContent reasoning:
+                    bubble.AppendThinking(reasoning.Text);
+                    break;
+                case TextContent textContent:
+                    bubble.AppendText(textContent.Text);
+                    break;
+                case FunctionCallContent call:
+                    bubble.AddToolCall(call.CallId, call.Name, SerializeArguments(call.Arguments));
+                    break;
+                case FunctionResultContent result:
+                    bubble.CompleteToolCall(result.CallId, result.Result?.ToString() ?? "");
+                    break;
+                case ErrorContent error:
+                    StatusText.Text = $"{_loc["Error"]}: {error.Message}";
+                    break;
+            }
+        }
+        ChatScroll.ScrollToEnd();
+    }
+
+    private static string SerializeArguments(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+        {
+            return "{}";
+        }
+        try
+        {
+            return JsonSerializer.Serialize(arguments);
+        }
+        catch
+        {
+            return string.Join(", ", arguments.Keys);
+        }
+    }
+
+    private string BuildSystemPrompt(bool agentMode)
+    {
+        if (!string.IsNullOrWhiteSpace(_settings.SystemPrompt))
+        {
+            return _settings.SystemPrompt;
+        }
+        string prompt =
+            "You are the AI assistant embedded in VelaShell, an SSH terminal application. " +
+            "Help the user with servers, shell commands, log analysis and DevOps questions. Be concise and practical. " +
+            "Format responses in Markdown. " +
+            $"Respond in the user's language (UI locale: {_context.Host.Locale}).";
+        if (agentMode)
+        {
+            prompt +=
+                " You can call tools to inspect the user's selected SSH session (read terminal output, run one-shot commands, read files). " +
+                "Prefer read-only commands; destructive commands require user approval and should be proposed carefully.";
+        }
+        return prompt;
+    }
+
+    /// <summary>新建会话:终止进行中的请求,清空历史与消息流,回到聊天视图。</summary>
+    private void StartNewChat()
+    {
+        _cts?.Cancel();
+        _history.Clear();
+        MessagesPanel.Children.Clear();
+        _totalInputTokens = 0;
+        _totalOutputTokens = 0;
+        StatusText.Text = "";
+        SettingsToggle.IsChecked = false;
+        InputBox.Focus();
+    }
+
+    // ---------- 审批交互 ----------
+
+    private async Task<bool> RequestApprovalAsync(string summary)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Dispatcher.UIThread.Post(() => AddApprovalCard(summary, tcs));
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    private void AddApprovalCard(string summary, TaskCompletionSource<bool> tcs)
+    {
+        var stack = new StackPanel { Spacing = 6 };
+        stack.Children.Add(new TextBlock { Classes = { "dim" }, Text = _loc["ApprovalTitle"] });
+        stack.Children.Add(new SelectableTextBlock { Classes = { "mono" }, Text = Truncate(summary, 600) });
+        // 主/次操作对齐宿主按钮方案:批准 = 强调药丸,拒绝 = 描边换危险色
+        var approveButton = new Button { Content = _loc["Approve"], Height = 24, Padding = new Thickness(12, 0) };
+        var denyButton = new Button { Content = _loc["Deny"], Height = 24, Padding = new Thickness(12, 0) };
+        ApplyThemeResource(approveButton, "VelaAccentPillButtonTheme");
+        ApplyThemeResource(denyButton, "VelaOutlineButtonTheme");
+        if (FindBrush("VelaError") is { } error)
+        {
+            denyButton.Foreground = error;
+            denyButton.BorderBrush = error;
+        }
+        var buttons = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 6, Margin = new Thickness(0, 2, 0, 0) };
+        buttons.Children.Add(approveButton);
+        buttons.Children.Add(denyButton);
+        stack.Children.Add(buttons);
+        var card = new Border { Classes = { "toolCard" }, Child = stack };
+
+        void Finish(bool approved)
+        {
+            approveButton.IsEnabled = false;
+            denyButton.IsEnabled = false;
+            stack.Children.Add(new TextBlock { Classes = { "dim" }, Text = approved ? _loc["Approve"] + " ✓" : _loc["Deny"] + " ✕" });
+            tcs.TrySetResult(approved);
+        }
+
+        approveButton.Click += (_, _) => Finish(true);
+        denyButton.Click += (_, _) => Finish(false);
+        MessagesPanel.Children.Add(card);
+        ChatScroll.ScrollToEnd();
+    }
+
+    // ---------- 气泡构建 ----------
+
+    private void AddUserBubble(string text)
+    {
+        var stack = new StackPanel();
+        stack.Children.Add(new TextBlock { Classes = { "roleHeader" }, Text = _loc["You"] });
+        stack.Children.Add(new SelectableTextBlock { Classes = { "body" }, Text = text });
+        MessagesPanel.Children.Add(new Border { Classes = { "msg", "userMsg" }, Child = stack });
+    }
+
+    private static string Truncate(string text, int max)
+        => text.Length <= max ? text : text[..max] + "…";
+
+    /// <summary>套用宿主 ControlTheme(进程内可查;隔离进程缺失时保持默认外观)。</summary>
+    private void ApplyThemeResource(Avalonia.Controls.Primitives.TemplatedControl control, string themeKey)
+    {
+        if (this.TryFindResource(themeKey, out object? value) && value is Avalonia.Styling.ControlTheme theme)
+        {
+            control.Theme = theme;
+        }
+    }
+
+    private Geometry? FindIcon(string key)
+        => this.TryFindResource(key, out object? value) && value is Geometry geometry ? geometry : null;
+
+    private IBrush? FindBrush(string key)
+        => this.TryFindResource(key, out object? value) && value is IBrush brush ? brush : null;
+
+    /// <summary>lucide 描边图标(24 视图框经 Viewbox 等比缩放)。</summary>
+    private Control MakeIcon(string geometryKey, string brushKey, double size)
+    {
+        var path = new Avalonia.Controls.Shapes.Path
+        {
+            Width = 24,
+            Height = 24,
+            Data = FindIcon(geometryKey),
+            Stroke = FindBrush(brushKey) ?? Brushes.Gray,
+            StrokeThickness = 2,
+            StrokeLineCap = PenLineCap.Round,
+            StrokeJoin = PenLineJoin.Round
+        };
+        return new Viewbox { Width = size, Height = size, Child = path };
+    }
+
+    /// <summary>一条 assistant 回复的可视化容器:Markdown 段落、思考折叠区与工具卡片。</summary>
+    private sealed class AssistantBubble
+    {
+        private readonly ChatPanelView _owner;
+        private readonly StackPanel _stack;
+        private readonly Dictionary<string, ToolCard> _toolCards = [];
+        private readonly List<MarkdownSegment> _segments = [];
+        private MarkdownSegment? _currentSegment;
+        private Collapsible? _thinking;
+        private readonly StringBuilder _thinkingText = new();
+
+        public Border Root { get; }
+
+        public AssistantBubble(ChatPanelView owner)
+        {
+            _owner = owner;
+            _stack = new StackPanel { Spacing = 4 };
+            _stack.Children.Add(new TextBlock { Classes = { "roleHeader" }, Text = owner._loc["AssistantRole"] });
+            Root = new Border { Classes = { "msg" }, Child = _stack };
+        }
+
+        public void AppendText(string text)
+        {
+            if (text.Length == 0)
+            {
+                return;
+            }
+            // 工具卡片之后的新一轮文本另起 Markdown 段
+            if (_currentSegment is null || !ReferenceEquals(_stack.Children[^1], _currentSegment.Host))
+            {
+                _currentSegment = new MarkdownSegment(_owner._markdown);
+                _segments.Add(_currentSegment);
+                _stack.Children.Add(_currentSegment.Host);
+            }
+            _currentSegment.Append(text);
+        }
+
+        public void AppendThinking(string text)
+        {
+            if (text.Length == 0)
+            {
+                return;
+            }
+            _thinkingText.Append(text);
+            if (_thinking is null)
+            {
+                _thinking = new Collapsible(_owner, _owner._loc["Thinking"]);
+                _stack.Children.Insert(1, _thinking.Root);
+            }
+            _thinking.SetBody(_thinkingText.ToString());
+        }
+
+        public void AddToolCall(string callId, string name, string argumentsJson)
+        {
+            if (_toolCards.ContainsKey(callId))
+            {
+                return;
+            }
+            var card = new ToolCard(_owner, name, argumentsJson);
+            _toolCards[callId] = card;
+            _stack.Children.Add(card.Root);
+            _currentSegment = null;
+        }
+
+        public void CompleteToolCall(string callId, string result)
+        {
+            if (_toolCards.TryGetValue(callId, out ToolCard? card))
+            {
+                card.Complete(result);
+            }
+            _currentSegment = null;
+        }
+
+        /// <summary>流结束(成功/取消/出错都会走到):所有 Markdown 段落立即定稿渲染。</summary>
+        public void FinishStreaming()
+        {
+            foreach (MarkdownSegment segment in _segments)
+            {
+                segment.RenderNow();
+            }
+        }
+    }
+
+    /// <summary>
+    /// 一段流式 Markdown:增量进 StringBuilder,按 ≥200ms 节流整段重渲染
+    /// (Markdig 解析半截文本安全;定稿由 <see cref="RenderNow" /> 收口)。
+    /// </summary>
+    private sealed class MarkdownSegment(MarkdownRenderer renderer)
+    {
+        private readonly StringBuilder _text = new();
+        private bool _renderScheduled;
+
+        public Decorator Host { get; } = new();
+
+        public void Append(string text)
+        {
+            _text.Append(text);
+            if (!_renderScheduled)
+            {
+                _renderScheduled = true;
+                DispatcherTimer.RunOnce(RenderNow, TimeSpan.FromMilliseconds(200));
+            }
+        }
+
+        public void RenderNow()
+        {
+            _renderScheduled = false;
+            Host.Child = renderer.Render(_text.ToString());
+        }
+    }
+
+    /// <summary>紧凑可折叠区(思考过程):单行头部点击展开,正文等宽文本。</summary>
+    private sealed class Collapsible
+    {
+        private readonly SelectableTextBlock _body;
+        private readonly Avalonia.Controls.Shapes.Path _chevron;
+        private readonly ScrollViewer _details;
+
+        public Border Root { get; }
+
+        public Collapsible(ChatPanelView owner, string title)
+        {
+            var header = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("Auto,Auto,*"),
+                Background = Brushes.Transparent,
+                Cursor = new Cursor(StandardCursorType.Hand)
+            };
+            _chevron = new Avalonia.Controls.Shapes.Path
+            {
+                Width = 24,
+                Height = 24,
+                Data = owner.FindIcon("Icon.chevron-right"),
+                Stroke = owner.FindBrush("VelaTextMuted") ?? Brushes.Gray,
+                StrokeThickness = 2,
+                StrokeLineCap = PenLineCap.Round,
+                StrokeJoin = PenLineJoin.Round
+            };
+            var chevronBox = new Viewbox { Width = 10, Height = 10, Child = _chevron, Margin = new Thickness(0, 0, 5, 0), VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+            header.Children.Add(chevronBox);
+            var titleText = new TextBlock { Classes = { "dim" }, Text = title, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+            Grid.SetColumn(titleText, 1);
+            header.Children.Add(titleText);
+
+            _body = new SelectableTextBlock { Classes = { "mono" } };
+            _details = new ScrollViewer
+            {
+                MaxHeight = 200,
+                Content = _body,
+                IsVisible = false,
+                Margin = new Thickness(15, 4, 0, 0)
+            };
+            header.PointerPressed += (_, _) => Toggle();
+
+            var stack = new StackPanel();
+            stack.Children.Add(header);
+            stack.Children.Add(_details);
+            Root = new Border { Classes = { "toolCard" }, Child = stack };
+        }
+
+        public void SetBody(string text) => _body.Text = text;
+
+        private void Toggle()
+        {
+            _details.IsVisible = !_details.IsVisible;
+            _chevron.RenderTransform = _details.IsVisible ? new RotateTransform(90) : null;
+        }
+    }
+
+    /// <summary>
+    /// 一次工具调用的紧凑卡片(主流 Agent 风格):
+    /// 单行 = 状态图标 + 工具名 + 参数摘要 + 箭头;点击展开完整参数与结果。
+    /// </summary>
+    private sealed class ToolCard
+    {
+        private readonly ChatPanelView _owner;
+        private readonly Decorator _statusIconHost;
+        private readonly SelectableTextBlock _detailsText;
+        private readonly ScrollViewer _details;
+        private readonly Avalonia.Controls.Shapes.Path _chevron;
+        private readonly string _argumentsJson;
+        private string _result = "";
+
+        public Border Root { get; }
+
+        public ToolCard(ChatPanelView owner, string name, string argumentsJson)
+        {
+            _owner = owner;
+            _argumentsJson = argumentsJson;
+
+            var header = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("Auto,Auto,*,Auto"),
+                Background = Brushes.Transparent,
+                Cursor = new Cursor(StandardCursorType.Hand)
+            };
+            _statusIconHost = new Decorator
+            {
+                Child = owner.MakeIcon("Icon.ellipsis", "VelaAccent", 11),
+                Margin = new Thickness(0, 0, 6, 0),
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+            ToolTip.SetTip(_statusIconHost, owner._loc["ToolRunning"]);
+            header.Children.Add(_statusIconHost);
+
+            var nameText = new TextBlock { Classes = { "toolName" }, Text = name };
+            Grid.SetColumn(nameText, 1);
+            header.Children.Add(nameText);
+
+            var argsText = new TextBlock
+            {
+                Classes = { "toolArgs" },
+                Text = OneLine(argumentsJson, 160),
+                Margin = new Thickness(8, 0, 8, 0)
+            };
+            Grid.SetColumn(argsText, 2);
+            header.Children.Add(argsText);
+
+            _chevron = new Avalonia.Controls.Shapes.Path
+            {
+                Width = 24,
+                Height = 24,
+                Data = owner.FindIcon("Icon.chevron-right"),
+                Stroke = owner.FindBrush("VelaTextMuted") ?? Brushes.Gray,
+                StrokeThickness = 2,
+                StrokeLineCap = PenLineCap.Round,
+                StrokeJoin = PenLineJoin.Round
+            };
+            var chevronBox = new Viewbox { Width = 10, Height = 10, Child = _chevron, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+            Grid.SetColumn(chevronBox, 3);
+            header.Children.Add(chevronBox);
+
+            _detailsText = new SelectableTextBlock { Classes = { "mono" } };
+            _details = new ScrollViewer
+            {
+                MaxHeight = 220,
+                Content = _detailsText,
+                IsVisible = false,
+                Margin = new Thickness(17, 4, 0, 0)
+            };
+            header.PointerPressed += (_, _) => Toggle();
+
+            var stack = new StackPanel();
+            stack.Children.Add(header);
+            stack.Children.Add(_details);
+            Root = new Border { Classes = { "toolCard" }, Child = stack };
+        }
+
+        public void Complete(string result)
+        {
+            _result = result;
+            _statusIconHost.Child = _owner.MakeIcon("Icon.circle-check", "VelaStatusConnected", 11);
+            ToolTip.SetTip(_statusIconHost, _owner._loc["ToolDone"]);
+        }
+
+        private void Toggle()
+        {
+            if (!_details.IsVisible)
+            {
+                var sb = new StringBuilder();
+                sb.Append(_argumentsJson);
+                if (_result.Length > 0)
+                {
+                    sb.Append("\n────────\n");
+                    sb.Append(Truncate(_result, 4000));
+                }
+                _detailsText.Text = sb.ToString();
+            }
+            _details.IsVisible = !_details.IsVisible;
+            _chevron.RenderTransform = _details.IsVisible ? new RotateTransform(90) : null;
+        }
+
+        private static string OneLine(string text, int max)
+        {
+            string flat = text.Replace('\n', ' ').Replace('\r', ' ');
+            return flat.Length <= max ? flat : flat[..max] + "…";
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -1,0 +1,96 @@
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// 插件自理的多语言文案,与宿主同覆盖五语(en / zh-Hans / zh-Hant / ja / ko)。
+/// 用法:<c>var loc = new Loc(context.Host.Locale); loc["Send"]</c>。
+/// </summary>
+public sealed class Loc(string locale)
+{
+    private const int En = 0, ZhHans = 1, ZhHant = 2, Ja = 3, Ko = 4;
+
+    private int _index = Resolve(locale);
+
+    /// <summary>宿主语言切换时更新(共享实例即处处生效,调用方随后重刷各自文案)。</summary>
+    public void Switch(string newLocale) => _index = Resolve(newLocale);
+
+    private static int Resolve(string locale)
+    {
+        if (locale.StartsWith("zh", StringComparison.OrdinalIgnoreCase))
+        {
+            return locale.Contains("Hant", StringComparison.OrdinalIgnoreCase)
+                   || locale.Contains("TW", StringComparison.OrdinalIgnoreCase)
+                   || locale.Contains("HK", StringComparison.OrdinalIgnoreCase)
+                   || locale.Contains("MO", StringComparison.OrdinalIgnoreCase)
+                ? ZhHant
+                : ZhHans;
+        }
+        if (locale.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+        {
+            return Ja;
+        }
+        if (locale.StartsWith("ko", StringComparison.OrdinalIgnoreCase))
+        {
+            return Ko;
+        }
+        return En;
+    }
+
+    /// <summary>取词;缺键时返回键名本身(可视化暴露问题)。</summary>
+    public string this[string key] => Table.TryGetValue(key, out string[]? values) ? values[_index] : key;
+
+    /// <summary>带格式化参数取词。</summary>
+    public string F(string key, params object[] args) => string.Format(this[key], args);
+
+    //                                 en, zh-Hans, zh-Hant, ja, ko
+    private static readonly Dictionary<string, string[]> Table = new()
+    {
+        ["Title"] = ["AI Assistant", "AI 助手", "AI 助手", "AI アシスタント", "AI 어시스턴트"],
+        ["NoProvider"] = ["No provider configured — open Settings (⚙) to add one.", "尚未配置模型接入 —— 点右上角 ⚙ 添加。", "尚未設定模型接入 —— 點右上角 ⚙ 新增。", "プロバイダー未設定 — 右上の ⚙ から追加してください。", "프로바이더가 없습니다 — 오른쪽 위 ⚙에서 추가하세요."],
+        ["Agent"] = ["Agent", "Agent", "Agent", "Agent", "Agent"],
+        ["AgentTip"] = ["Agent mode: the model may call tools (read terminal, run commands…).", "Agent 模式:模型可调用工具(读终端、执行命令等)。", "Agent 模式:模型可呼叫工具(讀終端、執行命令等)。", "Agent モード:モデルがツールを呼び出せます(端末読取・コマンド実行など)。", "Agent 모드: 모델이 도구를 호출할 수 있습니다(터미널 읽기, 명령 실행 등)."],
+        ["AutoApprove"] = ["Auto-approve", "自动批准", "自動批准", "自動承認", "자동 승인"],
+        ["AutoApproveTip"] = ["Run commands without asking (risky).", "不再逐条审批命令(有风险)。", "不再逐條審批命令(有風險)。", "確認なしでコマンドを実行します(危険)。", "확인 없이 명령을 실행합니다(위험)."],
+        ["NoSession"] = ["(no session)", "(无会话)", "(無會話)", "(セッションなし)", "(세션 없음)"],
+        ["InputPlaceholder"] = ["Ask anything…  (Enter to send, Shift+Enter for newline)", "问点什么… (Enter 发送,Shift+Enter 换行)", "問點什麼… (Enter 傳送,Shift+Enter 換行)", "質問を入力… (Enter で送信、Shift+Enter で改行)", "질문을 입력하세요… (Enter 전송, Shift+Enter 줄바꿈)"],
+        ["Send"] = ["Send", "发送", "傳送", "送信", "전송"],
+        ["Stop"] = ["Stop", "停止", "停止", "停止", "중지"],
+        ["NewChat"] = ["New chat", "新会话", "新會話", "新規チャット", "새 채팅"],
+        ["NewChatTip"] = ["Start a new conversation (discards the current one).", "开始新会话(丢弃当前对话)。", "開始新會話(丟棄當前對話)。", "新しい会話を開始します(現在の会話は破棄)。", "새 대화를 시작합니다(현재 대화는 삭제)."],
+        ["Settings"] = ["Settings", "设置", "設定", "設定", "설정"],
+        ["You"] = ["You", "你", "你", "あなた", "나"],
+        ["AssistantRole"] = ["Assistant", "助手", "助手", "アシスタント", "어시스턴트"],
+        ["Thinking"] = ["Thinking", "思考过程", "思考過程", "思考プロセス", "사고 과정"],
+        ["ApprovalTitle"] = ["The agent wants to run:", "Agent 请求执行:", "Agent 請求執行:", "エージェントが実行を要求:", "에이전트가 실행을 요청:"],
+        ["Approve"] = ["Approve", "批准", "批准", "承認", "승인"],
+        ["Deny"] = ["Deny", "拒绝", "拒絕", "拒否", "거부"],
+        ["ToolRunning"] = ["running…", "执行中…", "執行中…", "実行中…", "실행 중…"],
+        ["ToolDone"] = ["done", "完成", "完成", "完了", "완료"],
+        ["Copy"] = ["Copy", "复制", "複製", "コピー", "복사"],
+        ["Copied"] = ["Copied ✓", "已复制 ✓", "已複製 ✓", "コピー済み ✓", "복사됨 ✓"],
+        ["Error"] = ["Error", "错误", "錯誤", "エラー", "오류"],
+        ["Cancelled"] = ["Cancelled.", "已取消。", "已取消。", "キャンセルしました。", "취소되었습니다."],
+        ["Usage"] = ["tokens: in {0} / out {1}", "tokens:输入 {0} / 输出 {1}", "tokens:輸入 {0} / 輸出 {1}", "tokens:入力 {0} / 出力 {1}", "tokens: 입력 {0} / 출력 {1}"],
+        ["Providers"] = ["Providers", "模型接入", "模型接入", "プロバイダー", "프로바이더"],
+        ["Add"] = ["Add", "新增", "新增", "追加", "추가"],
+        ["Delete"] = ["Delete", "删除", "刪除", "削除", "삭제"],
+        ["Save"] = ["Save", "保存", "儲存", "保存", "저장"],
+        ["Saved"] = ["Saved.", "已保存。", "已儲存。", "保存しました。", "저장되었습니다."],
+        ["Test"] = ["Test", "测试", "測試", "テスト", "테스트"],
+        ["Testing"] = ["Testing…", "测试中…", "測試中…", "テスト中…", "테스트 중…"],
+        ["TestOk"] = ["Connection OK: {0}", "连接正常:{0}", "連接正常:{0}", "接続 OK:{0}", "연결 정상: {0}"],
+        ["TestFail"] = ["Test failed: {0}", "测试失败:{0}", "測試失敗:{0}", "テスト失敗:{0}", "테스트 실패: {0}"],
+        ["Name"] = ["Name", "名称", "名稱", "名前", "이름"],
+        ["Protocol"] = ["Protocol", "协议", "協議", "プロトコル", "프로토콜"],
+        ["BaseUrl"] = ["Base URL", "基地址", "基底位址", "ベース URL", "베이스 URL"],
+        ["Model"] = ["Model", "模型", "模型", "モデル", "모델"],
+        ["MaxTokens"] = ["Max output tokens", "最大输出 tokens", "最大輸出 tokens", "最大出力トークン", "최대 출력 토큰"],
+        ["ApiKey"] = ["API Key", "API Key", "API Key", "API キー", "API 키"],
+        ["ApiKeyHint"] = ["Stored encrypted via the host secret store.", "经宿主机密存储加密保存。", "經宿主機密儲存加密保存。", "ホストのシークレットストアで暗号化保存されます。", "호스트 시크릿 저장소에 암호화되어 저장됩니다."],
+        ["SystemPrompt"] = ["System prompt (optional)", "系统提示词(可选)", "系統提示詞(可選)", "システムプロンプト(任意)", "시스템 프롬프트(선택)"],
+        ["ExplainPrompt"] = ["Explain the following terminal output. Point out any errors and suggest fixes:\n", "请解释以下终端输出,指出其中的错误并给出可能的解决办法:\n", "請解釋以下終端輸出,指出其中的錯誤並給出可能的解決辦法:\n", "以下のターミナル出力を説明し、エラーがあれば指摘して解決策を提案してください:\n", "다음 터미널 출력을 설명하고, 오류를 지적하고 해결 방법을 제안해 주세요:\n"],
+        ["NoConnectedSession"] = ["No connected session.", "没有已连接的会话。", "沒有已連接的會話。", "接続中のセッションがありません。", "연결된 세션이 없습니다."],
+        ["CmdChat"] = ["AI: Open Chat (Tab)", "AI:打开聊天(标签页)", "AI:開啟聊天(標籤頁)", "AI:チャットを開く(タブ)", "AI: 채팅 열기(탭)"],
+        ["CmdChatWindow"] = ["AI: Open Chat (Window)", "AI:打开聊天(窗口)", "AI:開啟聊天(視窗)", "AI:チャットを開く(ウィンドウ)", "AI: 채팅 열기(창)"],
+        ["CmdExplain"] = ["AI: Explain Terminal Output", "AI:解释终端输出", "AI:解釋終端輸出", "AI:ターミナル出力を説明", "AI: 터미널 출력 설명"]
+    };
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/MarkdownRenderer.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/MarkdownRenderer.cs
@@ -1,0 +1,406 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Markdig;
+using Markdig.Extensions.Tables;
+using Markdig.Helpers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using AvaloniaInline = Avalonia.Controls.Documents.Inline;
+using MdInline = Markdig.Syntax.Inlines.Inline;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// Markdown → Avalonia 控件渲染器(Markdig 解析)。支持:标题、段落、行内样式
+/// (粗体/斜体/删除线/行内代码/链接)、围栏代码块(带语言标签与复制按钮)、
+/// 有序/无序列表(可嵌套)、引用块、分隔线、管道表格。
+/// 视觉全部走样式类(在 ChatPanelView.axaml 定义,配 Vela* 令牌,主题切换即时跟随);
+/// 未覆盖的语法节点回退渲染原文,保证内容永不丢失。
+/// </summary>
+internal sealed class MarkdownRenderer(Control resourceHost, Func<string, Task> copyAsync, Loc loc)
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UsePipeTables()
+        .UseAutoLinks()
+        .UseEmphasisExtras()
+        .Build();
+
+    /// <summary>渲染整段 Markdown(输入可以是流式中的半截文本,Markdig 容忍)。</summary>
+    public Control Render(string markdown)
+    {
+        var panel = new StackPanel { Spacing = 6 };
+        MarkdownDocument document;
+        try
+        {
+            document = Markdown.Parse(markdown, Pipeline);
+        }
+        catch
+        {
+            panel.Children.Add(PlainText(markdown, "body"));
+            return panel;
+        }
+        foreach (Block block in document)
+        {
+            if (RenderBlock(block, markdown) is { } control)
+            {
+                panel.Children.Add(control);
+            }
+        }
+        return panel;
+    }
+
+    // ---------- 块级 ----------
+
+    private Control? RenderBlock(Block block, string source) => block switch
+    {
+        HeadingBlock heading => RenderHeading(heading),
+        ParagraphBlock paragraph => RenderLeafInlines(paragraph, "body"),
+        FencedCodeBlock fenced => RenderCode(CodeText(fenced), fenced.Info),
+        CodeBlock code => RenderCode(CodeText(code), null),
+        QuoteBlock quote => RenderQuote(quote, source),
+        ListBlock list => RenderList(list, source),
+        ThematicBreakBlock => new Border { Height = 1, Classes = { "mdRule" }, Margin = new Thickness(0, 4) },
+        Table table => RenderTable(table, source),
+        HtmlBlock html => PlainText(Slice(source, html.Span), "mono"),
+        LinkReferenceDefinitionGroup => null,
+        BlankLineBlock => null,
+        _ => PlainText(Slice(source, block.Span), "body")
+    };
+
+    private Control RenderHeading(HeadingBlock heading)
+    {
+        var text = new SelectableTextBlock { Classes = { $"mdH{Math.Clamp(heading.Level, 1, 4)}" } };
+        AppendInlines(text.Inlines!, heading.Inline, default);
+        return text;
+    }
+
+    private Control RenderLeafInlines(LeafBlock block, string cls)
+    {
+        var text = new SelectableTextBlock { Classes = { cls } };
+        AppendInlines(text.Inlines!, block.Inline, default);
+        return text;
+    }
+
+    private Control RenderCode(string code, string? language)
+    {
+        var layout = new StackPanel { Spacing = 4 };
+        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
+        header.Children.Add(new TextBlock
+        {
+            Classes = { "dim" },
+            Text = string.IsNullOrWhiteSpace(language) ? "code" : language.Trim(),
+            VerticalAlignment = VerticalAlignment.Center
+        });
+        var copyButton = new Button { Classes = { "mdCopy" }, Content = loc["Copy"] };
+        Grid.SetColumn(copyButton, 1);
+        copyButton.Click += async (_, _) =>
+        {
+            try
+            {
+                await copyAsync(code);
+                copyButton.Content = loc["Copied"];
+            }
+            catch
+            {
+                // 剪贴板失败静默(不打断阅读)
+            }
+        };
+        header.Children.Add(copyButton);
+        layout.Children.Add(header);
+        layout.Children.Add(new SelectableTextBlock { Classes = { "mono" }, Text = code.TrimEnd('\n') });
+        return new Border { Classes = { "mdCode" }, Child = layout };
+    }
+
+    private Control RenderQuote(QuoteBlock quote, string source)
+    {
+        var inner = new StackPanel { Spacing = 4 };
+        foreach (Block child in quote)
+        {
+            if (RenderBlock(child, source) is { } control)
+            {
+                inner.Children.Add(control);
+            }
+        }
+        return new Border { Classes = { "mdQuote" }, Child = inner };
+    }
+
+    private Control RenderList(ListBlock list, string source)
+    {
+        var panel = new StackPanel { Spacing = 2 };
+        int index = int.TryParse(list.OrderedStart, out int start) ? start : 1;
+        foreach (Block item in list)
+        {
+            if (item is not ListItemBlock listItem)
+            {
+                continue;
+            }
+            string marker = list.IsOrdered ? $"{index++}." : "•";
+            var row = new Grid { ColumnDefinitions = new ColumnDefinitions("20,*") };
+            row.Children.Add(new TextBlock
+            {
+                Classes = { "mdBullet" },
+                Text = marker,
+                VerticalAlignment = VerticalAlignment.Top
+            });
+            var content = new StackPanel { Spacing = 2 };
+            foreach (Block child in listItem)
+            {
+                if (RenderBlock(child, source) is { } control)
+                {
+                    content.Children.Add(control);
+                }
+            }
+            Grid.SetColumn(content, 1);
+            row.Children.Add(content);
+            panel.Children.Add(row);
+        }
+        return panel;
+    }
+
+    private Control RenderTable(Table table, string source)
+    {
+        int columnCount = 0;
+        foreach (Block row in table)
+        {
+            if (row is TableRow tableRow)
+            {
+                columnCount = Math.Max(columnCount, tableRow.Count);
+            }
+        }
+        if (columnCount == 0)
+        {
+            return PlainText(Slice(source, table.Span), "mono");
+        }
+
+        var grid = new Grid();
+        for (int i = 0; i < columnCount; i++)
+        {
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        }
+        int rowIndex = 0;
+        foreach (Block rowBlock in table)
+        {
+            if (rowBlock is not TableRow tableRow)
+            {
+                continue;
+            }
+            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+            for (int col = 0; col < columnCount; col++)
+            {
+                var cellBorder = new Border { Classes = { tableRow.IsHeader ? "mdTableHead" : "mdTableCell" } };
+                if (col < tableRow.Count && tableRow[col] is TableCell cell)
+                {
+                    var cellContent = new StackPanel { Spacing = 2, MaxWidth = 360 };
+                    foreach (Block child in cell)
+                    {
+                        Control? rendered = child is ParagraphBlock p
+                            ? RenderLeafInlines(p, tableRow.IsHeader ? "mdTableHeadText" : "mdTableText")
+                            : RenderBlock(child, source);
+                        if (rendered is not null)
+                        {
+                            cellContent.Children.Add(rendered);
+                        }
+                    }
+                    cellBorder.Child = cellContent;
+                }
+                Grid.SetRow(cellBorder, rowIndex);
+                Grid.SetColumn(cellBorder, col);
+                grid.Children.Add(cellBorder);
+            }
+            rowIndex++;
+        }
+        // 外框补上表格的上/左边线(单元格只画右/下),横向可滚避免撑破面板
+        return new ScrollViewer
+        {
+            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+            Content = new Border { Classes = { "mdTableFrame" }, Child = grid, HorizontalAlignment = HorizontalAlignment.Left }
+        };
+    }
+
+    // ---------- 行内 ----------
+
+    private readonly record struct InlineStyle(bool Bold, bool Italic, bool Strike);
+
+    private void AppendInlines(InlineCollection target, ContainerInline? container, InlineStyle style)
+    {
+        if (container is null)
+        {
+            return;
+        }
+        for (MdInline? inline = container.FirstChild; inline is not null; inline = inline.NextSibling)
+        {
+            AppendInline(target, inline, style);
+        }
+    }
+
+    private void AppendInline(InlineCollection target, MdInline inline, InlineStyle style)
+    {
+        switch (inline)
+        {
+            case LiteralInline literal:
+                target.Add(StyledRun(literal.Content.ToString(), style));
+                break;
+
+            case EmphasisInline emphasis:
+                {
+                    InlineStyle merged = emphasis.DelimiterChar == '~'
+                        ? style with { Strike = true }
+                        : emphasis.DelimiterCount >= 2
+                            ? style with { Bold = true }
+                            : style with { Italic = true };
+                    AppendInlines(target, emphasis, merged);
+                    break;
+                }
+
+            case CodeInline code:
+                {
+                    Run run = StyledRun(code.Content, style);
+                    run.FontFamily = MonoFont;
+                    run.Foreground = Brush("VelaAccent") ?? run.Foreground;
+                    target.Add(run);
+                    break;
+                }
+
+            case LinkInline link:
+                target.Add(RenderLink(link, style));
+                break;
+
+            case AutolinkInline autolink:
+                target.Add(LinkContainer(autolink.Url, autolink.Url));
+                break;
+
+            case LineBreakInline:
+                target.Add(new Run("\n"));
+                break;
+
+            case HtmlEntityInline entity:
+                target.Add(StyledRun(entity.Transcoded.ToString(), style));
+                break;
+
+            case HtmlInline html:
+                target.Add(StyledRun(html.Tag, style));
+                break;
+
+            case ContainerInline nested:
+                AppendInlines(target, nested, style);
+                break;
+
+            default:
+                target.Add(StyledRun(inline.ToString() ?? "", style));
+                break;
+        }
+    }
+
+    private AvaloniaInline RenderLink(LinkInline link, InlineStyle style)
+    {
+        string text = InlineText(link);
+        if (string.IsNullOrEmpty(text))
+        {
+            text = link.Url ?? "";
+        }
+        if (link.IsImage)
+        {
+            // 终端面板不加载远程图片:降级为可点击的占位链接
+            return LinkContainer($"🖼 {text}", link.Url);
+        }
+        return LinkContainer(text, link.Url, style);
+    }
+
+    private AvaloniaInline LinkContainer(string text, string? url, InlineStyle style = default)
+    {
+        var textBlock = new TextBlock
+        {
+            Classes = { "mdLink" },
+            Text = text,
+            FontWeight = style.Bold ? FontWeight.SemiBold : FontWeight.Normal,
+            FontStyle = style.Italic ? FontStyle.Italic : FontStyle.Normal
+        };
+        if (!string.IsNullOrWhiteSpace(url) && Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+            && uri.Scheme is "http" or "https")
+        {
+            ToolTip.SetTip(textBlock, url);
+            textBlock.PointerReleased += (_, e) =>
+            {
+                if (e.InitialPressMouseButton == MouseButton.Left)
+                {
+                    _ = TopLevel.GetTopLevel(resourceHost)?.Launcher.LaunchUriAsync(uri);
+                }
+            };
+        }
+        return new InlineUIContainer(textBlock) { BaselineAlignment = BaselineAlignment.TextBottom };
+    }
+
+    private static Run StyledRun(string text, InlineStyle style)
+    {
+        var run = new Run(text);
+        if (style.Bold)
+        {
+            run.FontWeight = FontWeight.SemiBold;
+        }
+        if (style.Italic)
+        {
+            run.FontStyle = FontStyle.Italic;
+        }
+        if (style.Strike)
+        {
+            run.TextDecorations = TextDecorations.Strikethrough;
+        }
+        return run;
+    }
+
+    // ---------- 辅助 ----------
+
+    private static string InlineText(ContainerInline container)
+    {
+        var sb = new StringBuilder();
+        for (MdInline? inline = container.FirstChild; inline is not null; inline = inline.NextSibling)
+        {
+            switch (inline)
+            {
+                case LiteralInline literal:
+                    sb.Append(literal.Content.ToString());
+                    break;
+                case CodeInline code:
+                    sb.Append(code.Content);
+                    break;
+                case ContainerInline nested:
+                    sb.Append(InlineText(nested));
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string CodeText(CodeBlock block)
+    {
+        StringLineGroup lines = block.Lines;
+        var sb = new StringBuilder();
+        for (int i = 0; i < lines.Count; i++)
+        {
+            sb.AppendLine(lines.Lines[i].Slice.ToString());
+        }
+        return sb.ToString();
+    }
+
+    private static string Slice(string source, SourceSpan span)
+        => span.Start >= 0 && span.End < source.Length && span.Length > 0
+            ? source.Substring(span.Start, span.Length)
+            : source;
+
+    private static Control PlainText(string text, string cls)
+        => new SelectableTextBlock { Classes = { cls }, Text = text };
+
+    private FontFamily MonoFont
+        => resourceHost.TryFindResource("VelaUiMonoFont", out object? value) && value is FontFamily family
+            ? family
+            : new FontFamily("Cascadia Mono,Consolas,Menlo,monospace");
+
+    private IBrush? Brush(string key)
+        => resourceHost.TryFindResource(key, out object? value) && value is IBrush brush ? brush : null;
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
@@ -1,0 +1,131 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="VelaShell.Plugin.Ai.Ui.SettingsView">
+
+  <!-- 与聊天面板同一套视觉语言:主操作药丸 / 次操作描边 / 危险操作描边换 VelaError。 -->
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://VelaShell.Plugin.Ai/Ui/AiTheme.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <UserControl.Styles>
+    <Style Selector="TextBlock.label">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+      <Setter Property="Margin" Value="0,8,0,3" />
+    </Style>
+    <Style Selector="TextBlock.dim">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+    </Style>
+    <Style Selector="TextBox">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="MinHeight" Value="30" />
+    </Style>
+    <Style Selector="ComboBox">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="MinHeight" Value="30" />
+    </Style>
+    <Style Selector="ListBox">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+    </Style>
+  </UserControl.Styles>
+
+  <Grid ColumnDefinitions="190,14,*">
+    <!-- 左:接入列表 + 新增 -->
+    <DockPanel Grid.Column="0">
+      <TextBlock x:Name="ProvidersHeader" DockPanel.Dock="Top" Classes="label" Margin="0,0,0,4" />
+      <StackPanel DockPanel.Dock="Bottom" Spacing="6" Margin="0,8,0,0">
+        <ComboBox x:Name="PresetCombo" HorizontalAlignment="Stretch" />
+        <Button x:Name="AddButton" Theme="{DynamicResource VelaOutlineButtonTheme}"
+                HorizontalAlignment="Stretch" Height="26">
+          <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+            <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+              <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
+                    Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
+                    StrokeLineCap="Round" StrokeJoin="Round" />
+            </Viewbox>
+            <TextBlock x:Name="AddText" VerticalAlignment="Center" />
+          </StackPanel>
+        </Button>
+      </StackPanel>
+      <ListBox x:Name="ProvidersList" />
+    </DockPanel>
+
+    <!-- 右:编辑表单 -->
+    <ScrollViewer Grid.Column="2" HorizontalScrollBarVisibility="Disabled">
+      <StackPanel>
+        <TextBlock x:Name="NameLabel" Classes="label" Margin="0,0,0,3" />
+        <TextBox x:Name="NameBox" />
+        <TextBlock x:Name="ProtocolLabel" Classes="label" />
+        <ComboBox x:Name="ProtocolCombo" HorizontalAlignment="Stretch" />
+        <TextBlock x:Name="BaseUrlLabel" Classes="label" />
+        <TextBox x:Name="BaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+        <TextBlock x:Name="ModelLabel" Classes="label" />
+        <TextBox x:Name="ModelBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+        <TextBlock x:Name="MaxTokensLabel" Classes="label" />
+        <TextBox x:Name="MaxTokensBox" MaxWidth="180" HorizontalAlignment="Left" />
+        <TextBlock x:Name="ApiKeyLabel" Classes="label" />
+        <Grid ColumnDefinitions="*,6,Auto">
+          <TextBox x:Name="ApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
+          <ToggleButton x:Name="RevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
+                        Width="30" Height="30" Padding="0" VerticalAlignment="Center">
+            <Viewbox Width="13" Height="13">
+              <Path Width="24" Height="24" Data="{DynamicResource Icon.eye}"
+                    Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                    StrokeLineCap="Round" StrokeJoin="Round" />
+            </Viewbox>
+          </ToggleButton>
+        </Grid>
+        <TextBlock x:Name="ApiKeyHintText" Classes="dim" Margin="0,3,0,0" />
+
+        <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,14,0,0">
+          <Button x:Name="SaveButton" Theme="{DynamicResource VelaAccentPillButtonTheme}" Height="26" Padding="12,0">
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.save}"
+                      Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="SaveText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+            </StackPanel>
+          </Button>
+          <Button x:Name="TestButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0">
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.play}"
+                      Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="TestText" VerticalAlignment="Center" />
+            </StackPanel>
+          </Button>
+          <Button x:Name="DeleteButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0"
+                  Foreground="{DynamicResource VelaError}" BorderBrush="{DynamicResource VelaError}">
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.trash-2}"
+                      Stroke="{DynamicResource VelaError}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="DeleteText" VerticalAlignment="Center" />
+            </StackPanel>
+          </Button>
+        </StackPanel>
+
+        <Separator Margin="0,14" Background="{DynamicResource VelaBorderPrimary}" />
+        <TextBlock x:Name="SystemPromptLabel" Classes="label" Margin="0,0,0,3" />
+        <TextBox x:Name="SystemPromptBox" AcceptsReturn="True" MinHeight="64" TextWrapping="Wrap" />
+
+        <TextBlock x:Name="StatusText" Classes="dim" TextWrapping="Wrap" Margin="0,10,0,0" />
+      </StackPanel>
+    </ScrollViewer>
+  </Grid>
+</UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
@@ -1,0 +1,248 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// 设置页:管理模型接入(名称/协议/基地址/模型/最大输出/API Key)与全局系统提示词。
+/// 直接编辑面板共享的 <see cref="AiSettings" /> 实例,保存后经回调通知聊天面板刷新。
+/// </summary>
+public partial class SettingsView : UserControl
+{
+    private static readonly string[] ProtocolLabels =
+        ["OpenAI Chat Completions", "OpenAI Responses", "Anthropic Messages"];
+
+    private readonly IPluginContext _context;
+    private readonly AiSettingsStore _store;
+    private readonly AiSettings _settings;
+    private readonly Loc _loc;
+    private readonly Action _onProvidersChanged;
+    private bool _loadingEditor;
+
+    /// <summary>由聊天面板构造(UI 线程)。</summary>
+    public SettingsView(IPluginContext context, AiSettingsStore store, AiSettings settings, Loc loc, Action onProvidersChanged)
+    {
+        _context = context;
+        _store = store;
+        _settings = settings;
+        _loc = loc;
+        _onProvidersChanged = onProvidersChanged;
+        InitializeComponent();
+        ApplyLoc();
+
+        PresetCombo.ItemsSource = ProviderPresets.All.Select(p => p.Label).ToList();
+        PresetCombo.SelectedIndex = 0;
+        ProtocolCombo.ItemsSource = ProtocolLabels;
+
+        ProvidersList.SelectionChanged += (_, _) => _ = LoadEditorAsync();
+        AddButton.Click += OnAddClick;
+        SaveButton.Click += OnSaveClick;
+        DeleteButton.Click += OnDeleteClick;
+        TestButton.Click += OnTestClick;
+        RevealKeyToggle.IsCheckedChanged += (_, _) =>
+            ApiKeyBox.PasswordChar = RevealKeyToggle.IsChecked == true ? '\0' : '●';
+
+        SystemPromptBox.Text = _settings.SystemPrompt ?? "";
+        ReloadList(selectIndex: _settings.Providers.Count > 0 ? 0 : -1);
+    }
+
+    /// <summary>语言切换时由面板调用。</summary>
+    public void ApplyLoc()
+    {
+        ProvidersHeader.Text = _loc["Providers"];
+        AddText.Text = _loc["Add"];
+        NameLabel.Text = _loc["Name"];
+        ProtocolLabel.Text = _loc["Protocol"];
+        BaseUrlLabel.Text = _loc["BaseUrl"];
+        ModelLabel.Text = _loc["Model"];
+        MaxTokensLabel.Text = _loc["MaxTokens"];
+        ApiKeyLabel.Text = _loc["ApiKey"];
+        ApiKeyHintText.Text = _loc["ApiKeyHint"];
+        SaveText.Text = _loc["Save"];
+        TestText.Text = _loc["Test"];
+        DeleteText.Text = _loc["Delete"];
+        SystemPromptLabel.Text = _loc["SystemPrompt"];
+    }
+
+    private AiProviderConfig? SelectedProvider
+        => ProvidersList.SelectedIndex >= 0 && ProvidersList.SelectedIndex < _settings.Providers.Count
+            ? _settings.Providers[ProvidersList.SelectedIndex]
+            : null;
+
+    private void ReloadList(int selectIndex)
+    {
+        ProvidersList.ItemsSource = _settings.Providers
+            .Select(p => string.IsNullOrWhiteSpace(p.Name) ? "(unnamed)" : p.Name)
+            .ToList();
+        ProvidersList.SelectedIndex = Math.Min(selectIndex, _settings.Providers.Count - 1);
+        bool hasSelection = ProvidersList.SelectedIndex >= 0;
+        SaveButton.IsEnabled = hasSelection;
+        TestButton.IsEnabled = hasSelection;
+        DeleteButton.IsEnabled = hasSelection;
+        if (!hasSelection)
+        {
+            _ = LoadEditorAsync();
+        }
+    }
+
+    private async Task LoadEditorAsync()
+    {
+        _loadingEditor = true;
+        try
+        {
+            AiProviderConfig? provider = SelectedProvider;
+            NameBox.Text = provider?.Name ?? "";
+            ProtocolCombo.SelectedIndex = provider is null ? -1 : (int)provider.Protocol;
+            BaseUrlBox.Text = provider?.BaseUrl ?? "";
+            ModelBox.Text = provider?.Model ?? "";
+            MaxTokensBox.Text = provider?.MaxTokens.ToString() ?? "";
+            ApiKeyBox.Text = "";
+            bool hasSelection = provider is not null;
+            SaveButton.IsEnabled = hasSelection;
+            TestButton.IsEnabled = hasSelection;
+            DeleteButton.IsEnabled = hasSelection;
+            if (provider is not null)
+            {
+                string? key = await _store.GetApiKeyAsync(provider.Id);
+                // 加载期间用户可能已切换选择
+                if (SelectedProvider?.Id == provider.Id)
+                {
+                    ApiKeyBox.Text = key ?? "";
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Load provider editor failed.", ex);
+        }
+        finally
+        {
+            _loadingEditor = false;
+        }
+    }
+
+    private void OnAddClick(object? sender, RoutedEventArgs e)
+    {
+        int presetIndex = Math.Max(0, PresetCombo.SelectedIndex);
+        AiProviderConfig provider = ProviderPresets.All[presetIndex].Create();
+        _settings.Providers.Add(provider);
+        _settings.ActiveProviderId ??= provider.Id;
+        ReloadList(_settings.Providers.Count - 1);
+        _ = PersistAsync(notify: true);
+    }
+
+    private void OnSaveClick(object? sender, RoutedEventArgs e) => _ = SaveAsync();
+
+    private async Task SaveAsync()
+    {
+        if (_loadingEditor || SelectedProvider is not { } provider)
+        {
+            return;
+        }
+        provider.Name = NameBox.Text?.Trim() ?? "";
+        provider.Protocol = ProtocolCombo.SelectedIndex >= 0 ? (ChatProtocol)ProtocolCombo.SelectedIndex : provider.Protocol;
+        provider.BaseUrl = BaseUrlBox.Text?.Trim() ?? "";
+        provider.Model = ModelBox.Text?.Trim() ?? "";
+        if (int.TryParse(MaxTokensBox.Text?.Trim(), out int maxTokens) && maxTokens > 0)
+        {
+            provider.MaxTokens = maxTokens;
+        }
+        _settings.SystemPrompt = string.IsNullOrWhiteSpace(SystemPromptBox.Text) ? null : SystemPromptBox.Text;
+        try
+        {
+            await _store.SetApiKeyAsync(provider.Id, ApiKeyBox.Text);
+            await PersistAsync(notify: true);
+            int index = ProvidersList.SelectedIndex;
+            ReloadList(index);
+            StatusText.Text = _loc["Saved"];
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Save AI settings failed.", ex);
+            StatusText.Text = $"{_loc["Error"]}: {ex.Message}";
+        }
+    }
+
+    private void OnDeleteClick(object? sender, RoutedEventArgs e) => _ = DeleteAsync();
+
+    private async Task DeleteAsync()
+    {
+        if (SelectedProvider is not { } provider)
+        {
+            return;
+        }
+        int index = ProvidersList.SelectedIndex;
+        _settings.Providers.Remove(provider);
+        if (_settings.ActiveProviderId == provider.Id)
+        {
+            _settings.ActiveProviderId = _settings.Providers.FirstOrDefault()?.Id;
+        }
+        try
+        {
+            await _store.DeleteApiKeyAsync(provider.Id);
+            await PersistAsync(notify: true);
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Delete provider failed.", ex);
+        }
+        ReloadList(Math.Max(0, index - 1));
+    }
+
+    private void OnTestClick(object? sender, RoutedEventArgs e) => _ = TestAsync();
+
+    private async Task TestAsync()
+    {
+        if (SelectedProvider is not { } provider)
+        {
+            return;
+        }
+        // 用表单当前值(可能未保存)测试
+        var candidate = new AiProviderConfig
+        {
+            Id = provider.Id,
+            Name = NameBox.Text ?? "",
+            Protocol = ProtocolCombo.SelectedIndex >= 0 ? (ChatProtocol)ProtocolCombo.SelectedIndex : provider.Protocol,
+            BaseUrl = BaseUrlBox.Text?.Trim() ?? "",
+            Model = ModelBox.Text?.Trim() ?? "",
+            MaxTokens = int.TryParse(MaxTokensBox.Text?.Trim(), out int maxTokens) && maxTokens > 0 ? maxTokens : provider.MaxTokens
+        };
+        TestButton.IsEnabled = false;
+        StatusText.Text = _loc["Testing"];
+        try
+        {
+            IChatClient client = await _store.CreateClientAsync(candidate, ApiKeyBox.Text);
+            ChatResponse response = await Task.Run(() => client.GetResponseAsync(
+                "Reply with exactly: OK", new ChatOptions { MaxOutputTokens = 64 }));
+            string text = response.Text.Trim();
+            StatusText.Text = _loc.F("TestOk", text.Length > 80 ? text[..80] + "…" : text);
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = _loc.F("TestFail", ex.Message);
+        }
+        finally
+        {
+            TestButton.IsEnabled = SelectedProvider is not null;
+        }
+    }
+
+    private async Task PersistAsync(bool notify)
+    {
+        try
+        {
+            await _store.SaveAsync(_settings);
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error("Persist AI settings failed.", ex);
+        }
+        if (notify)
+        {
+            _onProvidersChanged();
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>VelaShell AI 助手插件:多提供商(OpenAI/Anthropic/Grok/Ollama/中转站)流式对话与 Agent 模式。</Description>
+    <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<id>/。 -->
+    <VelaPluginId>velashell.ai</VelaPluginId>
+    <!-- AVLN3001:面板视图刻意只有带上下文的构造(由 ShowPanelAsync 工厂创建),
+         不需要运行时 XAML 装载器的无参构造路径。 -->
+    <NoWarn>$(NoWarn);AVLN3001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SDK 由宿主统一提供(共享契约程序集),不随插件输出复制。 -->
+    <ProjectReference Include="..\..\plugin-sdk\VelaShell.PluginSdk\VelaShell.PluginSdk.csproj" Private="false" ExcludeAssets="runtime" />
+    <!-- 仅编译期引用 Avalonia,运行时由装载方共享同一套(版本须与宿主一致)。 -->
+    <PackageReference Include="Avalonia" Version="12.1.1" ExcludeAssets="runtime" />
+    <!-- AI 栈(用户决策 2026-08-10):Microsoft.Extensions.AI 抽象 + 各家官方 SDK,
+         统一到 IChatClient;Agent 循环用 FunctionInvokingChatClient。
+         这些依赖随插件目录分发,由插件 ALC 按 deps.json 隔离解析,与宿主互不干扰。 -->
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
+    <PackageReference Include="OpenAI" Version="2.12.0" />
+    <PackageReference Include="Anthropic" Version="12.40.0" />
+    <!-- Markdown 解析(纯托管、无 UI 依赖);渲染为 Avalonia 控件由 Ui/MarkdownRenderer 完成。 -->
+    <PackageReference Include="Markdig" Version="1.3.2" />
+  </ItemGroup>
+
+</Project>

--- a/plugins/VelaShell.Plugin.Ai/plugin.json
+++ b/plugins/VelaShell.Plugin.Ai/plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "velashell.ai",
+  "version": "0.1.0",
+  "displayName": "AI Assistant",
+  "description": "多提供商 AI 助手:OpenAI / Anthropic / Grok / Ollama / 自定义中转站,流式对话与 Agent 模式。",
+  "publisher": "velashell",
+  "entry": "VelaShell.Plugin.Ai.dll",
+  "apiLevel": 1,
+  "license": "MIT",
+  "homepage": "https://github.com/joesdu/VelaShell",
+  // 惰性激活:不打开 AI 功能就不装载程序集,启动零开销。
+  "activationEvents": [
+    "onCommand:velashell.ai.chat",
+    "onCommand:velashell.ai.chat-window",
+    "onCommand:velashell.ai.explain-terminal"
+  ],
+  "contributes": {
+    "commands": [
+      { "id": "velashell.ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
+      { "id": "velashell.ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
+      { "id": "velashell.ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
+    ]
+  }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxTests.cs
@@ -1,0 +1,173 @@
+using System.Text;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>Agent 工具箱:工具形状、审批闸门与各工具对插件能力的桥接语义。</summary>
+[TestClass]
+public sealed class AgentToolboxTests
+{
+    private static async Task<string> InvokeAsync(AgentToolbox toolbox, string name, Dictionary<string, object?>? args = null)
+    {
+        AIFunction function = toolbox.CreateTools().OfType<AIFunction>().Single(f => f.Name == name);
+        object? result = await function.InvokeAsync(new AIFunctionArguments(args ?? []), CancellationToken.None);
+        return result?.ToString() ?? "";
+    }
+
+    [TestMethod]
+    public void CreateTools_ExposesExpectedToolSet()
+    {
+        using var context = new TestPluginContext();
+        var toolbox = new AgentToolbox(context);
+
+        string[] names = toolbox.CreateTools().OfType<AIFunction>().Select(f => f.Name).ToArray();
+
+        CollectionAssert.AreEquivalent(
+            new[] { "list_sessions", "read_terminal", "run_command", "read_remote_file", "write_terminal" },
+            names);
+    }
+
+    [TestMethod]
+    public async Task ListSessions_ReportsConnectedSessions()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        var toolbox = new AgentToolbox(context);
+
+        string result = await InvokeAsync(toolbox, "list_sessions");
+
+        StringAssert.Contains(result, "prod-1");
+        StringAssert.Contains(result, "root");
+    }
+
+    [TestMethod]
+    public async Task ReadTerminal_WithoutSelectedSession_ReturnsHintInsteadOfThrowing()
+    {
+        using var context = new TestPluginContext();
+        var toolbox = new AgentToolbox(context) { SessionIdProvider = () => null };
+
+        string result = await InvokeAsync(toolbox, "read_terminal");
+
+        StringAssert.Contains(result, "No SSH session");
+    }
+
+    [TestMethod]
+    public async Task ReadTerminal_ReturnsBufferTail()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        context.FakeTerminal.Output[session.SessionId] = ["$ systemctl status nginx", "active (running)"];
+        var toolbox = new AgentToolbox(context) { SessionIdProvider = () => session.SessionId };
+
+        string result = await InvokeAsync(toolbox, "read_terminal");
+
+        StringAssert.Contains(result, "active (running)");
+    }
+
+    [TestMethod]
+    public async Task RunCommand_WithoutApprovalHandler_IsDeniedAndNotExecuted()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        var toolbox = new AgentToolbox(context) { SessionIdProvider = () => session.SessionId };
+
+        string result = await InvokeAsync(toolbox, "run_command", new() { ["command"] = "rm -rf /" });
+
+        StringAssert.Contains(result, "DENIED");
+        Assert.AreEqual(0, context.FakeRemoteExec.Executed.Count);
+    }
+
+    [TestMethod]
+    public async Task RunCommand_Approved_ExecutesAndReturnsOutput()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        context.FakeRemoteExec.Handler = (_, cmd) => cmd == "uptime" ? "up 42 days" : "";
+        var toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => session.SessionId,
+            ApprovalHandler = _ => Task.FromResult(true)
+        };
+
+        string result = await InvokeAsync(toolbox, "run_command", new() { ["command"] = "uptime" });
+
+        Assert.AreEqual("up 42 days", result);
+        Assert.AreEqual(1, context.FakeRemoteExec.Executed.Count);
+    }
+
+    [TestMethod]
+    public async Task RunCommand_AutoApprove_SkipsApprovalHandler()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        context.FakeRemoteExec.Responses.Enqueue("ok");
+        bool handlerCalled = false;
+        var toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => session.SessionId,
+            ApprovalHandler = _ =>
+            {
+                handlerCalled = true;
+                return Task.FromResult(false);
+            },
+            AutoApprove = true
+        };
+
+        string result = await InvokeAsync(toolbox, "run_command", new() { ["command"] = "ls" });
+
+        Assert.AreEqual("ok", result);
+        Assert.IsFalse(handlerCalled);
+    }
+
+    [TestMethod]
+    public async Task ReadRemoteFile_ReturnsUtf8Content()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", Encoding.UTF8.GetBytes("web-01\n"));
+        var toolbox = new AgentToolbox(context) { SessionIdProvider = () => session.SessionId };
+
+        string result = await InvokeAsync(toolbox, "read_remote_file", new() { ["path"] = "/etc/hostname" });
+
+        StringAssert.Contains(result, "web-01");
+    }
+
+    [TestMethod]
+    public async Task WriteTerminal_DeniedByHost_ReturnsHintInsteadOfThrowing()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        context.FakeTerminal.DenyWrites = true;
+        var toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => session.SessionId,
+            ApprovalHandler = _ => Task.FromResult(true)
+        };
+
+        string result = await InvokeAsync(toolbox, "write_terminal", new() { ["text"] = "echo hi\n" });
+
+        StringAssert.Contains(result, "denied");
+        Assert.AreEqual(0, context.FakeTerminal.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task WriteTerminal_Approved_WritesThroughHostQueue()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo session = context.FakeSessions.AddConnected();
+        var toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => session.SessionId,
+            ApprovalHandler = _ => Task.FromResult(true)
+        };
+
+        string result = await InvokeAsync(toolbox, "write_terminal", new() { ["text"] = "echo hi\n" });
+
+        StringAssert.Contains(result, "typed");
+        Assert.AreEqual(1, context.FakeTerminal.Writes.Count);
+        Assert.AreEqual("echo hi\n", context.FakeTerminal.Writes[0].Input);
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/AiSettingsStoreTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/AiSettingsStoreTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>设置存储:配置往返、机密隔离与三种协议的客户端构造。</summary>
+[TestClass]
+public sealed class AiSettingsStoreTests
+{
+    [TestMethod]
+    public async Task Load_WithoutSavedSettings_ReturnsDefaults()
+    {
+        using var context = new TestPluginContext();
+        var store = new AiSettingsStore(context);
+
+        AiSettings settings = await store.LoadAsync();
+
+        Assert.AreEqual(0, settings.Providers.Count);
+        Assert.IsFalse(settings.AgentMode);
+        Assert.IsFalse(settings.AutoApproveCommands);
+    }
+
+    [TestMethod]
+    public async Task SaveAndLoad_RoundTripsProviders()
+    {
+        using var context = new TestPluginContext();
+        var store = new AiSettingsStore(context);
+        var settings = new AiSettings
+        {
+            Providers =
+            [
+                new AiProviderConfig
+                {
+                    Name = "Claude",
+                    Protocol = ChatProtocol.AnthropicMessages,
+                    BaseUrl = "https://api.anthropic.com",
+                    Model = "claude-opus-5",
+                    MaxTokens = 4096
+                }
+            ],
+            AgentMode = true
+        };
+        settings.ActiveProviderId = settings.Providers[0].Id;
+
+        await store.SaveAsync(settings);
+        AiSettings loaded = await store.LoadAsync();
+
+        Assert.AreEqual(1, loaded.Providers.Count);
+        Assert.AreEqual("Claude", loaded.Providers[0].Name);
+        Assert.AreEqual(ChatProtocol.AnthropicMessages, loaded.Providers[0].Protocol);
+        Assert.AreEqual(4096, loaded.Providers[0].MaxTokens);
+        Assert.AreEqual(settings.ActiveProviderId, loaded.ActiveProviderId);
+        Assert.IsTrue(loaded.AgentMode);
+    }
+
+    [TestMethod]
+    public async Task ApiKey_SetGetDelete_UsesSecretStore()
+    {
+        using var context = new TestPluginContext();
+        var store = new AiSettingsStore(context);
+
+        await store.SetApiKeyAsync("p1", "sk-secret");
+        Assert.AreEqual("sk-secret", await store.GetApiKeyAsync("p1"));
+
+        // 空值 = 清除
+        await store.SetApiKeyAsync("p1", "");
+        Assert.IsNull(await store.GetApiKeyAsync("p1"));
+    }
+
+    [TestMethod]
+    public async Task CreateClient_EachProtocol_BuildsChatClient()
+    {
+        using var context = new TestPluginContext();
+        var store = new AiSettingsStore(context);
+        foreach (ChatProtocol protocol in Enum.GetValues<ChatProtocol>())
+        {
+            var provider = new AiProviderConfig
+            {
+                Name = "t",
+                Protocol = protocol,
+                BaseUrl = protocol == ChatProtocol.AnthropicMessages ? "https://example.com/v1" : "https://example.com/v1",
+                Model = "test-model"
+            };
+
+            IChatClient client = await store.CreateClientAsync(provider, "sk-test");
+
+            Assert.IsNotNull(client, protocol.ToString());
+        }
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj
+++ b/tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 被测插件(Agent 工具箱/配置存储为纯逻辑,不触碰 Avalonia 类型)。 -->
+    <ProjectReference Include="..\..\plugins\VelaShell.Plugin.Ai\VelaShell.Plugin.Ai.csproj" />
+    <ProjectReference Include="..\..\plugin-sdk\VelaShell.PluginSdk.Testing\VelaShell.PluginSdk.Testing.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
实现 VelaShell.Plugin.Ai，支持 OpenAI/Anthropic/Grok/Ollama/自定义模型流式对话与 Agent 工具调用，含审批机制。完善插件入口、Agent 工具箱、模型配置、设置与密钥安全存储。实现聊天面板、设置页、主题、多语言、Markdown 渲染等 UI。声明插件元数据与依赖，纳入解决方案。配套测试覆盖工具能力、存储隔离、协议兼容，文档详述功能与安全。