### PR TITLE
统一命令命名风格为中划线分隔

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/plugin.json
+++ b/plugins/VelaShell.Plugin.Ai/plugin.json
@@ -10,15 +10,15 @@
   "homepage": "https://github.com/joesdu/VelaShell",
   // 惰性激活:不打开 AI 功能就不装载程序集,启动零开销。
   "activationEvents": [
-    "onCommand:velashell.ai.chat",
-    "onCommand:velashell.ai.chat-window",
-    "onCommand:velashell.ai.explain-terminal"
+    "onCommand:velashell-ai.chat",
+    "onCommand:velashell-ai.chat-window",
+    "onCommand:velashell-ai.explain-terminal"
   ],
   "contributes": {
     "commands": [
-      { "id": "velashell.ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
-      { "id": "velashell.ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
-      { "id": "velashell.ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
+      { "id": "velashell-ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
+      { "id": "velashell-ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
+      { "id": "velashell-ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
     ]
   }
 }


### PR DESCRIPTION
将 activationEvents 和 commands 中的命令 id 由 velashell.ai.xxx 修改为 velashell-ai.xxx，统一命名风格（点号改为中划线）。