### PR TITLE
fix: 修复 resx 合并损坏导致 main 编译失败

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3628,7 +3628,8 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   </data>
   <data name="Ftp_CertTrust" xml:space="preserve">
     <value>信頼して接続</value>
-  <data name="PluginManager_VpxFilter"><value>VelaShell プラグインパッケージ</value></data>  <data name="XImport_MenuItemAll" xml:space="preserve">
+  </data>
+  <data name="XImport_MenuItemAll" xml:space="preserve">
     <value>他のツールからセッションをインポート…</value>
   </data>
   <data name="XImport_TitleAll" xml:space="preserve">

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3628,7 +3628,8 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   </data>
   <data name="Ftp_CertTrust" xml:space="preserve">
     <value>신뢰하고 연결</value>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 플러그인 패키지</value></data>  <data name="XImport_MenuItemAll" xml:space="preserve">
+  </data>
+  <data name="XImport_MenuItemAll" xml:space="preserve">
     <value>다른 도구에서 세션 가져오기…</value>
   </data>
   <data name="XImport_TitleAll" xml:space="preserve">

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3629,7 +3629,8 @@ Overwrite it?</value>
   </data>
   <data name="Ftp_CertTrust" xml:space="preserve">
     <value>Trust and connect</value>
-  <data name="PluginManager_VpxFilter"><value>VelaShell plugin package</value></data>  <data name="XImport_MenuItemAll" xml:space="preserve">
+  </data>
+  <data name="XImport_MenuItemAll" xml:space="preserve">
     <value>Import sessions from another tool…</value>
   </data>
   <data name="XImport_TitleAll" xml:space="preserve">

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3720,7 +3720,8 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   </data>
   <data name="Ftp_CertTrust" xml:space="preserve">
     <value>信任并连接</value>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 插件包</value></data>  <data name="XImport_MenuItemAll" xml:space="preserve">
+  </data>
+  <data name="XImport_MenuItemAll" xml:space="preserve">
     <value>从其他工具导入会话…</value>
   </data>
   <data name="XImport_TitleAll" xml:space="preserve">

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3628,7 +3628,8 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   </data>
   <data name="Ftp_CertTrust" xml:space="preserve">
     <value>信任並連線</value>
-  <data name="PluginManager_VpxFilter"><value>VelaShell 外掛程式套件</value></data>  <data name="XImport_MenuItemAll" xml:space="preserve">
+  </data>
+  <data name="XImport_MenuItemAll" xml:space="preserve">
     <value>從其他工具匯入工作階段…</value>
   </data>
   <data name="XImport_TitleAll" xml:space="preserve">

--- a/src/VelaShell.Infrastructure/Sftp/RoutingRemoteFileService.cs
+++ b/src/VelaShell.Infrastructure/Sftp/RoutingRemoteFileService.cs
@@ -5,8 +5,8 @@ using VelaShell.Core.Sftp;
 namespace VelaShell.Infrastructure.Sftp;
 
 /// <summary>
-/// 按会话归属把远程文件操作分派到对应后端的路由:FTP 会话交给 <see cref="FtpFileService" />,
-/// 其余(SSH 上的 SFTP)走原本的实现。
+/// 按会话归属把远程文件操作分派到对应后端的路由:FTP 会话交给
+/// <see cref="Ftp.FtpFileService" />,其余(SSH 上的 SFTP)走原本的实现。
 /// <para>
 /// 之所以能这么干,是因为 <see cref="ISftpService" /> 的每个成员都以 <c>Guid sessionId</c> 为键、
 /// 返回协议无关的 <see cref="RemoteFileInfo" /> —— 文件浏览器、传输管理器、限速、拖放


### PR DESCRIPTION
## 问题：`main` 当前编译不过

合并 #160 时的冲突解法把五个 `Strings*.resx` 的尾部拼坏了：

```xml
  <data name="Ftp_CertTrust" xml:space="preserve">
    <value>Trust and connect</value>
  <data name="PluginManager_VpxFilter"><value>…</value></data>  <data name="XImport_MenuItemAll" …>
```

`Ftp_CertTrust` 的 `</data>` 被吃掉了，同时又粘上一份重复的 `PluginManager_VpxFilter`（该键在文件靠前处已经存在）。结果是 XML 无效：

```
error MSB3103: Resx 文件无效。System.Xml.XmlException:
The 'data' start tag on line 3630 does not match the end tag of 'root'.
```

五个语言文件全中，`VelaShell.Core` 直接构建失败，整个解决方案编译不过。

## 修复

- 补回被吃掉的 `</data>`；
- 删除那份重复的 `PluginManager_VpxFilter`（保留靠前的原件）。

修完五个文件键数一致（1244）、XML 可解析、无重复键。

顺带修掉一个 `CS1574`：`RoutingRemoteFileService` 的文档注释里 `FtpFileService` 的 cref 在去掉 using 之后解析不到，改成带命名空间前缀。

## 验证

- `dotnet build VelaShell.slnx`：**0 警告 0 错误**（修复前：MSB3103 直接失败）。
- 测试：770 + 304 + 138 + 43 + 265 + 2 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uer9zL14cBskqov2KfrYBq
