### PR TITLE
更新 .NET SDK 至预览版并允许预发行版

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
+    "version": "11.0.100-preview.7.26381.103",
     "rollForward": "latestFeature",
-    "version": "11.0.0"
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
将 .NET SDK 版本从 11.0.0 升级为 11.0.100-preview.7.26381.103，新增 allowPrerelease 字段以支持预发行版 SDK，保留 rollForward: latestFeature 设置。