### PR TITLE
清理全解决方案分析器提示,补齐异步释放与 P/Invoke 语义

### DIFF
--- a/VelaShell-zh.pen
+++ b/VelaShell-zh.pen
@@ -43448,7 +43448,7 @@
                   "id": "L0Xa1",
                   "name": "rowA",
                   "width": "fill_container",
-                  "height": 314,
+                  "height": 408,
                   "gap": 12,
                   "children": [
                     {
@@ -43534,7 +43534,7 @@
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "f8DHi",
+                                  "id": "HhPea",
                                   "name": "disk-nvme0n1",
                                   "width": "fill_container",
                                   "height": "fill_container",
@@ -43544,15 +43544,15 @@
                                   "strokeWidth": 1,
                                   "strokeAlignment": "inner",
                                   "layout": "vertical",
-                                  "gap": 4,
                                   "padding": [
-                                    7,
-                                    9
+                                    8,
+                                    10
                                   ],
+                                  "justifyContent": "space_between",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "sj7Bh",
+                                      "id": "bN3am",
                                       "name": "r1",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43560,14 +43560,14 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "o7llO",
+                                          "id": "O7rqg",
                                           "name": "r1l",
                                           "gap": 6,
                                           "alignItems": "center",
                                           "children": [
                                             {
                                               "type": "text",
-                                              "id": "B18Pvc",
+                                              "id": "V6R0L",
                                               "name": "dName",
                                               "fill": "$text-primary",
                                               "content": "nvme0n1",
@@ -43577,7 +43577,7 @@
                                             },
                                             {
                                               "type": "text",
-                                              "id": "psuUi",
+                                              "id": "W4sfS",
                                               "name": "dKind",
                                               "fill": "$text-muted",
                                               "content": "Samsung PM9A3 · NVMe",
@@ -43589,7 +43589,7 @@
                                         },
                                         {
                                           "type": "text",
-                                          "id": "Xx6uH",
+                                          "id": "t3tE4T",
                                           "name": "dAct",
                                           "fill": "$term-green",
                                           "content": "活动 82%",
@@ -43601,28 +43601,28 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "wsi5n",
+                                      "id": "q54wJ",
                                       "name": "bar",
                                       "clip": true,
-                                      "width": 246,
-                                      "height": 6,
+                                      "width": "fill_container",
+                                      "height": 8,
                                       "fill": "$bg-active",
-                                      "cornerRadius": 3,
+                                      "cornerRadius": 4,
                                       "children": [
                                         {
                                           "type": "rectangle",
-                                          "cornerRadius": 3,
-                                          "id": "xaE1G",
+                                          "cornerRadius": 4,
+                                          "id": "Clei2",
                                           "name": "barFill",
                                           "fill": "$term-green",
                                           "width": 113,
-                                          "height": 6
+                                          "height": 8
                                         }
                                       ]
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "r9vLoU",
+                                      "id": "ZmKPI",
                                       "name": "r3",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43630,22 +43630,22 @@
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "GRMT9",
+                                          "id": "fdWqK",
                                           "name": "dCap",
-                                          "fill": "$text-muted",
+                                          "fill": "$text-secondary",
                                           "content": "1.7 / 3.6 TB",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "normal"
                                         },
                                         {
                                           "type": "text",
-                                          "id": "xdz5B",
+                                          "id": "CB7O9",
                                           "name": "dPct",
                                           "fill": "$term-green",
                                           "content": "46%",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "600"
                                         }
                                       ]
@@ -43654,7 +43654,7 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "ZrxbQ",
+                                  "id": "WutMS",
                                   "name": "disk-nvme1n1",
                                   "width": "fill_container",
                                   "height": "fill_container",
@@ -43664,15 +43664,15 @@
                                   "strokeWidth": 1,
                                   "strokeAlignment": "inner",
                                   "layout": "vertical",
-                                  "gap": 4,
                                   "padding": [
-                                    7,
-                                    9
+                                    8,
+                                    10
                                   ],
+                                  "justifyContent": "space_between",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "ba4v4",
+                                      "id": "b9ibD",
                                       "name": "r1",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43680,14 +43680,14 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "YA1Za",
+                                          "id": "f3uE3d",
                                           "name": "r1l",
                                           "gap": 6,
                                           "alignItems": "center",
                                           "children": [
                                             {
                                               "type": "text",
-                                              "id": "pQUAi",
+                                              "id": "tkCGG",
                                               "name": "dName",
                                               "fill": "$text-primary",
                                               "content": "nvme1n1",
@@ -43697,7 +43697,7 @@
                                             },
                                             {
                                               "type": "text",
-                                              "id": "FNfJB",
+                                              "id": "rVYGZ",
                                               "name": "dKind",
                                               "fill": "$text-muted",
                                               "content": "Samsung PM9A3 · NVMe",
@@ -43709,7 +43709,7 @@
                                         },
                                         {
                                           "type": "text",
-                                          "id": "WJxDy",
+                                          "id": "Bx5sJ",
                                           "name": "dAct",
                                           "fill": "$term-green",
                                           "content": "活动 31%",
@@ -43721,28 +43721,28 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "GEFmj",
+                                      "id": "EOfMr",
                                       "name": "bar",
                                       "clip": true,
-                                      "width": 246,
-                                      "height": 6,
+                                      "width": "fill_container",
+                                      "height": 8,
                                       "fill": "$bg-active",
-                                      "cornerRadius": 3,
+                                      "cornerRadius": 4,
                                       "children": [
                                         {
                                           "type": "rectangle",
-                                          "cornerRadius": 3,
-                                          "id": "r44Fql",
+                                          "cornerRadius": 4,
+                                          "id": "fuCtz",
                                           "name": "barFill",
                                           "fill": "$term-green",
                                           "width": 93,
-                                          "height": 6
+                                          "height": 8
                                         }
                                       ]
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "w2zuO",
+                                      "id": "zp2IA",
                                       "name": "r3",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43750,22 +43750,22 @@
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "MWrx0",
+                                          "id": "OrHYe",
                                           "name": "dCap",
-                                          "fill": "$text-muted",
+                                          "fill": "$text-secondary",
                                           "content": "1.4 / 3.6 TB",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "normal"
                                         },
                                         {
                                           "type": "text",
-                                          "id": "ru8aM",
+                                          "id": "mdE69",
                                           "name": "dPct",
                                           "fill": "$term-green",
                                           "content": "38%",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "600"
                                         }
                                       ]
@@ -43774,7 +43774,7 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "Ztq91",
+                                  "id": "V6wn7H",
                                   "name": "disk-sda",
                                   "width": "fill_container",
                                   "height": "fill_container",
@@ -43784,15 +43784,15 @@
                                   "strokeWidth": 1,
                                   "strokeAlignment": "inner",
                                   "layout": "vertical",
-                                  "gap": 4,
                                   "padding": [
-                                    7,
-                                    9
+                                    8,
+                                    10
                                   ],
+                                  "justifyContent": "space_between",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "K98zj5",
+                                      "id": "X6no6A",
                                       "name": "r1",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43800,14 +43800,14 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "n8azE",
+                                          "id": "TykUe",
                                           "name": "r1l",
                                           "gap": 6,
                                           "alignItems": "center",
                                           "children": [
                                             {
                                               "type": "text",
-                                              "id": "exLUZ",
+                                              "id": "FfGdF",
                                               "name": "dName",
                                               "fill": "$text-primary",
                                               "content": "sda",
@@ -43817,7 +43817,7 @@
                                             },
                                             {
                                               "type": "text",
-                                              "id": "krwnP",
+                                              "id": "Tg0Rq",
                                               "name": "dKind",
                                               "fill": "$text-muted",
                                               "content": "Seagate EXOS · SATA",
@@ -43829,7 +43829,7 @@
                                         },
                                         {
                                           "type": "text",
-                                          "id": "a69NXG",
+                                          "id": "sQnf4",
                                           "name": "dAct",
                                           "fill": "$term-green",
                                           "content": "活动 12%",
@@ -43841,28 +43841,28 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "b7n0E",
+                                      "id": "Hu08W",
                                       "name": "bar",
                                       "clip": true,
-                                      "width": 246,
-                                      "height": 6,
+                                      "width": "fill_container",
+                                      "height": 8,
                                       "fill": "$bg-active",
-                                      "cornerRadius": 3,
+                                      "cornerRadius": 4,
                                       "children": [
                                         {
                                           "type": "rectangle",
-                                          "cornerRadius": 3,
-                                          "id": "mxTyk",
+                                          "cornerRadius": 4,
+                                          "id": "uyZ1m",
                                           "name": "barFill",
                                           "fill": "$warning",
                                           "width": 175,
-                                          "height": 6
+                                          "height": 8
                                         }
                                       ]
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "iVorM",
+                                      "id": "AoMlC",
                                       "name": "r3",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43870,22 +43870,22 @@
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "kf5PB",
+                                          "id": "XFeNN",
                                           "name": "dCap",
-                                          "fill": "$text-muted",
+                                          "fill": "$text-secondary",
                                           "content": "11.2 / 15.8 TB",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "normal"
                                         },
                                         {
                                           "type": "text",
-                                          "id": "KoInf",
+                                          "id": "XyGqQ",
                                           "name": "dPct",
                                           "fill": "$warning",
                                           "content": "71%",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "600"
                                         }
                                       ]
@@ -43894,7 +43894,7 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "kvI73",
+                                  "id": "kH5RN",
                                   "name": "disk-sdb",
                                   "width": "fill_container",
                                   "height": "fill_container",
@@ -43904,15 +43904,15 @@
                                   "strokeWidth": 1,
                                   "strokeAlignment": "inner",
                                   "layout": "vertical",
-                                  "gap": 4,
                                   "padding": [
-                                    7,
-                                    9
+                                    8,
+                                    10
                                   ],
+                                  "justifyContent": "space_between",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "tlAnj",
+                                      "id": "Mf5lL",
                                       "name": "r1",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43920,14 +43920,14 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "IzF1x",
+                                          "id": "g8xHP",
                                           "name": "r1l",
                                           "gap": 6,
                                           "alignItems": "center",
                                           "children": [
                                             {
                                               "type": "text",
-                                              "id": "boa1c",
+                                              "id": "yrqqU",
                                               "name": "dName",
                                               "fill": "$text-primary",
                                               "content": "sdb",
@@ -43937,7 +43937,7 @@
                                             },
                                             {
                                               "type": "text",
-                                              "id": "m0uFr",
+                                              "id": "Ki8y2",
                                               "name": "dKind",
                                               "fill": "$text-muted",
                                               "content": "Seagate EXOS · SATA",
@@ -43949,7 +43949,7 @@
                                         },
                                         {
                                           "type": "text",
-                                          "id": "Y9zOV",
+                                          "id": "LSf3S",
                                           "name": "dAct",
                                           "fill": "$term-green",
                                           "content": "活动 4%",
@@ -43961,28 +43961,28 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "b0ErnO",
+                                      "id": "hg8i0",
                                       "name": "bar",
                                       "clip": true,
-                                      "width": 246,
-                                      "height": 6,
+                                      "width": "fill_container",
+                                      "height": 8,
                                       "fill": "$bg-active",
-                                      "cornerRadius": 3,
+                                      "cornerRadius": 4,
                                       "children": [
                                         {
                                           "type": "rectangle",
-                                          "cornerRadius": 3,
-                                          "id": "Q7sdC",
+                                          "cornerRadius": 4,
+                                          "id": "CEgME",
                                           "name": "barFill",
                                           "fill": "$error",
                                           "width": 229,
-                                          "height": 6
+                                          "height": 8
                                         }
                                       ]
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "pnjgE",
+                                      "id": "lnvR6",
                                       "name": "r3",
                                       "width": "fill_container",
                                       "justifyContent": "space_between",
@@ -43990,22 +43990,22 @@
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "Tl4tw",
+                                          "id": "b3siO",
                                           "name": "dCap",
-                                          "fill": "$text-muted",
+                                          "fill": "$text-secondary",
                                           "content": "14.6 / 15.8 TB",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "normal"
                                         },
                                         {
                                           "type": "text",
-                                          "id": "qb7gs",
+                                          "id": "z7ctXo",
                                           "name": "dPct",
                                           "fill": "$error",
                                           "content": "93%",
                                           "fontFamily": "JetBrains Mono",
-                                          "fontSize": 9,
+                                          "fontSize": 10,
                                           "fontWeight": "600"
                                         }
                                       ]
@@ -44638,7 +44638,7 @@
                     },
                     {
                       "type": "frame",
-                      "id": "FR8LV",
+                      "id": "HsWh8",
                       "name": "partTable",
                       "width": "fill_container",
                       "height": "fill_container",
@@ -44646,7 +44646,7 @@
                       "children": [
                         {
                           "type": "frame",
-                          "id": "yQYYj",
+                          "id": "qqXjR",
                           "name": "partHead",
                           "width": "fill_container",
                           "height": 26,
@@ -44665,15 +44665,15 @@
                           "children": [
                             {
                               "type": "frame",
-                              "id": "Y1yR43",
-                              "name": "pth-挂载点",
-                              "width": 150,
+                              "id": "RDfy9",
+                              "clip": true,
+                              "width": "fill_container",
                               "height": "fill_container",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "IhW5l",
+                                  "id": "ZcnJR",
                                   "name": "pthT",
                                   "fill": "$text-muted",
                                   "content": "挂载点",
@@ -44685,15 +44685,15 @@
                             },
                             {
                               "type": "frame",
-                              "id": "pEehZ",
-                              "name": "pth-设备",
-                              "width": 130,
+                              "id": "Re03M",
+                              "clip": true,
+                              "width": 190,
                               "height": "fill_container",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "K9dnU",
+                                  "id": "GGA5f",
                                   "name": "pthT",
                                   "fill": "$text-muted",
                                   "content": "设备",
@@ -44705,15 +44705,15 @@
                             },
                             {
                               "type": "frame",
-                              "id": "g8tgZ",
-                              "name": "pth-文件系统",
+                              "id": "f1SMOl",
+                              "clip": true,
                               "width": 90,
                               "height": "fill_container",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "m8cfP",
+                                  "id": "Q3rD7I",
                                   "name": "pthT",
                                   "fill": "$text-muted",
                                   "content": "文件系统",
@@ -44725,18 +44725,18 @@
                             },
                             {
                               "type": "frame",
-                              "id": "a5j1c",
-                              "name": "pth-容量",
+                              "id": "lrCUZ",
+                              "clip": true,
                               "width": 180,
                               "height": "fill_container",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "i1csFm",
+                                  "id": "G1URCQ",
                                   "name": "pthT",
                                   "fill": "$text-muted",
-                                  "content": "容量",
+                                  "content": "使用率",
                                   "fontFamily": "Inter",
                                   "fontSize": 10,
                                   "fontWeight": "500"
@@ -44745,15 +44745,16 @@
                             },
                             {
                               "type": "frame",
-                              "id": "XM35o",
-                              "name": "pth-已用 / 总量",
-                              "width": 180,
+                              "id": "a5E0Z4",
+                              "clip": true,
+                              "width": 150,
                               "height": "fill_container",
+                              "justifyContent": "end",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "eFy5s",
+                                  "id": "h7Ffji",
                                   "name": "pthT",
                                   "fill": "$text-muted",
                                   "content": "已用 / 总量",
@@ -44765,19 +44766,19 @@
                             },
                             {
                               "type": "frame",
-                              "id": "WdYUT",
-                              "name": "pth-使用率",
-                              "width": "fill_container",
+                              "id": "uSEIg",
+                              "clip": true,
+                              "width": 64,
                               "height": "fill_container",
                               "justifyContent": "end",
                               "alignItems": "center",
                               "children": [
                                 {
                                   "type": "text",
-                                  "id": "gC654",
+                                  "id": "AyBuq",
                                   "name": "pthT",
                                   "fill": "$text-muted",
-                                  "content": "使用率",
+                                  "content": "%",
                                   "fontFamily": "Inter",
                                   "fontSize": 10,
                                   "fontWeight": "500"
@@ -44788,7 +44789,7 @@
                         },
                         {
                           "type": "frame",
-                          "id": "PdGcD",
+                          "id": "U6N3l2",
                           "name": "rowsScrollWrap",
                           "width": "fill_container",
                           "height": "fill_container",
@@ -44796,7 +44797,7 @@
                           "children": [
                             {
                               "type": "frame",
-                              "id": "lJ9Tp",
+                              "id": "x1wplX",
                               "name": "rowsArea",
                               "width": "fill_container",
                               "height": "fill_container",
@@ -44804,24 +44805,29 @@
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "Xbeqw",
+                                  "id": "NZo5i",
                                   "name": "pr-/",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "zss9g",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "oGfDG",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "nyu37",
+                                          "id": "CzKMO",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/",
@@ -44833,16 +44839,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "W86ug",
-                                      "name": "pc1",
+                                      "id": "wfkya",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "lvFJE",
+                                          "id": "OAatc",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "/dev/nvme0n1p2",
@@ -44854,15 +44859,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "VFjP6",
-                                      "name": "pc2",
+                                      "id": "gHAP3",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "C2Tto0",
+                                          "id": "UGpky",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "ext4",
@@ -44874,7 +44879,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "eNvar",
+                                      "id": "S1BuHl",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -44882,22 +44887,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "zYQ3V",
+                                          "id": "BdKlm",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "i3JHu6",
+                                              "cornerRadius": 4,
+                                              "id": "qRw2y",
                                               "name": "barFill",
                                               "fill": "$term-green",
                                               "width": 74,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -44905,15 +44910,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "Gt3gR",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "jhQqf",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "BWDgc",
+                                          "id": "Fu5Mf",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "1.6 / 3.5 TB",
@@ -44925,16 +44931,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "hx1ll",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "U87UB",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "V7lW7",
+                                          "id": "jbmVS",
                                           "name": "pt5",
                                           "fill": "$term-green",
                                           "content": "46%",
@@ -44948,24 +44954,29 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "E9e8C",
+                                  "id": "xG45F",
                                   "name": "pr-/boot/efi",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "$bg-page",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "ItW2D",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "E6OhzU",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "o9uFrU",
+                                          "id": "yqvvR",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/boot/efi",
@@ -44977,16 +44988,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "e21hs",
-                                      "name": "pc1",
+                                      "id": "qhC5b",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "dR0Ta",
+                                          "id": "i5rtY",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "/dev/nvme0n1p1",
@@ -44998,15 +45008,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "PGm56",
-                                      "name": "pc2",
+                                      "id": "B2dwt",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "TV8PF",
+                                          "id": "xfG5d",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "vfat",
@@ -45018,7 +45028,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "l1ucb",
+                                      "id": "Q8JAiD",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -45026,22 +45036,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "c7rhI",
+                                          "id": "CwYC8",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "KbByV",
+                                              "cornerRadius": 4,
+                                              "id": "X6tzqC",
                                               "name": "barFill",
                                               "fill": "$term-green",
                                               "width": 13,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -45049,15 +45059,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "nO8Br",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "S3dXb",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "MuPGz",
+                                          "id": "PNQOU",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "42 / 512 MB",
@@ -45069,16 +45080,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "kWZzJ",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "d31QZ3",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "gkKUz",
+                                          "id": "ocOml",
                                           "name": "pt5",
                                           "fill": "$term-green",
                                           "content": "8%",
@@ -45092,24 +45103,29 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "AbTO5",
+                                  "id": "t0V2sp",
                                   "name": "pr-/var/lib/docker",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "S92wlJ",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "wddwB",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "D5I8fI",
+                                          "id": "NzSA8",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/var/lib/docker",
@@ -45121,16 +45137,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "Y323j",
-                                      "name": "pc1",
+                                      "id": "p2hOR",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "HkEMH",
+                                          "id": "ugFvA",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "/dev/nvme1n1p1",
@@ -45142,15 +45157,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "pJOT8",
-                                      "name": "pc2",
+                                      "id": "n026C",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "LJAWS",
+                                          "id": "n2lRO",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "xfs",
@@ -45162,7 +45177,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "BI3KJ",
+                                      "id": "y6GHKL",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -45170,22 +45185,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "aUYal",
+                                          "id": "t1Xpl",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "VbNpF",
+                                              "cornerRadius": 4,
+                                              "id": "hpclC",
                                               "name": "barFill",
                                               "fill": "$term-green",
                                               "width": 61,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -45193,15 +45208,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "xielB",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "ltadQ",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "irH3e",
+                                          "id": "AWH5O",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "1.4 / 3.6 TB",
@@ -45213,16 +45229,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "mWbHn",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "SemSd",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "MXCv7",
+                                          "id": "BgBia",
                                           "name": "pt5",
                                           "fill": "$term-green",
                                           "content": "38%",
@@ -45236,24 +45252,29 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "o4Wwnk",
+                                  "id": "GJ5pr",
                                   "name": "pr-/data",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "$bg-page",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "mME0F",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "hh7O8",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "FCIEJ",
+                                          "id": "rOhWb",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/data",
@@ -45265,16 +45286,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "KtPsg",
-                                      "name": "pc1",
+                                      "id": "m4EFW",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "iJszn",
+                                          "id": "G1Ky03",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "/dev/sda1",
@@ -45286,15 +45306,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "m4Ghn",
-                                      "name": "pc2",
+                                      "id": "EPJqI",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "zApxS",
+                                          "id": "L8aX0k",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "xfs",
@@ -45306,7 +45326,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "yGNYT",
+                                      "id": "jI8h3",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -45314,22 +45334,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "dGUKw",
+                                          "id": "gm7uE",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "j6BIS",
+                                              "cornerRadius": 4,
+                                              "id": "AxL1e",
                                               "name": "barFill",
                                               "fill": "$warning",
                                               "width": 114,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -45337,15 +45357,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "pjTd4",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "EotPs",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "fUvT2",
+                                          "id": "K5orTy",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "11.2 / 15.8 TB",
@@ -45357,16 +45378,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "RFpQb",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "qqlWC",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "P4jYc",
+                                          "id": "MDrZS",
                                           "name": "pt5",
                                           "fill": "$warning",
                                           "content": "71%",
@@ -45380,24 +45401,29 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "V5G4Xb",
+                                  "id": "bIxOE",
                                   "name": "pr-/backup",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "iIkQm",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "uBcOU",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "sCsd6",
+                                          "id": "mzx7s",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/backup",
@@ -45409,16 +45435,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "zpSml",
-                                      "name": "pc1",
+                                      "id": "tNHVq",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "YUiWr",
+                                          "id": "u96j0",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "/dev/sdb1",
@@ -45430,15 +45455,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "a3bXW0",
-                                      "name": "pc2",
+                                      "id": "xEQ3j",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "Mw1kB",
+                                          "id": "M5pofQ",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "ext4",
@@ -45450,7 +45475,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "lSKVw",
+                                      "id": "ZagQm",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -45458,22 +45483,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "eFH7q",
+                                          "id": "QxuGI",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "enzTD",
+                                              "cornerRadius": 4,
+                                              "id": "ua7hZ",
                                               "name": "barFill",
                                               "fill": "$error",
                                               "width": 149,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -45481,15 +45506,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "avaCf",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "Nj1dd",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "pDavR",
+                                          "id": "yjUlS",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "14.6 / 15.8 TB",
@@ -45501,16 +45527,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "BO5HH",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "hotD3",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "kCoND",
+                                          "id": "DfjjG",
                                           "name": "pt5",
                                           "fill": "$error",
                                           "content": "93%",
@@ -45524,24 +45550,29 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "feN3o",
+                                  "id": "Qqacu",
                                   "name": "pr-/mnt/nas",
                                   "width": "fill_container",
                                   "height": "fill_container",
-                                  "cornerRadius": 3,
+                                  "fill": "$bg-page",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    0,
+                                    6
+                                  ],
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "frame",
-                                      "id": "s2cWD",
-                                      "name": "pc0",
-                                      "width": 150,
+                                      "id": "jdjZj",
+                                      "clip": true,
+                                      "width": "fill_container",
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "hq91B",
+                                          "id": "TNLwY",
                                           "name": "pt0",
                                           "fill": "$text-primary",
                                           "content": "/mnt/nas",
@@ -45553,16 +45584,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "OeJ9y",
-                                      "name": "pc1",
+                                      "id": "IujK6",
                                       "clip": true,
-                                      "width": 130,
+                                      "width": 190,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "DVSH4",
+                                          "id": "MR2UD",
                                           "name": "pt1",
                                           "fill": "$text-secondary",
                                           "content": "nfs://10.0.3.8/vol1",
@@ -45574,15 +45604,15 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "xdlMP",
-                                      "name": "pc2",
+                                      "id": "X0LCjb",
+                                      "clip": true,
                                       "width": 90,
                                       "height": "fill_container",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "zqePW",
+                                          "id": "ZQNga",
                                           "name": "pt2",
                                           "fill": "$text-secondary",
                                           "content": "nfs4",
@@ -45594,7 +45624,7 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "Xbdhd",
+                                      "id": "ZDSvu",
                                       "name": "pc3",
                                       "width": 180,
                                       "height": "fill_container",
@@ -45602,22 +45632,22 @@
                                       "children": [
                                         {
                                           "type": "frame",
-                                          "id": "CP5S9",
+                                          "id": "A5EZVn",
                                           "name": "bar",
                                           "clip": true,
                                           "width": 160,
-                                          "height": 6,
+                                          "height": 8,
                                           "fill": "$bg-active",
-                                          "cornerRadius": 3,
+                                          "cornerRadius": 4,
                                           "children": [
                                             {
                                               "type": "rectangle",
-                                              "cornerRadius": 3,
-                                              "id": "EC2JI",
+                                              "cornerRadius": 4,
+                                              "id": "u6QHWa",
                                               "name": "barFill",
                                               "fill": "$term-green",
                                               "width": 99,
-                                              "height": 6
+                                              "height": 8
                                             }
                                           ]
                                         }
@@ -45625,15 +45655,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "WnmFX",
-                                      "name": "pc4",
-                                      "width": 180,
+                                      "id": "eA9gy",
+                                      "clip": true,
+                                      "width": 150,
                                       "height": "fill_container",
+                                      "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "xo9Ue",
+                                          "id": "v2Li5",
                                           "name": "pt4",
                                           "fill": "$text-secondary",
                                           "content": "24.8 / 40.0 TB",
@@ -45645,16 +45676,16 @@
                                     },
                                     {
                                       "type": "frame",
-                                      "id": "ydFC4",
-                                      "name": "pc5",
-                                      "width": "fill_container",
+                                      "id": "RxTTp",
+                                      "clip": true,
+                                      "width": 64,
                                       "height": "fill_container",
                                       "justifyContent": "end",
                                       "alignItems": "center",
                                       "children": [
                                         {
                                           "type": "text",
-                                          "id": "EjetE",
+                                          "id": "m1CuNf",
                                           "name": "pt5",
                                           "fill": "$term-green",
                                           "content": "62%",
@@ -45670,7 +45701,7 @@
                             },
                             {
                               "type": "frame",
-                              "id": "XOooc",
+                              "id": "Dyb5K",
                               "name": "scrollbar",
                               "width": 6,
                               "height": "fill_container",
@@ -45679,15 +45710,15 @@
                               "layout": "none",
                               "children": [
                                 {
-                                  "type": "rectangle",
-                                  "cornerRadius": 3,
-                                  "id": "fQNys",
+                                  "type": "frame",
+                                  "id": "ChLID",
                                   "x": 0,
                                   "y": 0,
                                   "name": "scrollThumb",
-                                  "fill": "$border-secondary",
                                   "width": 6,
-                                  "height": 112
+                                  "height": 112,
+                                  "fill": "$border-secondary",
+                                  "cornerRadius": 3
                                 }
                               ]
                             }
@@ -47576,7 +47607,6 @@
                   "id": "MToK0",
                   "name": "netChartCard",
                   "width": "fill_container",
-                  "height": 300,
                   "fill": "$bg-input",
                   "cornerRadius": 8,
                   "stroke": "$border-primary",
@@ -47651,7 +47681,7 @@
                       "name": "plot",
                       "clip": true,
                       "width": 840,
-                      "height": 214,
+                      "height": 182,
                       "fill": "$bg-page",
                       "cornerRadius": 4,
                       "stroke": "$border-primary",
@@ -47663,7 +47693,7 @@
                           "type": "rectangle",
                           "id": "XHUkK",
                           "x": 0,
-                          "y": 27,
+                          "y": 23,
                           "name": "gridH1",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47674,7 +47704,7 @@
                           "type": "rectangle",
                           "id": "Ff5XB",
                           "x": 0,
-                          "y": 54,
+                          "y": 46,
                           "name": "gridH2",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47685,7 +47715,7 @@
                           "type": "rectangle",
                           "id": "KYiaM",
                           "x": 0,
-                          "y": 80,
+                          "y": 68,
                           "name": "gridH3",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47696,7 +47726,7 @@
                           "type": "rectangle",
                           "id": "J3rYDc",
                           "x": 0,
-                          "y": 134,
+                          "y": 114,
                           "name": "gridH5",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47707,7 +47737,7 @@
                           "type": "rectangle",
                           "id": "PSHEV",
                           "x": 0,
-                          "y": 161,
+                          "y": 137,
                           "name": "gridH6",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47718,7 +47748,7 @@
                           "type": "rectangle",
                           "id": "t8nWn6",
                           "x": 0,
-                          "y": 187,
+                          "y": 159,
                           "name": "gridH7",
                           "opacity": 0.45,
                           "fill": "$border-primary",
@@ -47734,7 +47764,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47745,7 +47775,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47756,7 +47786,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47767,7 +47797,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47778,7 +47808,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47789,7 +47819,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "rectangle",
@@ -47800,7 +47830,7 @@
                           "opacity": 0.3,
                           "fill": "$border-primary",
                           "width": 1,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "path",
@@ -47817,7 +47847,7 @@
                           ],
                           "fill": "#8BE9FD33",
                           "width": 840,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "path",
@@ -47834,7 +47864,7 @@
                           ],
                           "fill": "#00000000",
                           "width": 840,
-                          "height": 214,
+                          "height": 182,
                           "stroke": "#8BE9FD",
                           "strokeWidth": 1.6,
                           "strokeLinejoin": "round"
@@ -47854,7 +47884,7 @@
                           ],
                           "fill": "#FF79C633",
                           "width": 840,
-                          "height": 214
+                          "height": 182
                         },
                         {
                           "type": "path",
@@ -47871,7 +47901,7 @@
                           ],
                           "fill": "#00000000",
                           "width": 840,
-                          "height": 214,
+                          "height": 182,
                           "stroke": "#FF79C6",
                           "strokeWidth": 1.6,
                           "strokeLinejoin": "round"
@@ -47880,7 +47910,7 @@
                           "type": "rectangle",
                           "id": "LW8HU",
                           "x": 0,
-                          "y": 107,
+                          "y": 91,
                           "name": "midLine",
                           "fill": "$border-secondary",
                           "width": 840,
@@ -47890,7 +47920,7 @@
                           "type": "text",
                           "id": "L2UBkp",
                           "x": 8,
-                          "y": 6,
+                          "y": 5,
                           "name": "axTop",
                           "fill": "$text-muted",
                           "content": "↓ 40 MB/s",
@@ -47902,7 +47932,7 @@
                           "type": "text",
                           "id": "UMZ68",
                           "x": 8,
-                          "y": 198,
+                          "y": 168,
                           "name": "axBtm",
                           "fill": "$text-muted",
                           "content": "↑ 40 MB/s",
@@ -47914,7 +47944,7 @@
                           "type": "text",
                           "id": "ojLvi",
                           "x": 784,
-                          "y": 94,
+                          "y": 80,
                           "name": "axMid",
                           "fill": "$text-muted",
                           "content": "现在 →",
@@ -48017,6 +48047,7 @@
                   "name": "rowC",
                   "width": "fill_container",
                   "height": "fill_container",
+                  "layout": "vertical",
                   "gap": 12,
                   "children": [
                     {
@@ -48024,7 +48055,6 @@
                       "id": "ykioc",
                       "name": "nicDetailCard",
                       "width": "fill_container",
-                      "height": "fill_container",
                       "fill": "$bg-input",
                       "cornerRadius": 8,
                       "stroke": "$border-primary",
@@ -48075,31 +48105,88 @@
                         },
                         {
                           "type": "frame",
-                          "id": "g4v3oV",
-                          "name": "detailGrid",
+                          "id": "cknRl",
+                          "name": "detailBand",
                           "width": "fill_container",
-                          "height": "fill_container",
-                          "gap": 20,
+                          "layout": "vertical",
+                          "gap": 6,
                           "children": [
                             {
                               "type": "frame",
-                              "id": "ak7MZ",
-                              "name": "detailCol",
+                              "id": "eosw9",
+                              "name": "bandRow",
                               "width": "fill_container",
-                              "layout": "vertical",
-                              "gap": 8,
+                              "gap": 28,
+                              "alignItems": "center",
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "b2eRH",
-                                  "name": "d-MAC 地址",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "id": "RI2nj",
+                                  "name": "d-类型",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "dAi0T",
+                                      "id": "WWwFW",
+                                      "name": "dK",
+                                      "fill": "$text-secondary",
+                                      "content": "类型",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "SpD3m",
+                                      "name": "dV",
+                                      "fill": "$text-primary",
+                                      "content": "以太网",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "OROl9",
+                                  "name": "d-驱动",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ySWyy",
+                                      "name": "dK",
+                                      "fill": "$text-secondary",
+                                      "content": "驱动",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "lizB9",
+                                      "name": "dV",
+                                      "fill": "$text-primary",
+                                      "content": "ixgbe",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "YcphD",
+                                  "name": "d-MAC 地址",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "N9ljp6",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "MAC 地址",
@@ -48109,7 +48196,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "h1P3V",
+                                      "id": "HtD3T",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "b4:2e:99:0c:1a:77",
@@ -48121,15 +48208,14 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "uY59L",
+                                  "id": "Era4p",
                                   "name": "d-MTU",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "N1gMvE",
+                                      "id": "mQoj9",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "MTU",
@@ -48139,7 +48225,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "rls84",
+                                      "id": "Y3Uimr",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "9000",
@@ -48151,58 +48237,27 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "f9JrMp",
-                                  "name": "d-驱动 / 固件",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "id": "OZXRL",
+                                  "name": "d-链路速率",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "FGFlH",
+                                      "id": "V0Pa5h",
                                       "name": "dK",
                                       "fill": "$text-secondary",
-                                      "content": "驱动 / 固件",
+                                      "content": "链路速率",
                                       "fontFamily": "Inter",
                                       "fontSize": 10,
                                       "fontWeight": "normal"
                                     },
                                     {
                                       "type": "text",
-                                      "id": "Sfzyc",
+                                      "id": "qoSqQ",
                                       "name": "dV",
                                       "fill": "$text-primary",
-                                      "content": "ice / 4.30",
-                                      "fontFamily": "JetBrains Mono",
-                                      "fontSize": 10,
-                                      "fontWeight": "500"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "frame",
-                                  "id": "Ne0mF",
-                                  "name": "d-队列数",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
-                                  "alignItems": "center",
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "id": "OW0sg",
-                                      "name": "dK",
-                                      "fill": "$text-secondary",
-                                      "content": "队列数",
-                                      "fontFamily": "Inter",
-                                      "fontSize": 10,
-                                      "fontWeight": "normal"
-                                    },
-                                    {
-                                      "type": "text",
-                                      "id": "SQZIH",
-                                      "name": "dV",
-                                      "fill": "$text-primary",
-                                      "content": "64",
+                                      "content": "10 Gbps · 全双工",
                                       "fontFamily": "JetBrains Mono",
                                       "fontSize": 10,
                                       "fontWeight": "500"
@@ -48213,23 +48268,80 @@
                             },
                             {
                               "type": "frame",
-                              "id": "apwT6",
-                              "name": "detailCol",
+                              "id": "BgO0c",
+                              "name": "bandRow",
                               "width": "fill_container",
-                              "layout": "vertical",
-                              "gap": 8,
+                              "gap": 28,
+                              "alignItems": "center",
                               "children": [
                                 {
                                   "type": "frame",
-                                  "id": "y7LMAs",
-                                  "name": "d-累计接收",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "id": "T2wx47",
+                                  "name": "d-IPv4",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "n7UlQ",
+                                      "id": "D3xms",
+                                      "name": "dK",
+                                      "fill": "$text-secondary",
+                                      "content": "IPv4",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "jKAbp",
+                                      "name": "dV",
+                                      "fill": "$text-primary",
+                                      "content": "10.0.2.31/24",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Sy930",
+                                  "name": "d-IPv6",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "s2g8A",
+                                      "name": "dK",
+                                      "fill": "$text-secondary",
+                                      "content": "IPv6",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "nJs9e",
+                                      "name": "dV",
+                                      "fill": "$text-primary",
+                                      "content": "2001:db8:1::31/64",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "cHJix",
+                                  "name": "d-累计接收",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "W73EcR",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "累计接收",
@@ -48239,7 +48351,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "iFf9D",
+                                      "id": "QAMXJ",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "4.20 TB",
@@ -48251,15 +48363,14 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "Z2uyOr",
+                                  "id": "Vok9G",
                                   "name": "d-累计发送",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "gLZ1k",
+                                      "id": "wljxI",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "累计发送",
@@ -48269,7 +48380,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "KHB7P",
+                                      "id": "Bqk1c",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "1.08 TB",
@@ -48281,15 +48392,14 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "P2Xsty",
+                                  "id": "jqWLz",
                                   "name": "d-丢包 收/发",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "xxsFo",
+                                      "id": "werLd",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "丢包 收/发",
@@ -48299,7 +48409,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "P1ScMR",
+                                      "id": "KSh69",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "0 / 0",
@@ -48311,15 +48421,14 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "exyxE",
+                                  "id": "RT6m1",
                                   "name": "d-错误 收/发",
-                                  "width": "fill_container",
-                                  "justifyContent": "space_between",
+                                  "gap": 8,
                                   "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "GBXV6",
+                                      "id": "riq6v",
                                       "name": "dK",
                                       "fill": "$text-secondary",
                                       "content": "错误 收/发",
@@ -48329,7 +48438,7 @@
                                     },
                                     {
                                       "type": "text",
-                                      "id": "KqUyd",
+                                      "id": "c7bVjw",
                                       "name": "dV",
                                       "fill": "$text-primary",
                                       "content": "0 / 0",
@@ -48349,7 +48458,7 @@
                       "type": "frame",
                       "id": "J9o9o",
                       "name": "talkerCard",
-                      "width": 380,
+                      "width": "fill_container",
                       "height": "fill_container",
                       "fill": "$bg-input",
                       "cornerRadius": 8,
@@ -48400,7 +48509,7 @@
                                   "id": "kNKmh",
                                   "name": "sub",
                                   "fill": "$text-muted",
-                                  "content": "ss -ti 逐连接差分 · 显示 1-4 / 128",
+                                  "content": "ss -ti 逐连接差分 · 显示 1-2 / 128",
                                   "fontFamily": "Inter",
                                   "fontSize": 10,
                                   "fontWeight": "normal"
@@ -48440,7 +48549,7 @@
                                   "type": "frame",
                                   "id": "u5d3Ja",
                                   "name": "h",
-                                  "width": "fill_container",
+                                  "width": 320,
                                   "height": "fill_container",
                                   "alignItems": "center",
                                   "children": [
@@ -48460,7 +48569,7 @@
                                   "type": "frame",
                                   "id": "IwM0n",
                                   "name": "h",
-                                  "width": 90,
+                                  "width": "fill_container",
                                   "height": "fill_container",
                                   "alignItems": "center",
                                   "children": [
@@ -48480,7 +48589,7 @@
                                   "type": "frame",
                                   "id": "KN2ps",
                                   "name": "h",
-                                  "width": 70,
+                                  "width": 110,
                                   "height": "fill_container",
                                   "justifyContent": "end",
                                   "alignItems": "center",
@@ -48501,7 +48610,7 @@
                                   "type": "frame",
                                   "id": "sT7Bj",
                                   "name": "h",
-                                  "width": 70,
+                                  "width": 110,
                                   "height": "fill_container",
                                   "justifyContent": "end",
                                   "alignItems": "center",
@@ -48549,7 +48658,7 @@
                                           "id": "YkDls",
                                           "name": "c",
                                           "clip": true,
-                                          "width": "fill_container",
+                                          "width": 320,
                                           "height": "fill_container",
                                           "alignItems": "center",
                                           "children": [
@@ -48570,7 +48679,7 @@
                                           "id": "TYxoe",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 90,
+                                          "width": "fill_container",
                                           "height": "fill_container",
                                           "alignItems": "center",
                                           "children": [
@@ -48591,7 +48700,7 @@
                                           "id": "zcHEY",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 70,
+                                          "width": 110,
                                           "height": "fill_container",
                                           "justifyContent": "end",
                                           "alignItems": "center",
@@ -48613,7 +48722,7 @@
                                           "id": "UqJll",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 70,
+                                          "width": 110,
                                           "height": "fill_container",
                                           "justifyContent": "end",
                                           "alignItems": "center",
@@ -48645,7 +48754,7 @@
                                           "id": "Y19cu",
                                           "name": "c",
                                           "clip": true,
-                                          "width": "fill_container",
+                                          "width": 320,
                                           "height": "fill_container",
                                           "alignItems": "center",
                                           "children": [
@@ -48666,7 +48775,7 @@
                                           "id": "P1Z37",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 90,
+                                          "width": "fill_container",
                                           "height": "fill_container",
                                           "alignItems": "center",
                                           "children": [
@@ -48687,7 +48796,7 @@
                                           "id": "qiSNK",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 70,
+                                          "width": 110,
                                           "height": "fill_container",
                                           "justifyContent": "end",
                                           "alignItems": "center",
@@ -48709,7 +48818,7 @@
                                           "id": "Q2Ioq4",
                                           "name": "c",
                                           "clip": true,
-                                          "width": 70,
+                                          "width": 110,
                                           "height": "fill_container",
                                           "justifyContent": "end",
                                           "alignItems": "center",
@@ -48720,198 +48829,6 @@
                                               "name": "t",
                                               "fill": "$term-magenta",
                                               "content": "1.9 MB/s",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "n7Y9x2",
-                                      "name": "tk-10.0.4.31:9092",
-                                      "width": "fill_container",
-                                      "height": 26,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "TvMib",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": "fill_container",
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "dj1jx",
-                                              "name": "t",
-                                              "fill": "$text-primary",
-                                              "content": "10.0.4.31:9092",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "eCkCl",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 90,
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "K8DQF",
-                                              "name": "t",
-                                              "fill": "$text-muted",
-                                              "content": "—",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "aEna6",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "kuLzm",
-                                              "name": "t",
-                                              "fill": "$term-cyan",
-                                              "content": "3.1 MB/s",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "eRRIR",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "ZKn74",
-                                              "name": "t",
-                                              "fill": "$term-magenta",
-                                              "content": "0.7 MB/s",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "qTySW",
-                                      "name": "tk-10.0.2.9:6379",
-                                      "width": "fill_container",
-                                      "height": 26,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "sp7sw",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": "fill_container",
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "mQRK7",
-                                              "name": "t",
-                                              "fill": "$text-primary",
-                                              "content": "10.0.2.9:6379",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "Gm69I",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 90,
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "fDO0s",
-                                              "name": "t",
-                                              "fill": "$text-secondary",
-                                              "content": "redis-server",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "k3KXv",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "v8hGp",
-                                              "name": "t",
-                                              "fill": "$term-cyan",
-                                              "content": "1.4 MB/s",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "iqYaS",
-                                          "name": "c",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "e0G1B",
-                                              "name": "t",
-                                              "fill": "$term-magenta",
-                                              "content": "0.2 MB/s",
                                               "fontFamily": "JetBrains Mono",
                                               "fontSize": 10,
                                               "fontWeight": "normal"
@@ -50115,7 +50032,7 @@
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "磁盘：左侧物理盘列表（容量条 + 活动率），单选联动右图",
+                      "content": "磁盘：上半区定高(放得下 4 块盘);盘卡三段 —— 名称/型号·接口/活动率贴顶,8px 占用条居中,容量与占用率贴底",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50179,7 +50096,7 @@
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "分区表逐挂载点显示容量条，超阈值转警告 / 危险色",
+                      "content": "分区表列:挂载点 / 设备 / 文件系统 / 占用条 / 已用总量 / 使用率;隔行底纹,读数与条同步转警告/危险色",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50304,7 +50221,7 @@
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "网卡详情:MAC / MTU / 链路速率 / IPv4 / 累计收发",
+                      "content": "网卡详情:定宽 392,左右两列各四行 —— MAC / MTU / 链路速率·双工 / IPv4 | 累计收 / 累计发 / 丢包 / 错误",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50336,7 +50253,7 @@
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "连接占用 Top:ss -ti 的逐连接字节计数两次采样差分,按收发合计排序",
+                      "content": "连接占用 Top:吃剩余宽度(对端与进程名最占地方);ss -ti 逐连接差分,按收发合计排序",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50421,7 +50338,7 @@
           "children": [
             {
               "type": "frame",
-              "id": "VhoC8",
+              "id": "d6hWEr",
               "name": "sec-GPU 视图",
               "width": "fill_container",
               "fill": "$bg-input",
@@ -50438,24 +50355,24 @@
               "children": [
                 {
                   "type": "text",
-                  "id": "QRykS",
+                  "id": "G2jiP",
                   "name": "secT",
                   "fill": "$text-primary",
                   "content": "GPU 视图",
                   "fontFamily": "Inter",
-                  "fontSize": 12,
+                  "fontSize": 11,
                   "fontWeight": "600"
                 },
                 {
                   "type": "frame",
-                  "id": "X6xuc",
+                  "id": "J1RSJp",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "CA04j",
+                      "id": "K8JsI",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50465,7 +50382,7 @@
                     },
                     {
                       "type": "text",
-                      "id": "TCHbY",
+                      "id": "u8QVQa",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
@@ -50480,14 +50397,14 @@
                 },
                 {
                   "type": "frame",
-                  "id": "pgaxc",
+                  "id": "kTZnl",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "Bo6zm",
+                      "id": "BM3fz",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50497,7 +50414,7 @@
                     },
                     {
                       "type": "text",
-                      "id": "G43q2",
+                      "id": "VZE3J",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
@@ -50512,14 +50429,14 @@
                 },
                 {
                   "type": "frame",
-                  "id": "U9j4f",
+                  "id": "jM8CV",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "n0aXS",
+                      "id": "R52sl",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50529,7 +50446,7 @@
                     },
                     {
                       "type": "text",
-                      "id": "shkbm",
+                      "id": "IU6W9",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
@@ -50544,14 +50461,14 @@
                 },
                 {
                   "type": "frame",
-                  "id": "ifdkq",
+                  "id": "flAwf",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "FkXIc",
+                      "id": "YN2FO",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50561,12 +50478,12 @@
                     },
                     {
                       "type": "text",
-                      "id": "sDAuA",
+                      "id": "XdG33",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "型号名:AMD 读 product_name,Intel 靠静态探针的 lspci 按 PCI 槽位匹配",
+                      "content": "虚拟化兜底:静态探针扫 /sys/bus/pci 的 0x03 显示类设备。直通卡未装驱动、KVM virtio-gpu、ESXi SVGA 都没有 DRM 节点,靠这段才看得见(指标全 —,给出槽位与驱动)",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50576,14 +50493,14 @@
                 },
                 {
                   "type": "frame",
-                  "id": "Qo4YQ",
+                  "id": "CXvj5",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "lpvfE",
+                      "id": "eMIkJ",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50593,12 +50510,12 @@
                     },
                     {
                       "type": "text",
-                      "id": "N2ORC4",
+                      "id": "OwZJb",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
                       "width": "fill_container",
-                      "content": "多卡混排:卡片条一卡一张,序号 NVIDIA 在前、DRM 卡接续,选中卡展开双图与详情",
+                      "content": "WSL2 无 PCI 无 DRM:有 /dev/dxg 即认定 GPU 经 D3D12 直通(NVIDIA 卡仍走 nvidia-smi)",
                       "lineHeight": 1.5,
                       "fontFamily": "Inter",
                       "fontSize": 10,
@@ -50608,14 +50525,14 @@
                 },
                 {
                   "type": "frame",
-                  "id": "fIEuW",
+                  "id": "c2TC9",
                   "name": "li",
                   "width": "fill_container",
                   "gap": 6,
                   "children": [
                     {
                       "type": "text",
-                      "id": "onB2s",
+                      "id": "qZJEi",
                       "name": "liDot",
                       "fill": "$accent",
                       "content": "·",
@@ -50625,7 +50542,71 @@
                     },
                     {
                       "type": "text",
-                      "id": "r303g",
+                      "id": "EIN89",
+                      "name": "liT",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "型号名:AMD 读 product_name,其余靠静态探针的 lspci 按 PCI 槽位匹配;lspci 缺失时退回厂商名",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QWyQH",
+                  "name": "li",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RMIa7",
+                      "name": "liDot",
+                      "fill": "$accent",
+                      "content": "·",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "y2F6Y7",
+                      "name": "liT",
+                      "fill": "$text-secondary",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "多卡混排:卡片条一卡一张,序号 NVIDIA 在前、DRM 卡接续、只在 PCI 上看得见的卡排最后",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uXBzr",
+                  "name": "li",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "THaix",
+                      "name": "liDot",
+                      "fill": "$accent",
+                      "content": "·",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Z3mYi",
                       "name": "liT",
                       "fill": "$text-secondary",
                       "textGrowth": "fixed-width",
@@ -52926,7 +52907,7 @@
                   "id": "X7uiq",
                   "name": "rowB",
                   "width": "fill_container",
-                  "height": 268,
+                  "height": 253,
                   "gap": 12,
                   "children": [
                     {
@@ -53009,7 +52990,7 @@
                           "name": "plot",
                           "clip": true,
                           "width": 390,
-                          "height": 196,
+                          "height": 178,
                           "fill": "$bg-page",
                           "cornerRadius": 4,
                           "stroke": "$border-primary",
@@ -53021,7 +53002,7 @@
                               "type": "rectangle",
                               "id": "QB8Kp",
                               "x": 0,
-                              "y": 49,
+                              "y": 45,
                               "name": "gridH1",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53032,7 +53013,7 @@
                               "type": "rectangle",
                               "id": "ab5vD",
                               "x": 0,
-                              "y": 98,
+                              "y": 89,
                               "name": "gridH2",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53043,7 +53024,7 @@
                               "type": "rectangle",
                               "id": "M1V7Qu",
                               "x": 0,
-                              "y": 147,
+                              "y": 134,
                               "name": "gridH3",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53059,7 +53040,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53070,7 +53051,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53081,7 +53062,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53092,7 +53073,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53103,7 +53084,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "path",
@@ -53120,7 +53101,7 @@
                               ],
                               "fill": "#FF79C638",
                               "width": 390,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "path",
@@ -53137,7 +53118,7 @@
                               ],
                               "fill": "#00000000",
                               "width": 390,
-                              "height": 196,
+                              "height": 178,
                               "stroke": "#FF79C6",
                               "strokeWidth": 1.5,
                               "strokeLinejoin": "round"
@@ -53157,7 +53138,7 @@
                               ],
                               "fill": "#BD93F926",
                               "width": 390,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "path",
@@ -53174,7 +53155,7 @@
                               ],
                               "fill": "#00000000",
                               "width": 390,
-                              "height": 196,
+                              "height": 178,
                               "stroke": "#BD93F9",
                               "strokeWidth": 1.5,
                               "strokeLinejoin": "round"
@@ -53183,7 +53164,7 @@
                               "type": "text",
                               "id": "D3shu9",
                               "x": 8,
-                              "y": 6,
+                              "y": 5,
                               "name": "axisTop",
                               "fill": "$text-muted",
                               "content": "100%",
@@ -53195,7 +53176,7 @@
                               "type": "text",
                               "id": "F5DiG",
                               "x": 8,
-                              "y": 180,
+                              "y": 163,
                               "name": "axisL",
                               "fill": "$text-muted",
                               "content": "60 秒前",
@@ -53207,7 +53188,7 @@
                               "type": "text",
                               "id": "E6hrBO",
                               "x": 358,
-                              "y": 180,
+                              "y": 163,
                               "name": "axisR",
                               "fill": "$text-muted",
                               "content": "现在",
@@ -53384,7 +53365,7 @@
                           "name": "plot",
                           "clip": true,
                           "width": 390,
-                          "height": 196,
+                          "height": 178,
                           "fill": "$bg-page",
                           "cornerRadius": 4,
                           "stroke": "$border-primary",
@@ -53396,7 +53377,7 @@
                               "type": "rectangle",
                               "id": "iqGx4",
                               "x": 0,
-                              "y": 49,
+                              "y": 45,
                               "name": "gridH1",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53407,7 +53388,7 @@
                               "type": "rectangle",
                               "id": "o5iKeB",
                               "x": 0,
-                              "y": 98,
+                              "y": 89,
                               "name": "gridH2",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53418,7 +53399,7 @@
                               "type": "rectangle",
                               "id": "QfPyY",
                               "x": 0,
-                              "y": 147,
+                              "y": 134,
                               "name": "gridH3",
                               "opacity": 0.55,
                               "fill": "$border-primary",
@@ -53434,7 +53415,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53445,7 +53426,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53456,7 +53437,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53467,7 +53448,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "rectangle",
@@ -53478,7 +53459,7 @@
                               "opacity": 0.35,
                               "fill": "$border-primary",
                               "width": 1,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "path",
@@ -53495,7 +53476,7 @@
                               ],
                               "fill": "#8BE9FD38",
                               "width": 390,
-                              "height": 196
+                              "height": 178
                             },
                             {
                               "type": "path",
@@ -53512,7 +53493,7 @@
                               ],
                               "fill": "#00000000",
                               "width": 390,
-                              "height": 196,
+                              "height": 178,
                               "stroke": "#8BE9FD",
                               "strokeWidth": 1.5,
                               "strokeLinejoin": "round"
@@ -53521,7 +53502,7 @@
                               "type": "text",
                               "id": "iKozD",
                               "x": 8,
-                              "y": 6,
+                              "y": 5,
                               "name": "axisTop",
                               "fill": "$text-muted",
                               "content": "80.0 GB",
@@ -53533,7 +53514,7 @@
                               "type": "text",
                               "id": "KKIRP",
                               "x": 8,
-                              "y": 180,
+                              "y": 163,
                               "name": "axisL",
                               "fill": "$text-muted",
                               "content": "60 秒前",
@@ -53545,7 +53526,7 @@
                               "type": "text",
                               "id": "Od7ww",
                               "x": 358,
-                              "y": 180,
+                              "y": 163,
                               "name": "axisR",
                               "fill": "$text-muted",
                               "content": "现在",
@@ -53650,14 +53631,14 @@
                   "name": "rowC",
                   "width": "fill_container",
                   "height": "fill_container",
+                  "layout": "vertical",
                   "gap": 12,
                   "children": [
                     {
                       "type": "frame",
                       "id": "KgRX0",
                       "name": "gpuDetailCard",
-                      "width": 320,
-                      "height": "fill_container",
+                      "width": "fill_container",
                       "fill": "$bg-input",
                       "cornerRadius": 8,
                       "stroke": "$border-primary",
@@ -53708,250 +53689,232 @@
                         },
                         {
                           "type": "frame",
-                          "id": "IR4wV",
-                          "name": "detailList",
+                          "id": "Koz7y",
+                          "name": "detailBand",
                           "width": "fill_container",
-                          "height": "fill_container",
                           "layout": "vertical",
-                          "gap": 4,
+                          "gap": 6,
                           "children": [
                             {
                               "type": "frame",
-                              "id": "fg5sS",
-                              "name": "gd-厂商",
+                              "id": "KMNw8",
+                              "name": "bandRow",
                               "width": "fill_container",
-                              "justifyContent": "space_between",
+                              "gap": 28,
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "text",
-                                  "id": "W3NCwY",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "厂商",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
+                                  "type": "frame",
+                                  "id": "zrDbi",
+                                  "name": "gd-厂商",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "jSuOf",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "厂商",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "yk6Hu",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "NVIDIA",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
                                 },
                                 {
-                                  "type": "text",
-                                  "id": "IhOav",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "NVIDIA",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
+                                  "type": "frame",
+                                  "id": "Cn4QG",
+                                  "name": "gd-驱动 / CUDA",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "xQqYX",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "驱动 / CUDA",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "XY5WR",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "550.90.07 / 12.4",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "rkxan",
+                                  "name": "gd-核心 / 显存时钟",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "nvLLo",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "核心 / 显存时钟",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "NcLe6",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "1410 / 1593 MHz",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KFT4D",
+                                  "name": "gd-功耗 / 上限",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "vw4Wn",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "功耗 / 上限",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "N6nEJD",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "382 / 400 W",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
                                 }
                               ]
                             },
                             {
                               "type": "frame",
-                              "id": "egw7d",
-                              "name": "gd-驱动 / CUDA",
+                              "id": "SFic8",
+                              "name": "bandRow",
                               "width": "fill_container",
-                              "justifyContent": "space_between",
+                              "gap": 28,
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "text",
-                                  "id": "MB9jM",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "驱动 / CUDA",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
+                                  "type": "frame",
+                                  "id": "tFvkD",
+                                  "name": "gd-温度 / 上限",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "mo2tt",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "温度 / 上限",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "snssc",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "71 / 85 °C",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
                                 },
                                 {
-                                  "type": "text",
-                                  "id": "E69qoo",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "550.90.07 / 12.4",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "r7QWFt",
-                              "name": "gd-核心 / 显存时钟",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "UdntG",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "核心 / 显存时钟",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
+                                  "type": "frame",
+                                  "id": "u5vT7",
+                                  "name": "gd-持久模式 / ECC",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "TbSqX",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "持久模式 / ECC",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "S65zg",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "开启 / 开启",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
                                 },
                                 {
-                                  "type": "text",
-                                  "id": "azdoE",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "1410 / 1593 MHz",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "W51rs",
-                              "name": "gd-功耗 / 上限",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "mWegZ",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "功耗 / 上限",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "v0wwSL",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "382 / 400 W",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "WvDNL",
-                              "name": "gd-温度 / 上限",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "y39o7",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "温度 / 上限",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "qOu4S",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "71 / 85 °C",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "dDBiN",
-                              "name": "gd-风扇",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "uGayh",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "风扇",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "Jn7cM",
-                                  "name": "gdV",
-                                  "fill": "$text-muted",
-                                  "content": "—(被动散热)",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "U0IIP",
-                              "name": "gd-持久模式 / ECC",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "xDT0y",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "持久模式 / ECC",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "d1nelu",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "开启 / 开启",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "frame",
-                              "id": "LMci9",
-                              "name": "gd-显存",
-                              "width": "fill_container",
-                              "justifyContent": "space_between",
-                              "alignItems": "center",
-                              "children": [
-                                {
-                                  "type": "text",
-                                  "id": "nTb5E",
-                                  "name": "gdK",
-                                  "fill": "$text-secondary",
-                                  "content": "显存",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 10,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "owZNv",
-                                  "name": "gdV",
-                                  "fill": "$text-primary",
-                                  "content": "68.4 / 80.0 GB",
-                                  "fontFamily": "JetBrains Mono",
-                                  "fontSize": 10,
-                                  "fontWeight": "500"
+                                  "type": "frame",
+                                  "id": "NnOoN",
+                                  "name": "gd-显存",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Sfrfz",
+                                      "name": "gdK",
+                                      "fill": "$text-secondary",
+                                      "content": "显存",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "v9kii",
+                                      "name": "gdV",
+                                      "fill": "$text-primary",
+                                      "content": "68.4 / 80.0 GB",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
                                 }
                               ]
                             }
@@ -54478,292 +54441,6 @@
                                           ]
                                         }
                                       ]
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "nevIo",
-                                      "name": "gtr2",
-                                      "width": "fill_container",
-                                      "height": "fill_container",
-                                      "fill": "#00000000",
-                                      "cornerRadius": 3,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "f6AsH",
-                                          "name": "gtd2-0",
-                                          "clip": true,
-                                          "width": "fill_container",
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "Et8Wp",
-                                              "name": "gtdT",
-                                              "fill": "$text-primary",
-                                              "content": "ollama serve",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "500"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "LiHWK",
-                                          "name": "gtd2-1",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "P0vy3",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "2",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "RvFnx",
-                                          "name": "gtd2-2",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "ufsJB",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "2 318",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "hGw93",
-                                          "name": "gtd2-3",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "oE15b",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "C",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "szKL2",
-                                          "name": "gtd2-4",
-                                          "clip": true,
-                                          "width": 90,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "inxIQ",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "6.0 GB",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "aYUHU",
-                                          "name": "gtd2-5",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "JeqTQ",
-                                              "name": "gtdT",
-                                              "fill": "$term-magenta",
-                                              "content": "12%",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "frame",
-                                      "id": "WnRKQ",
-                                      "name": "gtr3",
-                                      "width": "fill_container",
-                                      "height": "fill_container",
-                                      "fill": "#00000000",
-                                      "cornerRadius": 3,
-                                      "alignItems": "center",
-                                      "children": [
-                                        {
-                                          "type": "frame",
-                                          "id": "PUDrm",
-                                          "name": "gtd3-0",
-                                          "clip": true,
-                                          "width": "fill_container",
-                                          "height": "fill_container",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "b4dpQH",
-                                              "name": "gtdT",
-                                              "fill": "$text-primary",
-                                              "content": "Xorg",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "500"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "FpNzB",
-                                          "name": "gtd3-1",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "v9haU",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "3",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "KBQYA",
-                                          "name": "gtd3-2",
-                                          "clip": true,
-                                          "width": 70,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "ZlttN",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "1 044",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "ehFbE",
-                                          "name": "gtd3-3",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "movXn",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "G",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "hkGV8",
-                                          "name": "gtd3-4",
-                                          "clip": true,
-                                          "width": 90,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "ZDCY1",
-                                              "name": "gtdT",
-                                              "fill": "$text-secondary",
-                                              "content": "0.2 GB",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "frame",
-                                          "id": "G8h6A",
-                                          "name": "gtd3-5",
-                                          "clip": true,
-                                          "width": 60,
-                                          "height": "fill_container",
-                                          "justifyContent": "end",
-                                          "alignItems": "center",
-                                          "children": [
-                                            {
-                                              "type": "text",
-                                              "id": "Fn4qq",
-                                              "name": "gtdT",
-                                              "fill": "$term-magenta",
-                                              "content": "0%",
-                                              "fontFamily": "JetBrains Mono",
-                                              "fontSize": 10,
-                                              "fontWeight": "normal"
-                                            }
-                                          ]
-                                        }
-                                      ]
                                     }
                                   ]
                                 },
@@ -54786,7 +54463,7 @@
                                       "name": "scrollThumb",
                                       "fill": "$border-secondary",
                                       "width": 6,
-                                      "height": 44
+                                      "height": 20
                                     }
                                   ]
                                 }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -679,7 +679,7 @@ public partial class ChatPanelView : UserControl
         => this.TryFindResource(key, out object? value) && value is IBrush brush ? brush : null;
 
     /// <summary>lucide 描边图标(24 视图框经 Viewbox 等比缩放)。</summary>
-    private Control MakeIcon(string geometryKey, string brushKey, double size)
+    private Viewbox MakeIcon(string geometryKey, string brushKey, double size)
     {
         var path = new Avalonia.Controls.Shapes.Path
         {

--- a/src/VelaShell.Core/Models/TerminalColorScheme.cs
+++ b/src/VelaShell.Core/Models/TerminalColorScheme.cs
@@ -83,9 +83,9 @@ public sealed record TerminalColorScheme(
 
     private static bool HexEquals(string? a, string? b) => string.Equals(a?.Trim(), b?.Trim(), StringComparison.OrdinalIgnoreCase);
 
-    private static bool HexSequenceEquals(IReadOnlyList<string>? a, IReadOnlyList<string> b)
+    private static bool HexSequenceEquals(List<string>? a, string[] b)
     {
-        if (a is null || a.Count != b.Count)
+        if (a is null || a.Count != b.Length)
         {
             return false;
         }

--- a/src/VelaShell.Core/Services/SessionMetrics.Extras.cs
+++ b/src/VelaShell.Core/Services/SessionMetrics.Extras.cs
@@ -417,8 +417,8 @@ public sealed partial class SessionMetrics
     /// <summary>解析 ps 的 "pid pcpu rss args" 输出;命令行含空格,取前三列后其余全部作为命令。</summary>
     /// <param name="section">ps 分段。</param>
     /// <param name="extras">按 PID 索引的共享/换出量;取不到就整段为空,对应列显示占位符。</param>
-    private static IReadOnlyList<ProcessUsage> ParseProcessList(
-        string section, IReadOnlyDictionary<int, (long? Shared, long? Swap)> extras)
+    private static List<ProcessUsage> ParseProcessList(
+        string section, Dictionary<int, (long? Shared, long? Swap)> extras)
     {
         var list = new List<ProcessUsage>();
         foreach (string line in LinesOf(section))

--- a/src/VelaShell.Core/Sftp/SerializedSftpService.cs
+++ b/src/VelaShell.Core/Sftp/SerializedSftpService.cs
@@ -140,7 +140,7 @@ public sealed class SerializedSftpService(ISftpService inner, Guid sessionId) : 
         }
     }
 
-    private Task ExecuteAsync(Guid sessionId, Func<CancellationToken, Task> operation, CancellationToken cancellationToken, bool serialize = true) =>
+    private Task<bool> ExecuteAsync(Guid sessionId, Func<CancellationToken, Task> operation, CancellationToken cancellationToken, bool serialize = true) =>
         ExecuteAsync(sessionId, async token =>
         {
             await operation(token).ConfigureAwait(false);

--- a/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
@@ -1,4 +1,3 @@
-using FluentFTP;
 using FluentFTP.Exceptions;
 using VelaShell.Core.Ftp;
 
@@ -14,32 +13,21 @@ internal static class FluentFtpInterop
     /// <summary>把 FluentFTP/Socket 的异常翻译成库中立异常;已是中立异常的原样返回。</summary>
     public static Exception Translate(Exception ex, string operation)
     {
-        switch (ex)
+        return ex switch
         {
-            case VelaFtpClientException:
-            case OperationCanceledException:
-                return ex;
-            case FtpAuthenticationException auth:
-                return new VelaFtpAuthenticationException(
-                    $"FTP login failed: {auth.CompletionCode} {auth.Message}", auth);
-            case FtpCommandException cmd:
-                return TranslateCommand(cmd, operation);
-            case FtpSecurityNotAvailableException tls:
-                return new VelaFtpConnectionException(
-                    $"The server does not support the requested FTPS mode ({operation}).", tls);
-            case TimeoutException timeout:
-                return new VelaFtpConnectionException($"FTP {operation} timed out.", timeout);
-            case System.Net.Sockets.SocketException socket:
-                return new VelaFtpConnectionException($"FTP {operation} failed: {socket.Message}", socket);
-            case System.Security.Authentication.AuthenticationException tlsAuth:
-                return new VelaFtpConnectionException($"TLS handshake failed: {tlsAuth.Message}", tlsAuth);
-            case IOException io:
-                return new VelaFtpConnectionException($"FTP {operation} failed: {io.Message}", io);
-            case FtpException ftp:
-                return new VelaFtpOperationException($"FTP {operation} failed: {ftp.Message}", ftp);
-            default:
-                return ex;
-        }
+            VelaFtpClientException or OperationCanceledException => ex,
+            FtpAuthenticationException auth => new VelaFtpAuthenticationException(
+                                $"FTP login failed: {auth.CompletionCode} {auth.Message}", auth),
+            FtpCommandException cmd => TranslateCommand(cmd, operation),
+            FtpSecurityNotAvailableException tls => new VelaFtpConnectionException(
+                                $"The server does not support the requested FTPS mode ({operation}).", tls),
+            TimeoutException timeout => new VelaFtpConnectionException($"FTP {operation} timed out.", timeout),
+            System.Net.Sockets.SocketException socket => new VelaFtpConnectionException($"FTP {operation} failed: {socket.Message}", socket),
+            System.Security.Authentication.AuthenticationException tlsAuth => new VelaFtpConnectionException($"TLS handshake failed: {tlsAuth.Message}", tlsAuth),
+            IOException io => new VelaFtpConnectionException($"FTP {operation} failed: {io.Message}", io),
+            FtpException ftp => new VelaFtpOperationException($"FTP {operation} failed: {ftp.Message}", ftp),
+            _ => ex,
+        };
     }
 
     /// <summary>

--- a/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
@@ -406,7 +406,7 @@ public sealed class FtpFileService : ISftpService, IFtpSessionService
         };
 
     /// <summary>把 FluentFTP 的进度回调翻译成 VelaShell 的传输进度快照。</summary>
-    private static IProgress<FtpProgress>? MapProgress(IProgress<TransferProgress>? progress, string fileName, long totalBytes) =>
+    private static Progress<FtpProgress>? MapProgress(IProgress<TransferProgress>? progress, string fileName, long totalBytes) =>
         progress is null
             ? null
             : new Progress<FtpProgress>(p => progress.Report(new()

--- a/src/VelaShell.Infrastructure/Import/XshellImportService.cs
+++ b/src/VelaShell.Infrastructure/Import/XshellImportService.cs
@@ -123,7 +123,7 @@ public sealed class XshellImportService(ISessionRepository repository) : ISessio
     private static string DedupKey(string host, int port, string user) => $"{host.Trim()}|{port}|{user.Trim()}";
 
     /// <summary>按 BOM 自动识别编码(Xshell 为 UTF-16 LE)读入全部行。</summary>
-    private static IReadOnlyList<string> ReadLines(string path)
+    private static List<string> ReadLines(string path)
     {
         using var reader = new StreamReader(path, Encoding.Unicode, detectEncodingFromByteOrderMarks: true);
         var lines = new List<string>();

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbPluginDataStore.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbPluginDataStore.cs
@@ -64,7 +64,7 @@ public sealed class SonnetDbPluginDataStore(SonnetDbEngine engine, ISecretProtec
         return json is null ? null : JsonSerializer.Deserialize<ValueDoc>(json)?.V;
     }
 
-    private Task SetRawAsync(string pluginId, string kind, string key, JsonElement value, CancellationToken cancellationToken)
+    private Task<object?> SetRawAsync(string pluginId, string kind, string key, JsonElement value, CancellationToken cancellationToken)
     {
         string json = JsonSerializer.Serialize(new ValueDoc(value));
         return engine.WithCollectionAsync<object?>(SonnetDbEngine.PluginDataCollection, store =>

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbQuickCommandRepository.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbQuickCommandRepository.cs
@@ -439,8 +439,8 @@ public sealed class SonnetDbQuickCommandRepository(
     }
 
     private static bool GroupsEquivalent(
-        IReadOnlyList<QuickCommandGroup> left,
-        IReadOnlyList<QuickCommandGroup> right
+        List<QuickCommandGroup> left,
+        List<QuickCommandGroup> right
     ) =>
         left.Count == right.Count
         && left.Zip(right)

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/ProtectedSecretsCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/ProtectedSecretsCapability.cs
@@ -110,7 +110,7 @@ internal sealed class ProtectedSecretsCapability(string dataDirectory, ISecretPr
 /// <summary>机密能力不可用(无保护器)时的空实现:绝不明文兜底,直接报不可用。</summary>
 internal sealed class UnavailableSecrets : ISecretsApi
 {
-    private static Exception Unavailable() =>
+    private static InvalidOperationException Unavailable() =>
         new InvalidOperationException("Secrets capability is unavailable in this host (no secret protector).");
 
     public Task<string?> GetAsync(string name, CancellationToken cancellationToken = default) => Task.FromException<string?>(Unavailable());
@@ -121,7 +121,7 @@ internal sealed class UnavailableSecrets : ISecretsApi
 /// <summary>剪贴板能力不可用(无 UI 宿主)时的空实现。</summary>
 internal sealed class UnavailableClipboard : PluginSdk.Clipboard.IClipboardApi
 {
-    private static Exception Unavailable() =>
+    private static InvalidOperationException Unavailable() =>
         new InvalidOperationException("Clipboard capability is unavailable in this host.");
 
     public Task<string?> GetTextAsync(CancellationToken cancellationToken = default) => Task.FromException<string?>(Unavailable());
@@ -131,7 +131,7 @@ internal sealed class UnavailableClipboard : PluginSdk.Clipboard.IClipboardApi
 /// <summary>终端能力不可用(无 UI 宿主)时的空实现。</summary>
 internal sealed class UnavailableTerminal : PluginSdk.Terminal.ITerminalApi
 {
-    private static Exception Unavailable() =>
+    private static InvalidOperationException Unavailable() =>
         new InvalidOperationException("Terminal capability is unavailable in this host.");
 
     public Task<string> GetOutputAsync(string sessionId, int maxLines = 1000, CancellationToken cancellationToken = default)

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteFsCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteFsCapability.cs
@@ -30,7 +30,7 @@ internal sealed class RemoteFsCapability(ISftpService sftp, ISshConnectionServic
     }
 
     /// <summary>把 SDK 进度包成宿主进度并节流:至少间隔 100ms 才转发一次,末帧(完成)始终放行。</summary>
-    private static IProgress<TransferProgress>? Throttle(IProgress<RemoteTransferProgress>? progress)
+    private static Progress<TransferProgress>? Throttle(IProgress<RemoteTransferProgress>? progress)
     {
         if (progress is null)
         {

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
@@ -379,7 +379,7 @@ internal sealed class PluginCapabilityRouter : IDisposable
             SupportsEmbedding: _embedHost is { IsSupported: true });
     }
 
-    private IProgress<RemoteTransferProgress>? ProgressFor(string? progressToken)
+    private Progress<RemoteTransferProgress>? ProgressFor(string? progressToken)
         => progressToken is null
             ? null
             : new Progress<RemoteTransferProgress>(p =>

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginProcessClient.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginProcessClient.cs
@@ -221,7 +221,9 @@ internal sealed class PluginProcessClient : IAsyncDisposable
     {
         if (_shuttingDown == 0 && Interlocked.Exchange(ref _disposed, 1) == 0)
         {
-            _ = _connection.DisposeAsync();
+            // Exited 是同步事件回调,不能在这里阻塞等管道回收;交给后台任务并吞掉异常,
+            // 既满足"ValueTask 只消费一次"(CA2012),也不留未观察任务异常。
+            _ = DisposeConnectionAsync();
             _router.Dispose();
             try
             {
@@ -231,6 +233,18 @@ internal sealed class PluginProcessClient : IAsyncDisposable
             {
                 // 崩溃回调不扩散。
             }
+        }
+    }
+
+    private async Task DisposeConnectionAsync()
+    {
+        try
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // 进程已退出,管道回收失败无处上报也无需上报。
         }
     }
 
@@ -259,14 +273,21 @@ internal sealed class PluginProcessClient : IAsyncDisposable
     }
 
     /// <summary>
-    /// 限时等待进程退出,超时返回 false。刻意不用取消令牌:
-    /// <see cref="Process.WaitForExitAsync(CancellationToken)" /> 超时会抛 TaskCanceledException,
-    /// 而"子进程没在期限内退出"是预期内的常规分支,不该在调试器里刷首发异常。
+    /// 限时等待进程退出,超时返回 false。刻意不抛超时异常:
+    /// <see cref="Process.WaitForExitAsync(CancellationToken)" /> 与 <c>WaitAsync(timeout)</c>
+    /// 超时都会抛(TaskCanceled/Timeout),而"子进程没在期限内退出"是预期内的常规分支,
+    /// 不该在调试器里刷首发异常。因此仍走 WhenAny,但给 Task.Delay 配取消令牌:
+    /// 进程先退出时立刻取消,不把定时器留到超时(CA2027)。
     /// </summary>
     private static async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout)
     {
         Task exited = process.WaitForExitAsync();
-        return await Task.WhenAny(exited, Task.Delay(timeout)).ConfigureAwait(false) == exited;
+        using var delayCts = new CancellationTokenSource();
+        // 取消的 Task.Delay 落在 Canceled 而非 Faulted,不会进未观察任务异常通道,无需 Observe。
+        var delay = Task.Delay(timeout, delayCts.Token);
+        bool exitedFirst = await Task.WhenAny(exited, delay).ConfigureAwait(false) == exited;
+        await delayCts.CancelAsync().ConfigureAwait(false);
+        return exitedFirst;
     }
 
     private static void TryKill(Process? process)

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -752,7 +752,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                 ? $"Activation timed out after {options.ActivationTimeout.TotalSeconds:0}s."
                 : ex.Message;
             Log($"Failed to activate '{manifest.Id}': {descriptor.Error}");
-            CleanupRuntime(runtime);
+            await CleanupRuntimeAsync(runtime).ConfigureAwait(false);
         }
         RaiseChanged();
     }
@@ -942,17 +942,50 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         }
         finally
         {
-            CleanupRuntime(runtime);
+            await CleanupRuntimeAsync(runtime).ConfigureAwait(false);
         }
     }
 
-    /// <summary>拆除命令/事件等宿主侧引用并卸载 ALC / 回收进程(不等待 GC 真正回收)。</summary>
+    /// <summary>回收隔离插件进程(IAsyncDisposable):ValueTask 只消费一次,异常不外溢。</summary>
+    private static async Task DisposeProcessAsync(PluginProcessClient process)
+    {
+        try
+        {
+            await process.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // 清理失败不阻断。
+        }
+    }
+
+    /// <summary>
+    /// 异步路径上的清理:进程回收与同步清理并发进行,但方法返回时进程确实已被杀掉、
+    /// 管道确实已断开——退出流程据此保证不留孤儿子进程。
+    /// </summary>
+    private static async Task CleanupRuntimeAsync(PluginRuntime runtime)
+    {
+        Task disposeProcess = Task.CompletedTask;
+        if (runtime.Process is { } process)
+        {
+            runtime.Process = null;
+            disposeProcess = DisposeProcessAsync(process); // 与下面的同步清理并行
+        }
+        CleanupRuntime(runtime);
+        await disposeProcess.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 拆除命令/事件等宿主侧引用并卸载 ALC / 回收进程(不等待 GC 真正回收)。
+    /// 同步入口只供 Process.Exited 这类无法 await 的回调使用,进程回收退化为后台尽力而为;
+    /// 能 await 的地方一律走 <see cref="CleanupRuntimeAsync" />。
+    /// </summary>
     private static void CleanupRuntime(PluginRuntime runtime)
     {
         if (runtime.Process is { } process)
         {
             runtime.Process = null;
-            _ = process.DisposeAsync(); // 杀进程 + 断管道,后台尽力而为
+            _ = DisposeProcessAsync(process); // 杀进程 + 断管道,后台尽力而为
         }
         try
         {
@@ -992,7 +1025,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
 
     private sealed class UnavailableRemoteFs : IRemoteFsApi
     {
-        private static Exception Unavailable() => new InvalidOperationException("Remote file capability is unavailable in this host.");
+        private static InvalidOperationException Unavailable() => new("Remote file capability is unavailable in this host.");
 
         public Task<IReadOnlyList<RemoteFileEntry>> ListDirectoryAsync(string sessionId, string path, CancellationToken cancellationToken = default) => Task.FromException<IReadOnlyList<RemoteFileEntry>>(Unavailable());
         public Task<RemoteFileEntry?> StatAsync(string sessionId, string path, CancellationToken cancellationToken = default) => Task.FromException<RemoteFileEntry?>(Unavailable());

--- a/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
+++ b/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
@@ -355,13 +355,17 @@ public sealed partial class ConPtyShellStream : IShellStreamWrapper
         [LibraryImport("kernel32.dll")]
         public static partial void DeleteProcThreadAttributeList(IntPtr lpAttributeList);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern bool CreateProcess(
+        // EntryPoint 必须写全:LibraryImport 不做 DllImport 那套 CharSet 自动加 "W" 后缀,
+        // 漏了就是运行期 EntryPointNotFoundException(编译期无感)。
+        [LibraryImport("kernel32.dll", EntryPoint = "CreateProcessW", SetLastError = true,
+            StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool CreateProcess(
             string? lpApplicationName,
             string lpCommandLine,
             IntPtr lpProcessAttributes,
             IntPtr lpThreadAttributes,
-            bool bInheritHandles,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandles,
             uint dwCreationFlags,
             IntPtr lpEnvironment,
             string? lpCurrentDirectory,
@@ -375,13 +379,15 @@ public sealed partial class ConPtyShellStream : IShellStreamWrapper
             public short Y;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        // 三个字符串字段本进程从不设置(始终 null),声明成指针即可让整个结构保持 blittable
+        // —— LibraryImport 的源生成封送要求结构可直接按位传递,含 string 字段会拒绝生成。
+        [StructLayout(LayoutKind.Sequential)]
         public struct STARTUPINFO
         {
             public int cb;
-            public string? lpReserved;
-            public string? lpDesktop;
-            public string? lpTitle;
+            public IntPtr lpReserved;
+            public IntPtr lpDesktop;
+            public IntPtr lpTitle;
             public int dwX;
             public int dwY;
             public int dwXSize;
@@ -398,7 +404,7 @@ public sealed partial class ConPtyShellStream : IShellStreamWrapper
             public IntPtr hStdError;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         public struct STARTUPINFOEX
         {
             public STARTUPINFO StartupInfo;

--- a/src/VelaShell.Infrastructure/Ssh/SshConnectionService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshConnectionService.cs
@@ -217,8 +217,12 @@ public class SshConnectionService(
             {
                 _sessions.Remove(session);
             }
-            logger?.LogDebug("SSH session {SessionId} to {Host}:{Port} was cancelled by the caller",
-                session.SessionId, connectionInfo.Host, connectionInfo.Port);
+            // 先问级别再拼参数:Debug 关闭时不为这条日志创建 object[]。
+            if (logger?.IsEnabled(LogLevel.Debug) == true)
+            {
+                logger.LogDebug("SSH session {SessionId} to {Host}:{Port} was cancelled by the caller",
+                    session.SessionId, connectionInfo.Host, connectionInfo.Port);
+            }
             throw;
         }
         catch (OperationCanceledException)

--- a/src/VelaShell.PluginHost/Program.cs
+++ b/src/VelaShell.PluginHost/Program.cs
@@ -113,11 +113,12 @@ internal static class Program
                         {
                             context?.Dispose(); // 关掉本插件的全部窗口
                                                 // 先应答再退出:让宿主拿到干净的完成信号。
+                                                // 显式 None:这条退出信号必须发出,不受请求生命周期取消影响。
                             _ = Task.Run(async () =>
                             {
-                                await Task.Delay(100).ConfigureAwait(false);
+                                await Task.Delay(100, CancellationToken.None).ConfigureAwait(false);
                                 ExitCode.TrySetResult(0);
-                            });
+                            }, CancellationToken.None);
                         }
                         return null;
                     }

--- a/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using ReactiveUI;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Import;
@@ -39,6 +40,7 @@ public sealed class SessionImportViewModel : ReactiveObject
     }
 
     /// <summary>对话框标题。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string Title => Strings.Get("XImport_TitleAll");
 
     /// <summary>所有来源(每个来源一张卡片)。</summary>

--- a/src/VelaShell.Terminal/Emulation/VtParser.cs
+++ b/src/VelaShell.Terminal/Emulation/VtParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 
 namespace VelaShell.Terminal.Emulation;
@@ -144,7 +145,7 @@ public sealed class VtParser(IVtActions actions)
                     case State.Vt52CursorCol:
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new UnreachableException($"Unhandled VT parser state {_state}.");
                 }
                 break;
         }
@@ -526,7 +527,7 @@ public sealed class VtParser(IVtActions actions)
             case State.SosPmApcString:
                 break;
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new UnreachableException($"Unhandled VT parser state {_state}.");
         }
     }
 

--- a/src/VelaShell/Controls/TraceWorldMap.cs
+++ b/src/VelaShell/Controls/TraceWorldMap.cs
@@ -332,7 +332,7 @@ public sealed class TraceWorldMap : Control
         return built;
     }
 
-    private static IReadOnlyList<Geometry> Build(MapView view, IReadOnlyList<double[]> rings)
+    private static List<Geometry> Build(MapView view, IReadOnlyList<double[]> rings)
     {
         List<Geometry> result = [];
         if (rings.Count == 0)
@@ -404,7 +404,7 @@ public sealed class TraceWorldMap : Control
     private static readonly Lazy<IReadOnlyList<double[]>> ProvinceRings =
         new(() => LoadRings("avares://VelaShell/Assets/world-provinces.txt"));
 
-    private static IReadOnlyList<double[]> LoadRings(string uri)
+    private static List<double[]> LoadRings(string uri)
     {
         try
         {

--- a/src/VelaShell/Services/Plugins/PluginThemeTokens.cs
+++ b/src/VelaShell/Services/Plugins/PluginThemeTokens.cs
@@ -84,5 +84,5 @@ internal static class PluginThemeTokens
     private static string PortableFontFallback(FontFamily font) =>
         string.Join(", ",
             font.FamilyNames.Select(name => name.Trim())
-                .Where(name => name.Length > 0 && !name.Contains('#') && !name.Contains(":")));
+                .Where(name => name.Length > 0 && !name.Contains('#') && !name.Contains(':')));
 }

--- a/src/VelaShell/ViewModels/PluginManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/PluginManagerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Threading;
 using ReactiveUI;
 using VelaShell.Core.Resources;
@@ -53,12 +54,14 @@ public sealed class PluginRowViewModel(PluginDescriptor descriptor, bool hasTerm
     public bool HasTerminalGrant => hasTerminalGrant;
 
     /// <summary>撤销终端授权按钮文案。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string RevokeText => Strings.Get("PluginManager_RevokePermission");
 
     /// <summary>是否可卸载(用户安装,非应用自带)。</summary>
     public bool CanUninstall { get; init; }
 
     /// <summary>卸载按钮文案。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string UninstallText => Strings.Get("PluginManager_Uninstall");
 }
 
@@ -76,15 +79,18 @@ public sealed class PluginManagerViewModel : ReactiveObject, IDisposable
     public ObservableCollection<PluginRowViewModel> Plugins { get; } = [];
 
     /// <summary>标题文案。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string Title => Strings.Get("PluginManager_Title");
 
     /// <summary>"安装 .vpx" 按钮文案。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string InstallText => Strings.Get("PluginManager_Install");
 
     /// <summary>是否可安装(有可写用户目录)。</summary>
     public bool CanInstall => _manager.IsInstallSupported;
 
     /// <summary>空态文案。</summary>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "XAML 绑定只解析实例成员。")]
     public string EmptyText => Strings.Get("PluginManager_Empty");
 
     /// <summary>顶部状态提示(安装成功/失败),null 时不显示。</summary>

--- a/src/VelaShell/ViewModels/ProcessManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/ProcessManagerViewModel.cs
@@ -692,7 +692,7 @@ public sealed class ProcessManagerViewModel : ReactiveObject, IDisposable
     /// 收集一棵进程树的全部 PID,子在前父在后 —— 先杀父的话子进程会被 init 收养,
     /// 后续按 ppid 就找不到它们了。
     /// </summary>
-    private IReadOnlyList<int> CollectTree(int rootPid)
+    private List<int> CollectTree(int rootPid)
     {
         Dictionary<int, List<int>> children = [];
         foreach (ProcessRowViewModel row in _all)

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -234,7 +234,7 @@ public partial class FileBrowserView : UserControl
         // 写死就会在用户改过设置后把列算窄一截(文字被截断)。
         Typeface typeface = ResolveMonoTypeface();
         double headerWidth = MeasureTextWidth(spec.Header, ResolveFontSize("VelaFontSize10", 10), typeface);
-        double rowsWidth = vm.Files.Any()
+        double rowsWidth = vm.Files.Count > 0
             ? vm.Files.Max(f => MeasureTextWidth(spec.Cell(f), ResolveFontSize("VelaFontSize11", 11), typeface))
             : 0;
         return Math.Clamp(

--- a/tests/VelaShell.Core.Tests/Services/SessionMetricsExtrasTests.cs
+++ b/tests/VelaShell.Core.Tests/Services/SessionMetricsExtrasTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using VelaShell.Core.Services;
 
 namespace VelaShell.Core.Tests.Services;
@@ -8,8 +9,12 @@ namespace VelaShell.Core.Tests.Services;
 /// </summary>
 [TestClass]
 [TestCategory("Metrics")]
-public class SessionMetricsExtrasTests
+public partial class SessionMetricsExtrasTests
 {
+    /// <summary>探针里那条“超过 n 列就截断”的 awk 语句,捕获列数上限。</summary>
+    [GeneratedRegex(@"awk -v n=(\d+) '\{ if \(length\(\$0\) > n\)")]
+    private static partial Regex ProcessColumnLimit { get; }
+
     /// <summary>一份包含全部分段的探针输出(MetricsScope.Full 口径)。</summary>
     internal const string FullOutput =
         "__P__\n8\n" +
@@ -250,8 +255,7 @@ public class SessionMetricsExtrasTests
 
         Assert.DoesNotContain("cut -c1-90", command, "90 列在常见窗口宽度下就会切掉命令行。");
 
-        System.Text.RegularExpressions.Match match =
-            System.Text.RegularExpressions.Regex.Match(command, @"awk -v n=(\d+) '\{ if \(length\(\$0\) > n\)");
+        Match match = ProcessColumnLimit.Match(command);
         Assert.IsTrue(match.Success, "进程段必须保留列数上限,否则超长命令行每秒回传一次会把带宽吃光。");
 
         int columns = int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceConcurrencyCharacterizationTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceConcurrencyCharacterizationTests.cs
@@ -46,7 +46,7 @@ public sealed class SftpServiceConcurrencyCharacterizationTests
                 Interlocked.Decrement(ref activeCalls);
             }
         });
-        ISftpService service = new SftpService(connection, _ => client);
+        SftpService service = new(connection, _ => client);
 
         // When
         Task<List<RemoteFileInfo>> first = service.ListDirectoryAsync(sessionId, "/one");

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -14,7 +14,7 @@ public class SftpServiceTests
     private readonly ISshConnectionService _connectionService;
     private readonly Guid _sessionId;
     private readonly ISftpClientWrapper _sftpClient;
-    private readonly ISftpService _sftpService;
+    private readonly SftpService _sftpService;
 
     public SftpServiceTests()
     {

--- a/tests/VelaShell.Core.Tests/Ssh/TmdsSshClientWrapperTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/TmdsSshClientWrapperTests.cs
@@ -59,20 +59,12 @@ public sealed class TmdsSshClientWrapperTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        try
-        {
-            await wrapper.ConnectAsync(cts.Token);
-            Assert.Fail("Expected the connect to fail.");
-        }
-        catch (VelaSshOperationTimeoutException)
-        {
-            Assert.Fail("主动取消不应被翻译为超时异常。");
-        }
-        catch (OperationCanceledException)
-        {
-            // 期望路径:取消语义被保留
-        }
+        // 断言写在 catch 外:取消语义被保留(抛 OperationCanceledException),
+        // 而不是被翻译成超时异常(两者互不继承,拿到实例后直接判类型即可)。
+        OperationCanceledException cancelled =
+            await Assert.ThrowsAsync<OperationCanceledException>(() => wrapper.ConnectAsync(cts.Token));
 
+        Assert.IsNotInstanceOfType<VelaSshOperationTimeoutException>(cancelled, "主动取消不应被翻译为超时异常。");
         Assert.IsFalse(wrapper.IsConnected);
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/ConPtyShellStreamTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/ConPtyShellStreamTests.cs
@@ -81,7 +81,12 @@ public class ConPtyShellStreamTests
         while (sw.Elapsed < timeout)
         {
             Task<int> read = stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
-            if (await Task.WhenAny(read, Task.Delay(timeout - sw.Elapsed)) != read)
+            // 超时定时器随本轮结束一起取消,否则每读一次都留下一个跑满 timeout 的计时器。
+            using var timeoutCts = new CancellationTokenSource();
+            var delay = Task.Delay(timeout - sw.Elapsed, timeoutCts.Token);
+            Task winner = await Task.WhenAny(read, delay);
+            await timeoutCts.CancelAsync();
+            if (winner != read)
             {
                 break;
             }
@@ -108,7 +113,11 @@ public class ConPtyShellStreamTests
         while (sw.Elapsed < timeout)
         {
             Task<int> read = stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
-            if (await Task.WhenAny(read, Task.Delay(timeout - sw.Elapsed)) != read)
+            using var timeoutCts = new CancellationTokenSource();
+            var delay = Task.Delay(timeout - sw.Elapsed, timeoutCts.Token);
+            Task winner = await Task.WhenAny(read, delay);
+            await timeoutCts.CancelAsync();
+            if (winner != read)
             {
                 return false;
             }

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
@@ -71,7 +71,7 @@ internal sealed class LoopbackFtpServer : IDisposable
                 return;
             }
             Interlocked.Increment(ref AcceptedConnections);
-            Task session = Task.Run(() => HandleClientAsync(client));
+            var session = Task.Run(() => HandleClientAsync(client));
             lock (_sync)
             {
                 _clients.Add(session);
@@ -168,21 +168,21 @@ internal sealed class LoopbackFtpServer : IDisposable
                 await SendListingAsync(state, argument, writer, command == "NLST").ConfigureAwait(false);
                 return true;
             case "SIZE":
-            {
-                string path = Local(Normalize(state, argument));
-                await writer.WriteLineAsync(File.Exists(path)
-                    ? $"213 {new FileInfo(path).Length}"
-                    : "550 Not found").ConfigureAwait(false);
-                return true;
-            }
+                {
+                    string path = Local(Normalize(state, argument));
+                    await writer.WriteLineAsync(File.Exists(path)
+                        ? $"213 {new FileInfo(path).Length}"
+                        : "550 Not found").ConfigureAwait(false);
+                    return true;
+                }
             case "MDTM":
-            {
-                string path = Local(Normalize(state, argument));
-                await writer.WriteLineAsync(File.Exists(path)
-                    ? $"213 {File.GetLastWriteTimeUtc(path):yyyyMMddHHmmss}"
-                    : "550 Not found").ConfigureAwait(false);
-                return true;
-            }
+                {
+                    string path = Local(Normalize(state, argument));
+                    await writer.WriteLineAsync(File.Exists(path)
+                        ? $"213 {File.GetLastWriteTimeUtc(path):yyyyMMddHHmmss}"
+                        : "550 Not found").ConfigureAwait(false);
+                    return true;
+                }
             case "RETR":
                 await SendFileAsync(state, argument, writer).ConfigureAwait(false);
                 return true;
@@ -191,68 +191,68 @@ internal sealed class LoopbackFtpServer : IDisposable
                 await ReceiveFileAsync(state, argument, writer, append: command == "APPE").ConfigureAwait(false);
                 return true;
             case "DELE":
-            {
-                string path = Local(Normalize(state, argument));
-                if (File.Exists(path))
                 {
-                    File.Delete(path);
-                    await writer.WriteLineAsync("250 Deleted").ConfigureAwait(false);
+                    string path = Local(Normalize(state, argument));
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                        await writer.WriteLineAsync("250 Deleted").ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
+                    }
+                    return true;
                 }
-                else
-                {
-                    await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
-                }
-                return true;
-            }
             case "MKD":
             case "XMKD":
-            {
-                string remote = Normalize(state, argument);
-                Directory.CreateDirectory(Local(remote));
-                await writer.WriteLineAsync($"257 \"{remote}\" created").ConfigureAwait(false);
-                return true;
-            }
+                {
+                    string remote = Normalize(state, argument);
+                    Directory.CreateDirectory(Local(remote));
+                    await writer.WriteLineAsync($"257 \"{remote}\" created").ConfigureAwait(false);
+                    return true;
+                }
             case "RMD":
             case "XRMD":
-            {
-                string path = Local(Normalize(state, argument));
-                if (Directory.Exists(path))
                 {
-                    Directory.Delete(path, true);
-                    await writer.WriteLineAsync("250 Removed").ConfigureAwait(false);
+                    string path = Local(Normalize(state, argument));
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                        await writer.WriteLineAsync("250 Removed").ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
+                    }
+                    return true;
                 }
-                else
-                {
-                    await writer.WriteLineAsync("550 Not found").ConfigureAwait(false);
-                }
-                return true;
-            }
             case "RNFR":
                 state.RenameFrom = Local(Normalize(state, argument));
                 await writer.WriteLineAsync("350 Ready for destination").ConfigureAwait(false);
                 return true;
             case "RNTO":
-            {
-                string target = Local(Normalize(state, argument));
-                if (state.RenameFrom is { } source && (File.Exists(source) || Directory.Exists(source)))
                 {
-                    if (Directory.Exists(source))
+                    string target = Local(Normalize(state, argument));
+                    if (state.RenameFrom is { } source && (File.Exists(source) || Directory.Exists(source)))
                     {
-                        Directory.Move(source, target);
+                        if (Directory.Exists(source))
+                        {
+                            Directory.Move(source, target);
+                        }
+                        else
+                        {
+                            File.Move(source, target, true);
+                        }
+                        await writer.WriteLineAsync("250 Renamed").ConfigureAwait(false);
                     }
                     else
                     {
-                        File.Move(source, target, true);
+                        await writer.WriteLineAsync("550 Rename failed").ConfigureAwait(false);
                     }
-                    await writer.WriteLineAsync("250 Renamed").ConfigureAwait(false);
+                    state.RenameFrom = null;
+                    return true;
                 }
-                else
-                {
-                    await writer.WriteLineAsync("550 Rename failed").ConfigureAwait(false);
-                }
-                state.RenameFrom = null;
-                return true;
-            }
             case "SITE":
                 // SITE CHMOD:真实服务器上是可选命令,这里接受并忽略,足以验证调用链路。
                 await writer.WriteLineAsync("200 OK").ConfigureAwait(false);
@@ -266,7 +266,7 @@ internal sealed class LoopbackFtpServer : IDisposable
         }
     }
 
-    private async Task OpenPassiveAsync(SessionState state, StreamWriter writer, bool extended)
+    private static async Task OpenPassiveAsync(SessionState state, StreamWriter writer, bool extended)
     {
         state.CloseData();
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/tests/VelaShell.Infrastructure.Tests/FtpSupportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/FtpSupportTests.cs
@@ -190,7 +190,7 @@ public class FtpSupportTests
             Username = "deploy",
         };
 
-        FtpConnectionInfo info = FtpConnectionInfo.FromProfile(profile);
+        var info = FtpConnectionInfo.FromProfile(profile);
 
         Assert.AreEqual(FtpSettings.DefaultPort, info.Port);
         Assert.AreEqual(FtpEncryptionMode.Auto, info.Settings.EncryptionMode);
@@ -209,7 +209,7 @@ public class FtpSupportTests
             Ftp = new FtpSettings { Anonymous = true },
         };
 
-        FtpConnectionInfo info = FtpConnectionInfo.FromProfile(profile);
+        var info = FtpConnectionInfo.FromProfile(profile);
 
         Assert.AreEqual(FtpConnectionInfo.AnonymousUser, info.EffectiveUsername);
         Assert.IsNotEmpty(info.EffectivePassword);

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/HelloWorldDemoPanelTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/HelloWorldDemoPanelTests.cs
@@ -13,6 +13,14 @@ namespace VelaShell.Infrastructure.Tests.Plugins;
 [TestCategory("Plugins")]
 public class HelloWorldDemoPanelTests
 {
+    private static readonly string[] ExpectedCommandIds =
+    [
+        "velashell.hello-world.panel",
+        "velashell.hello-world.panel-window",
+        "velashell.hello-world.list-sessions",
+        "velashell.hello-world.uptime"
+    ];
+
     private static async Task<TestPluginContext> ActivateAsync()
     {
         var ctx = new TestPluginContext { PluginId = "velashell.hello-world" };
@@ -27,13 +35,7 @@ public class HelloWorldDemoPanelTests
         try
         {
             string[] ids = [.. ctx.RecordingCommands.Registered.Select(c => c.Id)];
-            CollectionAssert.IsSubsetOf(new[]
-            {
-                "velashell.hello-world.panel",
-                "velashell.hello-world.panel-window",
-                "velashell.hello-world.list-sessions",
-                "velashell.hello-world.uptime"
-            }, ids);
+            CollectionAssert.IsSubsetOf(ExpectedCommandIds, ids);
         }
         finally
         {
@@ -76,8 +78,8 @@ public class HelloWorldDemoPanelTests
             ctx.FakeSessions.AddConnected(host: "prod-1");
             ctx.FakeRemoteExec.Handler = (_, cmd) => cmd == "uptime" ? "up 42 days" : "";
             await ctx.RecordingCommands.RunAsync("velashell.hello-world.uptime");
-            Assert.IsTrue(ctx.FakeRemoteExec.Executed.Any(e => e.Command == "uptime"));
-            Assert.IsTrue(ctx.CollectingLog.Entries.Any(e => e.Message.Contains("up 42 days")));
+            Assert.Contains(e => e.Command == "uptime", ctx.FakeRemoteExec.Executed);
+            Assert.Contains(e => e.Message.Contains("up 42 days"), ctx.CollectingLog.Entries);
         }
         finally
         {

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/HelloWorldTerminalTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/HelloWorldTerminalTests.cs
@@ -31,7 +31,7 @@ public class HelloWorldTerminalTests
         try
         {
             await ctx.RecordingCommands.RunAsync("velashell.hello-world.grep-errors");
-            Assert.IsTrue(ctx.CollectingLog.Entries.Any(e => e.Message.Contains("disk full")),
+            Assert.Contains(e => e.Message.Contains("disk full"), ctx.CollectingLog.Entries,
                 "应在终端输出里搜到 error 行");
         }
         finally
@@ -47,7 +47,7 @@ public class HelloWorldTerminalTests
         try
         {
             await ctx.RecordingCommands.RunAsync("velashell.hello-world.echo-terminal");
-            Assert.IsTrue(ctx.FakeTerminal.Writes.Any(w => w.Input.Contains("hello-from-plugin")));
+            Assert.Contains(w => w.Input.Contains("hello-from-plugin"), ctx.FakeTerminal.Writes);
         }
         finally
         {
@@ -63,8 +63,8 @@ public class HelloWorldTerminalTests
         {
             ctx.FakeTerminal.DenyWrites = true;
             await ctx.RecordingCommands.RunAsync("velashell.hello-world.echo-terminal"); // 不抛
-            Assert.IsFalse(ctx.FakeTerminal.Writes.Any());
-            Assert.IsTrue(ctx.CollectingLog.Entries.Any(e => e.Message.Contains("denied")));
+            Assert.IsEmpty(ctx.FakeTerminal.Writes);
+            Assert.Contains(e => e.Message.Contains("denied"), ctx.CollectingLog.Entries);
         }
         finally
         {

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
@@ -122,7 +122,7 @@ public class IsolatedPluginTests
         System.Diagnostics.Process.GetProcessById(secondPid).Kill();
         await WaitForAsync(() => manager.Plugins.Single().State == PluginState.Failed,
             TimeSpan.FromSeconds(15), "窗口内第二次崩溃应判 Failed 放弃自愈");
-        StringAssert.Contains(manager.Plugins.Single().Error, "crashed");
+        Assert.Contains("crashed", manager.Plugins.Single().Error);
 
         await manager.DisposeAsync();
     }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/JsonFilePluginStorageTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/JsonFilePluginStorageTests.cs
@@ -1,5 +1,4 @@
 using VelaShell.PluginSdk.Hosting;
-using VelaShell.PluginSdk.Storage;
 
 namespace VelaShell.Infrastructure.Tests.Plugins;
 
@@ -7,6 +6,9 @@ namespace VelaShell.Infrastructure.Tests.Plugins;
 [TestCategory("Plugins")]
 public class JsonFilePluginStorageTests
 {
+    private static readonly string[] NameKeyOnly = ["name"];
+    private static readonly int[] Numbers = [1, 2, 3];
+
     private string _dir = null!;
 
     [TestInitialize]
@@ -32,7 +34,7 @@ public class JsonFilePluginStorageTests
     [TestMethod]
     public async Task SetGetRemove_RoundTrips()
     {
-        IPluginStorage storage = new JsonFilePluginStorage(_dir);
+        JsonFilePluginStorage storage = new(_dir);
         await storage.SetAsync("count", 42);
         await storage.SetAsync("name", "vela");
         Assert.AreEqual(42, await storage.GetAsync<int>("count"));
@@ -40,15 +42,15 @@ public class JsonFilePluginStorageTests
         Assert.IsNull(await storage.GetAsync<string>("missing"));
         Assert.IsTrue(await storage.RemoveAsync("count"));
         Assert.IsFalse(await storage.RemoveAsync("count"));
-        CollectionAssert.AreEquivalent(new[] { "name" }, (await storage.GetKeysAsync()).ToArray());
+        Assert.AreSequenceEqual(NameKeyOnly, (await storage.GetKeysAsync()).ToArray(), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]
     public async Task Values_PersistAcrossInstances()
     {
-        await new JsonFilePluginStorage(_dir).SetAsync("key", new[] { 1, 2, 3 });
+        await new JsonFilePluginStorage(_dir).SetAsync("key", Numbers);
         int[]? roundTripped = await new JsonFilePluginStorage(_dir).GetAsync<int[]>("key");
-        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, roundTripped);
+        Assert.AreSequenceEqual(Numbers, roundTripped);
     }
 
     [TestMethod]
@@ -56,7 +58,7 @@ public class JsonFilePluginStorageTests
     {
         string file = Path.Combine(_dir, "storage.json");
         await File.WriteAllTextAsync(file, "{ not valid json !!!");
-        IPluginStorage storage = new JsonFilePluginStorage(_dir);
+        JsonFilePluginStorage storage = new(_dir);
         Assert.IsNull(await storage.GetAsync<string>("anything"));
         await storage.SetAsync("fresh", true);
         Assert.IsTrue(await storage.GetAsync<bool>("fresh"));

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
@@ -11,6 +11,8 @@ namespace VelaShell.Infrastructure.Tests.Plugins;
 [TestCategory("Plugins")]
 public class LazyActivationTests
 {
+    private static readonly string[] GhostPluginOnly = ["ghost.plugin"];
+
     private string _root = null!;
     private string _dataRoot = null!;
     private RecordingCommands _commands = null!;
@@ -155,7 +157,7 @@ public class LazyActivationTests
         });
         await manager.StartAsync();
 
-        CollectionAssert.AreEqual(new[] { "ghost.plugin" }, dataStore.Purged, "只清除已卸载插件的 DB 数据");
+        Assert.AreSequenceEqual(GhostPluginOnly, dataStore.Purged, "只清除已卸载插件的 DB 数据");
         Assert.IsFalse(Directory.Exists(Path.Combine(_dataRoot, "ghost.plugin")), "已卸载插件的数据目录应删除");
         Assert.IsTrue(Directory.Exists(Path.Combine(_dataRoot, "acme.disabled")), "禁用 ≠ 卸载,数据保留");
         await manager.DisposeAsync();

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
@@ -64,7 +64,7 @@ public class PluginInstallUninstallTests
     });
 
     /// <summary>把 HelloWorld 打成一个 .vpx(zip:plugin.json + dll)。</summary>
-    private string BuildVpx(string id = "acme.packaged")
+    private static string BuildVpx(string id = "acme.packaged")
     {
         string stage = Path.Combine(Path.GetTempPath(), "velashell-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(stage);
@@ -103,9 +103,9 @@ public class PluginInstallUninstallTests
         string id = await manager.InstallFromVpxAsync(BuildVpx());
 
         Assert.IsTrue(await manager.UninstallAsync(id));
-        Assert.IsFalse(manager.Plugins.Any(p => p.Id == id));
+        Assert.DoesNotContain(p => p.Id == id, manager.Plugins);
         Assert.IsFalse(Directory.Exists(Path.Combine(_userRoot, id)), "插件目录应被删除");
-        CollectionAssert.Contains(_dataStore.Purged, id);
+        Assert.Contains(id, _dataStore.Purged);
 
         await manager.DisposeAsync();
     }
@@ -158,7 +158,7 @@ public class PluginInstallUninstallTests
         await manager.InstallFromVpxAsync(BuildVpx("acme.dup"));
         // 覆盖安装同 id:不抛,替换。
         string id = await manager.InstallFromVpxAsync(BuildVpx("acme.dup"));
-        Assert.AreEqual(1, manager.Plugins.Count(p => p.Id == "acme.dup"));
+        Assert.ContainsSingle(p => p.Id == "acme.dup", manager.Plugins);
         Assert.AreEqual(PluginState.Active, manager.Plugins.Single(p => p.Id == id).State);
         await manager.DisposeAsync();
     }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
@@ -62,15 +62,15 @@ public class PluginManagerTests
         manager.Discover();
         var byId = manager.Plugins.ToDictionary(p => p.Id);
 
-        Assert.AreEqual(5, byId.Count);
+        Assert.HasCount(5, byId);
         Assert.AreEqual(PluginState.Discovered, byId["a.ok"].State);
         Assert.AreEqual(PluginState.Invalid, byId["bad-json"].State);
         Assert.IsNotNull(byId["bad-json"].Error);
         Assert.AreEqual(PluginState.Disabled, byId["a.disabled"].State);
         Assert.AreEqual(PluginState.Incompatible, byId["a.future"].State);
-        StringAssert.Contains(byId["a.future"].Error, "apiLevel");
+        Assert.Contains("apiLevel", byId["a.future"].Error);
         Assert.AreEqual(PluginState.Incompatible, byId["a.newer"].State);
-        StringAssert.Contains(byId["a.newer"].Error, "9.9.9");
+        Assert.Contains("9.9.9", byId["a.newer"].Error);
     }
 
     [TestMethod]
@@ -105,10 +105,10 @@ public class PluginManagerTests
         manager.Discover();
 
         List<PluginDescriptor> dups = [.. manager.Plugins.Where(p => p.Id == "a.dup")];
-        Assert.AreEqual(2, dups.Count);
-        Assert.AreEqual(1, dups.Count(d => d.State == PluginState.Discovered));
+        Assert.HasCount(2, dups);
+        Assert.ContainsSingle(d => d.State == PluginState.Discovered, dups);
         PluginDescriptor rejected = dups.Single(d => d.State == PluginState.Invalid);
-        StringAssert.Contains(rejected.Error, "Duplicate");
+        Assert.Contains("Duplicate", rejected.Error);
     }
 
     [TestMethod]
@@ -144,7 +144,7 @@ public class PluginManagerTests
         await manager.StartAsync();
         PluginDescriptor descriptor = manager.Plugins.Single();
         Assert.AreEqual(PluginState.Failed, descriptor.State);
-        StringAssert.Contains(descriptor.Error, "Ghost.dll");
+        Assert.Contains("Ghost.dll", descriptor.Error);
         await manager.DisposeAsync();
     }
 
@@ -155,7 +155,7 @@ public class PluginManagerTests
         var manager = new PluginManager(Options());
         await manager.StartAsync();
         await manager.StartAsync();
-        Assert.AreEqual(1, manager.Plugins.Count(p => p.Id == "a.ok"));
+        Assert.ContainsSingle(p => p.Id == "a.ok", manager.Plugins);
         await manager.DisposeAsync();
     }
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManifestReaderTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManifestReaderTests.cs
@@ -31,7 +31,7 @@ public class PluginManifestReaderTests
     {
         PluginManifestException ex = Assert.ThrowsExactly<PluginManifestException>(() =>
             PluginManifestReader.Parse("""{ "id": "a.b", "version": "1.0.0", "displayName": "X" }"""));
-        StringAssert.Contains(ex.Message, "JSON");
+        Assert.Contains("JSON", ex.Message);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/ProtectedSecretsCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/ProtectedSecretsCapabilityTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using VelaShell.Core.Data;
 using VelaShell.Infrastructure.Plugins.Capabilities;
-using VelaShell.PluginSdk.Secrets;
 
 namespace VelaShell.Infrastructure.Tests.Plugins;
 
@@ -46,13 +45,13 @@ public class ProtectedSecretsCapabilityTests
     [TestMethod]
     public async Task SetGetDelete_RoundTrips_AndPersistsAcrossInstances()
     {
-        ISecretsApi secrets = new ProtectedSecretsCapability(_dir, new Base64Protector());
+        ProtectedSecretsCapability secrets = new(_dir, new Base64Protector());
         await secrets.SetAsync("api-token", "s3cret-value");
         Assert.AreEqual("s3cret-value", await secrets.GetAsync("api-token"));
         Assert.IsNull(await secrets.GetAsync("missing"));
 
         // 新实例(模拟重启)仍能解出。
-        ISecretsApi reopened = new ProtectedSecretsCapability(_dir, new Base64Protector());
+        ProtectedSecretsCapability reopened = new(_dir, new Base64Protector());
         Assert.AreEqual("s3cret-value", await reopened.GetAsync("api-token"));
 
         Assert.IsTrue(await reopened.DeleteAsync("api-token"));
@@ -63,17 +62,17 @@ public class ProtectedSecretsCapabilityTests
     [TestMethod]
     public async Task SecretsFile_NeverContainsPlaintext()
     {
-        ISecretsApi secrets = new ProtectedSecretsCapability(_dir, new Base64Protector());
+        ProtectedSecretsCapability secrets = new(_dir, new Base64Protector());
         await secrets.SetAsync("password", "hunter2-plaintext");
         string onDisk = await File.ReadAllTextAsync(Path.Combine(_dir, "secrets.json"));
-        Assert.IsFalse(onDisk.Contains("hunter2-plaintext"), "机密必须加密落盘");
-        StringAssert.Contains(onDisk, "enc:");
+        Assert.DoesNotContain("hunter2-plaintext", onDisk, "机密必须加密落盘");
+        Assert.Contains("enc:", onDisk);
     }
 
     [TestMethod]
     public async Task WithoutProtector_SecretsCapabilityRefusesInsteadOfPlaintext()
     {
-        ISecretsApi unavailable = new UnavailableSecrets();
+        UnavailableSecrets unavailable = new();
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => unavailable.SetAsync("k", "v"));
         await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => unavailable.GetAsync("k"));
     }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RpcConnectionTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RpcConnectionTests.cs
@@ -71,7 +71,7 @@ public class RpcConnectionTests
         {
             PluginSessionNotFoundException ex = await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
                 () => client.RequestAsync<object>("anything", null, TimeSpan.FromSeconds(5)));
-            StringAssert.Contains(ex.Message, "s-42");
+            Assert.Contains("s-42", ex.Message);
         }
         finally
         {
@@ -146,9 +146,9 @@ public class RpcConnectionTests
     {
         // 两个并发慢请求总耗时应接近单个,而不是两倍(读循环不被处理器阻塞)。
         (RpcConnection _, RpcConnection client, Func<ValueTask> cleanup) = await ConnectPairAsync(
-            async (_, _, _) =>
+            async (_, _, token) =>
             {
-                await Task.Delay(300);
+                await Task.Delay(300, token);
                 return new Echo("done");
             });
         try

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SonnetDbPluginDataStoreTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SonnetDbPluginDataStoreTests.cs
@@ -22,6 +22,11 @@ public class SonnetDbPluginDataStoreTests
             : ciphertext;
     }
 
+    private static readonly int[] SnapshotValues = [1, 2, 3];
+    private static readonly string[] CountAndSnapshotKeys = ["count", "snapshot"];
+    private static readonly string[] BothPluginIds = ["acme.one", "acme.two"];
+    private static readonly string[] SecondPluginIdOnly = ["acme.two"];
+
     private string _dbDir = null!;
     private SonnetDbEngine _engine = null!;
     private SonnetDbPluginDataStore _store = null!;
@@ -55,12 +60,12 @@ public class SonnetDbPluginDataStoreTests
     {
         IPluginStorage storage = _store.CreateStorage("acme.one");
         await storage.SetAsync("count", 42);
-        await storage.SetAsync("snapshot", new Snapshot("s1", [1, 2, 3]));
+        await storage.SetAsync("snapshot", new Snapshot("s1", SnapshotValues));
         Assert.AreEqual(42, await storage.GetAsync<int>("count"));
         Snapshot? snapshot = await storage.GetAsync<Snapshot>("snapshot");
         Assert.AreEqual("s1", snapshot!.Name);
-        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, snapshot.Values);
-        CollectionAssert.AreEquivalent(new[] { "count", "snapshot" }, (await storage.GetKeysAsync()).ToArray());
+        Assert.AreSequenceEqual(SnapshotValues, snapshot.Values);
+        Assert.AreSequenceEqual(CountAndSnapshotKeys, (await storage.GetKeysAsync()).ToArray(), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         Assert.IsTrue(await storage.RemoveAsync("count"));
         Assert.IsFalse(await storage.RemoveAsync("count"));
         Assert.AreEqual(0, await storage.GetAsync<int>("count"));
@@ -91,8 +96,8 @@ public class SonnetDbPluginDataStoreTests
         // 落库的是密文:直接扫原始文档验证。
         List<string> rawDocs = await _engine.WithCollectionAsync(SonnetDbEngine.PluginDataCollection,
             store => store.Scan().Select(row => row.Json).ToList());
-        Assert.IsFalse(rawDocs.Any(json => json.Contains("hunter2-plaintext")), "机密必须加密落库");
-        Assert.IsTrue(rawDocs.Any(json => json.Contains("enc:")));
+        Assert.DoesNotContain(json => json.Contains("hunter2-plaintext"), rawDocs, "机密必须加密落库");
+        Assert.Contains(json => json.Contains("enc:"), rawDocs);
 
         Assert.IsNull(await _store.CreateSecrets("acme.two").GetAsync("token"), "机密同样按插件隔离");
         Assert.IsTrue(await secrets.DeleteAsync("token"));
@@ -106,9 +111,9 @@ public class SonnetDbPluginDataStoreTests
         await _store.CreateSecrets("acme.one").SetAsync("s", "v");
         await _store.CreateStorage("acme.two").SetAsync("k", 2);
 
-        CollectionAssert.AreEqual(new[] { "acme.one", "acme.two" }, (await _store.ListPluginIdsAsync()).ToArray());
+        Assert.AreSequenceEqual(BothPluginIds, (await _store.ListPluginIdsAsync()).ToArray());
         await _store.PurgeAsync("acme.one");
-        CollectionAssert.AreEqual(new[] { "acme.two" }, (await _store.ListPluginIdsAsync()).ToArray());
+        Assert.AreSequenceEqual(SecondPluginIdOnly, (await _store.ListPluginIdsAsync()).ToArray());
         Assert.AreEqual(0, await _store.CreateStorage("acme.one").GetAsync<int>("k"));
         Assert.IsNull(await _store.CreateSecrets("acme.one").GetAsync("s"));
         Assert.AreEqual(2, await _store.CreateStorage("acme.two").GetAsync<int>("k"));

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
@@ -80,7 +80,7 @@ public class StreamingRoutingTests
                     break;
                 }
             }
-            CollectionAssert.AreEqual(payload, assembled.ToArray());
+            Assert.AreSequenceEqual(payload, assembled.ToArray());
 
             // EOF 后宿主已自动释放:再拉块报"流未打开"。
             await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>

--- a/tests/VelaShell.Infrastructure.Tests/XshellImportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/XshellImportTests.cs
@@ -44,7 +44,7 @@ public class XshellImportTests
         byte[] cipher = Rc4.Transform(key, plain);
         byte[] round = Rc4.Transform(key, cipher);
 
-        CollectionAssert.AreEqual(plain, round);
+        Assert.AreSequenceEqual(plain, round);
     }
 
     /// <summary>

--- a/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxTests.cs
@@ -10,6 +10,9 @@ namespace VelaShell.Plugin.Ai.Tests;
 [TestClass]
 public sealed class AgentToolboxTests
 {
+    private static readonly string[] ExpectedToolNames =
+        ["list_sessions", "read_terminal", "run_command", "read_remote_file", "write_terminal"];
+
     private static async Task<string> InvokeAsync(AgentToolbox toolbox, string name, Dictionary<string, object?>? args = null)
     {
         AIFunction function = toolbox.CreateTools().OfType<AIFunction>().Single(f => f.Name == name);
@@ -25,9 +28,7 @@ public sealed class AgentToolboxTests
 
         string[] names = toolbox.CreateTools().OfType<AIFunction>().Select(f => f.Name).ToArray();
 
-        CollectionAssert.AreEquivalent(
-            new[] { "list_sessions", "read_terminal", "run_command", "read_remote_file", "write_terminal" },
-            names);
+        Assert.AreSequenceEqual(ExpectedToolNames, names, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]
@@ -39,8 +40,8 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "list_sessions");
 
-        StringAssert.Contains(result, "prod-1");
-        StringAssert.Contains(result, "root");
+        Assert.Contains("prod-1", result);
+        Assert.Contains("root", result);
     }
 
     [TestMethod]
@@ -51,7 +52,7 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "read_terminal");
 
-        StringAssert.Contains(result, "No SSH session");
+        Assert.Contains("No SSH session", result);
     }
 
     [TestMethod]
@@ -64,7 +65,7 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "read_terminal");
 
-        StringAssert.Contains(result, "active (running)");
+        Assert.Contains("active (running)", result);
     }
 
     [TestMethod]
@@ -76,8 +77,8 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "run_command", new() { ["command"] = "rm -rf /" });
 
-        StringAssert.Contains(result, "DENIED");
-        Assert.AreEqual(0, context.FakeRemoteExec.Executed.Count);
+        Assert.Contains("DENIED", result);
+        Assert.IsEmpty(context.FakeRemoteExec.Executed);
     }
 
     [TestMethod]
@@ -95,7 +96,7 @@ public sealed class AgentToolboxTests
         string result = await InvokeAsync(toolbox, "run_command", new() { ["command"] = "uptime" });
 
         Assert.AreEqual("up 42 days", result);
-        Assert.AreEqual(1, context.FakeRemoteExec.Executed.Count);
+        Assert.HasCount(1, context.FakeRemoteExec.Executed);
     }
 
     [TestMethod]
@@ -132,7 +133,7 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "read_remote_file", new() { ["path"] = "/etc/hostname" });
 
-        StringAssert.Contains(result, "web-01");
+        Assert.Contains("web-01", result);
     }
 
     [TestMethod]
@@ -149,8 +150,8 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "write_terminal", new() { ["text"] = "echo hi\n" });
 
-        StringAssert.Contains(result, "denied");
-        Assert.AreEqual(0, context.FakeTerminal.Writes.Count);
+        Assert.Contains("denied", result);
+        Assert.IsEmpty(context.FakeTerminal.Writes);
     }
 
     [TestMethod]
@@ -166,8 +167,8 @@ public sealed class AgentToolboxTests
 
         string result = await InvokeAsync(toolbox, "write_terminal", new() { ["text"] = "echo hi\n" });
 
-        StringAssert.Contains(result, "typed");
-        Assert.AreEqual(1, context.FakeTerminal.Writes.Count);
+        Assert.Contains("typed", result);
+        Assert.HasCount(1, context.FakeTerminal.Writes);
         Assert.AreEqual("echo hi\n", context.FakeTerminal.Writes[0].Input);
     }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/AiSettingsStoreTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/AiSettingsStoreTests.cs
@@ -16,7 +16,7 @@ public sealed class AiSettingsStoreTests
 
         AiSettings settings = await store.LoadAsync();
 
-        Assert.AreEqual(0, settings.Providers.Count);
+        Assert.IsEmpty(settings.Providers);
         Assert.IsFalse(settings.AgentMode);
         Assert.IsFalse(settings.AutoApproveCommands);
     }
@@ -46,7 +46,7 @@ public sealed class AiSettingsStoreTests
         await store.SaveAsync(settings);
         AiSettings loaded = await store.LoadAsync();
 
-        Assert.AreEqual(1, loaded.Providers.Count);
+        Assert.HasCount(1, loaded.Providers);
         Assert.AreEqual("Claude", loaded.Providers[0].Name);
         Assert.AreEqual(ChatProtocol.AnthropicMessages, loaded.Providers[0].Protocol);
         Assert.AreEqual(4096, loaded.Providers[0].MaxTokens);

--- a/tests/VelaShell.Plugin.Ai.Tests/McpConfigTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/McpConfigTests.cs
@@ -7,28 +7,30 @@ namespace VelaShell.Plugin.Ai.Tests;
 [TestClass]
 public sealed class McpConfigTests
 {
+    private static readonly string[] FilesystemServerArgs = ["-y", "@modelcontextprotocol/server-filesystem", "C:\\data"];
+    private static readonly string[] QuotedArgs = ["--root", "C:\\My Files\\docs", "a\"b"];
+    private static readonly string[] SingleEmptyToken = [""];
+
     [TestMethod]
     public void SplitArguments_SplitsOnWhitespace()
     {
-        CollectionAssert.AreEqual(
-            new[] { "-y", "@modelcontextprotocol/server-filesystem", "C:\\data" },
-            McpConfigParser.SplitArguments("-y  @modelcontextprotocol/server-filesystem   C:\\data").ToArray());
+        Assert.AreSequenceEqual(
+            FilesystemServerArgs, McpConfigParser.SplitArguments("-y  @modelcontextprotocol/server-filesystem   C:\\data").ToArray());
     }
 
     [TestMethod]
     public void SplitArguments_QuotesPreserveSpaces_AndDoubledQuoteEscapes()
     {
-        CollectionAssert.AreEqual(
-            new[] { "--root", "C:\\My Files\\docs", "a\"b" },
-            McpConfigParser.SplitArguments("--root \"C:\\My Files\\docs\" \"a\"\"b\"").ToArray());
+        Assert.AreSequenceEqual(
+            QuotedArgs, McpConfigParser.SplitArguments("--root \"C:\\My Files\\docs\" \"a\"\"b\"").ToArray());
     }
 
     [TestMethod]
     public void SplitArguments_EmptyQuotes_YieldEmptyToken()
     {
-        CollectionAssert.AreEqual(new[] { "" }, McpConfigParser.SplitArguments("\"\"").ToArray());
-        Assert.AreEqual(0, McpConfigParser.SplitArguments("   ").Count);
-        Assert.AreEqual(0, McpConfigParser.SplitArguments(null).Count);
+        Assert.AreSequenceEqual(SingleEmptyToken, McpConfigParser.SplitArguments("\"\"").ToArray());
+        Assert.IsEmpty(McpConfigParser.SplitArguments("   "));
+        Assert.IsEmpty(McpConfigParser.SplitArguments(null));
     }
 
     [TestMethod]
@@ -37,7 +39,7 @@ public sealed class McpConfigTests
         Dictionary<string, string?> env = McpConfigParser.ParseEnvironmentLines(
             "API_KEY=abc\r\n\r\nnot-a-pair\r\nCONN=a=b=c\r\n =missing-key");
 
-        Assert.AreEqual(2, env.Count);
+        Assert.HasCount(2, env);
         Assert.AreEqual("abc", env["API_KEY"]);
         Assert.AreEqual("a=b=c", env["CONN"]);
     }
@@ -48,7 +50,7 @@ public sealed class McpConfigTests
         Dictionary<string, string> headers = McpConfigParser.ParseHeaderLines(
             "Authorization: Bearer x:y\r\nplain line\r\nX-Api-Key:  k1 ");
 
-        Assert.AreEqual(2, headers.Count);
+        Assert.HasCount(2, headers);
         Assert.AreEqual("Bearer x:y", headers["Authorization"]);
         Assert.AreEqual("k1", headers["X-Api-Key"]);
     }
@@ -94,7 +96,7 @@ public sealed class McpConfigTests
         await store.SaveAsync(settings);
         AiSettings loaded = await store.LoadAsync();
 
-        Assert.AreEqual(2, loaded.McpServers.Count);
+        Assert.HasCount(2, loaded.McpServers);
         Assert.AreEqual("files", loaded.McpServers[0].Name);
         Assert.AreEqual(McpTransportType.Stdio, loaded.McpServers[0].Transport);
         Assert.AreEqual("npx", loaded.McpServers[0].Command);

--- a/tests/VelaShell.Presentation.Tests/Plugins/PluginCommandsApiTests.cs
+++ b/tests/VelaShell.Presentation.Tests/Plugins/PluginCommandsApiTests.cs
@@ -53,7 +53,7 @@ public class PluginCommandsApiTests
         {
             await Task.Delay(20);
         }
-        Assert.IsTrue(log.Entries.Any(e => e.Level == PluginLogLevel.Error && e.Exception is InvalidOperationException));
+        Assert.Contains(e => e.Level == PluginLogLevel.Error && e.Exception is InvalidOperationException, log.Entries);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Presentation.Tests/ViewModels/SessionImportViewModelTests.cs
+++ b/tests/VelaShell.Presentation.Tests/ViewModels/SessionImportViewModelTests.cs
@@ -11,6 +11,9 @@ namespace VelaShell.Presentation.Tests.ViewModels;
 [TestCategory("SessionImport")]
 public class SessionImportViewModelTests
 {
+    private static readonly string[] WebOnly = ["web"];
+    private static readonly string[] DbOnly = ["db"];
+
     [TestMethod]
     public async Task Initialize_ScansEverySource_AndAutoSelectsImportableSessions()
     {
@@ -111,9 +114,9 @@ public class SessionImportViewModelTests
         Assert.IsNotNull(outcome);
         Assert.AreEqual(2, outcome.Imported);
         Assert.AreEqual(1, outcome.PasswordsRecovered);
-        CollectionAssert.AreEqual(new[] { "web" }, xshell.ImportedNames);
-        CollectionAssert.AreEqual(new[] { "db" }, winscp.ImportedNames);   // 重复项不写入
-        StringAssert.Contains(xshell.ImportedGroup ?? string.Empty, "Xshell");   // 按来源各建一个分组
+        Assert.AreSequenceEqual(WebOnly, xshell.ImportedNames);
+        Assert.AreSequenceEqual(DbOnly, winscp.ImportedNames);   // 重复项不写入
+        Assert.Contains("Xshell", xshell.ImportedGroup ?? string.Empty);   // 按来源各建一个分组
     }
 
     [TestMethod]
@@ -142,7 +145,7 @@ public class SessionImportViewModelTests
         await vm.InitializeAsync();
 
         Assert.IsTrue(vm.HasMasterPasswordWarning);
-        StringAssert.Contains(vm.MasterPasswordWarning, "Xshell");
+        Assert.Contains("Xshell", vm.MasterPasswordWarning);
         Assert.IsFalse(vm.MasterPasswordWarning.Contains("WinSCP", StringComparison.Ordinal));
     }
 

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
@@ -7,6 +7,9 @@ namespace VelaShell.Terminal.Tests.Emulation;
 [TestCategory("Emulator")]
 public class TerminalEmulatorTests
 {
+    /// <summary>DA2 / DECRQSS / CPR 三条应答,其余探针不应答。</summary>
+    private static readonly string[] ExpectedProbeReplies = ["\x1b[>41;360;0c", "\x1bP1$r0 q\x1b\\", "\x1b[1;1R"];
+
     private static TerminalEmulator New(int cols = 20, int rows = 6, TerminalType type = TerminalType.XtermColor256) => new(cols, rows, type);
 
     private static void Feed(TerminalEmulator e, string s) => e.Feed(Encoding.UTF8.GetBytes(s));
@@ -409,7 +412,7 @@ public class TerminalEmulatorTests
         Feed(e, "\x1b]11;?\x1b\\");      // OSC 11 背景色:不应答
         Feed(e, "\x1bPzz\x1b\\\x1b[0%m"); // xterm 兼容性探针:不应答、不动光标
         Feed(e, "\x1b[6n");              // CPR
-        CollectionAssert.AreEqual(new[] { "\x1b[>41;360;0c", "\x1bP1$r0 q\x1b\\", "\x1b[1;1R" }, replies);
+        Assert.AreSequenceEqual(ExpectedProbeReplies, replies);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Tests/Integration/ZModemRealChannelIntegrationTests.cs
+++ b/tests/VelaShell.Tests/Integration/ZModemRealChannelIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
@@ -20,6 +21,11 @@ namespace VelaShell.Tests.Integration;
 /// 走的就是生产管线:TmdsSshClientWrapper → ShellStreamWrapper → SshTerminalBridge
 /// → ZModemTerminalRouter → 引擎,只有 UI 被替身化。
 /// </summary>
+// MSTEST0045(建议给 [Timeout] 加 CooperativeCancellation)在这里不适用:本组用例卡住的地方
+// 是 docker CLI、SSH 握手与 lrzsz 传输,它们都不观察 TestContext 的取消令牌;改成协作取消后
+// 超时形同虚设,挂死的用例会一直占着 CI。保留强制超时。
+[SuppressMessage("Usage", "MSTEST0045:Use cooperative cancellation with [Timeout]",
+    Justification = "被等待的 docker/SSH 操作不接受测试取消令牌,协作取消无法中断它们。")]
 [TestClass]
 public class ZModemRealChannelIntegrationTests
 {
@@ -123,7 +129,7 @@ public class ZModemRealChannelIntegrationTests
                 // 用远端自己的校验和验证落盘完整性(busybox md5sum)。
                 string expected = Convert.ToHexStringLower(MD5.HashData(payload));
                 string output = await client.RunCommandAsync($"md5sum /tmp/{remoteName}");
-                StringAssert.StartsWith(output.Trim(), expected);
+                Assert.StartsWith(expected, output.Trim());
             }
             finally
             {

--- a/tests/VelaShell.Tests/Localization/LocalizedKeyUsageTests.cs
+++ b/tests/VelaShell.Tests/Localization/LocalizedKeyUsageTests.cs
@@ -20,13 +20,15 @@ namespace VelaShell.Tests.Localization;
 /// </remarks>
 [TestClass]
 [TestCategory("i18n")]
-public class LocalizedKeyUsageTests
+public partial class LocalizedKeyUsageTests
 {
     /// <summary>XAML 里的位置参数写法 {loc:Localize SomeKey}(LocalizeExtension 的唯一用法)。</summary>
-    private static readonly Regex XamlKey = new(@"\{loc:Localize\s+([A-Za-z0-9_]+)\s*\}", RegexOptions.Compiled);
+    [GeneratedRegex(@"\{loc:Localize\s+([A-Za-z0-9_]+)\s*\}")]
+    private static partial Regex XamlKey { get; }
 
     /// <summary>代码里的字面量取词 Strings.Get("SomeKey");变量传参匹配不到,也不该匹配。</summary>
-    private static readonly Regex CodeKey = new(@"Strings\.Get\(""([A-Za-z0-9_]+)""\)", RegexOptions.Compiled);
+    [GeneratedRegex(@"Strings\.Get\(""([A-Za-z0-9_]+)""\)")]
+    private static partial Regex CodeKey { get; }
 
     [TestMethod]
     public void EveryLocalizeKeyUsedInXaml_ExistsInResources()

--- a/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
+++ b/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
@@ -14,8 +14,12 @@ namespace VelaShell.Tests.Services;
 /// </remarks>
 [TestClass]
 [TestCategory("PackageVersions")]
-public class PackageVersionsTests
+public partial class PackageVersionsTests
 {
+    /// <summary>版本形如 12.1.0。</summary>
+    [GeneratedRegex(@"^\d+\.\d+")]
+    private static partial Regex VersionPrefix { get; }
+
     /// <summary>构建目标确实把包版本写进了程序集(失效则此处为空)。</summary>
     [TestMethod]
     public void Read_FindsPackageVersions_EmbeddedAtBuildTime()
@@ -34,7 +38,7 @@ public class PackageVersionsTests
         string? version = PackageVersions.Of(packageId);
 
         Assert.IsNotNull(version, $"关于页要显示 {packageId} 的版本,应能查到。");
-        Assert.MatchesRegex(new Regex(@"^\d+\.\d+"), version, "版本应形如 12.1.0。");
+        Assert.MatchesRegex(VersionPrefix, version, "版本应形如 12.1.0。");
     }
 
     /// <summary>SSH 库被隔离在 Infrastructure 层,按包名查得到才说明没走类型引用那条路。</summary>

--- a/tests/VelaShell.Tests/Views/PluginThemeTokensTests.cs
+++ b/tests/VelaShell.Tests/Views/PluginThemeTokensTests.cs
@@ -25,7 +25,7 @@ public sealed class PluginThemeTokensTests
             // 语义画刷(主题字典,当前变体解析):#AARRGGBB。
             ThemeTokenDto error = byKey["VelaError"];
             Assert.AreEqual("brush", error.Kind);
-            StringAssert.StartsWith(error.Value, "#");
+            Assert.StartsWith("#", error.Value);
 
             // 字号阶梯(与主题无关的 double)。
             ThemeTokenDto fontSize = byKey["VelaFontSize12"];
@@ -39,7 +39,7 @@ public sealed class PluginThemeTokensTests
             Assert.IsFalse(string.IsNullOrWhiteSpace(uiFont.Value));
 
             // 图标几何等非 Vela* 或不可序列化资源不外发。
-            Assert.IsFalse(byKey.Keys.Any(k => k.StartsWith("Icon.", StringComparison.Ordinal)));
+            Assert.DoesNotContain(k => k.StartsWith("Icon.", StringComparison.Ordinal), byKey.Keys);
         }, CancellationToken.None).GetAwaiter().GetResult();
     }
 }

--- a/tests/VelaShell.Tests/Views/SessionImportViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SessionImportViewUiTests.cs
@@ -32,7 +32,7 @@ public sealed class SessionImportViewUiTests
             Dispatcher.UIThread.RunJobs();
 
             // 打开即扫完:两个来源各一张卡片,勾选与统计都已就绪。
-            Assert.AreEqual(2, vm.Sources.Count);
+            Assert.HasCount(2, vm.Sources);
             Assert.AreEqual(3, vm.TotalCount);
             Assert.AreEqual(2, vm.SelectedCount);   // 重复项自动跳过
             Assert.IsFalse(vm.IsBusy);
@@ -42,7 +42,7 @@ public sealed class SessionImportViewUiTests
 
             Button import = PrimaryButton(window);
             Assert.IsTrue(import.IsEffectivelyEnabled, "扫描完成后导入按钮应可直接点击。");
-            StringAssert.Contains((string)import.Content!, "2", "导入按钮要写清将导入几个会话。");
+            Assert.Contains("2", (string)import.Content!, "导入按钮要写清将导入几个会话。");
 
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();
@@ -67,7 +67,7 @@ public sealed class SessionImportViewUiTests
             vm.Sources[0].Items[0].IsSelected = false;
             Dispatcher.UIThread.RunJobs();
             Assert.AreEqual(1, vm.SelectedCount);
-            StringAssert.Contains((string)PrimaryButton(window).Content!, "1");
+            Assert.Contains("1", (string)PrimaryButton(window).Content!);
 
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
## 背景

VS 错误列表里以「消息」严重性出现的分析器诊断,不会进 `dotnet build` 输出,因而长期累积到 139 条。本次按**默认规则集**(非 `AnalysisMode=All`)全量清零。

枚举方式:`dotnet format analyzers --severity info --verify-no-changes`,这正是 VS 默认显示为消息的那一批。

## 主要修改

### 异步与生命周期(CA2012 / CA2027 / CA2016)

- `PluginProcessClient.OnExited`、`PluginManager.CleanupRuntime` 不再丢弃 `ValueTask`,改由包装成 `Task` 的私有方法消费一次并吞掉异常,不再产生未观察任务异常。
- 新增 `CleanupRuntimeAsync`:激活失败与停用两条**可 await** 的路径真正等待进程回收,方法返回时子进程确实已杀、管道确实已断,退出流程不会留孤儿 PluginHost 进程。`Process.Exited` 那类同步回调仍是后台尽力而为(`async void` 会掀掉进程)。
- 限时等待改为给 `Task.Delay` 配取消令牌,操作先完成即取消定时器。仍不用 `WaitAsync` / 带令牌的 `WaitForExitAsync`:超时在这里是常规分支,不该在调试器里刷首发异常。

### P/Invoke(SYSLIB1054)

- `CreateProcess` 由 `DllImport` 改 `LibraryImport`,**必须显式 `EntryPoint = "CreateProcessW"`** —— 源生成封送不做 `CharSet` 自动加 `W` 后缀,漏写编译期无感、只在运行期抛 `EntryPointNotFoundException`(已由 ConPty 测试当场拦下)。
- `STARTUPINFO` 三个从不赋值的字符串字段改 `IntPtr`,使结构保持 blittable,布局与大小不变。

### 按建议直改

CA1859/CA1860/CA1861/CA1847 的类型收窄与常量数组提取、SYSLIB1045 改 `GeneratedRegex`、CA1873 补日志级别判断、CA2208 换 `UnreachableException`,以及 MSTest 断言现代化(`HasCount`/`Contains`/`AreSequenceEqual`,多数由官方修复器批量应用)。

## 三处刻意不照建议改

均带理由注释或 `[SuppressMessage]`:

| 规则 | 原因 |
|---|---|
| CA1822 | XAML 绑定只解析实例成员,VM 文案属性改 static 会直接断掉绑定 |
| MSTEST0045 | docker CLI / SSH 握手不接受测试取消令牌,协作取消会让超时形同虚设 |
| CA2208 | VtParser 的兜底分支是不可达状态而非参数校验 |

## 验证

- 全解决方案构建:0 警告 0 错误
- 测试:1558 个全部通过
- 分析器复扫:剩余 0 条

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSMH5CXWZqScQH8mgCrNRb