### PR TITLE
统一插件目录命名规范及相关流程适配

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@
 #   Windows x64/arm64 → zip
 #   macOS   x64/arm64 → tar.gz + dmg(未签名/未公证;Unix 可执行位在原生 runner 上保留)
 #   Linux   x64/arm64 → tar.gz
-# 随包分发的插件(plugins/<id>/)由 MSBuild 在 publish 期登记入包,三平台各 job 无需特殊处理;
+# 随包分发的插件(plugins/<目录名>/,目录名 = id 把点换成短横,原因见 macOS job 的签名一步)
+# 由 MSBuild 在 publish 期登记入包,三平台各 job 无需特殊处理;
 # 哪个插件进包看它 csproj 的 <VelaPluginShip>(示例插件 velashell.hello-world 设为 false,
 # 只作开发范例不进产物)。一个可发行插件都收不到时发布会直接失败,不会悄悄出一个没插件的包。
 # 另有 build-msix 任务产出商店版 .msixbundle,但它不附加到 Release —— 作为工作流

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ docker-compose -f docker-compose.test.yml up
 pwsh scripts/publish-all.ps1
 ```
 
-产物覆盖 Windows x64/arm64（便携 zip）、macOS 与 Linux x64/arm64（tar.gz），全部为含运行时的自包含发布,解压到任意目录即可运行,无需预装 .NET。包内除主程序外还带着隔离插件的宿主进程 `VelaShell.PluginHost` 与随包分发的插件目录 `plugins/<id>/`。
+产物覆盖 Windows x64/arm64（便携 zip）、macOS 与 Linux x64/arm64（tar.gz），全部为含运行时的自包含发布,解压到任意目录即可运行,无需预装 .NET。包内除主程序外还带着隔离插件的宿主进程 `VelaShell.PluginHost` 与随包分发的插件目录 `plugins/`。
 
 > 从 Microsoft Store 安装的版本(MSIX)更新由商店接管,应用内的更新操作会自动隐藏。商店版装在只读的 `WindowsApps` 下,数据目录被系统重定向到包私有位置,因此**与便携版的配置、会话、密钥互不相通**。
 

--- a/build/msix/Build-Msix.ps1
+++ b/build/msix/Build-Msix.ps1
@@ -278,7 +278,7 @@ foreach ($rid in $Runtimes) {
     if (Test-Path $layout) { Remove-Item -Recurse -Force $layout }
 
     # 与便携版同一条命令(摊开的 self-contained 产物);makeappx 稍后递归打包整个 layout,
-    # 因此 plugins/<id>/ 与 VelaShell.PluginHost 会一并进包,无需在这里另作处理。
+    # 因此 plugins/ 与 VelaShell.PluginHost 会一并进包,无需在这里另作处理。
     & dotnet publish $projectPath -c Release -r $rid -o $layout `
         -p:Version=$Version -p:SelfContained=true `
         -p:DebugType=None --nologo

--- a/docs/plugins/STATUS.md
+++ b/docs/plugins/STATUS.md
@@ -49,7 +49,7 @@ inProcess 停靠 / 隔离独立窗口)、可靠性(心跳/自愈/回收)、数�
 | 激活事件 | onStartup / onCommand | onSessionConnect、onFileOpen、onSchedule、onUri(蓝图 03 §4) |
 | UI 挂载点 | 命令面板、停靠文档、独立窗口、插件管理页 | 侧栏视图、状态栏、设置页、右键菜单贡献点(蓝图 08) |
 | 跨进程 dock 停靠 | RPC 协议层保留(EmbedRoutingTests),但**宿主 Win32 实现已移除**:跨进程窗口收养与 dock reparenting 根本冲突(卡顿/窗口飘出),**弃用** | 隔离插件一律独立卡片窗口;真·dock 标签用 inProcess;跨平台稳态 = 共享内存表面(蓝图 08 §4,远期) |
-| 发布形态 | 目录即插件 + **.vpx 包一键装/卸**(zip,zip-slip 防护);SDK 以 ProjectReference 使用;**发布产物携带 `plugins/<id>/` 与 `VelaShell.PluginHost.*`**(前者按各插件 `<VelaPluginShip>` 取舍,示例插件不进包;为让宿主进程在磁盘上有真实可执行体,主程序 2026-08-12 起改为摊开发布) | SDK NuGet 包发布、`dotnet new` 模板、.vpx 签名/校验(蓝图 09/10) |
+| 发布形态 | 目录即插件 + **.vpx 包一键装/卸**(zip,zip-slip 防护);SDK 以 ProjectReference 使用;**发布产物携带 `plugins/<目录名>/` 与 `VelaShell.PluginHost.*`**(前者按各插件 `<VelaPluginShip>` 取舍,示例插件不进包,目录名 = id 把点换成短横以避开 macOS codesign 的嵌套 bundle 误判;为让宿主进程在磁盘上有真实可执行体,主程序 2026-08-12 起改为摊开发布) | SDK NuGet 包发布、`dotnet new` 模板、.vpx 签名/校验(蓝图 09/10) |
 
 ### ❌ 未开始
 

--- a/docs/plugins/dev-guide.md
+++ b/docs/plugins/dev-guide.md
@@ -105,8 +105,13 @@ public sealed class DemoPlugin : IVelaPlugin
 
 `true` 的插件在 `dotnet publish` 时由 `src/VelaShell/VelaShell.csproj` 的
 `AddVelaPluginsToPublish` 登记进 `ResolvedFileToPublish`,落到安装包的
-`plugins/<id>/`(并标记 `ExcludeFromSingleFile`,保证是磁盘上的真实文件,
+`plugins/<目录名>/`(并标记 `ExcludeFromSingleFile`,保证是磁盘上的真实文件,
 ALC 才能按 deps.json 装载)。官方示例插件 `velashell.hello-world` 就设了 `false`。
+
+> **目录名 = id 把点换成短横**(`velashell.ai` → `velashell-ai`)。macOS 的 `codesign`
+> 会把 `.app` 内带点号的目录当成嵌套 bundle 去解析,原样用 id 做目录名会让签名直接失败
+> (`bundle format unrecognized, invalid, or unsuitable`)。目录名**不参与任何逻辑** ——
+> 宿主是枚举子目录后从 `plugin.json` 读 id,因此这只是打包侧的命名约定。
 
 ### 2.2 仓库外插件(第三方)
 
@@ -442,8 +447,8 @@ public async Task Refresh_ListsContainers()
 
 | 事项 | 位置/方法 |
 | --- | --- |
-| 应用自带插件 | `<应用目录>/plugins/<id>/` |
-| 用户安装插件 | `<数据根>/plugins/<id>/`(Windows 为 `%LocalAppData%\VelaShell\plugins\`) |
+| 应用自带插件 | `<应用目录>/plugins/<id 把点换成短横>/`(如 `plugins/velashell-ai/`,见 §2.1 的说明) |
+| 用户安装插件 | `<数据根>/plugins/<id>/`(Windows 为 `%LocalAppData%\VelaShell\plugins\`;这里不在 `.app` 内,不参与签名,故仍按 id 建目录) |
 | 插件数据 | KV/机密在宿主 SonnetDB(`plugin_data` 集合);文件在 `<数据根>/plugin-data/<id>/` |
 | 卸载清理 | 从 plugins/ 删除插件目录 → 下次启动自动整体清除其 DB 数据与数据目录(`.disabled` 只禁用,数据保留) |
 | 禁用单个插件 | 插件目录内放一个空的 `.disabled` 文件 |

--- a/plugins/Directory.Build.props
+++ b/plugins/Directory.Build.props
@@ -6,7 +6,7 @@
 		     把自带 NuGet 依赖复制到输出目录、不复制共享框架。 -->
 		<EnableDynamicLoading>true</EnableDynamicLoading>
 
-		<!-- 是否随应用分发。true(默认)= 发布时进安装包的 plugins/<id>/;
+		<!-- 是否随应用分发。true(默认)= 发布时进安装包的 plugins/<目录名>/;
 		     false = 只留在仓库和开发构建里(F5 仍能装载),不进任何发行产物 ——
 		     示例插件用它:代码是给人读的范例,不是给用户装的功能。
 		     取值见 Directory.Build.targets 的 GetVelaPluginPayload。 -->

--- a/plugins/Directory.Build.targets
+++ b/plugins/Directory.Build.targets
@@ -1,17 +1,41 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-	<!-- 开发内环:构建后把插件输出镜像到应用输出目录的 plugins/<id>/ 下,
+	<!-- 插件在应用目录下的文件夹名:插件 id 把点换成短横(velashell.ai → velashell-ai)。
+	     为什么不直接用 id:macOS 的 codesign 会把 .app 内**带点号的目录**当成嵌套 bundle 去解析,
+	     `plugins/velashell.ai` 的 ".ai" 正好长得像扩展名,签名直接失败
+	     ("bundle format unrecognized, invalid, or unsuitable",1.2.0 发版时踩到)。
+	     为什么不干脆把 id 也改成短横:id 同时是插件数据与机密的命名空间
+	     (plugin-data/<id>、SonnetDB 的 plugin_data 键前缀),改 id 等于让已有用户的
+	     插件配置(AI 插件的 API key 就在里面)全部失联;而目录名不参与任何逻辑 ——
+	     宿主发现插件是枚举子目录后从 plugin.json 读 id(PluginManager.Describe)。
+	     三平台统一改,免得 tar.gz 与 .app 的 Contents/MacOS 布局分叉(那会让自更新解出
+	     两份同 id 插件而互相判重)。注:用户经 .vpx 装到数据目录的插件仍按 id 建目录 ——
+	     那些不在 .app 里,不参与签名。
+	     本属性在 targets 而非 props 里算:props 先于项目正文导入,那时 VelaPluginId 还没赋值。 -->
+	<PropertyGroup Condition="'$(VelaPluginId)' != ''">
+		<VelaPluginDirName>$(VelaPluginId.Replace(".", "-"))</VelaPluginDirName>
+	</PropertyGroup>
+
+	<!-- 开发内环:构建后把插件输出镜像到应用输出目录的 plugins/<目录名>/ 下,
 	     F5 启动应用即可加载到最新插件,无需手工拷贝。
 	     插件项目需在 csproj 里声明 <VelaPluginId>(与 plugin.json 的 id 一致)。
 	     这里不看 VelaPluginShip:本机构建目录是开发环境,示例插件也要能跑起来看效果;
 	     "不进安装包"由下面的 GetVelaPluginPayload 在发布期把关。 -->
 	<Target Name="CopyVelaPluginToAppOutput" AfterTargets="Build" Condition="'$(VelaPluginId)' != ''">
+		<PropertyGroup>
+			<_VelaPluginOutputRoot>$(MSBuildThisFileDirectory)..\src\VelaShell\bin\$(Configuration)\net11.0\plugins</_VelaPluginOutputRoot>
+		</PropertyGroup>
+		<!-- 清掉改名前(目录名 = 原始 id)留下的那一份:两份同 id 会被 PluginManager 判重,
+		     后来者标 Invalid,表象是"插件莫名其妙用不了",很难往构建产物残留上想。
+		     只在两个名字确实不同时才删,免得 id 本就无点号时把刚要写的目录删掉。 -->
+		<RemoveDir Directories="$(_VelaPluginOutputRoot)\$(VelaPluginId)"
+		           Condition="'$(VelaPluginDirName)' != '$(VelaPluginId)'" />
 		<ItemGroup>
 			<_VelaPluginFiles Include="$(TargetDir)**\*" />
 		</ItemGroup>
 		<Copy SourceFiles="@(_VelaPluginFiles)"
-		      DestinationFiles="@(_VelaPluginFiles->'$(MSBuildThisFileDirectory)..\src\VelaShell\bin\$(Configuration)\net11.0\plugins\$(VelaPluginId)\%(RecursiveDir)%(Filename)%(Extension)')"
+		      DestinationFiles="@(_VelaPluginFiles->'$(_VelaPluginOutputRoot)\$(VelaPluginDirName)\%(RecursiveDir)%(Filename)%(Extension)')"
 		      SkipUnchangedFiles="true" />
 	</Target>
 
@@ -24,7 +48,7 @@
 		<ItemGroup Condition="'$(VelaPluginShip)' == 'true' and '$(VelaPluginId)' != ''">
 			<_VelaPluginPayloadFile Include="$(TargetDir)**\*" Exclude="$(TargetDir)**\*.pdb;$(TargetDir)**\*.xml" />
 			<VelaPluginPayload Include="@(_VelaPluginPayloadFile)">
-				<VelaPluginRelativePath>$(VelaPluginId)\%(_VelaPluginPayloadFile.RecursiveDir)%(_VelaPluginPayloadFile.Filename)%(_VelaPluginPayloadFile.Extension)</VelaPluginRelativePath>
+				<VelaPluginRelativePath>$(VelaPluginDirName)\%(_VelaPluginPayloadFile.RecursiveDir)%(_VelaPluginPayloadFile.Filename)%(_VelaPluginPayloadFile.Extension)</VelaPluginRelativePath>
 			</VelaPluginPayload>
 		</ItemGroup>
 	</Target>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,7 +24,10 @@ SDK 契约见 [plugin-sdk/](../plugin-sdk/),开发文档见
 1. 复制 `VelaShell.Plugin.HelloWorld/` 为新目录,改 csproj 中的 `<VelaPluginId>` 与 `plugin.json`;
 2. 把项目加入 `VelaShell.slnx` 的 `/plugins/` 文件夹(仅为 IDE 可见性);
 3. 直接 F5:主程序按通配符对本目录所有插件建立了构建顺序引用,启动前
-   插件自动重建并镜像到应用输出目录的 `plugins/<id>/`(含 `plugin.json`)。
+   插件自动重建并镜像到应用输出目录的 `plugins/<目录名>/`(含 `plugin.json`)。
+   目录名 = 插件 id 把点换成短横(`velashell.ai` → `velashell-ai`):macOS 的 `codesign`
+   会把 `.app` 内带点号的目录当成嵌套 bundle 而签名失败。目录名不参与任何逻辑,
+   宿主是枚举子目录后从 `plugin.json` 读 id。
 
 本目录的 `Directory.Build.props/targets` 已统一处理:`EnableDynamicLoading`、
 `plugin.json` 随构建输出、构建后复制到应用输出目录、发布期按 `VelaPluginShip`

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <Description>VelaShell AI 助手插件:多提供商(OpenAI/Anthropic/Grok/Ollama/中转站)流式对话、Agent 模式与自定义 MCP 服务器工具。</Description>
-    <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<id>/。 -->
-    <VelaPluginId>velashell-ai</VelaPluginId>
+    <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<目录名>/
+         (目录名 = id 把点换成短横,原因见 plugins/Directory.Build.targets)。 -->
+    <VelaPluginId>velashell.ai</VelaPluginId>
     <!-- AVLN3001:面板视图刻意只有带上下文的构造(由 ShowPanelAsync 工厂创建),
          不需要运行时 XAML 装载器的无参构造路径。 -->
     <NoWarn>$(NoWarn);AVLN3001</NoWarn>

--- a/plugins/VelaShell.Plugin.Ai/plugin.json
+++ b/plugins/VelaShell.Plugin.Ai/plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "velashell-ai",
+  "id": "velashell.ai",
   "version": "0.2.0",
   "displayName": "AI Assistant",
   "description": "多提供商 AI 助手:OpenAI / Anthropic / Grok / Ollama / 自定义中转站,流式对话、Agent 模式与自定义 MCP 服务器工具。",
@@ -10,15 +10,15 @@
   "homepage": "https://github.com/joesdu/VelaShell",
   // 惰性激活:不打开 AI 功能就不装载程序集,启动零开销。
   "activationEvents": [
-    "onCommand:velashell-ai.chat",
-    "onCommand:velashell-ai.chat-window",
-    "onCommand:velashell-ai.explain-terminal"
+    "onCommand:velashell.ai.chat",
+    "onCommand:velashell.ai.chat-window",
+    "onCommand:velashell.ai.explain-terminal"
   ],
   "contributes": {
     "commands": [
-      { "id": "velashell-ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
-      { "id": "velashell-ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
-      { "id": "velashell-ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
+      { "id": "velashell.ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
+      { "id": "velashell.ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
+      { "id": "velashell.ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
     ]
   }
 }

--- a/plugins/VelaShell.Plugin.HelloWorld/VelaShell.Plugin.HelloWorld.csproj
+++ b/plugins/VelaShell.Plugin.HelloWorld/VelaShell.Plugin.HelloWorld.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <Description>VelaShell 官方示例插件:演示激活生命周期、命令注册、存储、会话枚举、事件订阅与远程执行。</Description>
-    <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<id>/。 -->
-    <VelaPluginId>velashell-hello-world</VelaPluginId>
+    <!-- 与 plugin.json 的 id 一致;驱动构建后复制到应用输出的 plugins/<目录名>/
+         (目录名 = id 把点换成短横,原因见 plugins/Directory.Build.targets)。 -->
+    <VelaPluginId>velashell.hello-world</VelaPluginId>
     <!-- 不随应用分发:这是"插件怎么写"的教学范例(生命周期/命令/存储/会话/事件/远程执行
          各来一段最小用法),不是给最终用户的功能。本机构建仍会镜像进 bin 的 plugins/,
          F5 能装载它验证插件系统;但 dotnet publish 出来的安装包里不会有它。 -->

--- a/plugins/VelaShell.Plugin.HelloWorld/plugin.json
+++ b/plugins/VelaShell.Plugin.HelloWorld/plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "velashell-hello-world",
+  "id": "velashell.hello-world",
   "version": "0.1.0",
   "displayName": "Hello World",
   "description": "VelaShell 官方示例插件:演示 SDK 各能力的最小用法。",

--- a/scripts/publish-all.ps1
+++ b/scripts/publish-all.ps1
@@ -6,7 +6,8 @@
 #       都是 macOS 独有工具。tar.gz 是应用内更新器的资产,dmg 只供人工安装,
 #       latest.json 永远只指向 tar.gz,详见 release.yml 文件头"macOS 双产物分工")
 #   Linux  x64 / arm64 含运行时 → tar.gz
-# 每份产物内含 plugins/<id>/:仓库内声明了 <VelaPluginShip>true</VelaPluginShip> 的插件
+# 每份产物内含 plugins/<目录名>/(目录名 = 插件 id 把点换成短横,原因见
+#   plugins/Directory.Build.targets):仓库内声明了 <VelaPluginShip>true</VelaPluginShip> 的插件
 #   (当前为 velashell.ai)由 MSBuild 在发布期登记入包,脚本无需额外拷贝;示例插件
 #   velashell.hello-world 设了 false,只留在仓库与开发构建里,不进任何发行产物。
 #   latest.json    — 应用内自更新清单(版本/标签/各 RID 产物名+sha256+大小)

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -94,7 +94,7 @@
   </ItemGroup>
 
   <!--
-    发布期把"随应用分发"的插件放进安装包的 plugins/<id>/ —— 运行时的插件发现根之一
+    发布期把"随应用分发"的插件放进安装包的 plugins/<目录名>/ —— 运行时的插件发现根之一
     (另一个是用户数据目录下的 plugins/,见 PluginServiceCollectionExtensions)。
 
     为什么必须显式做这件事:上面的 ProjectReference 只建立构建顺序,插件产物是被

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
@@ -74,6 +74,23 @@ public class PluginManagerTests
     }
 
     [TestMethod]
+    public void Discover_DirectoryNameNeedNotMatchId()
+    {
+        // 随包分发的插件目录名把 id 里的点换成了短横(velashell.ai → velashell-ai),
+        // 否则 macOS 的 codesign 会把 .app 内带点号的目录当嵌套 bundle 而签名失败
+        // (见 plugins/Directory.Build.targets)。id 只认 plugin.json,目录名不参与任何逻辑 ——
+        // 这条测试就是钉住这个前提,免得日后有人把发现逻辑改成按目录名取 id。
+        AddPlugin("velashell-ai", """{ "id": "velashell.ai", "version": "1.0.0", "displayName": "AI", "entry": "Ai.dll" }""");
+
+        var manager = new PluginManager(Options());
+        manager.Discover();
+
+        PluginDescriptor plugin = manager.Plugins.Single();
+        Assert.AreEqual("velashell.ai", plugin.Id);
+        Assert.AreEqual(PluginState.Discovered, plugin.State);
+    }
+
+    [TestMethod]
     public void Discover_DuplicateId_FirstRootWins()
     {
         string secondRoot = Path.Combine(Path.GetDirectoryName(_root)!, "plugins2");


### PR DESCRIPTION
本次提交将插件目录名由 plugins/<id>/ 调整为 plugins/<目录名>/，目录名规则为插件 id 中的点号替换为短横，解决 macOS codesign 对 .app 内带点目录的兼容性问题。同步更新相关文档，明确目录名与 id 的映射关系，强调目录名仅为打包约定，插件 id 仍以 plugin.json 为准。构建脚本与 MSBuild 属性已适配新规则，插件示例恢复带点 id，目录名自动映射。新增单元测试确保插件发现仅依赖 plugin.json 的 id，避免目录名误用。所有涉及目录结构的注释、说明、脚本均已同步修正。