### PR TITLE
修复FTP文档状态灯绑定及相关内存泄漏问题

### DIFF
--- a/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
@@ -67,7 +67,7 @@
           BorderBrush="Transparent" VerticalAlignment="Stretch">
     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
       <Ellipse Width="7" Height="7" VerticalAlignment="Center"
-               Fill="{Binding ViewModel.Session.Status, Converter={x:Static conv:SessionStatusToBrushConverter.Instance}}" />
+               Fill="{Binding ViewModel.Status, Converter={x:Static conv:SessionStatusToBrushConverter.Instance}}" />
       <Border Width="3" Height="12" CornerRadius="1.5" VerticalAlignment="Center"
               Background="{Binding ConnectionAccentBrush}" />
       <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.folder-open}"

--- a/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
+++ b/src/VelaShell/ViewModels/SftpDocumentViewModel.cs
@@ -41,8 +41,13 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
                sftpService,
                transferOptions,
                transferSink,
-               getDefaultEditorPath) =>
+               getDefaultEditorPath)
+    {
         Session = session;
+        // 标签页状态灯读的是 Status,而它的真值住在 SshSession 上 —— 转发一次属性变更,
+        // 灯才会跟着会话断开/重连改色。FTP 走另一个构造函数,没有这条线。
+        session.PropertyChanged += OnSessionPropertyChanged;
+    }
 
     /// <summary>
     /// 以「一个会话标识 + 一个断开回调」构造文档,不绑定具体协议。
@@ -95,6 +100,18 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
     public SessionProfile Profile { get; }
     /// <summary>当前活跃的 SSH 会话;FTP 文档没有 SSH 会话,为 null。</summary>
     public SshSession? Session { get; }
+
+    /// <summary>
+    /// 标签页状态灯的连接状态。必须由本视图模型给出,不能让界面直接绑 <c>Session.Status</c>:
+    /// FTP 文档的 <see cref="Session" /> 是 null,那样每开一个 FTP 标签都会刷一条
+    /// <c>An error occurred binding 'Fill' to 'ViewModel.Session.Status': 'Value is null.'</c>,
+    /// 而且那颗灯自始至终不上色。
+    /// </summary>
+    /// <remarks>
+    /// FTP 没有会话级状态可读(<c>IFtpSessionService</c> 只管开/关),而文档只在登录成功后才建出来,
+    /// 因此按「已连接」呈现;掉线由文件面板的错误提示承担。等 FTP 侧补上状态跟踪再接上来。
+    /// </remarks>
+    public SessionStatus Status => Session?.Status ?? SessionStatus.Connected;
     /// <summary>SSH 会话的唯一标识。</summary>
     public Guid SessionId { get; }
     /// <summary>SFTP 文档标签页的显示标题。</summary>
@@ -138,10 +155,22 @@ public sealed class SftpDocumentViewModel : ReactiveObject, IAsyncDisposable
         }
     }
 
+    private void OnSessionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(SshSession.Status) or null)
+        {
+            this.RaisePropertyChanged(nameof(Status));
+        }
+    }
+
     /// <summary>分离文件浏览器并取消生命周期令牌。</summary>
     public void Detach()
     {
         _lifetime.Cancel();
+        if (Session is { } session)
+        {
+            session.PropertyChanged -= OnSessionPropertyChanged;
+        }
         RemoteFiles.Detach();
         LocalFiles.Detach();
     }

--- a/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
@@ -1,8 +1,12 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Headless;
+using Avalonia.Logging;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
@@ -655,6 +659,105 @@ public sealed class StandaloneSftpDocumentBehaviorTests
             sftpService
         );
     }
+
+    [TestMethod]
+    [TestCategory("Sftp")]
+    public async Task SftpTabItem_ForAnFtpDocumentWithoutSshSession_BindsTheStatusDotWithoutErrors()
+    {
+        // FTP 文档没有 SshSession(它不走 SSH 握手)。标签页曾直接绑 ViewModel.Session.Status,
+        // 于是每开一个 FTP 标签就刷一条
+        // "An error occurred binding 'Fill' to 'ViewModel.Session.Status': 'Value is null.'",
+        // 那颗状态灯还自始至终不上色。状态改由视图模型给出,两个问题一起消失。
+        ISftpService sftp = Substitute.For<ISftpService>();
+        var sessionId = Guid.NewGuid();
+        ConfigureInitialLoad(sftp, sessionId);
+
+        await _session.Dispatch(() =>
+        {
+            var sink = new BindingErrorSink();
+            ILogSink? previous = Logger.Sink;
+            Logger.Sink = sink;
+            try
+            {
+                // 先用一条必错的绑定验明接收器在工作,否则"没有错误"只是空跑。
+                var canary = new TextBlock();
+                canary.Bind(TextBlock.TextProperty, new Avalonia.Data.Binding("Missing.Deeper"));
+                var probe = new Window { Content = canary, DataContext = new object() };
+                probe.Show();
+                Dispatcher.UIThread.RunJobs();
+                probe.Close();
+                Assert.IsNotEmpty(sink.Errors, "绑定错误接收器没有生效,后面的断言会一直是空跑。");
+                sink.Errors.Clear();
+
+                var document = new SftpDocument(new SftpDocumentViewModel(
+                    CreateFtpProfile(),
+                    sessionId,
+                    static (_, _) => Task.CompletedTask,
+                    sftp,
+                    new TransferOptions()));
+                Assert.IsNull(document.ViewModel.Session, "FTP 文档不该有 SSH 会话。");
+                Assert.AreEqual(SessionStatus.Connected, document.ViewModel.Status);
+
+                var tab = new SftpDockTabItem { DataContext = document };
+                var window = new Window { Content = tab };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+                try
+                {
+                    Ellipse dot = tab.GetVisualDescendants().OfType<Ellipse>().First();
+                    Assert.IsNotNull(dot.Fill, "状态灯没有拿到画刷,标签上就是个看不见的点。");
+                }
+                finally
+                {
+                    window.Close();
+                }
+            }
+            finally
+            {
+                Logger.Sink = previous;
+            }
+
+            Assert.IsEmpty(sink.Errors, $"出现了 {sink.Errors.Count} 条绑定错误,例如:{sink.Errors.FirstOrDefault()}");
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+    }
+
+    /// <summary>只收集绑定相关的告警/错误,供上面的回归测试断言。</summary>
+    private sealed class BindingErrorSink : ILogSink
+    {
+        public List<string> Errors { get; } = [];
+
+        public bool IsEnabled(LogEventLevel level, string area) =>
+            level >= LogEventLevel.Warning && area == LogArea.Binding;
+
+        public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
+        {
+            if (IsEnabled(level, area))
+            {
+                Errors.Add(messageTemplate);
+            }
+        }
+
+        public void Log(LogEventLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues)
+        {
+            if (IsEnabled(level, area))
+            {
+                Errors.Add(messageTemplate + " | " + string.Join(", ", propertyValues));
+            }
+        }
+    }
+
+    private static SessionProfile CreateFtpProfile() => new()
+    {
+        ConnectionType = ConnectionType.FTP,
+        Name = "Files",
+        Host = "files.example.com",
+        Port = 21,
+        Username = "anonymous",
+        AuthMethod = AuthMethod.Password,
+        Password = "secret",
+    };
 
     private static void ConfigureInitialLoad(ISftpService sftp, Guid sessionId)
     {


### PR DESCRIPTION
修正了SftpDockTabItem在FTP文档下状态灯绑定错误，现统一绑定ViewModel.Status，避免状态灯不显示。SftpDocumentViewModel新增Status属性，FTP文档默认返回Connected。构造函数中为Session订阅属性变更，Detach时取消订阅防止内存泄漏。新增单元测试验证FTP文档状态灯绑定无误，增加BindingErrorSink辅助类和CreateFtpProfile测试工具方法。