### PR TITLE
fix: FTP 会话状态与断线后的错误提示

### DIFF
--- a/src/VelaShell.Core/Ftp/IFtpSessionService.cs
+++ b/src/VelaShell.Core/Ftp/IFtpSessionService.cs
@@ -1,5 +1,23 @@
 namespace VelaShell.Core.Ftp;
 
+/// <summary>一条 FTP 会话的健康状态。</summary>
+public enum FtpSessionState
+{
+    /// <summary>已建立连接。</summary>
+    Connected,
+
+    /// <summary>连接已失效(服务器断开、网络中断、重连失败);会话仍在,但下一次操作需要重连。</summary>
+    Faulted,
+
+    /// <summary>会话已被关闭并释放。</summary>
+    Closed,
+}
+
+/// <summary>FTP 会话状态变化的事件数据。</summary>
+/// <param name="SessionId">发生变化的会话标识。</param>
+/// <param name="State">新的状态。</param>
+public readonly record struct FtpSessionStateChange(Guid SessionId, FtpSessionState State);
+
 /// <summary>
 /// FTP 会话的生命周期管理。文件操作本身仍走 <see cref="Sftp.ISftpService" />
 /// —— 那个接口以 <c>Guid sessionId</c> 为键、返回 <c>RemoteFileInfo</c>,本就与协议无关,
@@ -17,6 +35,16 @@ public interface IFtpSessionService
 
     /// <summary>该会话标识是否由本服务持有(供文件服务路由分派)。</summary>
     bool OwnsSession(Guid sessionId);
+
+    /// <summary>
+    /// 会话状态发生变化(连上 / 断开失效 / 已关闭)。
+    /// <para>
+    /// FTP 没有 SSH 那种长驻的会话对象可供界面订阅状态,断线只会在下一次操作时暴露出来。
+    /// 因此由本服务在操作失败时主动上报,资源管理器树的状态圆点才能自动从「活跃」变成「离线」,
+    /// 而不是一直停在绿点上。可能在任意线程触发,订阅方自行切回 UI 线程。
+    /// </para>
+    /// </summary>
+    event EventHandler<FtpSessionStateChange>? SessionStateChanged;
 
     /// <summary>关闭并释放一条 FTP 会话的全部连接;未知标识为空操作。</summary>
     Task CloseSessionAsync(Guid sessionId, CancellationToken cancellationToken = default);

--- a/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
@@ -37,10 +37,22 @@ internal static class FluentFtpInterop
                 return new VelaFtpConnectionException($"FTP {operation} failed: {io.Message}", io);
             case FtpException ftp:
                 return new VelaFtpOperationException($"FTP {operation} failed: {ftp.Message}", ftp);
+            // FluentFTP 在**底层套接字已死**时会从内部抛出 NullReference / ObjectDisposed /
+            // InvalidOperation —— 它并不总把断线包成 FtpException。不翻译的话,用户双击一个
+            // 远端文件只会看到「Object reference not set to an instance of an object」
+            // (实机反馈的「null 错误」就是它),既不知道发生了什么,也不知道该重连。
+            case NullReferenceException:
+            case ObjectDisposedException:
+            case InvalidOperationException:
+                return new VelaFtpConnectionException(
+                    $"FTP connection was lost during {operation}; reconnect and try again.", ex);
             default:
                 return ex;
         }
     }
+
+    /// <summary>该异常是否代表「连接已失效」——据此把会话标记为离线并丢弃池中的坏连接。</summary>
+    public static bool IsConnectionLost(Exception ex) => ex is VelaFtpConnectionException;
 
     /// <summary>
     /// 按 FTP 应答码分类。5xx 里 550 既可能是「不存在」也可能是「没权限」,

--- a/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
@@ -35,31 +35,30 @@ internal sealed class FtpConnectionPool(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);
+        AsyncFtpClient? client = null;
         try
         {
-            AsyncFtpClient client = _idle.TryTake(out AsyncFtpClient? pooled)
+            // 新建连接同样要翻译异常:服务器没了的时候这里抛的是裸 SocketException,
+            // 不翻译就会越过 Infrastructure 边界直接甩到界面上。
+            client = _idle.TryTake(out AsyncFtpClient? pooled)
                 ? pooled
                 : await CreateAsync(cancellationToken).ConfigureAwait(false);
 
             // 空闲期间可能被服务器按 idle timeout 踢掉(FTP 服务器普遍很短),这里就地重连。
             if (!client.IsConnected)
             {
-                try
-                {
-                    await client.Connect(cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    Forget(client);
-                    throw FluentFtpInterop.Translate(ex, "reconnect");
-                }
+                await client.Connect(cancellationToken).ConfigureAwait(false);
             }
             return new Lease(this, client);
         }
-        catch
+        catch (Exception ex)
         {
+            if (client is not null)
+            {
+                Forget(client);
+            }
             _slots.Release();
-            throw;
+            throw FluentFtpInterop.Translate(ex, "connect");
         }
     }
 
@@ -113,11 +112,15 @@ internal sealed class FtpConnectionPool(
         return client;
     }
 
+    /// <summary>
+    /// 归还连接。已经掉线的连接**不放回池子** —— 否则它会被反复租出去、每次都要先失败再重连,
+    /// 断线后的每一个操作都得多等一个连接超时。
+    /// </summary>
     private void Return(AsyncFtpClient client)
     {
-        if (_disposed)
+        if (_disposed || !client.IsConnected)
         {
-            client.Dispose();
+            Forget(client);
         }
         else
         {

--- a/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
@@ -28,6 +28,9 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
     private readonly ConcurrentDictionary<Guid, FtpConnectionPool> _sessions = new();
 
     /// <inheritdoc />
+    public event EventHandler<FtpSessionStateChange>? SessionStateChanged;
+
+    /// <inheritdoc />
     public async Task<Guid> OpenSessionAsync(FtpConnectionInfo info, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(info);
@@ -52,6 +55,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         var sessionId = Guid.NewGuid();
         _sessions[sessionId] = pool;
+        SessionStateChanged?.Invoke(this, new(sessionId, FtpSessionState.Connected));
         return sessionId;
     }
 
@@ -64,6 +68,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         if (_sessions.TryRemove(sessionId, out FtpConnectionPool? pool))
         {
             await pool.DisposeAsync().ConfigureAwait(false);
+            SessionStateChanged?.Invoke(this, new(sessionId, FtpSessionState.Closed));
         }
     }
 
@@ -78,7 +83,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "list directory");
+            throw Fault(sessionId, ex, "list directory");
         }
     }
 
@@ -112,7 +117,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "upload");
+            throw Fault(sessionId, ex, "upload");
         }
     }
 
@@ -145,7 +150,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "download");
+            throw Fault(sessionId, ex, "download");
         }
     }
 
@@ -188,7 +193,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "delete");
+            throw Fault(sessionId, ex, "delete");
         }
     }
 
@@ -202,7 +207,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "create directory");
+            throw Fault(sessionId, ex, "create directory");
         }
     }
 
@@ -218,7 +223,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "create file");
+            throw Fault(sessionId, ex, "create file");
         }
     }
 
@@ -236,7 +241,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "rename");
+            throw Fault(sessionId, ex, "rename");
         }
     }
 
@@ -279,7 +284,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "chmod");
+            throw Fault(sessionId, ex, "chmod");
         }
     }
 
@@ -297,7 +302,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "stat");
+            throw Fault(sessionId, ex, "stat");
         }
     }
 
@@ -316,7 +321,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         catch (Exception ex)
         {
             lease.Dispose();
-            throw FluentFtpInterop.Translate(ex, "open");
+            throw Fault(sessionId, ex, "open");
         }
     }
 
@@ -332,7 +337,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "exists");
+            throw Fault(sessionId, ex, "exists");
         }
     }
 
@@ -347,7 +352,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         }
         catch (Exception ex)
         {
-            throw FluentFtpInterop.Translate(ex, "pwd");
+            throw Fault(sessionId, ex, "pwd");
         }
     }
 
@@ -362,10 +367,37 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
 
     // ---- 内部实现 ---------------------------------------------------------
 
-    private async Task<FtpConnectionPool.Lease> RentAsync(Guid sessionId, CancellationToken cancellationToken) =>
-        _sessions.TryGetValue(sessionId, out FtpConnectionPool? pool)
-            ? await pool.RentAsync(cancellationToken).ConfigureAwait(false)
-            : throw new VelaFtpConnectionException($"FTP session {sessionId} is not open.");
+    private async Task<FtpConnectionPool.Lease> RentAsync(Guid sessionId, CancellationToken cancellationToken)
+    {
+        if (!_sessions.TryGetValue(sessionId, out FtpConnectionPool? pool))
+        {
+            throw new VelaFtpConnectionException($"FTP session {sessionId} is not open.");
+        }
+        try
+        {
+            return await pool.RentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // 租不到连接(服务器没了 / 重连失败)同样是一次「会话掉线」,要上报出去,
+            // 否则界面上的状态圆点会一直停在绿色。
+            throw Fault(sessionId, ex, "connect");
+        }
+    }
+
+    /// <summary>
+    /// 把库异常翻译成中立异常;若属于连接级失败,顺带把该会话标记为已失效并广播出去
+    /// —— 资源管理器树的状态圆点据此自动从「活跃」变「离线」。
+    /// </summary>
+    private Exception Fault(Guid sessionId, Exception ex, string operation)
+    {
+        Exception translated = FluentFtpInterop.Translate(ex, operation);
+        if (FluentFtpInterop.IsConnectionLost(translated))
+        {
+            SessionStateChanged?.Invoke(this, new(sessionId, FtpSessionState.Faulted));
+        }
+        return translated;
+    }
 
     private static async Task<AsyncFtpClient> CreateConnectedClientAsync(FtpConnectionInfo info, CertificateProbe probe, CancellationToken cancellationToken)
     {

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -101,6 +102,9 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     private readonly ISettingsService? _settingsService;
     private readonly ISftpService? _sftpService;
     private readonly IFtpSessionService? _ftpSessionService;
+
+    /// <summary>FTP 会话标识 → 会话配置标识:状态事件只带会话标识,树上按配置标识定位节点。</summary>
+    private readonly ConcurrentDictionary<Guid, Guid> _ftpSessionProfiles = new();
     private readonly ISshConnectionService? _sshConnectionService;
     private readonly Func<ITerminalEmulator> _terminalEmulatorFactory;
     private readonly ITunnelService? _tunnelService;
@@ -209,6 +213,12 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         _sessionRepository = sessionRepository;
         _sftpService = sftpService;
         _ftpSessionService = ftpSessionService;
+        if (ftpSessionService is not null)
+        {
+            // FTP 没有 SSH 那种可订阅的长驻会话对象:断线只在下一次操作时暴露。
+            // 由服务主动上报,树上的状态圆点才能自动变灰,而不是一直停在绿点上。
+            ftpSessionService.SessionStateChanged += OnFtpSessionStateChanged;
+        }
         _tunnelService = tunnelService;
         _tunnelWorkflowService = tunnelWorkflowService;
         _metricsService = metricsService;
@@ -2530,7 +2540,8 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
                         FileTransfer,
                         QueryDefaultEditorPathAsync));
                 Layout.AddDocument(document);
-                Sidebar.SessionTree?.SetSessionStatus(current.Id, SessionStatus.Connected);
+                // 与 FTP 同理:连接续体可能落在后台线程上,树节点是绑定属性,必须回主线程再改。
+                SetTreeSessionStatus(current.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -2613,8 +2624,11 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
                         settings.Transfer,
                         FileTransfer,
                         QueryDefaultEditorPathAsync));
+                // 用**原始** profile 的标识登记:登录弹窗可能换过 current 的字段,
+                // 但树上的节点始终是按最初那条配置的 Id 建的。
+                _ftpSessionProfiles[sessionId] = profile.Id;
                 Layout.AddDocument(document);
-                Sidebar.SessionTree?.SetSessionStatus(current.Id, SessionStatus.Connected);
+                SetTreeSessionStatus(profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -2649,6 +2663,40 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         }
         return null;
     }
+
+    /// <summary>
+    /// FTP 会话状态变化 → 资源管理器树的状态圆点。可能来自任意线程(操作失败的那条),
+    /// 因此统一切回 UI 线程再改绑定属性。
+    /// </summary>
+    private void OnFtpSessionStateChanged(object? sender, FtpSessionStateChange change)
+    {
+        if (!_ftpSessionProfiles.TryGetValue(change.SessionId, out Guid profileId))
+        {
+            return;
+        }
+        if (change.State == FtpSessionState.Closed)
+        {
+            _ftpSessionProfiles.TryRemove(change.SessionId, out _);
+        }
+        SetTreeSessionStatus(profileId, change.State switch
+        {
+            FtpSessionState.Connected => SessionStatus.Connected,
+            // 掉线显示为「离线」而不是「未连接」:文档还开着,用户需要看出是断了而不是没连过。
+            FtpSessionState.Faulted => SessionStatus.Error,
+            _ => SessionStatus.Disconnected,
+        });
+    }
+
+    /// <summary>
+    /// 在主线程上更新树节点状态(绑定属性不得在后台线程改)。
+    /// <para>
+    /// 用 <c>RxSchedulers.MainThreadScheduler</c> 而不是裸 <c>Dispatcher.UIThread.Post</c>:
+    /// 与本类其它 VM 更新一致,并且在没有跑 Avalonia 消息循环的宿主(headless 测试)里也能落地
+    /// —— 直接 Post 的作业在那种环境下永远不会被执行。
+    /// </para>
+    /// </summary>
+    private void SetTreeSessionStatus(Guid profileId, SessionStatus status) =>
+        RxSchedulers.MainThreadScheduler.Schedule(() => Sidebar.SessionTree?.SetSessionStatus(profileId, status));
 
     /// <summary>FTP 缺少登录凭据时才需要弹登录框;匿名登录不需要用户名与口令。</summary>
     private static bool RequiresFtpCredentials(SessionProfile profile) =>

--- a/tests/VelaShell.Tests/Views/FtpSessionStatusTests.cs
+++ b/tests/VelaShell.Tests/Views/FtpSessionStatusTests.cs
@@ -1,0 +1,174 @@
+using Avalonia.Headless;
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Docking;
+using VelaShell.Infrastructure.Ftp;
+using VelaShell.Infrastructure.Tests.Ftp;
+using VelaShell.Presentation.ViewModels;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// FTP 会话在资源管理器树上的状态圆点:连上要变绿、断开/关闭要变回红,
+/// 且断线后再操作远端不得抛 NullReference。三条都是实机反馈的缺陷。
+/// </summary>
+[TestClass]
+[TestCategory("FtpSessionStatus")]
+public sealed class FtpSessionStatusTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(FtpSessionStatusTests).Assembly);
+
+    [TestMethod]
+    public async Task ConnectingFtp_TurnsTreeDotGreen_AndClosingTurnsItBack()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vela-ftp-status-{Guid.NewGuid():N}");
+        using var server = new LoopbackFtpServer(root);
+        File.WriteAllText(Path.Combine(root, "a.txt"), "a");
+
+        await Task.Run(async () =>
+        {
+            var ftp = new FtpFileService();
+            SessionProfile profile = FtpProfile(server.Port);
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(new List<SessionProfile> { profile }));
+            repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+            repository.GetSessionAsync(profile.Id).Returns(_ => Task.FromResult<SessionProfile?>(profile));
+
+            var vm = new MainWindowViewModel(sessionRepository: repository, sftpService: ftp, ftpSessionService: ftp);
+            SessionTreeViewModel tree = vm.Sidebar.SessionTree!;
+            await tree.LoadCommand.Execute().FirstAsync();
+            SessionTreeNodeViewModel node = tree.Nodes.Single(n => n.Id == profile.Id);
+            Assert.AreEqual(SessionStatus.Disconnected, node.Status);
+
+            await vm.TryConnectProfileAsync(profile);
+
+            await AssertStatusAsync(node, SessionStatus.Connected, "FTP 连上后树上的圆点必须变绿。");
+
+            SftpDocument document = vm.Layout.AllDocuments().OfType<SftpDocument>().Single();
+            await document.ViewModel.CloseAsync();
+            Assert.IsFalse(ftp.OwnsSession(document.ViewModel.SessionId), "关闭文档应连同释放 FTP 会话。");
+
+            await AssertStatusAsync(node, SessionStatus.Disconnected, "关闭 FTP 文档后圆点应变回红。");
+        });
+
+        TryDeleteDirectory(root);
+    }
+
+    [TestMethod]
+    public async Task ServerGoesAway_TreeDotGoesBackToOffline()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vela-ftp-drop-{Guid.NewGuid():N}");
+        var server = new LoopbackFtpServer(root);
+        File.WriteAllText(Path.Combine(root, "a.txt"), "a");
+
+        await Task.Run(async () =>
+        {
+            var ftp = new FtpFileService();
+            SessionProfile profile = FtpProfile(server.Port);
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(new List<SessionProfile> { profile }));
+            repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+
+            var vm = new MainWindowViewModel(sessionRepository: repository, sftpService: ftp, ftpSessionService: ftp);
+            SessionTreeViewModel tree = vm.Sidebar.SessionTree!;
+            await tree.LoadCommand.Execute().FirstAsync();
+            SessionTreeNodeViewModel node = tree.Nodes.Single(n => n.Id == profile.Id);
+            await vm.TryConnectProfileAsync(profile);
+            await AssertStatusAsync(node, SessionStatus.Connected, "连上后应先变绿。");
+
+            SftpDocument document = vm.Layout.AllDocuments().OfType<SftpDocument>().Single();
+            server.Dispose();   // 服务器消失:后续任何远端操作都会失败
+
+            await document.ViewModel.RemoteFiles.RefreshCommand.Execute().FirstAsync();
+
+            await AssertStatusAsync(node, SessionStatus.Error,
+                "服务器断开后,树上的状态应自动变成离线,而不是一直显示活跃。");
+        });
+
+        TryDeleteDirectory(root);
+    }
+
+    [TestMethod]
+    public async Task OpeningRemoteFileAfterDisconnect_ReportsError_WithoutNullReference()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vela-ftp-open-{Guid.NewGuid():N}");
+        var server = new LoopbackFtpServer(root);
+        File.WriteAllText(Path.Combine(root, "note.txt"), "hello");
+
+        await Task.Run(async () =>
+        {
+            var ftp = new FtpFileService();
+            SessionProfile profile = FtpProfile(server.Port);
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(new List<SessionProfile> { profile }));
+            repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+
+            var vm = new MainWindowViewModel(sessionRepository: repository, sftpService: ftp, ftpSessionService: ftp);
+            await vm.Sidebar.SessionTree!.LoadCommand.Execute().FirstAsync();
+            await vm.TryConnectProfileAsync(profile);
+            SftpDocument document = vm.Layout.AllDocuments().OfType<SftpDocument>().Single();
+            await document.ViewModel.InitialLoadTask;
+
+            document.ViewModel.RemoteFiles.OpenLocalFile = _ => Task.CompletedTask;
+            RemoteFileInfoViewModel file = document.ViewModel.RemoteFiles.Files.Single(f => f.Name == "note.txt");
+            server.Dispose();   // 断线
+
+            // 双击远端文件 —— 断线后必须给出可读错误,不能抛 NullReferenceException。
+            await document.ViewModel.RemoteFiles.ActivateCommand.Execute(file).FirstAsync();
+
+            string? error = document.ViewModel.RemoteFiles.ErrorMessage;
+            Assert.IsNotNull(error, "断线后打开远端文件应给出错误提示。");
+            Assert.DoesNotContain("Object reference", error!,
+                "断线提示必须是可读的连接错误,而不是库内部漏出来的 NullReferenceException 文案。");
+        });
+
+        TryDeleteDirectory(root);
+    }
+
+    /// <summary>
+    /// 等到树节点变成期望状态。状态由 FTP 服务的事件驱动、再 Post 到 UI 线程,天生是异步的 ——
+    /// 直接断言等于赌调度时机(实测会偶发红)。每轮都把 UI 队列泵空再看一眼。
+    /// </summary>
+    private static async Task AssertStatusAsync(SessionTreeNodeViewModel node, SessionStatus expected, string because)
+    {
+        for (int i = 0; i < 100 && node.Status != expected; i++)
+        {
+            await Task.Delay(20);
+        }
+        Assert.AreEqual(expected, node.Status, because);
+    }
+
+    private static SessionProfile FtpProfile(int port) =>
+        new()
+        {
+            ConnectionType = ConnectionType.FTP,
+            Name = "环回 FTP",
+            Host = "127.0.0.1",
+            Port = port,
+            Username = "deploy",
+            Password = "secret123",
+            Ftp = new FtpSettings { EncryptionMode = FtpEncryptionMode.None, MaxConnections = 2 },
+        };
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+        catch (IOException)
+        {
+            // 临时目录删不掉不影响断言。
+        }
+    }
+}


### PR DESCRIPTION
实机反馈的三个 FTP 缺陷，根因各不相同，逐条修掉并用测试锁住。

## 1. 双击远端文件报 “null 错误”

FluentFTP 在**底层套接字已死**时会从内部抛 `NullReferenceException` / `ObjectDisposedException`，它并不总把断线包成 `FtpException`。异常翻译没覆盖这几类，裸 NRE 一路冒到界面，用户只看到 `Object reference not set to an instance of an object`，既不知道发生了什么，也不知道该重连。

用探针实测确认（服务器消失后逐个调用）：

```
List:     NullReferenceException :: Object reference not set to an instance of an object.
GetInfo:  SocketException        :: 由于目标计算机积极拒绝，无法连接。
Exists:   SocketException        :: ...
```

- `FluentFtpInterop.Translate` 补上 `NullReference` / `ObjectDisposed` / `InvalidOperation` → `VelaFtpConnectionException`（“连接已断开，请重连”）；
- 连接池**新建连接**那条路径也补上翻译 —— 服务器没了的时候它抛的是裸 `SocketException`，此前直接越过了 Infrastructure 边界。

## 2. 断线后状态不自动刷新

FTP 没有 SSH 那种可订阅的长驻会话对象，断线只在下一次操作时才暴露，树上的圆点会一直停在绿色。

- `IFtpSessionService` 新增 `SessionStateChanged` 事件（`Connected` / `Faulted` / `Closed`）；
- `FtpFileService` 在操作失败于**连接级**错误时上报 `Faulted`，开/关会话时上报 `Connected`/`Closed`；
- `MainWindowViewModel` 按 `会话 → 配置` 的映射把它落到资源管理器树上（掉线显示为「离线」而不是「未连接」——文档还开着，用户需要看出是断了而不是没连过）。

## 3. 连上后圆点不变绿

状态是直接在连接续体里写的，而那段续体可能落在后台线程上；树节点是绑定属性，后台线程改它不会生效。

改为统一经 `RxSchedulers.MainThreadScheduler` 调度（与本类其它 VM 更新一致）。**独立 SFTP 文档那条路径有同样的隐患，一并收口。**

## 顺带

掉线的连接不再放回池子 —— 否则它会被反复租出去、每次都要先失败再重连，断线后每个操作都得多等一个连接超时。

## 测试

新增 `FtpSessionStatusTests` 三条，对着进程内的环回 FTP 服务器复现并锁住上述行为：

- 连上后树节点变绿、关闭文档后变回红；
- 服务器消失 → 刷新远端 → 节点自动变「离线」；
- 断线后双击远端文件 → 给出可读的连接错误，且断言错误文案**不含** `Object reference`。

全仓 776 + 307 + 138 + 43 + 265 + 2 条测试通过，`dotnet build VelaShell.slnx` 0 警告 0 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uer9zL14cBskqov2KfrYBq
