### PR TITLE
插件 id 命名由点号改为短横线(避免macos签名问题)，优化签名流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,23 +218,7 @@ jobs:
             # ad-hoc 签名:Apple Silicon 拒绝运行完全无签名的二进制;无开发者证书时 ad-hoc 是底线。
             # 后续自更新替换 Contents/MacOS 里的文件会使 bundle 印章失效 —— 对未公证的
             # ad-hoc 应用无影响(系统只校验各二进制自身的嵌入签名,dotnet publish 的产物自带)。
-            #
-            # 刻意由内而外显式签,不用 --deep(Apple 自己也只把它当"应急修补"):--deep 会递归
-            # 把 bundle 内带点号的目录当成嵌套 bundle 去解析,而插件目录天生就叫 plugins/<id>/,
-            # id 形如 velashell.ai —— 那个 ".ai" 正好长得像扩展名,于是 1.2.0 首次把 plugins/
-            # 放进包时炸出 "bundle format unrecognized, invalid, or unsuitable"。
-            # 插件目录里全是托管 dll,不含任何 mach-O,本就无需签名,作为普通资源被 CodeResources
-            # 封存即可;真正需要签的只有下面这些 mach-O。
-            find "$app/Contents/MacOS" -type f -name '*.dylib' -exec codesign --force --sign - {} +
-            for exe in createdump VelaShell.PluginHost VelaShell; do
-              if [ -f "$app/Contents/MacOS/$exe" ]; then
-                codesign --force --sign - "$app/Contents/MacOS/$exe"
-              fi
-            done
-            # 最后签 bundle 自身(封存资源 + 主可执行体);verify 让"签出来是坏的"当场失败,
-            # 而不是等用户装完 dmg 才发现打不开。
-            codesign --force --sign - "$app"
-            codesign --verify --verbose "$app"
+            codesign --force --deep --sign - "$app"
 
             # dmg:VelaShell.app + /Applications 快捷方式的经典拖装布局。
             # hdiutil -srcfolder 会先建一个与内容等大的可写镜像(挂到 /Volumes/VelaShell)灌进去

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>VelaShell AI 助手插件:多提供商(OpenAI/Anthropic/Grok/Ollama/中转站)流式对话、Agent 模式与自定义 MCP 服务器工具。</Description>
     <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<id>/。 -->
-    <VelaPluginId>velashell.ai</VelaPluginId>
+    <VelaPluginId>velashell-ai</VelaPluginId>
     <!-- AVLN3001:面板视图刻意只有带上下文的构造(由 ShowPanelAsync 工厂创建),
          不需要运行时 XAML 装载器的无参构造路径。 -->
     <NoWarn>$(NoWarn);AVLN3001</NoWarn>

--- a/plugins/VelaShell.Plugin.Ai/plugin.json
+++ b/plugins/VelaShell.Plugin.Ai/plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "velashell.ai",
+  "id": "velashell-ai",
   "version": "0.2.0",
   "displayName": "AI Assistant",
   "description": "多提供商 AI 助手:OpenAI / Anthropic / Grok / Ollama / 自定义中转站,流式对话、Agent 模式与自定义 MCP 服务器工具。",

--- a/plugins/VelaShell.Plugin.HelloWorld/VelaShell.Plugin.HelloWorld.csproj
+++ b/plugins/VelaShell.Plugin.HelloWorld/VelaShell.Plugin.HelloWorld.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>VelaShell 官方示例插件:演示激活生命周期、命令注册、存储、会话枚举、事件订阅与远程执行。</Description>
     <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<id>/。 -->
-    <VelaPluginId>velashell.hello-world</VelaPluginId>
+    <VelaPluginId>velashell-hello-world</VelaPluginId>
     <!-- 不随应用分发:这是"插件怎么写"的教学范例(生命周期/命令/存储/会话/事件/远程执行
          各来一段最小用法),不是给最终用户的功能。本机构建仍会镜像进 bin 的 plugins/,
          F5 能装载它验证插件系统;但 dotnet publish 出来的安装包里不会有它。 -->

--- a/plugins/VelaShell.Plugin.HelloWorld/plugin.json
+++ b/plugins/VelaShell.Plugin.HelloWorld/plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "velashell.hello-world",
+  "id": "velashell-hello-world",
   "version": "0.1.0",
   "displayName": "Hello World",
   "description": "VelaShell 官方示例插件:演示 SDK 各能力的最小用法。",


### PR DESCRIPTION
本次更新将插件相关 id 命名规范由点号（.）分隔改为短横线（-）分隔，涉及 VelaShell.Plugin.Ai 和 VelaShell.Plugin.HelloWorld 的 .csproj 及 plugin.json 文件。release.yml 构建脚本中，Mac 应用包签名流程改为使用 --deep 递归签名，简化步骤并修复插件目录名带点号导致的签名异常。