### PR TITLE
feat: 支持 FTP / FTPS 连接

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ VelaShell 是一个使用 .NET 11 与 Avalonia 构建的桌面终端应用，支
 - **ZMODEM（rz / sz）**  
   终端内直接收发文件：从输出流中识别 ZMODEM 引导序列后接管通道，由自研 ZMODEM 协议引擎完成传输，结束后自动复位回终端。收发双向、传输无关（SSH / 本地 ConPTY 通用），排障可置 `VELASHELL_ZMODEM_TRACE=1` 打开协议帧跟踪。
 
+- **FTP / FTPS**  
+  连接配置可选 FTP 类型：支持显式 / 隐式 FTPS 与明文 FTP、匿名登录、被动/主动模式；服务器证书未通过校验时给出 SHA-256 指纹交由用户确认，信任后按指纹固定。基于 [FluentFTP](https://github.com/robinrodricks/FluentFTP)（MIT），自带连接池以支持并发传输（FTP 一条控制连接同时只能跑一条命令），并复用与 SFTP 完全相同的双栏文件面板与传输栈。设计与取舍见 [`docs/FTP客户端可行性调研.md`](docs/FTP客户端可行性调研.md)。
+
 - **独立 SFTP 标签与远程文件编辑**  
   连接配置可选 SSH 或 SFTP 类型；SFTP 标签在停靠工作区内以独立文档呈现，支持本地/远程双栏浏览与拖拽互传。远程文件可在内置编辑器中打开（AvaloniaEdit，按扩展名自动语法高亮），保存即回传；也可交给外部编辑器并监听落盘回传。
 
@@ -275,7 +278,7 @@ dotnet test --logger "console;verbosity=detailed"
 
 ## 🚧 开发状态
 
-项目处于活跃开发阶段。核心链路（终端引擎、SSH/SFTP、ZMODEM、本地终端、跳板机、会话管理、身份验证、持久化、设置中心、云同步、会话录制）已可用；部分设置项目前仅持久化、待接线到运行时，**Telnet / 串口**协议与**证书认证**暂未开放（可行性与改造清单见 [`docs/Telnet与串口可行性调研.md`](docs/Telnet与串口可行性调研.md)）。完整的完成情况与待办清单见 [`plan.md`](plan.md) §10–§12。
+项目处于活跃开发阶段。核心链路（终端引擎、SSH/SFTP、FTP/FTPS、ZMODEM、本地终端、跳板机、会话管理、身份验证、持久化、设置中心、云同步、会话录制）已可用；部分设置项目前仅持久化、待接线到运行时，**Telnet / 串口**协议与**证书认证**暂未开放（可行性与改造清单见 [`docs/Telnet与串口可行性调研.md`](docs/Telnet与串口可行性调研.md)）。完整的完成情况与待办清单见 [`plan.md`](plan.md) §10–§12。
 
 ---
 

--- a/docs/FTP客户端可行性调研.md
+++ b/docs/FTP客户端可行性调研.md
@@ -1,0 +1,301 @@
+# FTP 客户端支持：可行性调研
+
+> 编写日期：2026-08-13　　基准代码：`main` @ `937d322`
+>
+> 用途：为后续实现 FTP / FTPS 会话类型提供**事实依据与改造清单**。
+> 所有代码结论均有 `文件:行号` 依据；联网查证的部分标注了版本与许可证，未查实的一律标注"未核实"。
+>
+> 前置阅读：[`Telnet与串口可行性调研.md`](Telnet与串口可行性调研.md) —— 其第三节的"协议泛化"改造与本文完全共用，本文不重复展开。
+>
+> **落地情况（2026-08-13）**：本文的 P0 与 P1 已实现并合入 —— `ConnectionType.FTP` + `SessionProfile.Ftp`、
+> `FtpFileService`（`ISftpService` 实现）+ `FtpConnectionPool`、按会话分派的 `RoutingRemoteFileService`、
+> 连接弹窗的 FTP 页签与 FTPS 表单、证书指纹信任流程、导入器把 FTP/FTPS 转为受支持。
+> **唯一仍待验证的是第五节风险 1（TLS 会话复用）**：需拿默认配置的 vsftpd 与 FileZilla Server 各跑一次真实连通性验证，
+> 它决定是否必须引入 LGPL 的 `FluentFTP.GnuTLS`。本文其余内容保持原样，作为设计取舍的记录。
+
+---
+
+## 一、结论先行
+
+**FTP 与 Telnet / 串口不是同一类问题。** 后两者是**终端协议**，能白捡现成的 `IByteDuplex` / `IShellStreamWrapper` 抽象（那份调研的结论是"传输层零改动"）。FTP 是**文件协议**，它要接的是文件面板那条线，而那条线上有一个 SSH 专用的实现。
+
+**好消息：接缝已经存在，而且比预期的更靠上。**
+
+正确的接缝是 **`ISftpService`**，不是 `ISftpClientWrapper`：
+
+| 接口 | 形状 | 能否承载 FTP |
+|---|---|---|
+| `Core/Sftp/ISftpService.cs:21-88` | 全部以 `Guid sessionId` 为键，返回 `RemoteFileInfo`，**零 SSH 类型** | ✅ 可以 |
+| `Core/Ssh/ISftpClientWrapper.cs:9-140` | 要求可 Seek 流、`posix-rename@openssh.com`、UID/GID 整数、`ResumeSafetyMargin` | ❌ 是 SFTP 的形状 |
+
+决定性证据是**上层实际消费的模型**：`Core/Models/RemoteFileInfo.cs:26-30` 里 `Permissions` / `Owner` / `Group` 都是**字符串**（`rwxr-xr-x`、用户名、组名）——这正是 FTP 的 `LIST`/`MLSD` 能给出的东西。UID/GID 整数只存在于 `SftpEntry`（`Core/Ssh/SftpEntry.cs:25-28`）这一跳内部，且要靠 `RemoteIdentityResolver.cs:28,42` **跑 SSH exec 通道的 `getent passwd`** 才能翻译成名字。**FTP 走 `ISftpService` 这一层，可以整条绕开这个 SSH 依赖。**
+
+**坏消息 ①：FluentFTP 的数据流不可 Seek，与 `ISftpClientWrapper` 的契约硬冲突。**
+
+已从源码核实：`FtpSocketStream.CanSeek => false`，`Seek()` 直接 `throw new InvalidOperationException()`；`FtpDataStream.Position` 的 setter 明确抛异常（"You cannot modify the position of a FtpDataStream"）。而 `ISftpClientWrapper.cs:99-106` 的契约是"**实现必须返回可 Seek 的流**"，`SftpService.cs:583-586` 还会在续传校验时主动断言并抛错。
+
+→ 这条从反面印证了接缝必须选在 `ISftpService`：**不要试图让 FTP 去实现 `ISftpClientWrapper`。**
+
+**坏消息 ②：FTP 没有多路复用，而现有代码把"传输可并发"写进了设计前提。**
+
+`SerializedSftpService.cs:7-12` 的注释原文：
+
+> **传输（上传/下载/远端复制）不占串行闸**……底层 Tmds.Ssh 的 `SftpClient` 本身即为并发使用而设计，因此放行是安全的。
+
+FTP 一条控制连接同一时刻只能跑一条命令（FluentFTP 内部加锁，社区 issue [#1499](https://github.com/robinrodricks/FluentFTP/issues/1499) 即"传输期间 `GetListing` 报错"）。**FTP 后端必须自带连接池**：至少一条控制连接跑元数据、每个并发传输各占一条，否则要么退化成全串行、要么随机炸。
+
+**总判断：可行，工作量中等偏大。** 核心是"造一个 `FtpFileService : ISftpService` + 一个按会话分派的路由器"，外加 Telnet 调研里已列过的那批协议泛化改造。**真正的不确定性不在代码，而在 FTPS 的 TLS 会话复用（见第五节风险 1），那一条决定"能不能连上真实生产服务器"，必须先验证再动工。**
+
+---
+
+## 二、可直接复用（零改动）
+
+| 组件 | 位置 | 说明 |
+|---|---|---|
+| 文件浏览器双栏 | `ViewModels/FileBrowserViewModel.cs:89`、`LocalFilePaneViewModel.cs` | 只依赖 `ISftpService` + `Guid sessionId` |
+| 传输管理器与限速 | `Core/Sftp/TransferManager.cs`、`ThrottledStream.cs` | 协议无关 |
+| 传输浮窗、冲突策略、拖放 | `ViewModels/FileTransferViewModel.cs`、`Core/Sftp/DragDropFormats.cs` | 协议无关 |
+| 串行化装饰器 | `Core/Sftp/SerializedSftpService.cs` | `ISftpService → ISftpService`，可复用；但**闸门策略需为 FTP 调整**（见 §3.2） |
+| 独立 SFTP 双栏文档的生命周期 | `ViewModels/SftpDocumentViewModel.cs:42` | 只吃 `ISftpService` |
+| SonnetDB 持久化管线 | `Infrastructure/Persistence/*` | 见 §3.7 的字段同步代价 |
+| 会话导入框架 | `Infrastructure/Import/*` | 见下 |
+
+> **导入侧白捡**：`WinScpImportService.cs:183` 现在把 `FSProtocol=5` 映射成 `(SSH, false, "FTP")`。
+> 一旦 `ConnectionType` 有了 `FTP`，这里改一个枚举值就能翻成"支持"，
+> 而刚落地的全自动导入（PR #157）会**自动勾选**这些会话——WinSCP 用户迁过来即可用。
+> Xshell 侧 `XshellImportService.cs:101-108` 的 `_ =>` 兜底也要补 FTP/FTPS 分支。
+
+---
+
+## 三、必须改造的地方
+
+### 3.1 协议泛化（与 Telnet / 串口完全共用）
+
+四处枚举钳制、两个主分派点、校验谓词、树节点判据——**逐条清单见 [`Telnet与串口可行性调研.md`](Telnet与串口可行性调研.md) §3.1–3.4，此处不重复**。先做 Telnet 还是先做 FTP，这批改造都要做完一次；第二个协议的成本约为第一个的 40%。
+
+FTP 额外要撞的两处（Telnet 调研未覆盖）：
+
+| 位置 | 问题 |
+|---|---|
+| `Views/ConnectionProfileView.axaml:174-198` | 协议标签条只有 SSH/SFTP 可点 + Telnet/串口两个禁用 Border，**FTP 连禁用占位都没有**；滑动下划线 `ConnectionProfileView.axaml.cs:41` 是二元三目 |
+| `tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs:46,54` | 硬断言"恰好 2 个 proto-tab Button + 恰好 2 个禁用 Border"，**加 FTP 页签必然打红这两条** |
+
+### 3.2 文件服务的路由（本文的核心新增）
+
+`ISftpService` 是**单例**，每个方法都以 `sessionId` 为参数（`ISftpService.cs:24-87`），DI 里唯一装配点在 `InfrastructureServiceCollectionExtensions.cs:95-114`。加入 FTP 后需要一个按会话协议分派的路由器：
+
+```
+ISftpService（对外唯一契约，UI 侧零改动）
+  └── RoutingRemoteFileService            ← 新增：按 sessionId 查协议后转发
+        ├── SftpService  (现有，SSH 会话)
+        └── FtpFileService (新增，FTP 会话) ── FtpConnectionPool ── AsyncFtpClient × N
+```
+
+要点：
+
+- `SftpService.cs:731-732` 通过 `ISshConnectionService.GetSession(sessionId)` 解析会话并要求 `Status == Connected`；FTP 侧需要对等的 `IFtpConnectionService`，**且两者的会话 id 必须来自同一个命名空间**，否则路由器无从判断。
+- DI 里那句 `wrapper is not TmdsSshClientWrapper → throw "SFTP requires Tmds.Ssh backend."`（`InfrastructureServiceCollectionExtensions.cs:102-103`）是**硬向下转型**，路由器落地后应改成按 `ConnectionType` 选工厂。
+- `SerializedSftpService` 的闸门策略要按协议分化：SSH 侧维持"传输不占闸"，**FTP 侧要么让传输也占闸（退化成全串行）、要么由 `FtpFileService` 内部的连接池保证每条传输独占一条连接**。推荐后者，并把并发上限与用户设置里的"最大并发传输数"对齐。
+
+### 3.3 不要复用 `ConnectionWorkflowService` / `ConnectionInfo`
+
+`ConnectionWorkflowService.cs:64-85` 无条件调 `_sshConnectionService.ConnectAsync(...)`，`ConnectionInfo.cs:11-48` 是 `required` + `init` 的**纯 SSH 传输参数**（`Port=22`、`PrivateKeyPath`、`JumpHost`）。与 Telnet 调研同样的结论：**不要扩展它**，FTP 走自己的连接服务，但要纳入同一套会话生命周期（连接/断开/事件/状态栏/会话树）。
+
+另需注意 `ConnectionWorkflowService.ValidateProfile:239-270` 强制 `Username` 非空——**FTP 匿名登录会被挡死**，校验谓词必须按协议分派。
+
+### 3.4 元数据映射（三个模型的对照）
+
+| `RemoteFileInfo`（UI 消费） | SFTP 现路径 | FTP 新路径（FluentFTP `FtpListItem`） |
+|---|---|---|
+| `Name` / `FullPath` | `SftpEntry.Name/FullName` | `Name` / `FullName` |
+| `Size` | `Length` | `Size` |
+| `IsDirectory` | `IsDirectory` | `Type == FtpObjectType.Directory` |
+| `LastModified` | `LastWriteTime` | `Modified`（时区转换后）／`RawModified`（原始） |
+| `Permissions`（字符串） | 9 个 bool 位拼出 | `RawPermissions`，或由 `OwnerPermissions`/`GroupPermissions`/`OthersPermissions` 拼 |
+| `Owner` / `Group` | `UserId`/`GroupId` → **SSH exec `getent passwd`** 翻译（`SftpService.cs:785-786`、`RemoteIdentityResolver.cs:28,42`） | `RawOwner` / `RawGroup` **直接就是名字** |
+
+**结论：FTP 侧不经过 `SftpEntry`，直接产出 `RemoteFileInfo`，并整条绕开 `RemoteIdentityResolver`。**
+代价是这些字段在很多 FTP 服务器上是空的（Windows/IIS 风格 LIST 无属主属组），UI 需要容忍空值——见 §3.6。
+
+### 3.5 续传语义要重新定义
+
+现有续传依赖两件 SFTP 特有的东西：
+
+1. `ResumeSafetyMargin`（`ISftpClientWrapper.cs:129-139`，`TmdsSftpClientWrapper.cs:23` = 64×32KB）——为的是 Tmds.Ssh 多写缓冲区乱序完成留下的空洞。**FTP 单条数据连接顺序写，此值应为 0。**
+2. 尾部比对要求可 Seek 流（`SftpService.cs:520-586`）——FTP 做不到。
+
+**替代方案（可行且已核实）**：FluentFTP 的
+`DownloadStream(Stream outStream, string remotePath, long restartPosition = 0, IProgress<FtpProgress> progress = null, CancellationToken token = default, long stopPosition = 0)`
+带 `restartPosition` + `stopPosition`，等于**区间读**——尾部校验用它读远端最后 N 字节即可，不需要 Seek。上传侧用 `FtpRemoteExists.Resume` 或带偏移的写入。
+
+### 3.6 能力位：不能再假设"什么都能做"
+
+| 能力 | SFTP | FTP |
+|---|---|---|
+| chmod | 原生 `setstat` | 依赖 `SITE CHMOD`（FluentFTP 支持），**很多服务器不实现** |
+| 属主/属组 | UID/GID + 查表 | 视 LIST 方言，可能为空 |
+| 保留时间戳 | `setstat`（`ISftpClientWrapper.cs:94`） | `MFMT`/`MDTM`，非强制 |
+| 符号链接 | 原生 | `MLSD` 有 type=OS.unix=symlink，方言不一 |
+| 原子重命名 | `posix-rename` 扩展（`:77`） | `RNFR`/`RNTO`，跨目录行为因服务器而异 |
+
+建议给 `ISftpService`（或其上层）加一个能力查询，让 `FileBrowserViewModel` 按能力隐藏 chmod 菜单与属主/属组列，而不是无条件显示后抛错。
+
+### 3.7 `SessionProfile` 加 `FtpSettings?`
+
+沿用 Telnet 调研 §3.5 的手法——可空嵌套对象，缺失即 null，旧数据零影响：
+
+```csharp
+public FtpSettings? Ftp { get; set; }
+// EncryptionMode(None|Explicit|Implicit|Auto) / DataConnectionType(PASV|EPSV|PORT|EPRT)
+// / Anonymous / Encoding(UTF8|Auto|指定) / MaxConnections / ValidateCertificate 策略
+```
+
+**代价照旧**：`SessionProfile` 全仓是逐字段手写拷贝，新增字段必须五处同步——
+`SonnetDbSessionRepository.cs:131-151`、`ConnectionWorkflowService.cs:113-131`、
+`SessionTreeViewModel.cs:341`、`ConnectionProfileViewModel.cs:520-542`（`BuildProfile`）、`MainWindowViewModel.cs:2553-2555`。
+
+> Telnet 调研里这五处的行号已随后续提交漂移，上面是 `937d322` 上重新核过的位置。
+
+### 3.8 本地化
+
+五个 resx 现无任何 FTP 键（连"暂未支持"的占位都没有）。新增协议名、FTPS 加密模式、被动/主动模式、匿名登录、证书信任提示等，**五语言必须同步**（有 `LocalizedKeyUsageTests` 与键集一致性测试守着）。
+
+---
+
+## 四、技术选型
+
+### 4.1 推荐：FluentFTP 54.2.0（MIT）
+
+| 项 | 值 |
+|---|---|
+| 版本 / 发布 | **54.2.0 / 2026-05-26** |
+| 许可 | **MIT** —— 与本仓库 AGPL-3.0 + 商业双许可相容 |
+| 依赖 | **无** |
+| 下载量 | 56.9M（累计） |
+| TFM | net462、net472、netstandard2.0/2.1、net7.0、net8.0、**net9.0** |
+
+**TFM 注意**：本仓库是 `net11.0`（`Directory.Build.props`），FluentFTP 尚无 net10/net11 资产，会解析到 **net9.0** 那份。这在功能上没问题，但值得写进 CPM 注释。发布形态上无风险：`VelaShell.csproj` 是 `SelfContained=true` + `PublishTrimmed=false` + **刻意不用 PublishSingleFile**，纯托管 DLL 不涉及裁剪或原生资源打包。
+
+**API 对照（`ISftpService` → `AsyncFtpClient`）**：
+
+| `ISftpService` 成员 | FluentFTP |
+|---|---|
+| `ListDirectoryAsync` | `GetListing(path, FtpListOption, token)` → `FtpListItem[]`（另有 `GetListingAsyncEnumerable`） |
+| `UploadFileAsync`（含 `resumeOffset`） | `UploadStream` / `UploadFile` + `FtpRemoteExists.Resume`，`IProgress<FtpProgress>` |
+| `DownloadFileAsync`（含 `resumeOffset`） | `DownloadStream(out, path, restartPosition, progress, token, stopPosition)` |
+| `DeleteAsync`（递归） | `DeleteFile` / `DeleteDirectory`（递归需自行按列举展开以回报进度） |
+| `CreateDirectoryAsync` / `EnsureDirectoryAsync` | `CreateDirectory(path, force)` |
+| `RenameAsync` | `Rename` / `MoveFile` / `MoveDirectory` |
+| `SetPermissionsAsync` | `Chmod`（`SITE CHMOD`，需能力检测） |
+| `GetFileInfoAsync` | `GetObjectInfo` |
+| `OpenReadAsync` | `OpenRead`（**流不可 Seek**，`ISftpService` 该成员的注释本就写明"顺序读取"，兼容） |
+| `ExistsAsync` | `FileExists` / `DirectoryExists` |
+| `GetWorkingDirectoryAsync` | `GetWorkingDirectory` |
+| 校验（可选增强） | 内建 MD5 / CRC32 / SHA-1/256/512 |
+
+另外它自带 30+ 种服务器类型的 LIST 方言解析、自动能力探测、限速与断线重连——**这些正是自研最耗时且最容易出错的部分**。
+
+### 4.2 不推荐的选项
+
+| 方案 | 结论 |
+|---|---|
+| `FtpWebRequest`（BCL 内建） | **已废弃**（SYSLIB0014，自 .NET 6 起标注 obsolete），无 MLSD、FTPS 控制粒度不足。不可用 |
+| 自研 FTP 客户端 | 协议面比 Telnet 大一个数量级：控制/数据双连接、PASV/EPSV/PORT/EPRT、RFC 4217 FTPS 的 AUTH/PBSZ/PROT、RFC 3659 的 MLSD/REST/SIZE/MDTM，再加各家 LIST 方言。Telnet 那次"自研更划算"的判断**不适用于此** |
+| 其他 .NET FTP 库 | *未核实*——未逐个查证维护状态与许可证。FluentFTP 在活跃度、许可、下载量上已明显占优 |
+
+### 4.3 ⚠️ `FluentFTP.GnuTLS` 是 LGPL，不要随手引入
+
+| 项 | 值 |
+|---|---|
+| 版本 / 发布 | 1.0.40 / 2026-05-05 |
+| 许可 | **LGPL-2.1-only** |
+| 用途 | "Adds support for TLS1.3 streams into FluentFTP using a .NET wrapper of GnuTLS" |
+| 依赖 | FluentFTP ≥ 48.0.3 |
+
+它是第五节风险 1（TLS 会话复用）的主流绕过方案，但本仓库有 `LICENSE-COMMERCIAL.md`，**LGPL 依赖在商业授权分发路径下需要法务确认**（与 Telnet 调研对 `RJCP.SerialPortStream` 的 MS-PL 提醒同理）。且它带原生 GnuTLS，与 `SelfContained` 三平台发布的打包需另行验证（*未核实：该包的原生二进制覆盖哪些 RID*）。
+
+**建议：先用纯 .NET SslStream 路径验证目标服务器；只有在确认踩到会话复用问题、且无服务端配置余地时，才把 GnuTLS 作为可选插件引入。**
+
+---
+
+## 五、主要风险点
+
+### 1. FTPS 的 TLS 会话复用（**最高风险，先验证再动工**）
+
+大量生产 FTPS 服务器要求**数据连接复用控制连接的 TLS 会话**：vsftpd 的 `require_ssl_reuse` **默认开启**，FileZilla Server 在协商到 TLS 1.3 时也强制复用。不满足时服务器直接回 `522 SSL connection failed; session reuse required`。
+
+这是 FluentFTP 上长期存在的一类问题（[#236](https://github.com/robinrodricks/FluentFTP/issues/236)、[#347](https://github.com/robinrodricks/FluentFTP/issues/347)、[#773](https://github.com/robinrodricks/FluentFTP/issues/773)、[#951](https://github.com/robinrodricks/FluentFTP/issues/951)、[#1283](https://github.com/robinrodricks/FluentFTP/issues/1283)、[#1738](https://github.com/robinrodricks/FluentFTP/issues/1738)），根因在 .NET `SslStream` 侧，社区方案是切到 `FluentFTP.GnuTLS`（`Config.CustomStream = typeof(GnuTlsStream)`）——即 §4.3 那个 LGPL 包。
+
+> **这不是"实现细节"，而是选型前提**：如果目标用户的 FTPS 服务器普遍要求会话复用，而 LGPL 又不可接受，那么 FTPS 这一块就要另找方案（或只支持明文 FTP + SFTP，价值大打折扣）。
+> **建议动工前先用真实/Docker 的 vsftpd（默认配置）与 FileZilla Server（TLS 1.3）各跑一次连通性验证。**
+
+### 2. 单连接串行 vs 并发传输
+
+见 §1、§3.2。表现形式是"传输期间刷新目录报错"（[#1499](https://github.com/robinrodricks/FluentFTP/issues/1499)）。不做连接池就只能全串行，用户设置里的"最大并发传输数"会被悄悄压回 1——与 `SerializedSftpService.cs:7-12` 明确要避免的那个退化完全一样。
+
+### 3. 安全语义缺失（与 Telnet 同源）
+
+明文 FTP 无加密、无主机身份验证；现有 `IHostKeyService` / known-hosts / `SecurityAlertService` 整条链路**只适用于 SSH host key，对 X.509 完全不适用**。需要：
+- FTPS 的证书校验与信任 UI（FluentFTP 的 `ValidateCertificate` 事件）——这是一套**新的**信任链，不要硬套 host key 那套；
+- 明文 FTP 在会话树/标签/状态栏上的显著"不加密"标识，避免用户误以为与 SSH 同等安全；
+- 凭据仍走现有 `ISecretProtector`，无需新增。
+
+### 4. LIST 方言与时区
+
+`MLSD`（RFC 3659）才给可靠的 UTC 时间戳与结构化 facts；老服务器只有 `LIST`，返回的是本地时间且格式因服务器而异（一年以上的文件甚至只有年份，没有时分）。FluentFTP 提供了 `Modified`（转换后）与 `RawModified`（原始）两个字段——**"保留时间戳"和"按时间排序/比对"两处必须明确用哪一个**，否则会出现跨时区的假差异。
+
+### 5. 被动模式与网络环境
+
+PASV/EPSV 在 NAT 与防火墙后的失败模式很多（服务器回私网地址、端口范围未放行）。需要在 `FtpSettings` 暴露开关，并把这类失败翻译成用户能看懂的提示，而不是裸抛 socket 异常——参照 `TmdsSshInterop.Translate` 把库异常收敛为 `VelaSsh*Exception` 族的既有做法（[`架构设计.md`](架构设计.md) §3「分层与依赖方向」，:78 起：库异常只在 Infrastructure 一处翻译）。
+
+### 6. 好消息：可自动化验证
+
+与串口需要真实硬件不同，FTP 可以用 Docker 起 vsftpd / pure-ftpd 做集成测试，仓库已有 `docker-compose.test.yml` 的先例（现用于 SSH 集成测试）。**建议直接建一个矩阵：明文 / 显式 FTPS / 隐式 FTPS × 会话复用开关 × MLSD 有无。**
+
+---
+
+## 六、实施建议
+
+### 工作量
+
+| 维度 | 估计 |
+|---|---|
+| 新增文件 | 8–10（连接服务、连接池、`FtpFileService`、路由器、`FtpSettings`、异常翻译、证书信任对话框、端口/模式表单） |
+| 修改文件 | ~18（§3.1 协议泛化全表 + §3.2 DI 装配 + §3.7 五处拷贝 + 5 个 resx + 导入器 2 处） |
+| 新增测试 | 5–7（Docker FTP 集成矩阵、LIST 方言解析映射、续传区间读、能力位降级、导入器 FTP 转支持） |
+
+> §3.1 的协议泛化与 Telnet/串口**共用**。若 Telnet 先落地，本项成本可减约 40%。
+
+### 分期建议
+
+| 阶段 | 范围 | 价值 |
+|---|---|---|
+| **P0** | 明文 FTP + 匿名/口令登录 + 浏览 / 上传 / 下载 / 删除 / 建目录 / 改名，连接池，路由器，协议泛化 | 打通全链路，可测 |
+| **P1** | FTPS（显式优先）+ 证书信任 UI + 断点续传（区间读校验）+ 导入器把 FTP 翻成支持 | 达到可用于生产的水平 |
+| **P2** | `SITE CHMOD`、保留时间戳、能力位驱动的 UI 降级、MLSD 时区精确化、校验和比对 | 与 SFTP 体验对齐 |
+
+**P0 之前插一个 P-1：拿 Docker vsftpd（默认配置，即 `require_ssl_reuse=YES`）与 FileZilla Server 各做一次 FTPS 连通性验证。** 这一步的结论直接决定 P1 是否需要引入 LGPL 依赖，进而影响整个特性的商业授权可行性。
+
+### 需要新写的文件
+
+**Core**
+- `Core/Models/FtpSettings.cs`（加密模式 / 数据连接模式 / 匿名 / 编码 / 并发数）
+- `Core/Ftp/IFtpConnectionService.cs`、`FtpSession.cs`（与 `SshSession` 对等，纳入统一会话生命周期）
+- `Core/Sftp/IRemoteFileCapabilities.cs`（能力位查询，供 UI 降级）
+
+**Infrastructure**
+- `Infrastructure/Ftp/FluentFtpConnectionService.cs`（连接、认证、状态事件）
+- `Infrastructure/Ftp/FtpConnectionPool.cs`（元数据连接 + 传输连接，上限对齐"最大并发传输数"）
+- `Infrastructure/Ftp/FtpFileService.cs`（`ISftpService` 实现，`FtpListItem → RemoteFileInfo` 映射）
+- `Infrastructure/Ftp/FluentFtpInterop.cs`（库异常 → Core 异常族，对标 `TmdsSshInterop`）
+- `Infrastructure/Sftp/RoutingRemoteFileService.cs`（按 `ConnectionType` 分派）
+
+**App / UI**
+- 协议页签与 FTP 表单（`ConnectionProfileView.axaml`）、证书信任对话框
+- 五个 resx 新键
+
+---
+
+## 七、一句话总结
+
+**技术上完全可行，且接缝（`ISftpService`）比想象中干净——文件浏览器、传输管理器、限速、拖放全部零改动。真正要做的是"造一个带连接池的 FTP 后端 + 把 SSH 从会话/枚举/分派里解耦"。唯一可能推翻方案的是 FTPS 的 TLS 会话复用问题：它把"要不要引入一个 LGPL 依赖"这个许可证问题摆到了技术决策前面，必须先验证。**

--- a/plan.md
+++ b/plan.md
@@ -132,7 +132,7 @@ tests/  6 个 MSTest 项目(见 §7)
 
 **B. 功能缺口**
 
-- 非 SSH 协议:**SFTP 已开放**(`ConnectionType.SFTP`,独立 SFTP 标签,见 §12-14);连接弹窗 Telnet/串口 标签仍禁用——可行性与改造清单见 [`docs/Telnet与串口可行性调研.md`](docs/Telnet与串口可行性调研.md)(结论:终端栈已为此预留,`IByteDuplex` 与本地化键均已就位)。第 2 步"证书"认证仍禁用。
+- 非 SSH 协议:**SFTP 已开放**(`ConnectionType.SFTP`,独立 SFTP 标签,见 §12-14);**FTP / FTPS 已开放**(2026-08-13,`ConnectionType.FTP` + `SessionProfile.Ftp`,FluentFTP 后端 + 连接池 + 按会话分派的 `RoutingRemoteFileService`,见 docs/FTP客户端可行性调研.md);连接弹窗 Telnet/串口 标签仍禁用——可行性与改造清单见 [`docs/Telnet与串口可行性调研.md`](docs/Telnet与串口可行性调研.md)(结论:终端栈已为此预留,`IByteDuplex` 与本地化键均已就位)。第 2 步"证书"认证仍禁用。
 - ✅ 快捷键展示表已与真实绑定逐条核对重建(2026-07-11,删除虚构项、补 Ctrl+N 绑定);**自定义键位确认不做**(产品决定,页面定位为"快捷键参考")。
 - 密钥生成仅 RSA(PEM+OpenSSH 公钥);ed25519 生成缺失(.NET 无内置 OpenSSH ed25519 私钥导出,需自行实现 OpenSSH 私钥封装或引入 BouncyCastle);导入不校验私钥有效性;删除无二次确认。
 - 审计日志已在写(connect/connect-failed),但**无查看界面**;`audit_log`/`conn_history` 无保留策略(retention),长期运行会累积。

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,6 +21,11 @@
     <PackageVersion Include="MaxMind.Db" Version="5.1.0" />
     <PackageVersion Include="SonnetDB.Core" Version="3.0.1" />
     <PackageVersion Include="Tmds.Ssh" Version="0.23.0" />
+    <!-- FTP / FTPS 客户端(MIT,零依赖)。截至 54.2.0 最高只出到 net9.0 资产,
+         本仓库 net11.0 会解析到那一份 —— 纯托管 DLL,且发布不裁剪、非单文件,无打包风险。
+         注意:不要顺手引 FluentFTP.GnuTLS(LGPL-2.1-only),与商业授权冲突,
+         详见 docs/FTP客户端可行性调研.md §4.3。 -->
+    <PackageVersion Include="FluentFTP" Version="54.2.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />

--- a/src/VelaShell.Core/Ftp/FtpConnectionInfo.cs
+++ b/src/VelaShell.Core/Ftp/FtpConnectionInfo.cs
@@ -1,0 +1,56 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Ftp;
+
+/// <summary>
+/// 建立一条 FTP / FTPS 会话所需的全部参数。
+/// <para>
+/// 刻意与 <see cref="ConnectionInfo" />(SSH 传输参数)分开:FTP 不经 SSH 握手,
+/// 把两者揉进同一个 required/init 对象只会让双方都长出对方用不到的字段。
+/// </para>
+/// </summary>
+public sealed class FtpConnectionInfo
+{
+    /// <summary>匿名登录使用的用户名。</summary>
+    public const string AnonymousUser = "anonymous";
+
+    /// <summary>目标主机(主机名或 IP)。</summary>
+    public required string Host { get; init; }
+
+    /// <summary>控制连接端口。</summary>
+    public int Port { get; init; } = FtpSettings.DefaultPort;
+
+    /// <summary>登录用户名;匿名登录时忽略。</summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>登录口令;匿名登录时忽略。</summary>
+    public string? Password { get; init; }
+
+    /// <summary>协议专属设置(加密方式、数据连接方式、并发数等)。</summary>
+    public required FtpSettings Settings { get; init; }
+
+    /// <summary>用于日志与错误提示的可读名称。</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>按 <see cref="FtpSettings.Anonymous" /> 解析出的实际登录用户名。</summary>
+    public string EffectiveUsername => Settings.Anonymous ? AnonymousUser : Username;
+
+    /// <summary>按 <see cref="FtpSettings.Anonymous" /> 解析出的实际登录口令(匿名时用邮箱占位)。</summary>
+    public string EffectivePassword => Settings.Anonymous ? "anonymous@velashell" : Password ?? string.Empty;
+
+    /// <summary>从一条会话配置构建连接参数;<see cref="SessionProfile.Ftp" /> 缺失时用默认设置。</summary>
+    public static FtpConnectionInfo FromProfile(SessionProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        return new()
+        {
+            Host = profile.Host.Trim(),
+            Port = profile.Port > 0 ? profile.Port : FtpSettings.DefaultPort,
+            Username = profile.Username.Trim(),
+            Password = profile.Password,
+            // 「最近连接」重连时会拿一份没有 Ftp 块的临时配置过来,此处兜底成默认设置。
+            Settings = profile.Ftp ?? new FtpSettings(),
+            DisplayName = string.IsNullOrWhiteSpace(profile.Name) ? profile.Host : profile.Name,
+        };
+    }
+}

--- a/src/VelaShell.Core/Ftp/IFtpSessionService.cs
+++ b/src/VelaShell.Core/Ftp/IFtpSessionService.cs
@@ -1,0 +1,23 @@
+namespace VelaShell.Core.Ftp;
+
+/// <summary>
+/// FTP 会话的生命周期管理。文件操作本身仍走 <see cref="Sftp.ISftpService" />
+/// —— 那个接口以 <c>Guid sessionId</c> 为键、返回 <c>RemoteFileInfo</c>,本就与协议无关,
+/// 因此 FTP 复用它,文件浏览器/传输管理器/限速/拖放全部零改动。
+/// </summary>
+public interface IFtpSessionService
+{
+    /// <summary>
+    /// 建立一条 FTP 会话并返回其标识;后续用该标识调用 <see cref="Sftp.ISftpService" /> 的成员。
+    /// </summary>
+    /// <exception cref="VelaFtpAuthenticationException">登录被拒。</exception>
+    /// <exception cref="VelaFtpCertificateException">FTPS 证书未通过校验且未被信任。</exception>
+    /// <exception cref="VelaFtpConnectionException">连接失败。</exception>
+    Task<Guid> OpenSessionAsync(FtpConnectionInfo info, CancellationToken cancellationToken = default);
+
+    /// <summary>该会话标识是否由本服务持有(供文件服务路由分派)。</summary>
+    bool OwnsSession(Guid sessionId);
+
+    /// <summary>关闭并释放一条 FTP 会话的全部连接;未知标识为空操作。</summary>
+    Task CloseSessionAsync(Guid sessionId, CancellationToken cancellationToken = default);
+}

--- a/src/VelaShell.Core/Ftp/VelaFtpException.cs
+++ b/src/VelaShell.Core/Ftp/VelaFtpException.cs
@@ -1,0 +1,55 @@
+namespace VelaShell.Core.Ftp;
+
+// 库中立的 FTP 异常层级,与 Core/Ssh/VelaSshClientException.cs 同样的约定:
+// Infrastructure 的 FluentFtpInterop 把 FluentFTP 的异常翻译成这些类型,Core/App 只依赖它们。
+// 上层请**直接按类型匹配**,不要按类型名字符串(见那份文件里记录的历史教训)。
+
+/// <summary>FTP 客户端操作失败的基类。</summary>
+public class VelaFtpClientException(string message, Exception? innerException = null) : Exception(message, innerException);
+
+/// <summary>无法建立或维持 FTP 控制连接(网络不可达、服务器拒绝、数据连接建立失败等)。</summary>
+public class VelaFtpConnectionException(string message, Exception? innerException = null) : VelaFtpClientException(message, innerException);
+
+/// <summary>登录失败(用户名/口令错误,或服务器不允许匿名登录)。</summary>
+public class VelaFtpAuthenticationException(string message, Exception? innerException = null) : VelaFtpClientException(message, innerException);
+
+/// <summary>FTP 命令被服务器拒绝(5xx),或本地路径/参数不合法。</summary>
+public class VelaFtpOperationException(string message, Exception? innerException = null) : VelaFtpClientException(message, innerException);
+
+/// <summary>远端路径不存在。</summary>
+public class VelaFtpPathNotFoundException(string message, Exception? innerException = null) : VelaFtpOperationException(message, innerException);
+
+/// <summary>服务器拒绝该操作(权限不足)。</summary>
+public class VelaFtpPermissionDeniedException(string message, Exception? innerException = null) : VelaFtpOperationException(message, innerException);
+
+/// <summary>
+/// 服务器证书未通过校验,且用户尚未信任它。
+/// <para>
+/// 携带指纹与主体信息,供上层弹出信任提示;用户确认后把
+/// <see cref="Thumbprint" /> 写进 <c>FtpSettings.TrustedCertificateThumbprint</c> 并重连即可。
+/// </para>
+/// </summary>
+public sealed class VelaFtpCertificateException(
+    string message,
+    string thumbprint,
+    string subject,
+    string issuer,
+    DateTimeOffset expiresOn,
+    string policyErrors,
+    Exception? innerException = null) : VelaFtpConnectionException(message, innerException)
+{
+    /// <summary>服务器证书的 SHA-256 指纹(十六进制,无分隔)。</summary>
+    public string Thumbprint { get; } = thumbprint;
+
+    /// <summary>证书主体。</summary>
+    public string Subject { get; } = subject;
+
+    /// <summary>证书颁发者。</summary>
+    public string Issuer { get; } = issuer;
+
+    /// <summary>证书到期时间。</summary>
+    public DateTimeOffset ExpiresOn { get; } = expiresOn;
+
+    /// <summary>校验未通过的原因(SslPolicyErrors 的可读形式)。</summary>
+    public string PolicyErrors { get; } = policyErrors;
+}

--- a/src/VelaShell.Core/Import/ImportedSession.cs
+++ b/src/VelaShell.Core/Import/ImportedSession.cs
@@ -40,4 +40,10 @@ public sealed class ImportedSession
 
     /// <summary>来源标识(文件路径或注册表键),用于诊断。</summary>
     public string Source { get; init; } = string.Empty;
+
+    /// <summary>
+    /// FTP / FTPS 的协议专属设置(加密方式等);仅当 <see cref="ConnectionType" /> 为
+    /// <see cref="Models.ConnectionType.FTP" /> 时非空。
+    /// </summary>
+    public FtpSettings? FtpSettings { get; init; }
 }

--- a/src/VelaShell.Core/Models/ConnectionType.cs
+++ b/src/VelaShell.Core/Models/ConnectionType.cs
@@ -8,4 +8,7 @@ public enum ConnectionType
 
     /// <summary>SFTP 文件连接。</summary>
     SFTP = 1,
+
+    /// <summary>FTP / FTPS 文件连接;是否加密由 <see cref="FtpSettings.EncryptionMode" /> 决定。</summary>
+    FTP = 2,
 }

--- a/src/VelaShell.Core/Models/FtpSettings.cs
+++ b/src/VelaShell.Core/Models/FtpSettings.cs
@@ -1,0 +1,75 @@
+namespace VelaShell.Core.Models;
+
+/// <summary>FTP 连接的加密方式。</summary>
+public enum FtpEncryptionMode
+{
+    /// <summary>明文 FTP,不加密(端口通常 21)。</summary>
+    None = 0,
+
+    /// <summary>显式 FTPS:先明文连接,再用 <c>AUTH TLS</c> 升级(端口通常 21)。</summary>
+    Explicit = 1,
+
+    /// <summary>隐式 FTPS:连接即 TLS 握手(端口通常 990)。</summary>
+    Implicit = 2,
+
+    /// <summary>自动:优先尝试显式 FTPS,服务器不支持时回落明文。</summary>
+    Auto = 3,
+}
+
+/// <summary>FTP 数据连接的建立方式。</summary>
+public enum FtpDataConnectionMode
+{
+    /// <summary>被动模式(PASV/EPSV):由客户端连服务端开的数据端口,能穿过大多数客户端侧 NAT。</summary>
+    Passive = 0,
+
+    /// <summary>主动模式(PORT/EPRT):由服务端回连客户端,客户端在 NAT 后通常不可用。</summary>
+    Active = 1,
+}
+
+/// <summary>
+/// FTP / FTPS 会话的协议专属设置。挂在 <see cref="SessionProfile.Ftp" /> 上,
+/// 缺失即 <c>null</c>(旧数据零影响),与 <see cref="SessionProfile.JumpHostProfileId" /> 的手法一致。
+/// <para>
+/// 刻意**不**扩展 <see cref="ConnectionInfo" />:那是 SSH 传输参数,FTP 不经 SSH 握手。
+/// </para>
+/// </summary>
+public sealed class FtpSettings
+{
+    /// <summary>默认的明文 / 显式 FTPS 端口。</summary>
+    public const int DefaultPort = 21;
+
+    /// <summary>默认的隐式 FTPS 端口。</summary>
+    public const int DefaultImplicitPort = 990;
+
+    /// <summary>加密方式,默认自动(优先显式 FTPS)。</summary>
+    public FtpEncryptionMode EncryptionMode { get; set; } = FtpEncryptionMode.Auto;
+
+    /// <summary>数据连接方式,默认被动。</summary>
+    public FtpDataConnectionMode DataConnectionMode { get; set; } = FtpDataConnectionMode.Passive;
+
+    /// <summary>是否匿名登录(用户名 <c>anonymous</c>,口令用邮箱占位);为 true 时不校验用户名非空。</summary>
+    public bool Anonymous { get; set; }
+
+    /// <summary>
+    /// 已信任的服务器证书指纹(SHA-256,十六进制无分隔)。用户在证书提示里选择「始终信任」后写入;
+    /// 与 SSH 的 known_hosts 是两套独立信任链 —— 主机密钥那套对 X.509 不适用。
+    /// </summary>
+    public string? TrustedCertificateThumbprint { get; set; }
+
+    /// <summary>
+    /// 该会话允许的最大并发连接数(1 条跑元数据 + 其余跑传输)。
+    /// FTP 一条控制连接同一时刻只能跑一条命令,并发传输必须靠多连接,与 SFTP 的多路复用不同。
+    /// </summary>
+    public int MaxConnections { get; set; } = 4;
+
+    /// <summary>返回一份深拷贝(<see cref="SessionProfile" /> 全仓是逐字段手写拷贝,这里配套提供)。</summary>
+    public FtpSettings Clone() =>
+        new()
+        {
+            EncryptionMode = EncryptionMode,
+            DataConnectionMode = DataConnectionMode,
+            Anonymous = Anonymous,
+            TrustedCertificateThumbprint = TrustedCertificateThumbprint,
+            MaxConnections = MaxConnections,
+        };
+}

--- a/src/VelaShell.Core/Models/RecentConnectionEntry.cs
+++ b/src/VelaShell.Core/Models/RecentConnectionEntry.cs
@@ -6,11 +6,11 @@ namespace VelaShell.Core.Models;
 /// </summary>
 public class RecentConnectionEntry
 {
-    /// <summary>连接协议类型;缺失或未知值均按 SSH 处理。</summary>
+    /// <summary>连接协议类型;缺失或未知值均按 SSH 处理(白名单同 <see cref="SessionProfile.ConnectionType" />)。</summary>
     public ConnectionType ConnectionType
     {
         get;
-        set => field = value == ConnectionType.SFTP ? ConnectionType.SFTP : ConnectionType.SSH;
+        set => field = Enum.IsDefined(value) ? value : ConnectionType.SSH;
     } = ConnectionType.SSH;
 
     /// <summary>关联的会话配置 Id;快速连接等临时连接为 null。</summary>

--- a/src/VelaShell.Core/Models/SessionProfile.cs
+++ b/src/VelaShell.Core/Models/SessionProfile.cs
@@ -3,11 +3,17 @@ namespace VelaShell.Core.Models;
 /// <summary>一条已保存的 SSH 连接配置,描述连接目标主机所需的地址、认证方式与凭据等信息。</summary>
 public class SessionProfile
 {
-    /// <summary>连接协议类型;缺失或未知值均按 SSH 处理。</summary>
+    /// <summary>
+    /// 连接协议类型;缺失或未知值均按 SSH 处理。
+    /// <para>
+    /// 用 <see cref="Enum.IsDefined{TEnum}" /> 做白名单而非逐值三元:语义仍是「不认识的一律降级为 SSH」
+    /// (旧数据兼容策略不变),但新增协议时不必再回来改这里 —— 之前正是这处三元把扩展口焊死了。
+    /// </para>
+    /// </summary>
     public ConnectionType ConnectionType
     {
         get;
-        set => field = value == ConnectionType.SFTP ? ConnectionType.SFTP : ConnectionType.SSH;
+        set => field = Enum.IsDefined(value) ? value : ConnectionType.SSH;
     } = ConnectionType.SSH;
 
     /// <summary>配置的全局唯一标识,创建时自动生成。</summary>
@@ -54,4 +60,10 @@ public class SessionProfile
     /// 跳板配置自身还可以再配跳板,链式即多段跳。null = 直连。
     /// </summary>
     public Guid? JumpHostProfileId { get; set; }
+
+    /// <summary>
+    /// FTP / FTPS 的协议专属设置;仅在 <see cref="ConnectionType" /> 为
+    /// <see cref="ConnectionType.FTP" /> 时有意义,其余协议为 null。
+    /// </summary>
+    public FtpSettings? Ftp { get; set; }
 }

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -3614,4 +3614,55 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="PluginManager_Installed"><value>「{0}」をインストールしました。</value></data>
   <data name="PluginManager_InstallFailed"><value>インストール失敗: {0}</value></data>
   <data name="PluginManager_ConfirmUninstall"><value>「{0}」をアンインストールしますか？データも削除されます。</value></data>
-  <data name="PluginManager_VpxFilter"><value>VelaShell プラグインパッケージ</value></data></root>
+  <data name="PluginManager_VpxFilter"><value>VelaShell プラグインパッケージ</value></data>  <data name="Ftp_Encryption" xml:space="preserve">
+    <value>暗号化</value>
+  </data>
+  <data name="Ftp_EncryptionAuto" xml:space="preserve">
+    <value>自動（可能なら FTPS）</value>
+  </data>
+  <data name="Ftp_EncryptionExplicit" xml:space="preserve">
+    <value>明示的 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionImplicit" xml:space="preserve">
+    <value>暗黙的 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionNone" xml:space="preserve">
+    <value>なし（平文 FTP）</value>
+  </data>
+  <data name="Ftp_Anonymous" xml:space="preserve">
+    <value>匿名ログイン</value>
+  </data>
+  <data name="Ftp_Passive" xml:space="preserve">
+    <value>パッシブモード</value>
+  </data>
+  <data name="Ftp_PassiveHint" xml:space="preserve">
+    <value>パッシブモード（PASV/EPSV）はほとんどの NAT を通過できます。サーバーがアクティブモードを要求する場合のみオフにしてください。</value>
+  </data>
+  <data name="Ftp_PlaintextWarn" xml:space="preserve">
+    <value>平文 FTP は認証情報もファイルも暗号化されず、サーバーの身元確認もありません。サーバーが対応しているなら FTPS を使ってください。</value>
+  </data>
+  <data name="Ftp_CertTitle" xml:space="preserve">
+    <value>サーバー証明書が信頼されていません</value>
+  </data>
+  <data name="Ftp_CertUntrustedFmt" xml:space="preserve">
+    <value>{0} が提示した証明書を検証できませんでした。下のフィンガープリントがサーバーのものと一致する場合のみ信頼してください。</value>
+  </data>
+  <data name="Ftp_CertSubject" xml:space="preserve">
+    <value>サブジェクト</value>
+  </data>
+  <data name="Ftp_CertIssuer" xml:space="preserve">
+    <value>発行者</value>
+  </data>
+  <data name="Ftp_CertExpires" xml:space="preserve">
+    <value>有効期限</value>
+  </data>
+  <data name="Ftp_CertFingerprint" xml:space="preserve">
+    <value>SHA-256</value>
+  </data>
+  <data name="Ftp_CertProblem" xml:space="preserve">
+    <value>問題</value>
+  </data>
+  <data name="Ftp_CertTrust" xml:space="preserve">
+    <value>信頼して接続</value>
+  </data>
+</root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -3614,4 +3614,55 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="PluginManager_Installed"><value>"{0}"을(를) 설치했습니다.</value></data>
   <data name="PluginManager_InstallFailed"><value>설치 실패: {0}</value></data>
   <data name="PluginManager_ConfirmUninstall"><value>"{0}"을(를) 제거하시겠습니까? 데이터도 삭제됩니다.</value></data>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 플러그인 패키지</value></data></root>
+  <data name="PluginManager_VpxFilter"><value>VelaShell 플러그인 패키지</value></data>  <data name="Ftp_Encryption" xml:space="preserve">
+    <value>암호화</value>
+  </data>
+  <data name="Ftp_EncryptionAuto" xml:space="preserve">
+    <value>자동(가능하면 FTPS)</value>
+  </data>
+  <data name="Ftp_EncryptionExplicit" xml:space="preserve">
+    <value>명시적 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionImplicit" xml:space="preserve">
+    <value>암시적 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionNone" xml:space="preserve">
+    <value>없음(일반 FTP)</value>
+  </data>
+  <data name="Ftp_Anonymous" xml:space="preserve">
+    <value>익명 로그인</value>
+  </data>
+  <data name="Ftp_Passive" xml:space="preserve">
+    <value>패시브 모드</value>
+  </data>
+  <data name="Ftp_PassiveHint" xml:space="preserve">
+    <value>패시브 모드(PASV/EPSV)는 대부분의 NAT를 통과합니다. 서버가 액티브 모드를 요구할 때만 끄세요.</value>
+  </data>
+  <data name="Ftp_PlaintextWarn" xml:space="preserve">
+    <value>일반 FTP는 자격 증명과 파일이 암호화되지 않으며 서버 신원 확인도 없습니다. 서버가 지원한다면 FTPS를 사용하세요.</value>
+  </data>
+  <data name="Ftp_CertTitle" xml:space="preserve">
+    <value>신뢰할 수 없는 서버 인증서</value>
+  </data>
+  <data name="Ftp_CertUntrustedFmt" xml:space="preserve">
+    <value>{0}이(가) 제시한 인증서를 확인할 수 없습니다. 아래 지문이 서버의 것과 일치할 때만 신뢰하세요.</value>
+  </data>
+  <data name="Ftp_CertSubject" xml:space="preserve">
+    <value>주체</value>
+  </data>
+  <data name="Ftp_CertIssuer" xml:space="preserve">
+    <value>발급자</value>
+  </data>
+  <data name="Ftp_CertExpires" xml:space="preserve">
+    <value>만료</value>
+  </data>
+  <data name="Ftp_CertFingerprint" xml:space="preserve">
+    <value>SHA-256</value>
+  </data>
+  <data name="Ftp_CertProblem" xml:space="preserve">
+    <value>문제</value>
+  </data>
+  <data name="Ftp_CertTrust" xml:space="preserve">
+    <value>신뢰하고 연결</value>
+  </data>
+</root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -3615,4 +3615,55 @@ Overwrite it?</value>
   <data name="PluginManager_Installed"><value>Installed "{0}".</value></data>
   <data name="PluginManager_InstallFailed"><value>Install failed: {0}</value></data>
   <data name="PluginManager_ConfirmUninstall"><value>Uninstall "{0}"? Its data will be removed.</value></data>
-  <data name="PluginManager_VpxFilter"><value>VelaShell plugin package</value></data></root>
+  <data name="PluginManager_VpxFilter"><value>VelaShell plugin package</value></data>  <data name="Ftp_Encryption" xml:space="preserve">
+    <value>Encryption</value>
+  </data>
+  <data name="Ftp_EncryptionAuto" xml:space="preserve">
+    <value>Auto (FTPS when available)</value>
+  </data>
+  <data name="Ftp_EncryptionExplicit" xml:space="preserve">
+    <value>Explicit FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionImplicit" xml:space="preserve">
+    <value>Implicit FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionNone" xml:space="preserve">
+    <value>None (plain FTP)</value>
+  </data>
+  <data name="Ftp_Anonymous" xml:space="preserve">
+    <value>Anonymous login</value>
+  </data>
+  <data name="Ftp_Passive" xml:space="preserve">
+    <value>Passive mode</value>
+  </data>
+  <data name="Ftp_PassiveHint" xml:space="preserve">
+    <value>Passive mode (PASV/EPSV) works behind most NATs. Turn it off only if the server requires active mode.</value>
+  </data>
+  <data name="Ftp_PlaintextWarn" xml:space="preserve">
+    <value>Plain FTP sends your credentials and files unencrypted, and there is no server identity check. Prefer FTPS whenever the server supports it.</value>
+  </data>
+  <data name="Ftp_CertTitle" xml:space="preserve">
+    <value>Untrusted server certificate</value>
+  </data>
+  <data name="Ftp_CertUntrustedFmt" xml:space="preserve">
+    <value>The certificate presented by {0} could not be verified. Trust it only if the fingerprint below matches the server's.</value>
+  </data>
+  <data name="Ftp_CertSubject" xml:space="preserve">
+    <value>Subject</value>
+  </data>
+  <data name="Ftp_CertIssuer" xml:space="preserve">
+    <value>Issuer</value>
+  </data>
+  <data name="Ftp_CertExpires" xml:space="preserve">
+    <value>Expires</value>
+  </data>
+  <data name="Ftp_CertFingerprint" xml:space="preserve">
+    <value>SHA-256</value>
+  </data>
+  <data name="Ftp_CertProblem" xml:space="preserve">
+    <value>Problem</value>
+  </data>
+  <data name="Ftp_CertTrust" xml:space="preserve">
+    <value>Trust and connect</value>
+  </data>
+</root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -3706,4 +3706,55 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="PluginManager_Installed"><value>已安装“{0}”。</value></data>
   <data name="PluginManager_InstallFailed"><value>安装失败:{0}</value></data>
   <data name="PluginManager_ConfirmUninstall"><value>卸载“{0}”?其数据将被清除。</value></data>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 插件包</value></data></root>
+  <data name="PluginManager_VpxFilter"><value>VelaShell 插件包</value></data>  <data name="Ftp_Encryption" xml:space="preserve">
+    <value>加密方式</value>
+  </data>
+  <data name="Ftp_EncryptionAuto" xml:space="preserve">
+    <value>自动（可用时使用 FTPS）</value>
+  </data>
+  <data name="Ftp_EncryptionExplicit" xml:space="preserve">
+    <value>显式 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionImplicit" xml:space="preserve">
+    <value>隐式 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionNone" xml:space="preserve">
+    <value>不加密（明文 FTP）</value>
+  </data>
+  <data name="Ftp_Anonymous" xml:space="preserve">
+    <value>匿名登录</value>
+  </data>
+  <data name="Ftp_Passive" xml:space="preserve">
+    <value>被动模式</value>
+  </data>
+  <data name="Ftp_PassiveHint" xml:space="preserve">
+    <value>被动模式（PASV/EPSV）能穿过大多数 NAT。仅在服务器要求主动模式时才关闭。</value>
+  </data>
+  <data name="Ftp_PlaintextWarn" xml:space="preserve">
+    <value>明文 FTP 的账号与文件都不加密，也没有服务器身份校验。服务器支持时请优先使用 FTPS。</value>
+  </data>
+  <data name="Ftp_CertTitle" xml:space="preserve">
+    <value>服务器证书不受信任</value>
+  </data>
+  <data name="Ftp_CertUntrustedFmt" xml:space="preserve">
+    <value>无法验证 {0} 提供的证书。请仅在下方指纹与服务器一致时才信任它。</value>
+  </data>
+  <data name="Ftp_CertSubject" xml:space="preserve">
+    <value>主体</value>
+  </data>
+  <data name="Ftp_CertIssuer" xml:space="preserve">
+    <value>颁发者</value>
+  </data>
+  <data name="Ftp_CertExpires" xml:space="preserve">
+    <value>到期</value>
+  </data>
+  <data name="Ftp_CertFingerprint" xml:space="preserve">
+    <value>SHA-256</value>
+  </data>
+  <data name="Ftp_CertProblem" xml:space="preserve">
+    <value>问题</value>
+  </data>
+  <data name="Ftp_CertTrust" xml:space="preserve">
+    <value>信任并连接</value>
+  </data>
+</root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -3614,4 +3614,55 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="PluginManager_Installed"><value>已安裝「{0}」。</value></data>
   <data name="PluginManager_InstallFailed"><value>安裝失敗：{0}</value></data>
   <data name="PluginManager_ConfirmUninstall"><value>解除安裝「{0}」？其資料將被清除。</value></data>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 外掛程式套件</value></data></root>
+  <data name="PluginManager_VpxFilter"><value>VelaShell 外掛程式套件</value></data>  <data name="Ftp_Encryption" xml:space="preserve">
+    <value>加密方式</value>
+  </data>
+  <data name="Ftp_EncryptionAuto" xml:space="preserve">
+    <value>自動（可用時使用 FTPS）</value>
+  </data>
+  <data name="Ftp_EncryptionExplicit" xml:space="preserve">
+    <value>顯式 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionImplicit" xml:space="preserve">
+    <value>隱式 FTPS</value>
+  </data>
+  <data name="Ftp_EncryptionNone" xml:space="preserve">
+    <value>不加密（明文 FTP）</value>
+  </data>
+  <data name="Ftp_Anonymous" xml:space="preserve">
+    <value>匿名登入</value>
+  </data>
+  <data name="Ftp_Passive" xml:space="preserve">
+    <value>被動模式</value>
+  </data>
+  <data name="Ftp_PassiveHint" xml:space="preserve">
+    <value>被動模式（PASV/EPSV）能穿過大多數 NAT。僅在伺服器要求主動模式時才關閉。</value>
+  </data>
+  <data name="Ftp_PlaintextWarn" xml:space="preserve">
+    <value>明文 FTP 的帳號與檔案都不加密，也沒有伺服器身分驗證。伺服器支援時請優先使用 FTPS。</value>
+  </data>
+  <data name="Ftp_CertTitle" xml:space="preserve">
+    <value>伺服器憑證不受信任</value>
+  </data>
+  <data name="Ftp_CertUntrustedFmt" xml:space="preserve">
+    <value>無法驗證 {0} 提供的憑證。請僅在下方指紋與伺服器一致時才信任它。</value>
+  </data>
+  <data name="Ftp_CertSubject" xml:space="preserve">
+    <value>主體</value>
+  </data>
+  <data name="Ftp_CertIssuer" xml:space="preserve">
+    <value>簽發者</value>
+  </data>
+  <data name="Ftp_CertExpires" xml:space="preserve">
+    <value>到期</value>
+  </data>
+  <data name="Ftp_CertFingerprint" xml:space="preserve">
+    <value>SHA-256</value>
+  </data>
+  <data name="Ftp_CertProblem" xml:space="preserve">
+    <value>問題</value>
+  </data>
+  <data name="Ftp_CertTrust" xml:space="preserve">
+    <value>信任並連線</value>
+  </data>
+</root>

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Tmds.Ssh;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
+using VelaShell.Core.Ftp;
 using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Recording;
@@ -11,8 +12,10 @@ using VelaShell.Core.Sftp;
 using VelaShell.Core.Ssh;
 using VelaShell.Core.Sync;
 using VelaShell.Core.Tunnels;
+using VelaShell.Infrastructure.Ftp;
 using VelaShell.Infrastructure.Import;
 using VelaShell.Infrastructure.Persistence;
+using VelaShell.Infrastructure.Sftp;
 using VelaShell.Infrastructure.Ssh;
 using VelaShell.Infrastructure.Tunnels;
 using VelaConnectionInfo = VelaShell.Core.Models.ConnectionInfo;
@@ -87,7 +90,16 @@ public static class InfrastructureServiceCollectionExtensions
         });
 
         // SFTP service
-        services.AddSingleton<ISftpService>(sp =>
+        // FTP / FTPS 后端:自带连接池(FTP 一条控制连接同时只能跑一条命令,不像 SFTP 能多路复用)。
+        services.AddSingleton<FtpFileService>();
+        services.AddSingleton<IFtpSessionService>(sp => sp.GetRequiredService<FtpFileService>());
+        // 远程文件服务对外仍是唯一的 ISftpService;路由按会话归属分派到 SFTP / FTP 两个后端,
+        // 文件浏览器、传输管理器、限速、拖放因此零改动。
+        services.AddSingleton<ISftpService>(sp => new RoutingRemoteFileService(
+            sp.GetRequiredService<SftpService>(),
+            sp.GetRequiredService<FtpFileService>(),
+            sp.GetRequiredService<FtpFileService>()));
+        services.AddSingleton<SftpService>(sp =>
         {
             ISshConnectionService connSvc = sp.GetRequiredService<ISshConnectionService>();
             ISettingsService settings = sp.GetRequiredService<ISettingsService>();

--- a/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
@@ -1,0 +1,66 @@
+using FluentFTP;
+using FluentFTP.Exceptions;
+using VelaShell.Core.Ftp;
+
+namespace VelaShell.Infrastructure.Ftp;
+
+/// <summary>
+/// FluentFTP 异常 → Core 的 <see cref="VelaFtpClientException" /> 族的一处翻译。
+/// 与 SSH 侧的 <c>TmdsSshInterop</c> 同样的约定:具体库的异常类型不得越过 Infrastructure 边界
+/// (见 docs/架构设计.md 的分层硬规则)。
+/// </summary>
+internal static class FluentFtpInterop
+{
+    /// <summary>把 FluentFTP/Socket 的异常翻译成库中立异常;已是中立异常的原样返回。</summary>
+    public static Exception Translate(Exception ex, string operation)
+    {
+        switch (ex)
+        {
+            case VelaFtpClientException:
+            case OperationCanceledException:
+                return ex;
+            case FtpAuthenticationException auth:
+                return new VelaFtpAuthenticationException(
+                    $"FTP login failed: {auth.CompletionCode} {auth.Message}", auth);
+            case FtpCommandException cmd:
+                return TranslateCommand(cmd, operation);
+            case FtpSecurityNotAvailableException tls:
+                return new VelaFtpConnectionException(
+                    $"The server does not support the requested FTPS mode ({operation}).", tls);
+            case TimeoutException timeout:
+                return new VelaFtpConnectionException($"FTP {operation} timed out.", timeout);
+            case System.Net.Sockets.SocketException socket:
+                return new VelaFtpConnectionException($"FTP {operation} failed: {socket.Message}", socket);
+            case System.Security.Authentication.AuthenticationException tlsAuth:
+                return new VelaFtpConnectionException($"TLS handshake failed: {tlsAuth.Message}", tlsAuth);
+            case IOException io:
+                return new VelaFtpConnectionException($"FTP {operation} failed: {io.Message}", io);
+            case FtpException ftp:
+                return new VelaFtpOperationException($"FTP {operation} failed: {ftp.Message}", ftp);
+            default:
+                return ex;
+        }
+    }
+
+    /// <summary>
+    /// 按 FTP 应答码分类。5xx 里 550 既可能是「不存在」也可能是「没权限」,
+    /// 服务器措辞不统一,因此再看一眼文本 —— 分不清时保守地归为一般操作失败。
+    /// </summary>
+    private static Exception TranslateCommand(FtpCommandException cmd, string operation)
+    {
+        string message = cmd.Message ?? string.Empty;
+        bool denied = message.Contains("permission", StringComparison.OrdinalIgnoreCase) ||
+                      message.Contains("access is denied", StringComparison.OrdinalIgnoreCase) ||
+                      cmd.CompletionCode is "530" or "532";
+        if (denied)
+        {
+            return new VelaFtpPermissionDeniedException($"FTP {operation} denied: {message}", cmd);
+        }
+        bool notFound = message.Contains("no such file", StringComparison.OrdinalIgnoreCase) ||
+                        message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+                        message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
+        return notFound
+            ? new VelaFtpPathNotFoundException($"FTP {operation} failed: {message}", cmd)
+            : new VelaFtpOperationException($"FTP {operation} failed: {message}", cmd);
+    }
+}

--- a/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using FluentFTP;
+using VelaShell.Core.Ftp;
+
+namespace VelaShell.Infrastructure.Ftp;
+
+/// <summary>
+/// 一条 FTP 会话持有的连接池。
+/// <para>
+/// **为什么必须有池**:FTP 一条控制连接同一时刻只能跑一条命令(FluentFTP 内部也是这么加锁的),
+/// 而 SFTP 是在一条 SSH 连接上多路复用、天然可并发 —— <c>SerializedSftpService</c> 正是基于后者
+/// 才敢让传输不占串行闸。若 FTP 也共用一条连接,「传输期间刷新目录」会直接报错,
+/// 用户设置的最大并发传输数也会被悄悄压回 1。
+/// </para>
+/// <para>
+/// 池的形状很简单:一个总量信号量 + 一袋空闲连接。租借时优先复用空闲连接,
+/// 发现掉线就地重连;归还时放回袋子。上限取 <see cref="Core.Models.FtpSettings.MaxConnections" />。
+/// </para>
+/// </summary>
+internal sealed class FtpConnectionPool(
+    FtpConnectionInfo info,
+    Func<CancellationToken, Task<AsyncFtpClient>> clientFactory) : IAsyncDisposable
+{
+    private readonly ConcurrentBag<AsyncFtpClient> _idle = [];
+    private readonly List<AsyncFtpClient> _all = [];
+    private readonly Lock _sync = new();
+    private readonly SemaphoreSlim _slots = new(Math.Max(1, info.Settings.MaxConnections), Math.Max(1, info.Settings.MaxConnections));
+    private bool _disposed;
+
+    /// <summary>该会话的连接参数。</summary>
+    public FtpConnectionInfo Info { get; } = info;
+
+    /// <summary>租借一条可用连接;释放 <see cref="Lease" /> 即归还。</summary>
+    public async Task<Lease> RentAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            AsyncFtpClient client = _idle.TryTake(out AsyncFtpClient? pooled)
+                ? pooled
+                : await CreateAsync(cancellationToken).ConfigureAwait(false);
+
+            // 空闲期间可能被服务器按 idle timeout 踢掉(FTP 服务器普遍很短),这里就地重连。
+            if (!client.IsConnected)
+            {
+                try
+                {
+                    await client.Connect(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Forget(client);
+                    throw FluentFtpInterop.Translate(ex, "reconnect");
+                }
+            }
+            return new Lease(this, client);
+        }
+        catch
+        {
+            _slots.Release();
+            throw;
+        }
+    }
+
+    /// <summary>释放全部连接。</summary>
+    public async ValueTask DisposeAsync()
+    {
+        List<AsyncFtpClient> clients;
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            clients = [.. _all];
+            _all.Clear();
+        }
+        foreach (AsyncFtpClient client in clients)
+        {
+            try
+            {
+                if (client.IsConnected)
+                {
+                    await client.Disconnect().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // 关闭期的失败无人可报,忽略即可。
+            }
+            finally
+            {
+                client.Dispose();
+            }
+        }
+        _slots.Dispose();
+    }
+
+    private async Task<AsyncFtpClient> CreateAsync(CancellationToken cancellationToken)
+    {
+        AsyncFtpClient client = await clientFactory(cancellationToken).ConfigureAwait(false);
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                client.Dispose();
+                throw new ObjectDisposedException(nameof(FtpConnectionPool));
+            }
+            _all.Add(client);
+        }
+        return client;
+    }
+
+    private void Return(AsyncFtpClient client)
+    {
+        if (_disposed)
+        {
+            client.Dispose();
+        }
+        else
+        {
+            _idle.Add(client);
+        }
+        _slots.Release();
+    }
+
+    /// <summary>把一条已经不可用的连接从池中剔除(不再归还给 <see cref="_idle" />)。</summary>
+    private void Forget(AsyncFtpClient client)
+    {
+        lock (_sync)
+        {
+            _all.Remove(client);
+        }
+        client.Dispose();
+    }
+
+    /// <summary>一次连接租借;释放即归还池中。</summary>
+    internal sealed class Lease(FtpConnectionPool pool, AsyncFtpClient client) : IDisposable
+    {
+        private bool _returned;
+
+        /// <summary>租到的连接。</summary>
+        public AsyncFtpClient Client { get; } = client;
+
+        /// <summary>归还连接。</summary>
+        public void Dispose()
+        {
+            if (_returned)
+            {
+                return;
+            }
+            _returned = true;
+            pool.Return(Client);
+        }
+    }
+}

--- a/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
@@ -1,0 +1,605 @@
+using System.Collections.Concurrent;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentFTP;
+using VelaShell.Core.Ftp;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+using CoreDataMode = VelaShell.Core.Models.FtpDataConnectionMode;
+using CoreEncryption = VelaShell.Core.Models.FtpEncryptionMode;
+
+namespace VelaShell.Infrastructure.Ftp;
+
+/// <summary>
+/// FTP / FTPS 的文件服务:同时实现 <see cref="ISftpService" />(文件操作,与协议无关的那套契约)
+/// 与 <see cref="IFtpSessionService" />(会话生命周期)。
+/// <para>
+/// 接缝选在 <see cref="ISftpService" /> 而不是 <c>ISftpClientWrapper</c>,原因有二
+/// (详见 docs/FTP客户端可行性调研.md §一):
+/// 其一,上层真正消费的 <see cref="RemoteFileInfo" /> 里权限/属主/属组都是**字符串**,
+/// 正是 FTP 的 LIST/MLSD 能给的,不必绕 UID/GID 与 SSH exec 查表;
+/// 其二,<c>ISftpClientWrapper.OpenAsync</c> 硬性要求返回**可 Seek** 的流,
+/// 而 FluentFTP 的数据流 <c>CanSeek == false</c>、<c>Seek()</c> 直接抛异常,根本满足不了。
+/// </para>
+/// </summary>
+public sealed class FtpFileService : ISftpService, IFtpSessionService
+{
+    private readonly ConcurrentDictionary<Guid, FtpConnectionPool> _sessions = new();
+
+    /// <inheritdoc />
+    public async Task<Guid> OpenSessionAsync(FtpConnectionInfo info, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        var probe = new CertificateProbe(info.Settings.TrustedCertificateThumbprint);
+        var pool = new FtpConnectionPool(info, token => CreateConnectedClientAsync(info, probe, token));
+        try
+        {
+            // 第一次租借即完成 TCP 连接、TLS 握手与登录 —— 把失败暴露在「打开会话」这一步,
+            // 而不是等用户点开目录才炸。
+            using FtpConnectionPool.Lease lease = await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await pool.DisposeAsync().ConfigureAwait(false);
+            // 证书没过校验时,FluentFTP 抛出来的是一个笼统的连接失败;这里换成带指纹的专用异常,
+            // 上层才能弹出「是否信任该证书」并把指纹写回配置。
+            throw probe.Failure is { } failure
+                ? new VelaFtpCertificateException(
+                    $"The server certificate for {info.Host} is not trusted ({failure.PolicyErrors}).",
+                    failure.Thumbprint, failure.Subject, failure.Issuer, failure.ExpiresOn, failure.PolicyErrors, ex)
+                : FluentFtpInterop.Translate(ex, "connect");
+        }
+        var sessionId = Guid.NewGuid();
+        _sessions[sessionId] = pool;
+        return sessionId;
+    }
+
+    /// <inheritdoc />
+    public bool OwnsSession(Guid sessionId) => _sessions.ContainsKey(sessionId);
+
+    /// <inheritdoc />
+    public async Task CloseSessionAsync(Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        if (_sessions.TryRemove(sessionId, out FtpConnectionPool? pool))
+        {
+            await pool.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<List<RemoteFileInfo>> ListDirectoryAsync(Guid sessionId, string path, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            FtpListItem[] items = await lease.Client.GetListing(NormalizePath(path), cancellationToken).ConfigureAwait(false);
+            return [.. items.Where(static item => item is not null).Select(Map)];
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "list directory");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UploadFileAsync(Guid sessionId,
+        string localPath,
+        string remotePath,
+        IProgress<TransferProgress>? progress = null,
+        long resumeOffset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        string fileName = Path.GetFileName(localPath);
+        long totalBytes = new FileInfo(localPath).Length;
+        try
+        {
+            await using FileStream source = File.OpenRead(localPath);
+            // 续传交给 FluentFTP:Resume 模式下它自己 SIZE 远端、再把本地流 Seek 到同一偏移。
+            // 不需要 SFTP 那套「回退一个在途写入窗口」—— FTP 单条数据连接顺序写,没有乱序空洞。
+            FtpStatus status = await lease.Client.UploadStream(
+                source,
+                NormalizePath(remotePath),
+                resumeOffset > 0 ? FtpRemoteExists.Resume : FtpRemoteExists.Overwrite,
+                createRemoteDir: false,
+                progress: MapProgress(progress, fileName, totalBytes),
+                token: cancellationToken).ConfigureAwait(false);
+            if (status == FtpStatus.Failed)
+            {
+                throw new VelaFtpOperationException($"FTP upload of {fileName} failed.");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "upload");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DownloadFileAsync(Guid sessionId,
+        string remotePath,
+        string localPath,
+        IProgress<TransferProgress>? progress = null,
+        long resumeOffset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        string fileName = GetRemoteFileName(remotePath);
+        try
+        {
+            long totalBytes = await lease.Client.GetFileSize(NormalizePath(remotePath), -1, cancellationToken).ConfigureAwait(false);
+            await using FileStream target = resumeOffset > 0
+                ? new FileStream(localPath, FileMode.Append, FileAccess.Write, FileShare.None)
+                : new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            bool ok = await lease.Client.DownloadStream(
+                target,
+                NormalizePath(remotePath),
+                resumeOffset,
+                MapProgress(progress, fileName, totalBytes),
+                cancellationToken).ConfigureAwait(false);
+            if (!ok)
+            {
+                throw new VelaFtpOperationException($"FTP download of {fileName} failed.");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "download");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(Guid sessionId, string remotePath, IProgress<SftpDeleteProgress>? progress = null, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        AsyncFtpClient client = lease.Client;
+        string path = NormalizePath(remotePath);
+        try
+        {
+            FtpListItem? item = await client.GetObjectInfo(path, false, cancellationToken).ConfigureAwait(false);
+            if (item is null || item.Type != FtpObjectType.Directory)
+            {
+                await client.DeleteFile(path, cancellationToken).ConfigureAwait(false);
+                progress?.Report(new(1, 1, path));
+                return;
+            }
+            // 递归删:先数一遍再删,才能给出「已删 n / 共 m」的确定进度(与 SFTP 侧的语义一致)。
+            List<string> files = [];
+            List<string> directories = [];
+            await CollectAsync(client, path, files, directories, cancellationToken).ConfigureAwait(false);
+            int total = files.Count + directories.Count + 1;
+            int done = 0;
+            foreach (string file in files)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await client.DeleteFile(file, cancellationToken).ConfigureAwait(false);
+                progress?.Report(new(++done, total, file));
+            }
+            // 子目录按深度倒序删,保证先空后删。
+            foreach (string directory in directories.OrderByDescending(static d => d.Count(static c => c == '/')))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await client.DeleteDirectory(directory, cancellationToken).ConfigureAwait(false);
+                progress?.Report(new(++done, total, directory));
+            }
+            await client.DeleteDirectory(path, cancellationToken).ConfigureAwait(false);
+            progress?.Report(new(++done, total, path));
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "delete");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task CreateDirectoryAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await lease.Client.CreateDirectory(NormalizePath(remotePath), true, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "create directory");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task CreateFileAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var empty = new MemoryStream([]);
+            await lease.Client.UploadStream(empty, NormalizePath(remotePath), FtpRemoteExists.Overwrite,
+                createRemoteDir: false, token: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "create file");
+        }
+    }
+
+    /// <inheritdoc />
+    public Task EnsureDirectoryAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        CreateDirectoryAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task RenameAsync(Guid sessionId, string oldPath, string newPath, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await lease.Client.Rename(NormalizePath(oldPath), NormalizePath(newPath), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "rename");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task CopyAsync(Guid sessionId, string sourcePath, string destPath, IProgress<TransferProgress>? progress = null, CancellationToken cancellationToken = default)
+    {
+        // FTP 没有服务端复制命令(FXP 是站点间传输,不是同站复制),只能下行再上行。
+        // 走临时文件而非内存:远端文件可能远大于可用内存。
+        string temp = Path.Combine(Path.GetTempPath(), $"vela-ftp-copy-{Guid.NewGuid():N}");
+        try
+        {
+            await DownloadFileAsync(sessionId, sourcePath, temp, progress, 0, cancellationToken).ConfigureAwait(false);
+            await UploadFileAsync(sessionId, temp, destPath, progress, 0, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(temp))
+                {
+                    File.Delete(temp);
+                }
+            }
+            catch (IOException)
+            {
+                // 临时文件删不掉不影响结果。
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetPermissionsAsync(Guid sessionId, string remotePath, short octalMode, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // SITE CHMOD 是可选命令,很多服务器(尤其 Windows/IIS 系)不实现 —— 失败会被翻译成
+            // VelaFtpOperationException,由上层提示,而不是静默当成功。
+            await lease.Client.Chmod(NormalizePath(remotePath), octalMode, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "chmod");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<RemoteFileInfo> GetFileInfoAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        string path = NormalizePath(remotePath);
+        try
+        {
+            FtpListItem? item = await lease.Client.GetObjectInfo(path, true, cancellationToken).ConfigureAwait(false);
+            return item is null
+                ? throw new VelaFtpPathNotFoundException($"FTP path not found: {path}")
+                : Map(item);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "stat");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> OpenReadAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Stream inner = await lease.Client
+                .OpenRead(NormalizePath(remotePath), FtpDataType.Binary, 0L, 0L, token: cancellationToken)
+                .ConfigureAwait(false);
+            // 数据连接的生命周期就是这个流的生命周期:必须等调用方释放流,才能把连接还回池子。
+            return new LeasedStream(inner, lease);
+        }
+        catch (Exception ex)
+        {
+            lease.Dispose();
+            throw FluentFtpInterop.Translate(ex, "open");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ExistsAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        string path = NormalizePath(remotePath);
+        try
+        {
+            return await lease.Client.FileExists(path, cancellationToken).ConfigureAwait(false) ||
+                   await lease.Client.DirectoryExists(path, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "exists");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetWorkingDirectoryAsync(Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            string path = await lease.Client.GetWorkingDirectory(cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(path) ? "/" : path;
+        }
+        catch (Exception ex)
+        {
+            throw FluentFtpInterop.Translate(ex, "pwd");
+        }
+    }
+
+    /// <summary>释放全部 FTP 会话与其连接。</summary>
+    public async ValueTask DisposeAsync()
+    {
+        foreach (Guid sessionId in _sessions.Keys.ToArray())
+        {
+            await CloseSessionAsync(sessionId).ConfigureAwait(false);
+        }
+    }
+
+    // ---- 内部实现 ---------------------------------------------------------
+
+    private async Task<FtpConnectionPool.Lease> RentAsync(Guid sessionId, CancellationToken cancellationToken) =>
+        _sessions.TryGetValue(sessionId, out FtpConnectionPool? pool)
+            ? await pool.RentAsync(cancellationToken).ConfigureAwait(false)
+            : throw new VelaFtpConnectionException($"FTP session {sessionId} is not open.");
+
+    private static async Task<AsyncFtpClient> CreateConnectedClientAsync(FtpConnectionInfo info, CertificateProbe probe, CancellationToken cancellationToken)
+    {
+        var config = new FtpConfig
+        {
+            EncryptionMode = MapEncryption(info.Settings.EncryptionMode),
+            DataConnectionType = info.Settings.DataConnectionMode == CoreDataMode.Passive
+                ? FtpDataConnectionType.AutoPassive
+                : FtpDataConnectionType.AutoActive,
+            // 绝不无条件信任证书:校验逻辑在 ValidateCertificate 里,未信任的指纹要能一路冒泡到 UI。
+            ValidateAnyCertificate = false,
+            ConnectTimeout = 15_000,
+            ReadTimeout = 30_000,
+            DataConnectionConnectTimeout = 15_000,
+            DataConnectionReadTimeout = 30_000,
+        };
+        var client = new AsyncFtpClient(info.Host, info.EffectiveUsername, info.EffectivePassword, info.Port, config);
+        client.ValidateCertificate += (_, e) => probe.Validate(e);
+        try
+        {
+            await client.Connect(cancellationToken).ConfigureAwait(false);
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
+    }
+
+    private static FluentFTP.FtpEncryptionMode MapEncryption(CoreEncryption mode) =>
+        mode switch
+        {
+            CoreEncryption.None => FluentFTP.FtpEncryptionMode.None,
+            CoreEncryption.Explicit => FluentFTP.FtpEncryptionMode.Explicit,
+            CoreEncryption.Implicit => FluentFTP.FtpEncryptionMode.Implicit,
+            _ => FluentFTP.FtpEncryptionMode.Auto,
+        };
+
+    /// <summary>把 FluentFTP 的进度回调翻译成 VelaShell 的传输进度快照。</summary>
+    private static IProgress<FtpProgress>? MapProgress(IProgress<TransferProgress>? progress, string fileName, long totalBytes) =>
+        progress is null
+            ? null
+            : new Progress<FtpProgress>(p => progress.Report(new()
+            {
+                FileName = fileName,
+                BytesTransferred = p.TransferredBytes,
+                TotalBytes = totalBytes > 0 ? totalBytes : p.TransferredBytes,
+                Percentage = p.Progress is >= 0 and <= 100 ? (int)p.Progress : 0,
+                SpeedBytesPerSecond = p.TransferSpeed,
+                EstimatedTimeRemaining = p.ETA,
+            }));
+
+    /// <summary>递归收集目录下的文件与子目录(不含目录自身)。</summary>
+    private static async Task CollectAsync(AsyncFtpClient client, string path, List<string> files, List<string> directories, CancellationToken cancellationToken)
+    {
+        FtpListItem[] items = await client.GetListing(path, cancellationToken).ConfigureAwait(false);
+        foreach (FtpListItem item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (item.Type == FtpObjectType.Directory)
+            {
+                directories.Add(item.FullName);
+                await CollectAsync(client, item.FullName, files, directories, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                files.Add(item.FullName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <see cref="FtpListItem" /> → <see cref="RemoteFileInfo" />。
+    /// 属主/属组直接取服务器给的**名字**(FTP 没有 UID/GID),因此整条绕开了 SFTP 那边
+    /// 靠 SSH exec 跑 <c>getent passwd</c> 的身份翻译。服务器不给时留空,由界面自行留白。
+    /// </summary>
+    private static RemoteFileInfo Map(FtpListItem item) =>
+        new()
+        {
+            Name = item.Name ?? string.Empty,
+            FullPath = item.FullName ?? string.Empty,
+            Size = item.Size < 0 ? 0 : item.Size,
+            IsDirectory = item.Type == FtpObjectType.Directory,
+            LastModified = item.Modified,
+            Permissions = FormatPermissions(item),
+            Owner = item.RawOwner ?? string.Empty,
+            Group = item.RawGroup ?? string.Empty,
+        };
+
+    /// <summary>
+    /// 权限字符串:优先用服务器原样给的(Unix 风格 LIST 会给 <c>-rw-r--r--</c>),
+    /// 去掉首位的类型字符;拿不到就用解析出的三组权限位拼,再拿不到就留空。
+    /// </summary>
+    private static string FormatPermissions(FtpListItem item)
+    {
+        string raw = item.RawPermissions ?? string.Empty;
+        if (raw.Length >= 10)
+        {
+            return raw[1..10];
+        }
+        if (raw.Length == 9)
+        {
+            return raw;
+        }
+        if (item.OwnerPermissions == FtpPermission.None &&
+            item.GroupPermissions == FtpPermission.None &&
+            item.OthersPermissions == FtpPermission.None)
+        {
+            return string.Empty;
+        }
+        return string.Concat(
+            Rwx(item.OwnerPermissions),
+            Rwx(item.GroupPermissions),
+            Rwx(item.OthersPermissions));
+    }
+
+    private static string Rwx(FtpPermission permission) =>
+        string.Concat(
+            permission.HasFlag(FtpPermission.Read) ? "r" : "-",
+            permission.HasFlag(FtpPermission.Write) ? "w" : "-",
+            permission.HasFlag(FtpPermission.Execute) ? "x" : "-");
+
+    private static string NormalizePath(string path) =>
+        string.IsNullOrWhiteSpace(path) ? "/" : path.Replace('\\', '/');
+
+    private static string GetRemoteFileName(string remotePath)
+    {
+        string normalized = NormalizePath(remotePath).TrimEnd('/');
+        int slash = normalized.LastIndexOf('/');
+        return slash >= 0 && slash < normalized.Length - 1 ? normalized[(slash + 1)..] : normalized;
+    }
+
+    /// <summary>
+    /// 服务器证书校验策略:指纹已被用户信任、或链路本身无误 → 放行;
+    /// 否则记下证书信息并拒绝,由 <see cref="OpenSessionAsync" /> 换成带指纹的异常抛给上层。
+    /// <para>
+    /// 刻意**不**在这个同步事件里去弹 UI 等用户点确认 —— 那要把异步的对话框阻塞成同步,
+    /// 极易死锁。改成「先拒绝 → 上层提示 → 记住指纹后重连」,流程干净且不阻塞。
+    /// </para>
+    /// </summary>
+    private sealed class CertificateProbe(string? trustedThumbprint)
+    {
+        /// <summary>最近一次未通过校验的证书信息;没有失败时为 null。</summary>
+        public CertificateFailure? Failure { get; private set; }
+
+        public void Validate(FtpSslValidationEventArgs e)
+        {
+            string thumbprint = ComputeThumbprint(e.Certificate);
+            if (e.PolicyErrors == SslPolicyErrors.None ||
+                (trustedThumbprint is { Length: > 0 } trusted &&
+                 string.Equals(trusted, thumbprint, StringComparison.OrdinalIgnoreCase)))
+            {
+                e.Accept = true;
+                return;
+            }
+            Failure = new(
+                thumbprint,
+                e.Certificate?.Subject ?? string.Empty,
+                e.Certificate?.Issuer ?? string.Empty,
+                e.Certificate is X509Certificate2 cert ? cert.NotAfter : DateTimeOffset.MinValue,
+                e.PolicyErrors.ToString());
+            e.Accept = false;
+        }
+
+        private static string ComputeThumbprint(X509Certificate? certificate)
+        {
+            if (certificate is null)
+            {
+                return string.Empty;
+            }
+            try
+            {
+                return Convert.ToHexString(SHA256.HashData(certificate.GetRawCertData()));
+            }
+            catch (CryptographicException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+
+    /// <summary>未通过校验的证书信息。</summary>
+    private sealed record CertificateFailure(string Thumbprint, string Subject, string Issuer, DateTimeOffset ExpiresOn, string PolicyErrors);
+
+    /// <summary>
+    /// 绑定了一次连接租借的只读流:调用方释放流时连同把连接还回池子。
+    /// FTP 的数据连接与流同生共死,不能像 SFTP 那样先还连接再慢慢读。
+    /// </summary>
+    private sealed class LeasedStream(Stream inner, FtpConnectionPool.Lease lease) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => throw new NotSupportedException("FTP data streams are sequential.");
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.ReadAsync(buffer, cancellationToken);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException("FTP data streams are not seekable.");
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+                lease.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync().ConfigureAwait(false);
+            lease.Dispose();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/VelaShell.Infrastructure/Import/SessionImportWriter.cs
+++ b/src/VelaShell.Infrastructure/Import/SessionImportWriter.cs
@@ -48,7 +48,8 @@ internal static class SessionImportWriter
                 Password = item.Password,
                 RememberPassword = item.PasswordRecovered,
                 GroupId = group.Id,
-                Tags = [tag.ToLowerInvariant()]
+                Tags = [tag.ToLowerInvariant()],
+                Ftp = item.FtpSettings
             };
             await repository.SaveSessionAsync(profile).ConfigureAwait(false);
             group.Sessions.Add(profile.Id);

--- a/src/VelaShell.Infrastructure/Import/WinScpImportService.cs
+++ b/src/VelaShell.Infrastructure/Import/WinScpImportService.cs
@@ -64,11 +64,20 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
                 continue;
             }
             (ConnectionType type, bool supported, string protocol) = MapProtocol(raw.FsProtocol);
+            FtpSettings? ftpSettings = type == ConnectionType.FTP
+                ? new FtpSettings { EncryptionMode = MapFtps(raw.Ftps) }
+                : null;
             bool hasEncrypted = !string.IsNullOrWhiteSpace(raw.Password);
             string? password = hasEncrypted && !masterPassword
                 ? WinScpCrypto.Decrypt(raw.Host, raw.Username, raw.Password)
                 : null;
-            int port = raw.Port is int p and > 0 ? p : 22;
+            // 端口缺省值按协议给:FTP 是 21(隐式 FTPS 是 990),不是 SSH 的 22。
+            int defaultPort = ftpSettings is null
+                ? 22
+                : ftpSettings.EncryptionMode == FtpEncryptionMode.Implicit
+                    ? Core.Models.FtpSettings.DefaultImplicitPort
+                    : Core.Models.FtpSettings.DefaultPort;
+            int port = raw.Port is int p and > 0 ? p : defaultPort;
 
             items.Add(new ImportedSession
             {
@@ -82,7 +91,8 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
                 HasEncryptedPassword = hasEncrypted,
                 Password = password,
                 AlreadyExists = existingKeys.Contains(DedupKey(raw.Host, port, raw.Username)),
-                Source = sourceLabel
+                Source = sourceLabel,
+                FtpSettings = ftpSettings
             });
         }
 
@@ -174,16 +184,31 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
         return result;
     }
 
-    /// <summary>把 WinSCP 的 FSProtocol 数值映射为 VelaShell 连接类型;仅 SSH 系(SCP/SFTP)受支持。</summary>
+    /// <summary>
+    /// 把 WinSCP 的 FSProtocol 数值映射为 VelaShell 连接类型:SSH 系(SCP/SFTP)与 FTP/FTPS 受支持,
+    /// WebDAV 与 S3 仍不支持。
+    /// </summary>
     private static (ConnectionType Type, bool Supported, string Protocol) MapProtocol(int? fsProtocol) =>
         fsProtocol switch
         {
             0 => (ConnectionType.SSH, true, "SCP"),
             1 or 2 or null => (ConnectionType.SSH, true, "SFTP"),
-            5 => (ConnectionType.SSH, false, "FTP"),
+            5 => (ConnectionType.FTP, true, "FTP"),
             6 => (ConnectionType.SSH, false, "WebDAV"),
             7 => (ConnectionType.SSH, false, "S3"),
             _ => (ConnectionType.SSH, false, "?")
+        };
+
+    /// <summary>
+    /// WinSCP 的 <c>Ftps</c> 取值 → 加密方式:0/缺失=明文,1=隐式,2(SSL)/3(TLS)=显式。
+    /// 缺失时用「不加密」而不是「自动」—— 用户在 WinSCP 里就是这么连的,导入不该悄悄改变行为。
+    /// </summary>
+    private static FtpEncryptionMode MapFtps(int? ftps) =>
+        ftps switch
+        {
+            1 => FtpEncryptionMode.Implicit,
+            2 or 3 => FtpEncryptionMode.Explicit,
+            _ => FtpEncryptionMode.None
         };
 
     private static string DedupKey(string host, int port, string user) => $"{host.Trim()}|{port}|{user.Trim()}";
@@ -245,7 +270,8 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
                         session.GetValue("UserName") as string ?? string.Empty,
                         session.GetValue("Password") as string,
                         session.GetValue("PortNumber") as int?,
-                        session.GetValue("FSProtocol") as int?));
+                        session.GetValue("FSProtocol") as int?,
+                        session.GetValue("Ftps") as int?));
                 }
             }
         }
@@ -280,7 +306,8 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
                         current.GetValueOrDefault("UserName", string.Empty),
                         current.GetValueOrDefault("Password"),
                         ParseInt(current.GetValueOrDefault("PortNumber")),
-                        ParseInt(current.GetValueOrDefault("FSProtocol"))));
+                        ParseInt(current.GetValueOrDefault("FSProtocol")),
+                        ParseInt(current.GetValueOrDefault("Ftps"))));
                 }
                 current.Clear();
                 sessionName = null;
@@ -334,5 +361,5 @@ public sealed class WinScpImportService(ISessionRepository repository) : ISessio
     /// <summary>去除会话名中的 BOM 与首尾空白(WinSCP.ini 偶有残留 BOM 混入名称)。</summary>
     private static string CleanName(string raw) => raw.Trim('﻿', ' ', '\t', '\r', '\n');
 
-    private sealed record WinScpRawSession(string Name, string Host, string Username, string? Password, int? Port, int? FsProtocol);
+    private sealed record WinScpRawSession(string Name, string Host, string Username, string? Password, int? Port, int? FsProtocol, int? Ftps = null);
 }

--- a/src/VelaShell.Infrastructure/Import/XshellImportService.cs
+++ b/src/VelaShell.Infrastructure/Import/XshellImportService.cs
@@ -69,7 +69,9 @@ public sealed class XshellImportService(ISessionRepository repository) : ISessio
                 password = XshellCrypto.TryDecryptPassword(parsed.EncryptedPassword, userName, sid);
             }
 
-            int port = parsed.Port > 0 ? parsed.Port : 22;
+            FtpSettings? ftpSettings = MapFtpSettings(parsed.Protocol);
+            // 端口缺省值按协议给:FTP 是 21,不是 SSH 的 22。
+            int port = parsed.Port > 0 ? parsed.Port : ftpSettings is null ? 22 : FtpSettings.DefaultPort;
             items.Add(new ImportedSession
             {
                 Name = Path.GetFileNameWithoutExtension(file),
@@ -82,7 +84,8 @@ public sealed class XshellImportService(ISessionRepository repository) : ISessio
                 HasEncryptedPassword = hasEncrypted,
                 Password = password,
                 AlreadyExists = existingKeys.Contains(DedupKey(parsed.Host!, port, parsed.UserName ?? string.Empty)),
-                Source = file
+                Source = file,
+                FtpSettings = ftpSettings
             });
         }
 
@@ -98,13 +101,23 @@ public sealed class XshellImportService(ISessionRepository repository) : ISessio
     public async Task<SessionImportOutcome> ImportAsync(IReadOnlyList<ImportedSession> items, string groupName, CancellationToken cancellationToken = default) =>
         await SessionImportWriter.WriteAsync(_repository, items, groupName, "Xshell", cancellationToken).ConfigureAwait(false);
 
-    /// <summary>把 Xshell 协议字段映射为 VelaShell 连接类型;仅 SSH / SFTP 受支持。</summary>
+    /// <summary>把 Xshell 协议字段映射为 VelaShell 连接类型;SSH / SFTP / FTP / FTPS 受支持。</summary>
     private static (ConnectionType Type, bool Supported) MapProtocol(string? protocol) =>
         protocol?.Trim().ToUpperInvariant() switch
         {
             "SFTP" => (ConnectionType.SFTP, true),
             "SSH" or null or "" => (ConnectionType.SSH, true),
+            "FTP" or "FTPS" => (ConnectionType.FTP, true),
             _ => (ConnectionType.SSH, false)
+        };
+
+    /// <summary>Xshell 的 FTPS 走显式 TLS(默认 21 端口),明文 FTP 不加密。</summary>
+    private static FtpSettings? MapFtpSettings(string? protocol) =>
+        protocol?.Trim().ToUpperInvariant() switch
+        {
+            "FTPS" => new FtpSettings { EncryptionMode = FtpEncryptionMode.Explicit },
+            "FTP" => new FtpSettings { EncryptionMode = FtpEncryptionMode.None },
+            _ => null
         };
 
     private static string DedupKey(string host, int port, string user) => $"{host.Trim()}|{port}|{user.Trim()}";

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbRecentConnectionService.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbRecentConnectionService.cs
@@ -124,8 +124,12 @@ public sealed class SonnetDbRecentConnectionService(SonnetDbEngine engine) : IRe
 
     private static string AsString(object? value) => value?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// 时序库里协议存的是 Int64。白名单化(<see cref="Enum.IsDefined{TEnum}" />)而非逐值比对:
+    /// 未知值仍降级为 SSH,但新增协议无需再改这里。
+    /// </summary>
     private static ConnectionType ParseConnectionType(object? value) =>
-        value is long raw && raw == (long)ConnectionType.SFTP
-            ? ConnectionType.SFTP
+        value is long raw && Enum.IsDefined((ConnectionType)raw)
+            ? (ConnectionType)raw
             : ConnectionType.SSH;
 }

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbSessionRepository.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbSessionRepository.cs
@@ -146,7 +146,9 @@ public sealed class SonnetDbSessionRepository(SonnetDbEngine engine, ISecretProt
             LastConnectedAt = profile.LastConnectedAt,
             Tags = [.. profile.Tags],
             RememberPassword = profile.RememberPassword,
-            JumpHostProfileId = profile.JumpHostProfileId
+            JumpHostProfileId = profile.JumpHostProfileId,
+            // 深拷贝:这份副本要落盘,不能与调用方共享可变对象。
+            Ftp = profile.Ftp?.Clone()
         };
     }
 

--- a/src/VelaShell.Infrastructure/Sftp/RoutingRemoteFileService.cs
+++ b/src/VelaShell.Infrastructure/Sftp/RoutingRemoteFileService.cs
@@ -1,0 +1,94 @@
+using VelaShell.Core.Ftp;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+
+namespace VelaShell.Infrastructure.Sftp;
+
+/// <summary>
+/// 按会话归属把远程文件操作分派到对应后端的路由:FTP 会话交给 <see cref="FtpFileService" />,
+/// 其余(SSH 上的 SFTP)走原本的实现。
+/// <para>
+/// 之所以能这么干,是因为 <see cref="ISftpService" /> 的每个成员都以 <c>Guid sessionId</c> 为键、
+/// 返回协议无关的 <see cref="RemoteFileInfo" /> —— 文件浏览器、传输管理器、限速、拖放
+/// 全部只认这个接口,因此新增一种协议对它们是零改动。
+/// </para>
+/// </summary>
+public sealed class RoutingRemoteFileService(ISftpService sftp, ISftpService ftp, IFtpSessionService ftpSessions) : ISftpService
+{
+    private readonly ISftpService _sftp = sftp ?? throw new ArgumentNullException(nameof(sftp));
+    private readonly ISftpService _ftp = ftp ?? throw new ArgumentNullException(nameof(ftp));
+    private readonly IFtpSessionService _ftpSessions = ftpSessions ?? throw new ArgumentNullException(nameof(ftpSessions));
+
+    /// <inheritdoc />
+    public Task<List<RemoteFileInfo>> ListDirectoryAsync(Guid sessionId, string path, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).ListDirectoryAsync(sessionId, path, cancellationToken);
+
+    /// <inheritdoc />
+    public Task UploadFileAsync(Guid sessionId, string localPath, string remotePath, IProgress<TransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).UploadFileAsync(sessionId, localPath, remotePath, progress, resumeOffset, cancellationToken);
+
+    /// <inheritdoc />
+    public Task DownloadFileAsync(Guid sessionId, string remotePath, string localPath, IProgress<TransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).DownloadFileAsync(sessionId, remotePath, localPath, progress, resumeOffset, cancellationToken);
+
+    /// <inheritdoc />
+    public Task DeleteAsync(Guid sessionId, string remotePath, IProgress<SftpDeleteProgress>? progress = null, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).DeleteAsync(sessionId, remotePath, progress, cancellationToken);
+
+    /// <inheritdoc />
+    public Task CreateDirectoryAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).CreateDirectoryAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task CreateFileAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).CreateFileAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task EnsureDirectoryAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).EnsureDirectoryAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RenameAsync(Guid sessionId, string oldPath, string newPath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).RenameAsync(sessionId, oldPath, newPath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task CopyAsync(Guid sessionId, string sourcePath, string destPath, IProgress<TransferProgress>? progress = null, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).CopyAsync(sessionId, sourcePath, destPath, progress, cancellationToken);
+
+    /// <inheritdoc />
+    public Task SetPermissionsAsync(Guid sessionId, string remotePath, short octalMode, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).SetPermissionsAsync(sessionId, remotePath, octalMode, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<RemoteFileInfo> GetFileInfoAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).GetFileInfoAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<Stream> OpenReadAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).OpenReadAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> ExistsAsync(Guid sessionId, string remotePath, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).ExistsAsync(sessionId, remotePath, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<string> GetWorkingDirectoryAsync(Guid sessionId, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).GetWorkingDirectoryAsync(sessionId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task CloseSessionAsync(Guid sessionId, CancellationToken cancellationToken = default) =>
+        Resolve(sessionId).CloseSessionAsync(sessionId, cancellationToken);
+
+    /// <summary>释放两个后端。</summary>
+    public async ValueTask DisposeAsync()
+    {
+        await _ftp.DisposeAsync().ConfigureAwait(false);
+        await _sftp.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 会话归属判定:只有 FTP 后端真正持有该会话时才走它,其余一律走 SFTP ——
+    /// 未知会话的报错也就仍由原本的 SFTP 实现给出,行为与加 FTP 之前一致。
+    /// </summary>
+    private ISftpService Resolve(Guid sessionId) => _ftpSessions.OwnsSession(sessionId) ? _ftp : _sftp;
+}

--- a/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
+++ b/src/VelaShell.Infrastructure/VelaShell.Infrastructure.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentFTP" />
     <PackageReference Include="MaxMind.Db" />
     <PackageReference Include="SonnetDB.Core" />
     <PackageReference Include="Tmds.Ssh" />

--- a/src/VelaShell.Presentation/Services/ConnectionWorkflowService.cs
+++ b/src/VelaShell.Presentation/Services/ConnectionWorkflowService.cs
@@ -127,7 +127,8 @@ public sealed class ConnectionWorkflowService(
             Tags = [.. profile.Tags],
             // 保留配置自身的勾选:全局开关只影响是否落盘,不改写每条配置的选择。
             RememberPassword = profile.RememberPassword,
-            JumpHostProfileId = profile.JumpHostProfileId
+            JumpHostProfileId = profile.JumpHostProfileId,
+            Ftp = profile.Ftp?.Clone()
         };
     }
 

--- a/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
@@ -351,6 +351,7 @@ public sealed class SessionTreeViewModel : ReactiveObject
             GroupId = source.GroupId,
             Tags = [.. source.Tags],
             JumpHostProfileId = source.JumpHostProfileId,
+            Ftp = source.Ftp?.Clone(),
         };
         await _repository.SaveSessionAsync(copy);
         await LoadTreeAsync();

--- a/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
@@ -33,6 +33,11 @@ public class ConnectionProfileViewModel : ReactiveObject
     private readonly ISessionRepository? _sessionRepository;
     private AuthMethod _authMethod = AuthMethod.Password;
     private ConnectionType _connectionType = ConnectionType.SSH;
+    private FtpEncryptionMode _ftpEncryption = FtpEncryptionMode.Auto;
+    private bool _ftpPassive = true;
+    private bool _ftpAnonymous;
+    private string? _ftpTrustedThumbprint;
+    private int _ftpMaxConnections = new FtpSettings().MaxConnections;
     private Guid? _groupId;
     private string _host = string.Empty;
     private bool _isKeyAuth;
@@ -94,6 +99,14 @@ public class ConnectionProfileViewModel : ReactiveObject
             _rememberPassword = existing.RememberPassword;
             _tagsText = string.Join(", ", existing.Tags);
             _jumpHostProfileId = existing.JumpHostProfileId;
+            if (existing.Ftp is { } ftp)
+            {
+                _ftpEncryption = ftp.EncryptionMode;
+                _ftpPassive = ftp.DataConnectionMode == FtpDataConnectionMode.Passive;
+                _ftpAnonymous = ftp.Anonymous;
+                _ftpTrustedThumbprint = ftp.TrustedCertificateThumbprint;
+                _ftpMaxConnections = ftp.MaxConnections;
+            }
         }
         else
         {
@@ -122,14 +135,17 @@ public class ConnectionProfileViewModel : ReactiveObject
         this.WhenAnyValue(x => x.SelectedJumpHost)
             .Skip(1)
             .Subscribe(option => _jumpHostProfileId = option?.Id);
+        // FTP 匿名登录不需要用户名 —— 保存/连接按钮不能因为这个永远灰着(串口调研里踩过同一个坑)。
         IObservable<bool> canExecute = this.WhenAnyValue(x => x.Host,
             x => x.Username,
             x => x.Port,
             x => x.IsBusy,
-            (host, username, port, isBusy) =>
+            x => x.FtpAnonymous,
+            x => x.ConnectionType,
+            (host, username, port, isBusy, anonymous, type) =>
                 !isBusy &&
                 !string.IsNullOrWhiteSpace(host) &&
-                !string.IsNullOrWhiteSpace(username) &&
+                (!string.IsNullOrWhiteSpace(username) || (type == ConnectionType.FTP && anonymous)) &&
                 port is >= 1 and <= 65535);
         SaveCommand = ReactiveCommand.CreateFromTask(SaveAsync, canExecute);
         ConnectCommand = ReactiveCommand.CreateFromTask(ConnectAsync, canExecute);
@@ -148,15 +164,16 @@ public class ConnectionProfileViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _name, value);
     }
 
-    /// <summary>当前连接协议;SSH 为默认值,SFTP 复用 SSH 认证但不创建终端。</summary>
+    /// <summary>
+    /// 当前连接协议;SSH 为默认值,SFTP 复用 SSH 认证但不创建终端,FTP 走独立的 FTP/FTPS 栈。
+    /// 未知值降级为 SSH(白名单同 <see cref="SessionProfile.ConnectionType" />)。
+    /// </summary>
     public ConnectionType ConnectionType
     {
         get => _connectionType;
         private set
         {
-            ConnectionType normalized = value == ConnectionType.SFTP
-                ? ConnectionType.SFTP
-                : ConnectionType.SSH;
+            ConnectionType normalized = Enum.IsDefined(value) ? value : ConnectionType.SSH;
             if (_connectionType == normalized)
             {
                 return;
@@ -164,6 +181,10 @@ public class ConnectionProfileViewModel : ReactiveObject
             this.RaiseAndSetIfChanged(ref _connectionType, normalized);
             this.RaisePropertyChanged(nameof(IsSshSelected));
             this.RaisePropertyChanged(nameof(IsSftpSelected));
+            this.RaisePropertyChanged(nameof(IsFtpSelected));
+            this.RaisePropertyChanged(nameof(RequiresSshAuth));
+            this.RaisePropertyChanged(nameof(ShowFtpPlaintextWarning));
+            this.RaisePropertyChanged(nameof(ShowPasswordField));
         }
     }
 
@@ -172,6 +193,79 @@ public class ConnectionProfileViewModel : ReactiveObject
 
     /// <summary>协议标签是否选中 SFTP。</summary>
     public bool IsSftpSelected => ConnectionType == ConnectionType.SFTP;
+
+    /// <summary>协议标签是否选中 FTP / FTPS。</summary>
+    public bool IsFtpSelected => ConnectionType == ConnectionType.FTP;
+
+    /// <summary>
+    /// 是否需要 SSH 认证表单(私钥、口令、跳板)。FTP 只有用户名/口令与匿名登录,
+    /// 把这些 SSH 专属项隐掉,避免用户以为 FTP 也能用私钥。
+    /// </summary>
+    public bool RequiresSshAuth => ConnectionType != ConnectionType.FTP;
+
+    /// <summary>加密方式下拉的下标:0 自动、1 显式 FTPS、2 隐式 FTPS、3 不加密。</summary>
+    public int FtpEncryptionIndex
+    {
+        get => _ftpEncryption switch
+        {
+            FtpEncryptionMode.Explicit => 1,
+            FtpEncryptionMode.Implicit => 2,
+            FtpEncryptionMode.None => 3,
+            _ => 0
+        };
+        set => FtpEncryption = value switch
+        {
+            1 => FtpEncryptionMode.Explicit,
+            2 => FtpEncryptionMode.Implicit,
+            3 => FtpEncryptionMode.None,
+            _ => FtpEncryptionMode.Auto
+        };
+    }
+
+    /// <summary>是否提示「明文 FTP 不加密」。选了不加密才提示;FTPS 不提示。</summary>
+    public bool ShowFtpPlaintextWarning => IsFtpSelected && FtpEncryption == FtpEncryptionMode.None;
+
+    /// <summary>是否显示口令输入框:匿名 FTP 不需要口令。</summary>
+    public bool ShowPasswordField => IsPasswordAuth && !(IsFtpSelected && FtpAnonymous);
+
+    /// <summary>FTP 加密方式;仅 <see cref="IsFtpSelected" /> 时有意义。</summary>
+    public FtpEncryptionMode FtpEncryption
+    {
+        get => _ftpEncryption;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _ftpEncryption, value);
+            this.RaisePropertyChanged(nameof(FtpEncryptionIndex));
+            this.RaisePropertyChanged(nameof(ShowFtpPlaintextWarning));
+            // 隐式 FTPS 与明文/显式的默认端口不同,用户没手动改过端口时跟着切,省一次踩坑。
+            if (value == FtpEncryptionMode.Implicit && Port == FtpSettings.DefaultPort)
+            {
+                Port = FtpSettings.DefaultImplicitPort;
+            }
+            else if (value != FtpEncryptionMode.Implicit && Port == FtpSettings.DefaultImplicitPort)
+            {
+                Port = FtpSettings.DefaultPort;
+            }
+        }
+    }
+
+    /// <summary>FTP 是否使用被动模式(默认开;主动模式在客户端 NAT 后基本不可用)。</summary>
+    public bool FtpPassive
+    {
+        get => _ftpPassive;
+        set => this.RaiseAndSetIfChanged(ref _ftpPassive, value);
+    }
+
+    /// <summary>FTP 是否匿名登录;开启后不再要求填写用户名。</summary>
+    public bool FtpAnonymous
+    {
+        get => _ftpAnonymous;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _ftpAnonymous, value);
+            this.RaisePropertyChanged(nameof(ShowPasswordField));
+        }
+    }
 
     /// <summary>目标主机地址(主机名或 IP)。</summary>
     public string Host
@@ -536,9 +630,48 @@ public class ConnectionProfileViewModel : ReactiveObject
             PrivateKeyPassphrase = PrivateKeyPassphrase,
             GroupId = GroupId,
             Tags = [.. TagsText.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)],
-            JumpHostProfileId = _jumpHostProfileId
+            JumpHostProfileId = _jumpHostProfileId,
+            // 只有 FTP 才落这块设置:其余协议保持 null,旧数据与旧版本读取零影响。
+            Ftp = ConnectionType == ConnectionType.FTP
+                ? new FtpSettings
+                {
+                    EncryptionMode = FtpEncryption,
+                    DataConnectionMode = FtpPassive ? FtpDataConnectionMode.Passive : FtpDataConnectionMode.Active,
+                    Anonymous = FtpAnonymous,
+                    TrustedCertificateThumbprint = _ftpTrustedThumbprint,
+                    MaxConnections = _ftpMaxConnections,
+                }
+                : null
         };
     }
 
-    private void SelectConnectionType(ConnectionType connectionType) => ConnectionType = connectionType;
+    /// <summary>
+    /// 切换协议标签。顺带把端口切到新协议的默认值(仅当当前端口还是别的协议的默认值时),
+    /// 免得用户从 SSH 切到 FTP 后仍在 22 端口上连不上。
+    /// </summary>
+    private void SelectConnectionType(ConnectionType connectionType)
+    {
+        ConnectionType previous = ConnectionType;
+        ConnectionType = connectionType;
+        if (previous == ConnectionType)
+        {
+            return;
+        }
+        // FTP 没有私钥认证:切过去时把认证方式落回口令,免得表单停在一个用不上的私钥页。
+        if (ConnectionType == ConnectionType.FTP && IsKeyAuth)
+        {
+            AuthMethodIndex = 0;
+        }
+        if (ConnectionType == ConnectionType.FTP && Port == 22)
+        {
+            Port = FtpEncryption == FtpEncryptionMode.Implicit
+                ? FtpSettings.DefaultImplicitPort
+                : FtpSettings.DefaultPort;
+        }
+        else if (ConnectionType != ConnectionType.FTP &&
+                 Port is FtpSettings.DefaultPort or FtpSettings.DefaultImplicitPort)
+        {
+            Port = 22;
+        }
+    }
 }

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -12,6 +12,7 @@ using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
+using VelaShell.Core.Ftp;
 using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Recording;
@@ -80,6 +81,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     private readonly ISessionRepository? _sessionRepository;
     private readonly ISettingsService? _settingsService;
     private readonly ISftpService? _sftpService;
+    private readonly IFtpSessionService? _ftpSessionService;
     private readonly ISshConnectionService? _sshConnectionService;
     private readonly Func<ITerminalEmulator> _terminalEmulatorFactory;
     private readonly ITunnelService? _tunnelService;
@@ -161,7 +163,8 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         IQuickCommandRepository? quickCommandRepository = null,
         IRemoteProcessService? remoteProcessService = null,
         ITraceRouteService? traceRouteService = null,
-        ICommandRegistry? commandRegistry = null
+        ICommandRegistry? commandRegistry = null,
+        IFtpSessionService? ftpSessionService = null
     )
     {
         // 注册表可注入(DI 里与插件命令桥共享同一单例);无 UI 单测传 null 时自建。
@@ -186,6 +189,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         _settingsService = settingsService;
         _sessionRepository = sessionRepository;
         _sftpService = sftpService;
+        _ftpSessionService = ftpSessionService;
         _tunnelService = tunnelService;
         _tunnelWorkflowService = tunnelWorkflowService;
         _metricsService = metricsService;
@@ -373,6 +377,12 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     /// 取消时返回 null。
     /// </summary>
     public Func<SessionProfile, Task<SessionProfile?>>? InteractiveAuthenticator { get; set; }
+
+    /// <summary>
+    /// FTPS 服务器证书未通过校验时的信任提示;返回 true 表示用户同意信任该指纹。
+    /// 由 View 层挂上(与 <see cref="InteractiveAuthenticator" /> 同样的手法);未挂时按拒绝处理。
+    /// </summary>
+    public Func<SessionProfile, VelaFtpCertificateException, Task<bool>>? FtpCertificateTrustPrompt { get; set; }
 
     /// <summary>最近一次连接的错误消息,若上次尝试成功则为 null。</summary>
     public string? LastConnectionError
@@ -2333,6 +2343,11 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
             await OpenSftpDocumentForProfileAsync(profile, cancellationToken).ConfigureAwait(true);
             return null;
         }
+        if (profile.ConnectionType == ConnectionType.FTP)
+        {
+            await OpenFtpDocumentForProfileAsync(profile, cancellationToken).ConfigureAwait(true);
+            return null;
+        }
         if (_connectionWorkflowService is null || _sshConnectionService is null)
         {
             return null;
@@ -2527,6 +2542,127 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// 打开一个 FTP / FTPS 文档标签:建立 FTP 会话并复用与 SFTP 完全相同的双栏文件面板。
+    /// <para>
+    /// 与 SFTP 的两点不同:一是不走 <see cref="IConnectionWorkflowService" />(那是 SSH 握手),
+    /// 二是 FTPS 证书没过校验时会抛 <see cref="VelaFtpCertificateException" /> ——
+    /// 此时弹一次信任提示,用户同意就把指纹记进配置再重连(刻意不在证书回调里同步等 UI,那样极易死锁)。
+    /// </para>
+    /// </summary>
+    public async Task<SftpDocument?> OpenFtpDocumentForProfileAsync(
+        SessionProfile profile,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        if (_ftpSessionService is null || _sftpService is null)
+        {
+            return null;
+        }
+
+        SessionProfile current = profile;
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            if (attempt > 0 || RequiresFtpCredentials(current))
+            {
+                if (InteractiveAuthenticator is not { } prompt)
+                {
+                    return null;
+                }
+                SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
+                if (prompted is null)
+                {
+                    return null;
+                }
+                current = prompted;
+            }
+
+            try
+            {
+                Guid sessionId = await _ftpSessionService
+                    .OpenSessionAsync(FtpConnectionInfo.FromProfile(current), cancellationToken)
+                    .ConfigureAwait(true);
+                AppSettings settings = _latestSettings ?? await LoadSettingsSnapshotAsync().ConfigureAwait(true);
+                var document = new SftpDocument(
+                    new SftpDocumentViewModel(
+                        current,
+                        sessionId,
+                        (id, token) => _ftpSessionService.CloseSessionAsync(id, token),
+                        _sftpService,
+                        settings.Transfer,
+                        FileTransfer,
+                        QueryDefaultEditorPathAsync));
+                Layout.AddDocument(document);
+                Sidebar.SessionTree?.SetSessionStatus(current.Id, SessionStatus.Connected);
+                return document;
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (VelaFtpCertificateException certificate)
+            {
+                // 用户同意信任 → 记下指纹后重来一次;拒绝(或没有提示钩子)→ 按普通连接失败上报。
+                if (FtpCertificateTrustPrompt is { } trustPrompt &&
+                    await trustPrompt(current, certificate).ConfigureAwait(true))
+                {
+                    current = WithTrustedCertificate(current, certificate.Thumbprint);
+                    await PersistFtpTrustAsync(current).ConfigureAwait(true);
+                    attempt--; // 信任后的这次重连不算认证重试
+                    continue;
+                }
+                LastConnectionError = certificate.Message;
+                StatusBar.Status = LastConnectionError;
+                return null;
+            }
+            catch (VelaFtpAuthenticationException)
+            {
+                continue;
+            }
+            catch (Exception ex)
+            {
+                LastConnectionError = DescribeConnectionError(ex, current);
+                StatusBar.Status = LastConnectionError;
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>FTP 缺少登录凭据时才需要弹登录框;匿名登录不需要用户名与口令。</summary>
+    private static bool RequiresFtpCredentials(SessionProfile profile) =>
+        profile.Ftp?.Anonymous != true &&
+        (string.IsNullOrWhiteSpace(profile.Username) || string.IsNullOrEmpty(profile.Password));
+
+    /// <summary>返回一份把服务器证书指纹记为已信任的配置副本。</summary>
+    private static SessionProfile WithTrustedCertificate(SessionProfile profile, string thumbprint)
+    {
+        FtpSettings settings = profile.Ftp?.Clone() ?? new FtpSettings();
+        settings.TrustedCertificateThumbprint = thumbprint;
+        profile.Ftp = settings;
+        return profile;
+    }
+
+    /// <summary>把新信任的证书指纹写回仓储(仅对已保存的配置;临时配置只在本次连接内有效)。</summary>
+    private async Task PersistFtpTrustAsync(SessionProfile profile)
+    {
+        if (_sessionRepository is null)
+        {
+            return;
+        }
+        try
+        {
+            if (await _sessionRepository.GetSessionAsync(profile.Id).ConfigureAwait(true) is not null)
+            {
+                await _sessionRepository.SaveSessionAsync(profile).ConfigureAwait(true);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            // 信任指纹没落盘不影响本次连接,下次会再问一遍。
+        }
     }
 
     /// <summary>

--- a/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
+++ b/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
@@ -9,7 +9,7 @@ namespace VelaShell.ViewModels;
 /// <summary>持有一个独立 SFTP 文档的全部状态与生命周期资源。</summary>
 public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
 {
-    private readonly IConnectionWorkflowService _workflow;
+    private readonly Func<Guid, CancellationToken, Task> _disconnectAsync;
     private readonly SerializedSftpService _serializedSftp;
     private readonly CancellationTokenSource _lifetime = new();
     private Task? _closeTask;
@@ -35,12 +35,40 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
         TransferOptions transferOptions,
         FileTransferViewModel? transferSink = null,
         Func<Task<string?>>? getDefaultEditorPath = null)
+        : this(profile,
+               (session ?? throw new ArgumentNullException(nameof(session))).SessionId,
+               (workflow ?? throw new ArgumentNullException(nameof(workflow))).DisconnectAsync,
+               sftpService,
+               transferOptions,
+               transferSink,
+               getDefaultEditorPath) =>
+        Session = session;
+
+    /// <summary>
+    /// 以「一个会话标识 + 一个断开回调」构造文档,不绑定具体协议。
+    /// FTP 会话走这条:它没有 <see cref="SshSession" />,也不经 <see cref="IConnectionWorkflowService" />
+    /// (那是 SSH 握手),但文件面板与传输栈完全共用 —— 它们只认 <see cref="ISftpService" /> + 会话标识。
+    /// </summary>
+    /// <param name="profile">用于建立连接的会话配置。</param>
+    /// <param name="sessionId">已建立的会话标识。</param>
+    /// <param name="disconnectAsync">关闭文档时断开该会话的回调。</param>
+    /// <param name="sftpService">底层远程文件服务,构造时会被包成本文档独占的串行化视图。</param>
+    /// <param name="transferOptions">设置 → 文件传输 的选项快照。</param>
+    /// <param name="transferSink">承载本文档所发起传输的浮动传输组件;为 null 时不上报进度。</param>
+    /// <param name="getDefaultEditorPath">解析「默认编辑器」的回调。</param>
+    public SftpDocumentViewModel(
+        SessionProfile profile,
+        Guid sessionId,
+        Func<Guid, CancellationToken, Task> disconnectAsync,
+        ISftpService sftpService,
+        TransferOptions transferOptions,
+        FileTransferViewModel? transferSink = null,
+        Func<Task<string?>>? getDefaultEditorPath = null)
     {
         Profile = profile ?? throw new ArgumentNullException(nameof(profile));
-        Session = session ?? throw new ArgumentNullException(nameof(session));
-        _workflow = workflow ?? throw new ArgumentNullException(nameof(workflow));
-        _serializedSftp = new SerializedSftpService(sftpService ?? throw new ArgumentNullException(nameof(sftpService)), session.SessionId);
-        SessionId = session.SessionId;
+        _disconnectAsync = disconnectAsync ?? throw new ArgumentNullException(nameof(disconnectAsync));
+        _serializedSftp = new SerializedSftpService(sftpService ?? throw new ArgumentNullException(nameof(sftpService)), sessionId);
+        SessionId = sessionId;
         Title = string.IsNullOrWhiteSpace(profile.Name) ? profile.Host : profile.Name;
         RemoteFiles = new FileBrowserViewModel(_serializedSftp, SessionId)
         {
@@ -65,8 +93,8 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
 
     /// <summary>用于建立连接的会话配置。</summary>
     public SessionProfile Profile { get; }
-    /// <summary>当前活跃的 SSH 会话。</summary>
-    public SshSession Session { get; }
+    /// <summary>当前活跃的 SSH 会话;FTP 文档没有 SSH 会话,为 null。</summary>
+    public SshSession? Session { get; }
     /// <summary>SSH 会话的唯一标识。</summary>
     public Guid SessionId { get; }
     /// <summary>SFTP 文档标签页的显示标题。</summary>
@@ -169,7 +197,7 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
         }
         finally
         {
-            await _workflow.DisconnectAsync(SessionId).ConfigureAwait(false);
+            await _disconnectAsync(SessionId, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -171,7 +171,7 @@
         </Grid>
       </Border>
 
-      <!-- 协议标签页:SSH/SFTP 可选;Telnet/串口保持禁用 -->
+      <!-- 协议标签页:SSH/SFTP/FTP 可选;Telnet/串口保持禁用 -->
       <Border Height="36" Padding="20,0"
               BorderThickness="0,0,0,1"
               BorderBrush="{DynamicResource VelaBorderPrimary}">
@@ -186,6 +186,11 @@
                     Command="{Binding SelectConnectionTypeCommand}"
                     CommandParameter="{x:Static models:ConnectionType.SFTP}">
               <TextBlock Classes="proto-label" Text="SFTP" FontWeight="Medium" />
+            </Button>
+            <Button x:Name="FtpTab" Classes="proto-tab" Classes.selected="{Binding IsFtpSelected}"
+                    Command="{Binding SelectConnectionTypeCommand}"
+                    CommandParameter="{x:Static models:ConnectionType.FTP}">
+              <TextBlock Classes="proto-label" Text="FTP" FontWeight="Medium" />
             </Button>
             <Border Classes="proto-tab" IsEnabled="False" ToolTip.Tip="{loc:Localize Profile_NotSupported}">
               <TextBlock Classes="proto-label" Text="Telnet"
@@ -236,17 +241,56 @@
             <TextBlock Classes="field-label" Text="{loc:Localize Username}" />
             <TextBox Text="{Binding Username}" PlaceholderText="root" />
           </StackPanel>
-          <StackPanel Grid.Column="2">
+          <StackPanel Grid.Column="2" IsVisible="{Binding RequiresSshAuth}">
             <TextBlock Classes="field-label" Text="{loc:Localize AuthMethodLabel}" />
             <ComboBox SelectedIndex="{Binding AuthMethodIndex}">
               <ComboBoxItem Content="{loc:Localize Profile_PasswordAuth}" />
               <ComboBoxItem Content="{loc:Localize Profile_KeyAuth}" />
             </ComboBox>
           </StackPanel>
+          <!-- FTP 没有私钥认证,这一格换成加密方式 -->
+          <StackPanel Grid.Column="2" IsVisible="{Binding IsFtpSelected}">
+            <TextBlock Classes="field-label" Text="{loc:Localize Ftp_Encryption}" />
+            <ComboBox SelectedIndex="{Binding FtpEncryptionIndex}">
+              <ComboBoxItem Content="{loc:Localize Ftp_EncryptionAuto}" />
+              <ComboBoxItem Content="{loc:Localize Ftp_EncryptionExplicit}" />
+              <ComboBoxItem Content="{loc:Localize Ftp_EncryptionImplicit}" />
+              <ComboBoxItem Content="{loc:Localize Ftp_EncryptionNone}" />
+            </ComboBox>
+          </StackPanel>
         </Grid>
 
-        <!-- 密码(密码认证) -->
-        <StackPanel IsVisible="{Binding IsPasswordAuth}">
+        <!-- FTP 专属:匿名登录 + 被动模式 -->
+        <StackPanel Orientation="Horizontal" Spacing="16" IsVisible="{Binding IsFtpSelected}">
+          <CheckBox IsChecked="{Binding FtpAnonymous}"
+                    Padding="0" MinHeight="0" VerticalAlignment="Center">
+            <TextBlock Text="{loc:Localize Ftp_Anonymous}"
+                       Margin="6,0,0,0"
+                       Foreground="{DynamicResource VelaTextSecondary}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+          </CheckBox>
+          <CheckBox IsChecked="{Binding FtpPassive}"
+                    Padding="0" MinHeight="0" VerticalAlignment="Center"
+                    ToolTip.Tip="{loc:Localize Ftp_PassiveHint}">
+            <TextBlock Text="{loc:Localize Ftp_Passive}"
+                       Margin="6,0,0,0"
+                       Foreground="{DynamicResource VelaTextSecondary}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+          </CheckBox>
+        </StackPanel>
+
+        <!-- 明文 FTP 的安全提示:与 SSH 不同,它没有主机身份校验,也不加密 -->
+        <Border Padding="10,7" CornerRadius="4"
+                Background="{DynamicResource VelaBgInput}"
+                BorderBrush="#66FFB020" BorderThickness="1"
+                IsVisible="{Binding ShowFtpPlaintextWarning}">
+          <TextBlock Text="{loc:Localize Ftp_PlaintextWarn}"
+                     Foreground="{DynamicResource VelaTextSecondary}"
+                     FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" />
+        </Border>
+
+        <!-- 密码(密码认证;匿名 FTP 不需要) -->
+        <StackPanel IsVisible="{Binding ShowPasswordField}">
           <TextBlock Classes="field-label" Text="{loc:Localize Password}" />
           <Border Classes="input-affix">
             <Grid ColumnDefinitions="*,Auto">
@@ -271,8 +315,9 @@
           </Border>
         </StackPanel>
 
-        <!-- 私钥(密钥认证) -->
-        <StackPanel IsVisible="{Binding IsKeyAuth}" Spacing="14">
+        <!-- 私钥(密钥认证;FTP 不支持) -->
+        <StackPanel IsVisible="{Binding IsKeyAuth}" Spacing="14"
+                    IsEnabled="{Binding RequiresSshAuth}">
           <StackPanel>
             <TextBlock Classes="field-label" Text="{loc:Localize Profile_PrivateKeyFile}" />
             <Grid ColumnDefinitions="*,8,Auto">
@@ -292,7 +337,7 @@
 
         <!-- 记住密码 -->
         <StackPanel Orientation="Horizontal" Spacing="8"
-                    IsVisible="{Binding IsPasswordAuth}">
+                    IsVisible="{Binding ShowPasswordField}">
           <CheckBox IsChecked="{Binding RememberPassword}"
                     Padding="0" MinHeight="0" VerticalAlignment="Center">
             <TextBlock Text="{loc:Localize Profile_RememberPassword}"

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 using ReactiveUI.Primitives;
+using VelaShell.Core.Models;
 using VelaShell.Core.Resources;
 using VelaShell.ViewModels;
 
@@ -29,7 +30,7 @@ public partial class ConnectionProfileView : Window
     }
 
     /// <summary>
-    /// 把滑动下划线对齐到当前协议标签(SSH/SFTP):首次落位不动画,此后位置与宽度经
+    /// 把滑动下划线对齐到当前协议标签(SSH/SFTP/FTP):首次落位不动画,此后位置与宽度经
     /// 180ms 过渡滑动 —— 取代旧实现里两个按钮各自下划线的瞬时跳变。
     /// </summary>
     private void UpdateProtoTabIndicator()
@@ -38,7 +39,14 @@ public partial class ConnectionProfileView : Window
         {
             return;
         }
-        Button target = viewModel.IsSftpSelected ? SftpTab : SshTab;
+        // 曾是「IsSftpSelected ? SftpTab : SshTab」的二元三目 —— 加第三个协议时必须改成按枚举分派,
+        // 否则 FTP 选中后下划线会停在 SSH 上。
+        Button target = viewModel.ConnectionType switch
+        {
+            ConnectionType.SFTP => SftpTab,
+            ConnectionType.FTP => FtpTab,
+            _ => SshTab
+        };
         if (target.Bounds.Width <= 0)
         {
             return;

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -11,6 +11,7 @@ using ReactiveUI;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Diagnostics;
+using VelaShell.Core.Ftp;
 using VelaShell.Core.Import;
 using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
@@ -204,6 +205,7 @@ public partial class MainWindow : Window
             vm.NewConnectionRequested += (_, _) => _ = OpenProfileDialogAsync(null);
             vm.SettingsRequested += (_, _) => _ = OpenSettingsAsync();
             vm.InteractiveAuthenticator = PromptCredentialsAsync;
+            vm.FtpCertificateTrustPrompt = PromptFtpCertificateTrustAsync;
             vm.MultilinePasteConfirmer = ConfirmMultilinePasteAsync;
             vm.ZModemDownloadFolderPicker = PromptForZModemDownloadFolderAsync;
             vm.ZModemUploadFilePicker = PromptForZModemUploadFilesAsync;
@@ -1087,6 +1089,38 @@ public partial class MainWindow : Window
     /// 登录验证流程(设计:身份验证 第1步/第2步):补全用户名与认证凭据。
     /// 一次只弹一扇(见 <see cref="_credentialPromptGate" />),排队的连接依次拿到弹窗。
     /// </summary>
+    /// <summary>
+    /// FTPS 证书未通过校验时的信任提示。把指纹与主体摊开给用户看,确认后由 VM 记进配置并重连。
+    /// <para>
+    /// 这条链路刻意做成「连接失败 → 提示 → 重连」而不是在 TLS 回调里同步等用户点按钮:
+    /// 后者要把异步对话框阻塞成同步,极易死锁(FTP 的证书回调不保证在哪个线程上触发)。
+    /// </para>
+    /// </summary>
+    private async Task<bool> PromptFtpCertificateTrustAsync(SessionProfile profile, VelaFtpCertificateException certificate)
+    {
+        string message = string.Join(Environment.NewLine,
+            Strings.Format("Ftp_CertUntrustedFmt", profile.Host),
+            string.Empty,
+            $"{Strings.Get("Ftp_CertSubject")}: {certificate.Subject}",
+            $"{Strings.Get("Ftp_CertIssuer")}: {certificate.Issuer}",
+            $"{Strings.Get("Ftp_CertExpires")}: {certificate.ExpiresOn:yyyy-MM-dd}",
+            $"{Strings.Get("Ftp_CertFingerprint")}: {FormatThumbprint(certificate.Thumbprint)}",
+            $"{Strings.Get("Ftp_CertProblem")}: {certificate.PolicyErrors}");
+        return await MessageDialog.ConfirmAsync(this,
+            Strings.Get("Ftp_CertTitle"),
+            message,
+            Strings.Get("Ftp_CertTrust"),
+            Strings.Cancel,
+            MessageDialogKind.Warning,
+            danger: true);
+    }
+
+    /// <summary>指纹按每两字节加冒号分组,便于与服务器端比对。</summary>
+    private static string FormatThumbprint(string thumbprint) =>
+        thumbprint.Length < 2
+            ? thumbprint
+            : string.Join(':', Enumerable.Range(0, thumbprint.Length / 2).Select(i => thumbprint.Substring(i * 2, 2)));
+
     private async Task<SessionProfile?> PromptCredentialsAsync(SessionProfile profile)
     {
         // 不带 ConfigureAwait(false):后续 ShowDialog 必须回到 UI 线程。

--- a/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
@@ -104,6 +104,53 @@ public class ModelSerializationTests
         Assert.AreEqual(ConnectionType.SSH, invalid!.ConnectionType);
     }
 
+    /// <summary>
+    /// FTP 协议与其专属设置的往返。枚举钳制已从「逐值三元」换成 Enum.IsDefined 白名单,
+    /// 语义不变(未知值仍降级为 SSH,见上一条测试),但新协议不再被静默改写成 SSH。
+    /// </summary>
+    [TestMethod]
+    public void SessionProfile_Ftp_RoundTripsTypeAndSettings()
+    {
+        SessionProfile ftp = new()
+        {
+            ConnectionType = ConnectionType.FTP,
+            Host = "ftp.example.com",
+            Port = 990,
+            Ftp = new FtpSettings
+            {
+                EncryptionMode = FtpEncryptionMode.Implicit,
+                DataConnectionMode = FtpDataConnectionMode.Active,
+                Anonymous = true,
+                TrustedCertificateThumbprint = "AABBCC",
+                MaxConnections = 6,
+            },
+        };
+
+        string json = JsonSerializer.Serialize(ftp, _options);
+        SessionProfile? roundTrip = JsonSerializer.Deserialize<SessionProfile>(json, _options);
+
+        Assert.IsNotNull(roundTrip);
+        Assert.AreEqual(ConnectionType.FTP, roundTrip!.ConnectionType);
+        Assert.IsNotNull(roundTrip.Ftp);
+        Assert.AreEqual(FtpEncryptionMode.Implicit, roundTrip.Ftp!.EncryptionMode);
+        Assert.AreEqual(FtpDataConnectionMode.Active, roundTrip.Ftp.DataConnectionMode);
+        Assert.IsTrue(roundTrip.Ftp.Anonymous);
+        Assert.AreEqual("AABBCC", roundTrip.Ftp.TrustedCertificateThumbprint);
+        Assert.AreEqual(6, roundTrip.Ftp.MaxConnections);
+    }
+
+    /// <summary>非 FTP 配置不带 Ftp 块 —— 旧版本读到的 JSON 结构不变。</summary>
+    [TestMethod]
+    public void SessionProfile_NonFtp_OmitsFtpSettings()
+    {
+        SessionProfile? roundTrip = JsonSerializer.Deserialize<SessionProfile>(
+            JsonSerializer.Serialize(new SessionProfile { ConnectionType = ConnectionType.SSH }, _options),
+            _options);
+
+        Assert.IsNotNull(roundTrip);
+        Assert.IsNull(roundTrip!.Ftp);
+    }
+
     [TestMethod]
     public void AppearanceOptions_BackgroundImage_DefaultsAndRoundTrip()
     {

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
@@ -1,0 +1,222 @@
+using System.Text;
+using VelaShell.Core.Ftp;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+using VelaShell.Infrastructure.Ftp;
+
+namespace VelaShell.Infrastructure.Tests.Ftp;
+
+/// <summary>
+/// <see cref="FtpFileService" /> 打通真实 FTP 协议的端到端验证:对着
+/// <see cref="LoopbackFtpServer" />(进程内、纯明文)跑登录、列目录、传输与目录操作。
+/// <para>
+/// 这里验证的是 Mock 验不到的那一段:PASV/EPSV 数据连接、Unix LIST 输出到
+/// <see cref="RemoteFileInfo" /> 的解析、以及连接池在并发下真的开了多条控制连接。
+/// FTPS 与 TLS 会话复用需要真实服务器(见 docs/FTP客户端可行性调研.md 第五节风险 1),不在此列。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("Ftp")]
+public class FtpFileServiceIntegrationTests
+{
+    private string _root = string.Empty;
+    private LoopbackFtpServer _server = null!;
+    private FtpFileService _service = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"vela-ftp-root-{Guid.NewGuid():N}");
+        _server = new LoopbackFtpServer(_root);
+        _service = new FtpFileService();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _service.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _server.Dispose();
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, true);
+            }
+        }
+        catch (IOException)
+        {
+            // 临时目录删不掉不影响断言。
+        }
+    }
+
+    [TestMethod]
+    public async Task OpenSession_ThenList_ParsesEntriesFromUnixListing()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "readme.txt"), "hello ftp");
+        Directory.CreateDirectory(Path.Combine(_root, "logs"));
+
+        Guid sessionId = await OpenAsync();
+
+        Assert.IsTrue(_service.OwnsSession(sessionId), "打开后该会话应归 FTP 后端所有(路由据此分派)。");
+        Assert.AreEqual("/", await _service.GetWorkingDirectoryAsync(sessionId));
+
+        List<RemoteFileInfo> entries = await _service.ListDirectoryAsync(sessionId, "/");
+
+        Assert.HasCount(2, entries);
+        RemoteFileInfo file = entries.Single(e => e.Name == "readme.txt");
+        Assert.IsFalse(file.IsDirectory);
+        Assert.AreEqual(9, file.Size);
+        Assert.AreEqual("rw-r--r--", file.Permissions);   // 首位类型字符已剥掉
+        Assert.AreEqual("deploy", file.Owner);            // FTP 给的是名字,不是 UID
+        Assert.AreEqual("staff", file.Group);
+        Assert.IsTrue(entries.Single(e => e.Name == "logs").IsDirectory);
+    }
+
+    [TestMethod]
+    public async Task UploadThenDownload_RoundTripsContent()
+    {
+        Guid sessionId = await OpenAsync();
+        string localSource = Path.Combine(_root, "..", $"vela-ftp-src-{Guid.NewGuid():N}.bin");
+        string localTarget = $"{localSource}.out";
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 40_000) + "-tail");
+        await File.WriteAllBytesAsync(localSource, payload);
+        try
+        {
+            var uploadReports = new List<TransferProgress>();
+            await _service.UploadFileAsync(sessionId, localSource, "/uploaded.bin",
+                new Progress<TransferProgress>(uploadReports.Add));
+
+            string remoteOnDisk = Path.Combine(_root, "uploaded.bin");
+            Assert.IsTrue(File.Exists(remoteOnDisk), "上传后服务器根目录下应出现该文件。");
+            Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(remoteOnDisk));
+            Assert.IsTrue(await _service.ExistsAsync(sessionId, "/uploaded.bin"));
+
+            RemoteFileInfo info = await _service.GetFileInfoAsync(sessionId, "/uploaded.bin");
+            Assert.AreEqual(payload.Length, info.Size);
+
+            await _service.DownloadFileAsync(sessionId, "/uploaded.bin", localTarget);
+            Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(localTarget));
+        }
+        finally
+        {
+            File.Delete(localSource);
+            File.Delete(localTarget);
+        }
+    }
+
+    [TestMethod]
+    public async Task OpenRead_StreamsSequentially_AndReleasesConnectionOnDispose()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_root, "log.txt"), "line-1\nline-2\n");
+        Guid sessionId = await OpenAsync();
+
+        string content;
+        await using (Stream stream = await _service.OpenReadAsync(sessionId, "/log.txt"))
+        {
+            Assert.IsFalse(stream.CanSeek, "FTP 数据流不可 Seek —— 这正是不能实现 ISftpClientWrapper 的原因。");
+            using var reader = new StreamReader(stream);
+            content = await reader.ReadToEndAsync();
+        }
+
+        Assert.AreEqual("line-1\nline-2\n", content);
+        // 流释放后连接必须已归还池子,否则后续操作会一直等在信号量上。
+        List<RemoteFileInfo> entries = await _service.ListDirectoryAsync(sessionId, "/");
+        Assert.HasCount(1, entries);
+    }
+
+    [TestMethod]
+    public async Task DirectoryOperations_CreateRenameDelete()
+    {
+        Guid sessionId = await OpenAsync();
+
+        await _service.CreateDirectoryAsync(sessionId, "/data");
+        Assert.IsTrue(Directory.Exists(Path.Combine(_root, "data")));
+
+        await _service.CreateFileAsync(sessionId, "/data/note.txt");
+        Assert.IsTrue(File.Exists(Path.Combine(_root, "data", "note.txt")));
+
+        await _service.RenameAsync(sessionId, "/data/note.txt", "/data/renamed.txt");
+        Assert.IsTrue(File.Exists(Path.Combine(_root, "data", "renamed.txt")));
+
+        var deleteReports = new List<SftpDeleteProgress>();
+        await _service.DeleteAsync(sessionId, "/data", new Progress<SftpDeleteProgress>(deleteReports.Add));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_root, "data")), "递归删除应连同目录本身一起删掉。");
+    }
+
+    [TestMethod]
+    public async Task MissingPath_TranslatesToPathNotFound()
+    {
+        Guid sessionId = await OpenAsync();
+
+        await Assert.ThrowsExactlyAsync<VelaFtpPathNotFoundException>(
+            () => _service.GetFileInfoAsync(sessionId, "/nope.txt"));
+        Assert.IsFalse(await _service.ExistsAsync(sessionId, "/nope.txt"));
+    }
+
+    [TestMethod]
+    public async Task ConcurrentTransfers_UseSeparatePooledConnections()
+    {
+        // FTP 一条控制连接同时只能跑一条命令:并发传输必须落到不同连接上,否则会互相打架。
+        for (int i = 0; i < 4; i++)
+        {
+            await File.WriteAllTextAsync(Path.Combine(_root, $"f{i}.txt"), new string((char)('a' + i), 2048));
+        }
+        Guid sessionId = await OpenAsync(maxConnections: 3);
+        string outDir = Path.Combine(Path.GetTempPath(), $"vela-ftp-out-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            await Task.WhenAll(Enumerable.Range(0, 4).Select(i =>
+                _service.DownloadFileAsync(sessionId, $"/f{i}.txt", Path.Combine(outDir, $"f{i}.txt"))));
+
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.AreEqual(2048, new FileInfo(Path.Combine(outDir, $"f{i}.txt")).Length);
+            }
+            Assert.IsGreaterThan(1, _server.AcceptedConnections, "并发传输应开出不止一条控制连接。");
+            Assert.IsLessThanOrEqualTo(3, _server.AcceptedConnections, "连接数不得超过 MaxConnections。");
+        }
+        finally
+        {
+            Directory.Delete(outDir, true);
+        }
+    }
+
+    [TestMethod]
+    public async Task AnonymousLogin_SendsAnonymousCredentials()
+    {
+        Guid sessionId = await OpenAsync(anonymous: true);
+
+        Assert.IsTrue(_service.OwnsSession(sessionId));
+        Assert.AreEqual(FtpConnectionInfo.AnonymousUser, _server.LastUser);
+        Assert.IsNotEmpty(_server.LastPassword ?? string.Empty);
+    }
+
+    [TestMethod]
+    public async Task CloseSession_ReleasesOwnership()
+    {
+        Guid sessionId = await OpenAsync();
+        Assert.IsTrue(_service.OwnsSession(sessionId));
+
+        await _service.CloseSessionAsync(sessionId);
+
+        Assert.IsFalse(_service.OwnsSession(sessionId));
+        await Assert.ThrowsExactlyAsync<VelaFtpConnectionException>(
+            () => _service.ListDirectoryAsync(sessionId, "/"));
+    }
+
+    private Task<Guid> OpenAsync(int maxConnections = 2, bool anonymous = false) =>
+        _service.OpenSessionAsync(new FtpConnectionInfo
+        {
+            Host = "127.0.0.1",
+            Port = _server.Port,
+            Username = anonymous ? string.Empty : "deploy",
+            Password = anonymous ? null : "secret123",
+            Settings = new FtpSettings
+            {
+                EncryptionMode = FtpEncryptionMode.None,
+                Anonymous = anonymous,
+                MaxConnections = maxConnections,
+            },
+        });
+}

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
@@ -1,0 +1,451 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace VelaShell.Infrastructure.Tests.Ftp;
+
+/// <summary>
+/// 仅供测试使用的环回 FTP 服务器:把一个临时目录当作 FTP 根,实现 RFC 959 里
+/// 客户端跑通「登录 → 列目录 → 上传/下载/改名/删除」所需的最小命令集。
+/// <para>
+/// 为什么自己写:CI 与开发机不保证能拉到 vsftpd 镜像,而只用 Mock 验证不了
+/// 「FluentFTP 到底能不能跟一个真服务器把 PASV 数据连接跑通、LIST 输出能不能被解析成
+/// <c>RemoteFileInfo</c>」—— 那正是这套后端最容易出错、也最值得守住的部分。
+/// </para>
+/// <para>
+/// 刻意**不**在 FEAT 里通告 MLSD:强制客户端走 Unix 风格 LIST 解析,那是真实老服务器上的
+/// 常见路径,也是权限/属主字符串真正被解析出来的路径。
+/// </para>
+/// </summary>
+internal sealed class LoopbackFtpServer : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<Task> _clients = [];
+    private readonly Lock _sync = new();
+
+    public LoopbackFtpServer(string rootDirectory)
+    {
+        Root = rootDirectory;
+        Directory.CreateDirectory(Root);
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _ = Task.Run(AcceptLoopAsync);
+    }
+
+    /// <summary>FTP 根目录在本地磁盘上的位置。</summary>
+    public string Root { get; }
+
+    /// <summary>监听端口(随机分配,避免与本机既有服务冲突)。</summary>
+    public int Port { get; }
+
+    /// <summary>最近一次登录使用的用户名(用于断言匿名登录)。</summary>
+    public string? LastUser { get; private set; }
+
+    /// <summary>最近一次登录使用的口令。</summary>
+    public string? LastPassword { get; private set; }
+
+    /// <summary>已接受的控制连接数(用于断言连接池确实开了多条连接)。</summary>
+    public int AcceptedConnections;
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _cts.Dispose();
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or SocketException or ObjectDisposedException)
+            {
+                return;
+            }
+            Interlocked.Increment(ref AcceptedConnections);
+            Task session = Task.Run(() => HandleClientAsync(client));
+            lock (_sync)
+            {
+                _clients.Add(session);
+            }
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client)
+    {
+        using (client)
+        {
+            var state = new SessionState();
+            NetworkStream stream = client.GetStream();
+            using var reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
+            using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 VelaShell loopback FTP").ConfigureAwait(false);
+            while (!_cts.IsCancellationRequested)
+            {
+                string? line;
+                try
+                {
+                    line = await reader.ReadLineAsync(_cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is IOException or OperationCanceledException)
+                {
+                    return;
+                }
+                if (line is null)
+                {
+                    return;
+                }
+                int space = line.IndexOf(' ');
+                string command = (space < 0 ? line : line[..space]).ToUpperInvariant();
+                string argument = space < 0 ? string.Empty : line[(space + 1)..].Trim();
+                if (!await ExecuteAsync(command, argument, state, writer).ConfigureAwait(false))
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    /// <summary>执行一条命令;返回 false 表示会话结束(QUIT)。</summary>
+    private async Task<bool> ExecuteAsync(string command, string argument, SessionState state, StreamWriter writer)
+    {
+        switch (command)
+        {
+            case "USER":
+                LastUser = argument;
+                await writer.WriteLineAsync("331 Need password").ConfigureAwait(false);
+                return true;
+            case "PASS":
+                LastPassword = argument;
+                await writer.WriteLineAsync("230 Logged in").ConfigureAwait(false);
+                return true;
+            case "SYST":
+                await writer.WriteLineAsync("215 UNIX Type: L8").ConfigureAwait(false);
+                return true;
+            case "FEAT":
+                // 只通告 SIZE / REST / UTF8:不给 MLSD,逼客户端走 Unix LIST 解析。
+                await writer.WriteLineAsync("211-Features:").ConfigureAwait(false);
+                await writer.WriteLineAsync(" SIZE").ConfigureAwait(false);
+                await writer.WriteLineAsync(" REST STREAM").ConfigureAwait(false);
+                await writer.WriteLineAsync(" UTF8").ConfigureAwait(false);
+                await writer.WriteLineAsync("211 End").ConfigureAwait(false);
+                return true;
+            case "OPTS":
+            case "TYPE":
+            case "NOOP":
+                await writer.WriteLineAsync("200 OK").ConfigureAwait(false);
+                return true;
+            case "PWD":
+            case "XPWD":
+                await writer.WriteLineAsync($"257 \"{state.WorkingDirectory}\" is current directory").ConfigureAwait(false);
+                return true;
+            case "CWD":
+                state.WorkingDirectory = Normalize(state, argument);
+                await writer.WriteLineAsync(Directory.Exists(Local(state.WorkingDirectory))
+                    ? "250 Directory changed"
+                    : "550 No such directory").ConfigureAwait(false);
+                return true;
+            case "REST":
+                state.RestartOffset = long.TryParse(argument, out long offset) ? offset : 0;
+                await writer.WriteLineAsync("350 Restarting").ConfigureAwait(false);
+                return true;
+            case "PASV":
+                await OpenPassiveAsync(state, writer, extended: false).ConfigureAwait(false);
+                return true;
+            case "EPSV":
+                await OpenPassiveAsync(state, writer, extended: true).ConfigureAwait(false);
+                return true;
+            case "LIST":
+            case "NLST":
+                await SendListingAsync(state, argument, writer, command == "NLST").ConfigureAwait(false);
+                return true;
+            case "SIZE":
+            {
+                string path = Local(Normalize(state, argument));
+                await writer.WriteLineAsync(File.Exists(path)
+                    ? $"213 {new FileInfo(path).Length}"
+                    : "550 Not found").ConfigureAwait(false);
+                return true;
+            }
+            case "MDTM":
+            {
+                string path = Local(Normalize(state, argument));
+                await writer.WriteLineAsync(File.Exists(path)
+                    ? $"213 {File.GetLastWriteTimeUtc(path):yyyyMMddHHmmss}"
+                    : "550 Not found").ConfigureAwait(false);
+                return true;
+            }
+            case "RETR":
+                await SendFileAsync(state, argument, writer).ConfigureAwait(false);
+                return true;
+            case "STOR":
+            case "APPE":
+                await ReceiveFileAsync(state, argument, writer, append: command == "APPE").ConfigureAwait(false);
+                return true;
+            case "DELE":
+            {
+                string path = Local(Normalize(state, argument));
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                    await writer.WriteLineAsync("250 Deleted").ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
+                }
+                return true;
+            }
+            case "MKD":
+            case "XMKD":
+            {
+                string remote = Normalize(state, argument);
+                Directory.CreateDirectory(Local(remote));
+                await writer.WriteLineAsync($"257 \"{remote}\" created").ConfigureAwait(false);
+                return true;
+            }
+            case "RMD":
+            case "XRMD":
+            {
+                string path = Local(Normalize(state, argument));
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                    await writer.WriteLineAsync("250 Removed").ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
+                }
+                return true;
+            }
+            case "RNFR":
+                state.RenameFrom = Local(Normalize(state, argument));
+                await writer.WriteLineAsync("350 Ready for destination").ConfigureAwait(false);
+                return true;
+            case "RNTO":
+            {
+                string target = Local(Normalize(state, argument));
+                if (state.RenameFrom is { } source && (File.Exists(source) || Directory.Exists(source)))
+                {
+                    if (Directory.Exists(source))
+                    {
+                        Directory.Move(source, target);
+                    }
+                    else
+                    {
+                        File.Move(source, target, true);
+                    }
+                    await writer.WriteLineAsync("250 Renamed").ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteLineAsync("550 Rename failed").ConfigureAwait(false);
+                }
+                state.RenameFrom = null;
+                return true;
+            }
+            case "SITE":
+                // SITE CHMOD:真实服务器上是可选命令,这里接受并忽略,足以验证调用链路。
+                await writer.WriteLineAsync("200 OK").ConfigureAwait(false);
+                return true;
+            case "QUIT":
+                await writer.WriteLineAsync("221 Bye").ConfigureAwait(false);
+                return false;
+            default:
+                await writer.WriteLineAsync("500 Unknown command").ConfigureAwait(false);
+                return true;
+        }
+    }
+
+    private async Task OpenPassiveAsync(SessionState state, StreamWriter writer, bool extended)
+    {
+        state.CloseData();
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        state.DataListener = listener;
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        if (extended)
+        {
+            await writer.WriteLineAsync($"229 Entering Extended Passive Mode (|||{port}|)").ConfigureAwait(false);
+        }
+        else
+        {
+            await writer.WriteLineAsync(
+                $"227 Entering Passive Mode (127,0,0,1,{port / 256},{port % 256})").ConfigureAwait(false);
+        }
+    }
+
+    private async Task SendListingAsync(SessionState state, string argument, StreamWriter writer, bool namesOnly)
+    {
+        // 客户端有时会给 LIST 带上 -a / -l 这类参数,得剥掉再当路径用。
+        string cleaned = string.Join(' ', argument.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(static token => !token.StartsWith('-')));
+        string remote = Normalize(state, cleaned);
+        string local = Local(remote);
+        if (!Directory.Exists(local))
+        {
+            await writer.WriteLineAsync("550 No such directory").ConfigureAwait(false);
+            return;
+        }
+        var payload = new StringBuilder();
+        foreach (string directory in Directory.GetDirectories(local))
+        {
+            var info = new DirectoryInfo(directory);
+            payload.Append(namesOnly ? info.Name : FormatEntry(info.Name, 4096, info.LastWriteTime, isDirectory: true)).Append("\r\n");
+        }
+        foreach (string file in Directory.GetFiles(local))
+        {
+            var info = new FileInfo(file);
+            payload.Append(namesOnly ? info.Name : FormatEntry(info.Name, info.Length, info.LastWriteTime, isDirectory: false)).Append("\r\n");
+        }
+        await writer.WriteLineAsync("150 Opening data connection").ConfigureAwait(false);
+        await using (Stream data = await state.AcceptDataAsync().ConfigureAwait(false))
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(payload.ToString());
+            await data.WriteAsync(bytes).ConfigureAwait(false);
+        }
+        state.CloseData();
+        await writer.WriteLineAsync("226 Transfer complete").ConfigureAwait(false);
+    }
+
+    private async Task SendFileAsync(SessionState state, string argument, StreamWriter writer)
+    {
+        string path = Local(Normalize(state, argument));
+        if (!File.Exists(path))
+        {
+            await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
+            return;
+        }
+        await writer.WriteLineAsync("150 Opening data connection").ConfigureAwait(false);
+        await using (Stream data = await state.AcceptDataAsync().ConfigureAwait(false))
+        await using (FileStream source = File.OpenRead(path))
+        {
+            if (state.RestartOffset > 0 && state.RestartOffset <= source.Length)
+            {
+                source.Seek(state.RestartOffset, SeekOrigin.Begin);
+            }
+            await source.CopyToAsync(data).ConfigureAwait(false);
+        }
+        state.RestartOffset = 0;
+        state.CloseData();
+        await writer.WriteLineAsync("226 Transfer complete").ConfigureAwait(false);
+    }
+
+    private async Task ReceiveFileAsync(SessionState state, string argument, StreamWriter writer, bool append)
+    {
+        string path = Local(Normalize(state, argument));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await writer.WriteLineAsync("150 Opening data connection").ConfigureAwait(false);
+        await using (Stream data = await state.AcceptDataAsync().ConfigureAwait(false))
+        await using (FileStream target = append || state.RestartOffset > 0
+                         ? new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.None)
+                         : new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            await data.CopyToAsync(target).ConfigureAwait(false);
+        }
+        state.RestartOffset = 0;
+        state.CloseData();
+        await writer.WriteLineAsync("226 Transfer complete").ConfigureAwait(false);
+    }
+
+    /// <summary>Unix 风格的 LIST 行:权限、链接数、属主、属组、大小、时间、名称。</summary>
+    private static string FormatEntry(string name, long length, DateTime modified, bool isDirectory)
+    {
+        string permissions = isDirectory ? "drwxr-xr-x" : "-rw-r--r--";
+        string timestamp = modified.ToString("MMM dd HH:mm", CultureInfo.InvariantCulture);
+        return $"{permissions}   1 deploy   staff {length,12} {timestamp} {name}";
+    }
+
+    /// <summary>把客户端给的相对/绝对路径规整成以 / 开头的远端绝对路径。</summary>
+    private static string Normalize(SessionState state, string path)
+    {
+        string candidate = string.IsNullOrWhiteSpace(path)
+            ? state.WorkingDirectory
+            : path.StartsWith('/') ? path : $"{state.WorkingDirectory.TrimEnd('/')}/{path}";
+        var segments = new List<string>();
+        foreach (string segment in candidate.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+            if (segment == "..")
+            {
+                if (segments.Count > 0)
+                {
+                    segments.RemoveAt(segments.Count - 1);
+                }
+                continue;
+            }
+            segments.Add(segment);
+        }
+        return "/" + string.Join('/', segments);
+    }
+
+    /// <summary>远端绝对路径 → 本地磁盘路径(始终限制在根目录内)。</summary>
+    private string Local(string remote) =>
+        Path.GetFullPath(Path.Combine(Root, remote.TrimStart('/').Replace('/', Path.DirectorySeparatorChar)));
+
+    private sealed class SessionState
+    {
+        public string WorkingDirectory { get; set; } = "/";
+        public long RestartOffset { get; set; }
+        public string? RenameFrom { get; set; }
+        public TcpListener? DataListener { get; set; }
+
+        public async Task<Stream> AcceptDataAsync()
+        {
+            TcpListener listener = DataListener ?? throw new InvalidOperationException("No PASV/EPSV issued.");
+            TcpClient client = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
+            return new DataStream(client);
+        }
+
+        public void CloseData()
+        {
+            DataListener?.Stop();
+            DataListener = null;
+        }
+    }
+
+    /// <summary>数据连接:释放流即关闭连接(FTP 用连接关闭表示传输结束)。</summary>
+    private sealed class DataStream(TcpClient client) : Stream
+    {
+        private readonly NetworkStream _inner = client.GetStream();
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                client.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/FtpSupportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/FtpSupportTests.cs
@@ -1,0 +1,225 @@
+using System.Text;
+using FluentFTP.Exceptions;
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Ftp;
+using VelaShell.Core.Import;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+using VelaShell.Infrastructure.Ftp;
+using VelaShell.Infrastructure.Import;
+using VelaShell.Infrastructure.Sftp;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>
+/// FTP / FTPS 支持:导入器的协议映射、远程文件服务的会话路由、库异常翻译。
+/// 需要真实服务器的连通性验证不在这里(见 docs/FTP客户端可行性调研.md 第五节的 Docker 矩阵)。
+/// </summary>
+[TestClass]
+[TestCategory("Ftp")]
+public class FtpSupportTests
+{
+    /// <summary>WinSCP 的 FTP 会话(FSProtocol=5)现在应被判为受支持,并按 Ftps 值带出加密方式。</summary>
+    [TestMethod]
+    [DataRow(3, FtpEncryptionMode.Explicit, 21)]   // 显式 TLS
+    [DataRow(2, FtpEncryptionMode.Explicit, 21)]   // 显式 SSL
+    [DataRow(1, FtpEncryptionMode.Implicit, 990)]  // 隐式
+    [DataRow(0, FtpEncryptionMode.None, 21)]       // 明文
+    public async Task WinScp_FtpSession_IsSupported_WithEncryptionAndDefaultPort(int ftps, FtpEncryptionMode expected, int expectedPort)
+    {
+        string ini = Path.Combine(Path.GetTempPath(), $"winscp-ftp-{Guid.NewGuid():N}.ini");
+        await File.WriteAllTextAsync(ini,
+            $"""
+             [Configuration\Security]
+             UseMasterPassword=0
+             [Sessions\files]
+             HostName=ftp.example.com
+             UserName=deploy
+             FSProtocol=5
+             Ftps={ftps}
+             """);
+        try
+        {
+            SessionImportScan scan = await ScanWinScpAsync(ini);
+
+            Assert.HasCount(1, scan.Items);
+            ImportedSession item = scan.Items[0];
+            Assert.AreEqual(ConnectionType.FTP, item.ConnectionType);
+            Assert.IsTrue(item.IsSupported, "FTP 会话应可导入(加入 ConnectionType.FTP 之前它被标为不支持)。");
+            Assert.AreEqual("FTP", item.Protocol);
+            Assert.IsNotNull(item.FtpSettings);
+            Assert.AreEqual(expected, item.FtpSettings.EncryptionMode);
+            // 端口缺省值按协议给:不能再落到 SSH 的 22。
+            Assert.AreEqual(expectedPort, item.Port);
+        }
+        finally
+        {
+            File.Delete(ini);
+        }
+    }
+
+    /// <summary>WebDAV / S3 仍然不受支持 —— 这次只放开了 FTP。</summary>
+    [TestMethod]
+    [DataRow(6)]
+    [DataRow(7)]
+    public async Task WinScp_WebDavAndS3_RemainUnsupported(int fsProtocol)
+    {
+        string ini = Path.Combine(Path.GetTempPath(), $"winscp-other-{Guid.NewGuid():N}.ini");
+        await File.WriteAllTextAsync(ini,
+            $"""
+             [Sessions\other]
+             HostName=example.com
+             UserName=u
+             FSProtocol={fsProtocol}
+             """);
+        try
+        {
+            SessionImportScan scan = await ScanWinScpAsync(ini);
+
+            Assert.HasCount(1, scan.Items);
+            Assert.IsFalse(scan.Items[0].IsSupported);
+            Assert.IsNull(scan.Items[0].FtpSettings);
+        }
+        finally
+        {
+            File.Delete(ini);
+        }
+    }
+
+    /// <summary>Xshell 的 FTP / FTPS 会话同样应被判为受支持,FTPS 走显式 TLS。</summary>
+    [TestMethod]
+    [DataRow("FTP", FtpEncryptionMode.None)]
+    [DataRow("FTPS", FtpEncryptionMode.Explicit)]
+    public async Task Xshell_FtpSession_IsSupported_WithEncryption(string protocol, FtpEncryptionMode expected)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"xshell-ftp-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        // Xshell 的 .xsh 是 UTF-16 LE 带 BOM 的分节 INI。
+        await File.WriteAllLinesAsync(
+            Path.Combine(directory, "files.xsh"),
+            ["[SessionInfo]", "Version=6.0", "[CONNECTION]", "Host=ftp.example.com", $"Protocol={protocol}",
+             "[CONNECTION:AUTHENTICATION]", "UserName=deploy"],
+            new UnicodeEncoding(false, true));
+        try
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+            var service = new XshellImportService(repository);
+
+            SessionImportScan scan = await service.ScanAsync(directory);
+
+            Assert.HasCount(1, scan.Items);
+            ImportedSession item = scan.Items[0];
+            Assert.AreEqual(ConnectionType.FTP, item.ConnectionType);
+            Assert.IsTrue(item.IsSupported);
+            Assert.IsNotNull(item.FtpSettings);
+            Assert.AreEqual(expected, item.FtpSettings.EncryptionMode);
+            Assert.AreEqual(21, item.Port);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    /// <summary>路由按会话归属分派:FTP 持有的会话走 FTP 后端,其余一律走 SFTP 后端。</summary>
+    [TestMethod]
+    public async Task Routing_DispatchesBySessionOwnership()
+    {
+        var ftpSession = Guid.NewGuid();
+        var sshSession = Guid.NewGuid();
+        ISftpService sftp = Substitute.For<ISftpService>();
+        ISftpService ftp = Substitute.For<ISftpService>();
+        IFtpSessionService sessions = Substitute.For<IFtpSessionService>();
+        sessions.OwnsSession(ftpSession).Returns(true);
+        sessions.OwnsSession(sshSession).Returns(false);
+        var router = new RoutingRemoteFileService(sftp, ftp, sessions);
+
+        await router.ListDirectoryAsync(ftpSession, "/pub");
+        await router.ListDirectoryAsync(sshSession, "/home");
+
+        await ftp.Received(1).ListDirectoryAsync(ftpSession, "/pub", Arg.Any<CancellationToken>());
+        await ftp.DidNotReceive().ListDirectoryAsync(sshSession, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await sftp.Received(1).ListDirectoryAsync(sshSession, "/home", Arg.Any<CancellationToken>());
+        await sftp.DidNotReceive().ListDirectoryAsync(ftpSession, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>未知会话仍走 SFTP 后端 —— 报错行为与加入 FTP 之前保持一致。</summary>
+    [TestMethod]
+    public async Task Routing_UnknownSession_FallsBackToSftp()
+    {
+        ISftpService sftp = Substitute.For<ISftpService>();
+        ISftpService ftp = Substitute.For<ISftpService>();
+        IFtpSessionService sessions = Substitute.For<IFtpSessionService>();
+        sessions.OwnsSession(Arg.Any<Guid>()).Returns(false);
+        var router = new RoutingRemoteFileService(sftp, ftp, sessions);
+
+        var unknown = Guid.NewGuid();
+        await router.GetWorkingDirectoryAsync(unknown);
+
+        await sftp.Received(1).GetWorkingDirectoryAsync(unknown, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>库异常必须翻译成 Core 的中立异常族,不得让 FluentFTP 的类型越过 Infrastructure 边界。</summary>
+    [TestMethod]
+    public void Interop_TranslatesLibraryExceptions()
+    {
+        Assert.IsInstanceOfType<VelaFtpAuthenticationException>(
+            FluentFtpInterop.Translate(new FtpAuthenticationException("530", "Login incorrect"), "connect"));
+        Assert.IsInstanceOfType<VelaFtpPathNotFoundException>(
+            FluentFtpInterop.Translate(new FtpCommandException("550", "No such file or directory"), "stat"));
+        Assert.IsInstanceOfType<VelaFtpPermissionDeniedException>(
+            FluentFtpInterop.Translate(new FtpCommandException("550", "Permission denied"), "delete"));
+        Assert.IsInstanceOfType<VelaFtpConnectionException>(
+            FluentFtpInterop.Translate(new TimeoutException("too slow"), "connect"));
+        // 取消不是错误,原样放行(否则会被上层当成连接失败提示给用户)。
+        var canceled = new OperationCanceledException();
+        Assert.AreSame(canceled, FluentFtpInterop.Translate(canceled, "list"));
+    }
+
+    /// <summary>没有 Ftp 设置块的临时配置(如「最近连接」重连)应回落到默认设置而不是崩掉。</summary>
+    [TestMethod]
+    public void ConnectionInfo_FromProfile_FallsBackToDefaults()
+    {
+        var profile = new SessionProfile
+        {
+            ConnectionType = ConnectionType.FTP,
+            Host = "ftp.example.com",
+            Port = 0,
+            Username = "deploy",
+        };
+
+        FtpConnectionInfo info = FtpConnectionInfo.FromProfile(profile);
+
+        Assert.AreEqual(FtpSettings.DefaultPort, info.Port);
+        Assert.AreEqual(FtpEncryptionMode.Auto, info.Settings.EncryptionMode);
+        Assert.AreEqual("deploy", info.EffectiveUsername);
+    }
+
+    /// <summary>匿名登录时用户名/口令由服务自行给出,不要求用户填。</summary>
+    [TestMethod]
+    public void ConnectionInfo_Anonymous_UsesAnonymousCredentials()
+    {
+        var profile = new SessionProfile
+        {
+            ConnectionType = ConnectionType.FTP,
+            Host = "ftp.example.com",
+            Username = string.Empty,
+            Ftp = new FtpSettings { Anonymous = true },
+        };
+
+        FtpConnectionInfo info = FtpConnectionInfo.FromProfile(profile);
+
+        Assert.AreEqual(FtpConnectionInfo.AnonymousUser, info.EffectiveUsername);
+        Assert.IsNotEmpty(info.EffectivePassword);
+    }
+
+    private static async Task<SessionImportScan> ScanWinScpAsync(string ini)
+    {
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+        var service = new WinScpImportService(repository);
+        return await service.ScanAsync(ini);
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/README.md
+++ b/tests/VelaShell.Infrastructure.Tests/README.md
@@ -13,6 +13,8 @@
 | `ConPtyShellStreamTests` | Windows ConPTY 本地终端流。 |
 | `SessionMetricsServiceTests` | 会话 CPU/内存/网速采集。 |
 | `VelaShellStoragePathsTests` | 数据目录与密钥文件路径解析。 |
+| `FtpSupportTests` | FTP/FTPS：导入器协议映射、远程文件服务的会话路由、FluentFTP 异常翻译、连接参数回落。 |
+| `WinScpImportTests` `XshellImportTests` | 会话导入:密码解码、INI/注册表解析、协议映射。 |
 
 ## 运行
 

--- a/tests/VelaShell.Infrastructure.Tests/README.md
+++ b/tests/VelaShell.Infrastructure.Tests/README.md
@@ -14,6 +14,7 @@
 | `SessionMetricsServiceTests` | 会话 CPU/内存/网速采集。 |
 | `VelaShellStoragePathsTests` | 数据目录与密钥文件路径解析。 |
 | `FtpSupportTests` | FTP/FTPS：导入器协议映射、远程文件服务的会话路由、FluentFTP 异常翻译、连接参数回落。 |
+| `Ftp/FtpFileServiceIntegrationTests` `Ftp/LoopbackFtpServer` | 对着进程内环回 FTP 服务器跑真实协议：登录（含匿名）、PASV/EPSV 数据连接、Unix LIST 解析、上传/下载往返、目录增删改、连接池并发。 |
 | `WinScpImportTests` `XshellImportTests` | 会话导入:密码解码、INI/注册表解析、协议映射。 |
 
 ## 运行

--- a/tests/VelaShell.Tests/README.md
+++ b/tests/VelaShell.Tests/README.md
@@ -13,7 +13,7 @@
 | `Services/` | `KeyboardShortcutService`、`CommandSuggestionProvider`、`ThemeService`、`InputLocaleSwitcher`、`ExternalEditSessionManager`、`SyntaxHighlighting`、`SyncDebounceLifecycle`、`PackageVersions`，以及自更新全链路（`UpdateService`/`UpdateApplier`/`UpdateManifest`/`UpdateVersion`/`GitHubReleaseSource`）。 |
 | `Services/`（ZMODEM） | `FileZModemFileSourceTests`、`FolderZModemFileSinkTests` —— 上传文件源与下载落盘目录的边界与路径安全。 |
 | `Docking/` | `DockWorkspace` 分屏模型。 |
-| `Views/` | headless 下的视图行为与视觉回归：设置页、连接弹窗、文件浏览器列、隧道面板、侧栏快捷命令、Dock 动效、菜单字形与像素回归。 |
+| `Views/` | headless 下的视图行为与视觉回归：设置页、连接弹窗（含 FTP 页签与协议下划线定位）、FTP 连接链路（`FtpConnectionFlowTests`：真连环回 FTP 服务器并列出远端文件）、文件浏览器列、隧道面板、侧栏快捷命令、Dock 动效、菜单字形与像素回归。 |
 | `Localization/` | `LocalizedKeyUsageTests`：校验代码中引用的本地化键均存在。 |
 | `Integration/` | `HeadlessUiTests`（无头 UI）、`SshIntegrationTests`（真实 SSH）、`CrossPlatformPublishTests`（跨平台发布）。 |
 | `SmokeTest.cs` | 应用启动冒烟测试。 |

--- a/tests/VelaShell.Tests/VelaShell.Tests.csproj
+++ b/tests/VelaShell.Tests/VelaShell.Tests.csproj
@@ -21,6 +21,13 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <!-- 环回 FTP 服务器与 Infrastructure.Tests 共用一份:FTP 的端到端验证既要覆盖
+       后端本身(那边),也要覆盖应用的连接路径(这边),没必要维护两份协议实现。 -->
+  <ItemGroup>
+    <Compile Include="..\VelaShell.Infrastructure.Tests\Ftp\LoopbackFtpServer.cs"
+             Link="Ftp\LoopbackFtpServer.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\VelaShell\VelaShell.csproj" />
     <ProjectReference Include="..\..\src\VelaShell.Infrastructure\VelaShell.Infrastructure.csproj" />

--- a/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
@@ -25,7 +25,7 @@ public sealed class ConnectionProfileViewUiTests
         _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(ConnectionProfileViewUiTests).Assembly);
 
     [TestMethod]
-    public void ProtocolTabs_ExposeFocusableSftpAndKeepLegacyProtocolsDisabled()
+    public void ProtocolTabs_ExposeFocusableSftpAndFtp_AndKeepLegacyProtocolsDisabled()
     {
         _session.Dispatch(() =>
         {
@@ -43,7 +43,8 @@ public sealed class ConnectionProfileViewUiTests
                 .OfType<Button>()
                 .Where(button => button.Classes.Contains("proto-tab"))
                 .ToList();
-            Assert.HasCount(2, protocolButtons);
+            // SSH / SFTP / FTP 三个可点页签(FTP 于 2026-08 加入);Telnet 与串口仍是禁用的 Border。
+            Assert.HasCount(3, protocolButtons);
             Assert.IsTrue(protocolButtons.All(button => button.IsTabStop));
             AssertProtocolTabMotion(protocolButtons);
 
@@ -64,6 +65,14 @@ public sealed class ConnectionProfileViewUiTests
             Dispatcher.UIThread.RunJobs();
             Assert.IsTrue(protocolButtons.Single(button => button.Classes.Contains("selected")).IsEffectivelyVisible);
             Assert.IsTrue(vm.IsSftpSelected);
+
+            // 切到 FTP:仍然只有一个页签处于选中态,且端口跟着切到 21(原本是 SSH 的 22)。
+            vm.SelectConnectionTypeCommand.Execute(ConnectionType.FTP).Subscribe();
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsTrue(vm.IsFtpSelected);
+            Assert.HasCount(1, protocolButtons.Where(button => button.Classes.Contains("selected")));
+            Assert.AreEqual(21, vm.Port);
+            Assert.IsFalse(vm.RequiresSshAuth);
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();
     }
@@ -97,6 +106,14 @@ public sealed class ConnectionProfileViewUiTests
             vm.SelectConnectionTypeCommand.Execute(ConnectionType.SFTP).Subscribe();
             Dispatcher.UIThread.RunJobs();
             AssertIndicatorAligned(indicator, sftpTab);
+
+            // 切到 FTP:定位逻辑曾是「IsSftpSelected ? SftpTab : SshTab」的二元三目,
+            // 加第三个协议后必须按枚举分派,否则下划线会留在 SFTP 上。
+            Button ftpTab = window.FindControl<Button>("FtpTab")!;
+            vm.SelectConnectionTypeCommand.Execute(ConnectionType.FTP).Subscribe();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            AssertIndicatorAligned(indicator, ftpTab);
 
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();

--- a/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
+++ b/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
@@ -1,0 +1,95 @@
+using Avalonia.Headless;
+using VelaShell.Core.Models;
+using VelaShell.Docking;
+using VelaShell.Infrastructure.Ftp;
+using VelaShell.Infrastructure.Tests.Ftp;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 应用层的 FTP 连接链路:走 <see cref="MainWindowViewModel.OpenFtpDocumentForProfileAsync" />
+/// 真连一个环回 FTP 服务器,验证文档被加进工作区、远端面板确实列出了服务器上的文件。
+/// <para>
+/// 这一条覆盖的是「用户双击一条 FTP 配置」之后发生的全部事情:建立会话 → 建文档 →
+/// 双栏面板走 <c>ISftpService</c> 拉目录。后端自身的协议细节在
+/// <c>VelaShell.Infrastructure.Tests</c> 的 FtpFileServiceIntegrationTests 里覆盖。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("FtpConnectionFlow")]
+public sealed class FtpConnectionFlowTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    /// <summary>
+    /// 本用例不往 UI 线程上派发(理由见测试方法的 remarks),但仍要启动 headless 会话:
+    /// <see cref="MainWindowViewModel" /> 途中会碰 <c>Dispatcher.UIThread</c>,没有 Avalonia 应用
+    /// 就会因测试执行顺序不同而偶发失败。
+    /// </summary>
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(FtpConnectionFlowTests).Assembly);
+
+    /// <remarks>
+    /// 用 <c>await await Dispatch(async …)</c> 而不是在 UI 线程里 <c>GetResult()</c>:
+    /// 连接链路全程 <c>ConfigureAwait(true)</c>,续体要回到 UI 线程,在那条线程上同步阻塞等它
+    /// 必然死锁(实测卡满 60s 超时)。异步 lambda 一遇 await 就交还线程,调度器才能把续体泵完。
+    /// </remarks>
+    [TestMethod]
+    public async Task ConnectingFtpProfile_OpensDocument_AndListsRemoteFiles()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vela-ftp-flow-{Guid.NewGuid():N}");
+        using var server = new LoopbackFtpServer(root);
+        File.WriteAllText(Path.Combine(root, "deploy.sh"), "#!/bin/sh\necho hi\n");
+        File.WriteAllText(Path.Combine(root, "notes.md"), "# notes");
+        Directory.CreateDirectory(Path.Combine(root, "backups"));
+
+        // 不进 headless UI 线程:连接链路全程 ConfigureAwait(true),在那条线程上等它会死锁,
+        // 而 Dispatch 只泵到 action 返回为止,异步 lambda 的续体等不到调度。这条链路本身不需要
+        // UI 线程(没有控件参与),因此直接在测试线程上跑。
+        await Task.Run(async () =>
+        {
+            var ftp = new FtpFileService();
+            var vm = new MainWindowViewModel(sftpService: ftp, ftpSessionService: ftp);
+            var profile = new SessionProfile
+            {
+                ConnectionType = ConnectionType.FTP,
+                Name = "环回 FTP",
+                Host = "127.0.0.1",
+                Port = server.Port,
+                Username = "deploy",
+                Password = "secret123",
+                Ftp = new FtpSettings { EncryptionMode = FtpEncryptionMode.None, MaxConnections = 2 },
+            };
+
+            SftpDocument? document = await vm.OpenFtpDocumentForProfileAsync(profile);
+
+            Assert.IsNotNull(document, "FTP 配置应能直接连上并打开一个文档标签。");
+            Assert.IsNull(document!.ViewModel.Session, "FTP 文档没有 SSH 会话 —— 这正是文档视图模型被泛化的原因。");
+            Assert.Contains(document, vm.Layout.AllDocuments().ToList());
+
+            await document.ViewModel.InitialLoadTask;
+
+            string[] names = [.. document.ViewModel.RemoteFiles.Files
+                .Where(entry => !entry.IsParentEntry)
+                .Select(entry => entry.Name)];
+            Assert.Contains("deploy.sh", names);
+            Assert.Contains("notes.md", names);
+            Assert.Contains("backups", names);
+            Assert.IsNull(document.ViewModel.RemoteFiles.ErrorMessage);
+
+            await document.ViewModel.CloseAsync();
+            Assert.IsFalse(ftp.OwnsSession(document.ViewModel.SessionId), "关闭文档应连同 FTP 会话一起断开。");
+        });
+
+        try
+        {
+            Directory.Delete(root, true);
+        }
+        catch (IOException)
+        {
+            // 临时目录删不掉不影响断言。
+        }
+    }
+}


### PR DESCRIPTION
## 背景

`ConnectionType` 此前只有 `SSH` / `SFTP`，FTP 会话在导入器里被直接标为「不支持」。本 PR 加入 FTP / FTPS 连接类型，落地 [`docs/FTP客户端可行性调研.md`](docs/FTP客户端可行性调研.md) 的 P0 与 P1。

## 关键设计：接缝选在 `ISftpService`，不是 `ISftpClientWrapper`

两条硬性理由（调研阶段定下，实现时都被证实）：

1. 上层真正消费的 `RemoteFileInfo` 里 `Permissions` / `Owner` / `Group` 都是**字符串**，正是 FTP 的 LIST/MLSD 能给的 —— 整条绕开了 SFTP 那边靠 SSH exec 跑 `getent passwd` 的 UID/GID 翻译。
2. `ISftpClientWrapper.OpenAsync` 硬性要求返回**可 Seek** 的流，而 FluentFTP 的数据流 `CanSeek == false`、`Seek()` 直接抛 `InvalidOperationException`，根本满足不了。

结果：**文件浏览器、传输管理器、限速、拖放、冲突策略、传输浮窗全部零改动** —— 它们只认 `ISftpService` + `Guid sessionId`。

```
ISftpService（对外唯一契约，UI 侧零改动）
  └── RoutingRemoteFileService        ← 按会话归属分派
        ├── SftpService   (SSH 会话)
        └── FtpFileService (FTP 会话) ── FtpConnectionPool ── AsyncFtpClient × N
```

## 改动

**Core**：`ConnectionType.FTP`、`FtpSettings`（加密方式 / 数据连接方式 / 匿名 / 信任指纹 / 并发数）、`FtpConnectionInfo`、`IFtpSessionService`、`VelaFtp*` 异常族。

**Infrastructure**：`FtpFileService`（同时实现 `ISftpService` + `IFtpSessionService`）、`FtpConnectionPool`、`FluentFtpInterop`（库异常 → Core 中立异常，对标 `TmdsSshInterop`）、`RoutingRemoteFileService`。

> **连接池不是可选项**：FTP 一条控制连接同一时刻只能跑一条命令，不像 SFTP 能在 SSH 连接上多路复用。`SerializedSftpService` 的注释明写「传输不占串行闸……底层 Tmds.Ssh 的 SftpClient 本身即为并发使用而设计」——这个前提对 FTP 不成立。共用一条连接会让「传输期间刷新目录」直接报错，用户设置的最大并发传输数也会被悄悄压回 1。

**App**：连接分派加 FTP 分支；`SftpDocumentViewModel` 增加「会话标识 + 断开回调」的协议无关构造（SSH 那条委托给它），FTP 文档因此不需要 `SshSession`。

**UI**：连接弹窗新增 FTP 页签与 FTPS 表单（加密方式 / 匿名登录 / 被动模式），切到 FTP 自动把端口切到 21（隐式 FTPS 990）、隐掉私钥认证、匿名时隐掉口令框；明文 FTP 给出「不加密且无服务器身份校验」提示。协议下划线的二元三目改为按枚举分派。

**安全**：FTPS 证书未过校验 → 抛带 SHA-256 指纹的 `VelaFtpCertificateException` → UI 弹信任提示（摊开主体/颁发者/到期/指纹/问题）→ 同意后把指纹记进配置并重连。**刻意不在 TLS 回调里同步等 UI**：那要把异步对话框阻塞成同步，极易死锁（证书回调不保证在哪个线程触发）。

**协议泛化**：四处「未知枚举值改写成 SSH」的三元换成 `Enum.IsDefined` 白名单 —— 语义不变（未知值仍降级 SSH，兼容测试照常通过），但不再焊死扩展口。`SessionProfile.Ftp` 同步到全部五处手写拷贝。

**导入**：WinSCP 的 `FSProtocol=5` 与 Xshell 的 `FTP`/`FTPS` 从「不支持」转为受支持，按 `Ftps` 值带出加密方式，端口缺省值按协议给（21 / 隐式 990）。

## 依赖

`FluentFTP 54.2.0`（**MIT**，零依赖，56.9M 下载）。TFM 最高到 net9.0，本仓库 net11.0 解析到那一份；发布是自包含、不裁剪、非单文件，无打包风险。

> ⚠️ **不要顺手引 `FluentFTP.GnuTLS`** —— LGPL-2.1-only，与 `LICENSE-COMMERCIAL.md` 的商业授权路径冲突。它是 TLS 会话复用问题的社区解法，引入前需法务确认。已在 CPM 注释与调研文档 §4.3 里写明。

## 测试

- **端到端（22 条）**：测试工程内自带一个最小实现的**环回 FTP 服务器**（临时目录当 FTP 根，实现登录 / PASV / EPSV / LIST / RETR / STOR / DELE / MKD / RMD / RNFR-RNTO / SIZE / REST）。刻意不通告 MLSD，逼客户端走 Unix LIST 解析——那正是权限/属主字符串真正被解析出来的路径。
  - Infrastructure：登录（含匿名）、列目录解析成 `RemoteFileInfo`、40KB 上传下载往返、顺序读流与连接归还、目录增删改、路径不存在的异常翻译、并发下载确实开出多条连接且不超过 `MaxConnections`。
  - App：`MainWindowViewModel.OpenFtpDocumentForProfileAsync` 真连服务器 → 文档进工作区 → 远端面板列出服务器上的文件 → 关闭文档连同断开会话。
- **单元**：导入协议映射、会话路由、异常翻译、连接参数回落、协议往返序列化、FTP 页签与下划线定位。
- **全仓**：764 + 138 + 301 + 34 + 265 + 2 条通过，**0 警告 0 错误**。

## 仍待验证

**FTPS 的 TLS 会话复用**：vsftpd 的 `require_ssl_reuse` 默认开启、FileZilla Server 在 TLS 1.3 下强制复用，不满足时服务器回 `522`。这是 .NET `SslStream` 侧的长期问题（FluentFTP #236/#347/#773/#951/#1283/#1738）。本 PR 走纯 `SslStream` 路径，未引入 GnuTLS。**建议合并前拿默认配置的 vsftpd 与 FileZilla Server 各跑一次真实连通性验证** —— 结论决定是否需要把 GnuTLS 作为可选插件引入。调研文档第五节风险 1 有详细记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uer9zL14cBskqov2KfrYBq
