### PR TITLE
修复画刷线程问题，增强插件宿主退出逻辑

### DIFF
--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -840,7 +840,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         await ActivateAsync(runtime, CancellationToken.None).ConfigureAwait(false);
     }
 
-    private TracePluginLogger GetOrCreateLogger(PluginRuntime runtime)
+    private static TracePluginLogger GetOrCreateLogger(PluginRuntime runtime)
         => runtime.Logger ??= new(runtime.Descriptor.Id);
 
     /// <summary>每插件命令能力(懒建、占位与真实注册共用;停用后置空重建)。</summary>

--- a/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
@@ -38,7 +38,7 @@ public sealed class PluginPermissionGate(IAppDataStore? store, IPluginPermission
 
     private sealed record PermissionsDoc(List<string> AlwaysAllow);
 
-    private readonly HashSet<string> _sessionAllowed = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _sessionAllowed = [with(StringComparer.Ordinal)];
     private readonly SemaphoreSlim _promptGate = new(1, 1);
     private HashSet<string>? _alwaysAllowed;
 

--- a/src/VelaShell.PluginHost/Program.cs
+++ b/src/VelaShell.PluginHost/Program.cs
@@ -60,7 +60,11 @@ internal static class Program
         {
             // 退出信号,正常路径。
         }
-        return run.IsCompletedSuccessfully ? run.Result : 1;
+        int exitCode = run.IsCompletedSuccessfully ? run.Result : 1;
+        // 硬退而不是 return:插件是第三方代码,可能起了前台线程;Main 返回后运行时会等它们,
+        // 进程于是赖着不走。派发循环都停了,这里没有任何理由再等谁。
+        Environment.Exit(exitCode);
+        return exitCode;
     }
 
     private static async Task<int> RunAsync(string pipeName, string token, string pluginId, string pluginVersion,
@@ -92,19 +96,29 @@ internal static class Program
                     }
                 case PluginRpc.PluginDeactivate:
                     {
-                        await shutdownSource.CancelAsync().ConfigureAwait(false);
-                        if (plugin is not null)
+                        // try/finally 是硬要求:DeactivateAsync 是第三方代码,抛异常(或被上面那句
+                        // CancelAsync 撞出 OperationCanceledException)就会跳过下面的关窗与退出信号,
+                        // 本进程从此挂在 ExitCode.Task 上不走 —— 主程序退出后它就是个孤儿宿主,
+                        // 白占内存不说,还锁着 bin 里的插件 dll 让下次编译直接失败。
+                        try
                         {
-                            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                            await plugin.DeactivateAsync(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                            await shutdownSource.CancelAsync().ConfigureAwait(false);
+                            if (plugin is not null)
+                            {
+                                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                                await plugin.DeactivateAsync(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                            }
                         }
-                        context?.Dispose(); // 关掉本插件的全部窗口
-                                            // 先应答再退出:让宿主拿到干净的完成信号。
-                        _ = Task.Run(async () =>
+                        finally
                         {
-                            await Task.Delay(100).ConfigureAwait(false);
-                            ExitCode.TrySetResult(0);
-                        });
+                            context?.Dispose(); // 关掉本插件的全部窗口
+                                                // 先应答再退出:让宿主拿到干净的完成信号。
+                            _ = Task.Run(async () =>
+                            {
+                                await Task.Delay(100).ConfigureAwait(false);
+                                ExitCode.TrySetResult(0);
+                            });
+                        }
                         return null;
                     }
                 case "ping":
@@ -177,6 +191,11 @@ internal static class Program
                 // 拿不到父进程 = 已经没了。
             }
             ExitCode.TrySetResult(3);
+
+            // 父进程没了之后再给优雅收尾两秒就地兜底硬退:此时管道多半是半开的,
+            // RPC 拆解可能永远等不到对端,而"父进程都不在了"这件事已经没有任何回旋余地。
+            await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            Environment.Exit(3);
         });
     }
 }

--- a/src/VelaShell/Converters/SessionStatusToBrushConverter.cs
+++ b/src/VelaShell/Converters/SessionStatusToBrushConverter.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using VelaShell.Core.Models;
 
 namespace VelaShell.Converters;
@@ -15,9 +16,11 @@ public sealed class SessionStatusToBrushConverter : IValueConverter
     /// <summary>供在 XAML 中直接使用的共享单例。</summary>
     public static readonly SessionStatusToBrushConverter Instance = new();
 
-    private static readonly IBrush Connected = new SolidColorBrush(Color.Parse("#00D4AA"));
-    private static readonly IBrush Connecting = new SolidColorBrush(Color.Parse("#FDCB6E"));
-    private static readonly IBrush Disconnected = new SolidColorBrush(Color.Parse("#FF6B6B"));
+    // 不可变画刷:静态共享的 SolidColorBrush 是 AvaloniaObject,带线程亲和性,
+    // 一旦被非 UI 线程先初始化,后续 UI 线程渲染就会抛 VerifyAccess(见 ConnectionAccent 同款注释)。
+    private static readonly IBrush Connected = new ImmutableSolidColorBrush(Color.Parse("#00D4AA"));
+    private static readonly IBrush Connecting = new ImmutableSolidColorBrush(Color.Parse("#FDCB6E"));
+    private static readonly IBrush Disconnected = new ImmutableSolidColorBrush(Color.Parse("#FF6B6B"));
 
     /// <summary>返回给定 <see cref="SessionStatus" /> 对应的状态点画刷,默认返回断开连接的颜色。</summary>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>

--- a/src/VelaShell/Services/ConnectionAccent.cs
+++ b/src/VelaShell/Services/ConnectionAccent.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 namespace VelaShell.Services;
 
@@ -10,16 +11,20 @@ namespace VelaShell.Services;
 /// </summary>
 public static class ConnectionAccent
 {
+    // 共享的静态画刷必须是不可变的:SolidColorBrush 是 AvaloniaObject,带线程亲和性 ——
+    // 谁先碰它,它就归谁;之后别的线程渲染到它就会在合成阶段抛
+    // "The calling thread cannot access this object because a different thread owns it"。
+    // 色板是全局静态的,先手线程无法保证(实测在测试套件里被后台线程先初始化后必崩)。
     private static readonly IBrush[] Palette =
     [
-        new SolidColorBrush(Color.Parse("#8BE9FD")), // cyan
-        new SolidColorBrush(Color.Parse("#50FA7B")), // green
-        new SolidColorBrush(Color.Parse("#FFB86C")), // orange
-        new SolidColorBrush(Color.Parse("#FF79C6")), // pink
-        new SolidColorBrush(Color.Parse("#BD93F9")), // purple
-        new SolidColorBrush(Color.Parse("#F1FA8C")), // yellow
-        new SolidColorBrush(Color.Parse("#FF5555")), // red
-        new SolidColorBrush(Color.Parse("#6FA8FF"))  // blue
+        new ImmutableSolidColorBrush(Color.Parse("#8BE9FD")), // cyan
+        new ImmutableSolidColorBrush(Color.Parse("#50FA7B")), // green
+        new ImmutableSolidColorBrush(Color.Parse("#FFB86C")), // orange
+        new ImmutableSolidColorBrush(Color.Parse("#FF79C6")), // pink
+        new ImmutableSolidColorBrush(Color.Parse("#BD93F9")), // purple
+        new ImmutableSolidColorBrush(Color.Parse("#F1FA8C")), // yellow
+        new ImmutableSolidColorBrush(Color.Parse("#FF5555")), // red
+        new ImmutableSolidColorBrush(Color.Parse("#6FA8FF"))  // blue
     ];
 
     /// <summary>返回该配置的标识色画刷(FNV-1a 哈希 Guid 字节,跨启动稳定)。</summary>

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
@@ -127,6 +127,42 @@ public class IsolatedPluginTests
         await manager.DisposeAsync();
     }
 
+    [TestMethod]
+    public async Task IsolatedPlugin_AfterDeactivation_HostProcessLeavesOnItsOwn()
+    {
+        // 宿主进程必须自己退场,不能靠父进程那一刀:主程序退出路径上的兜底强杀是有时限的
+        // (App 退出只给容器 2 秒),一旦子进程没能自行收摊,它就会活过主程序 ——
+        // 实测留下过一个孤儿 VelaShell.PluginHost,锁着 bin\plugins 里的 dll,
+        // 下一次编译直接以 MSB3027「文件被另一进程锁定」失败。
+        // 自退场的三个码:0 = 停用应答后自退,2 = 管道断后自退,3 = 父进程消失后自退;
+        // 被 Process.Kill 强杀则是 -1。
+        StageHelloWorld("isolated");
+        var manager = new PluginManager(new()
+        {
+            PluginRoots = [_root],
+            DataRootDirectory = _dataRoot,
+            HostVersion = "1.0.0",
+            ActivationTimeout = TimeSpan.FromSeconds(30),
+            DeactivationTimeout = TimeSpan.FromSeconds(10)
+        });
+        await manager.StartAsync();
+        Assert.AreEqual(PluginState.Active, manager.Plugins.Single().State, manager.Plugins.Single().Error);
+
+        int pid = manager.GetIsolatedProcessId("velashell.hello-world")!.Value;
+        // 自己开一个句柄:PluginManager 释放后它那份 Process 就没了,退出码得从这里读。
+        // 必须在进程还活着时把 Handle 抓在手里,否则退出后 ExitCode 会抛
+        //「Process was not started by this object」。
+        using var host = System.Diagnostics.Process.GetProcessById(pid);
+        _ = host.Handle;
+
+        await manager.DisposeAsync();
+
+        Assert.IsTrue(host.WaitForExit(15_000), "停用后插件宿主进程必须退出");
+        Assert.IsTrue(host.ExitCode is 0 or 2 or 3,
+            $"宿主应自行退场(0/2/3),实际退出码 {host.ExitCode} —— 其它码说明它是被父进程强杀的,"
+            + "而强杀在主程序退出路径上只有 2 秒预算,超时就会留下孤儿进程。");
+    }
+
     private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout, string message)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();

--- a/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/StandaloneSftpDocumentBehaviorTests.cs
@@ -14,6 +14,7 @@ using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
 using VelaShell.Core.Ssh;
 using VelaShell.Docking;
+using VelaShell.Docking.Controls;
 using VelaShell.Presentation.Services;
 using VelaShell.Presentation.ViewModels;
 using VelaShell.Terminal;


### PR DESCRIPTION
修复 Avalonia 静态画刷线程亲和性问题，使用 ImmutableSolidColorBrush 避免 UI 线程异常。PluginManager 的 GetOrCreateLogger 设为 static 提升线程安全。简化 PluginPermissionGate 初始化。Program 退出流程改用 Environment.Exit，插件停用流程加 try/finally，父进程消失后延时强退，防止残留进程和 DLL 锁定。新增单元测试验证宿主进程可自行退出。补充 using 和注释，提升可维护性。