### PR TITLE
大幅清理未用本地化资源及同步测试

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.cs
+++ b/src/VelaShell.Core/Resources/Strings.cs
@@ -34,9 +34,6 @@ public static class Strings
     /// <summary>“最近连接”分组标题文案。</summary>
     public static string RecentConnections => ResourceManager.GetString(nameof(RecentConnections), CultureInfo.CurrentUICulture) ?? nameof(RecentConnections);
 
-    /// <summary>“服务器分组”标题文案。</summary>
-    public static string ServerGroups => ResourceManager.GetString(nameof(ServerGroups), CultureInfo.CurrentUICulture) ?? nameof(ServerGroups);
-
     /// <summary>“设置”标签/按钮文案。</summary>
     public static string Settings => ResourceManager.GetString(nameof(Settings), CultureInfo.CurrentUICulture) ?? nameof(Settings);
 
@@ -60,9 +57,6 @@ public static class Strings
 
     /// <summary>“拆分”窗格菜单/按钮文案。</summary>
     public static string Split => ResourceManager.GetString(nameof(Split), CultureInfo.CurrentUICulture) ?? nameof(Split);
-
-    /// <summary>“同步分组”菜单/按钮文案。</summary>
-    public static string SyncGroup => ResourceManager.GetString(nameof(SyncGroup), CultureInfo.CurrentUICulture) ?? nameof(SyncGroup);
 
     /// <summary>文件列表“文件名”列标题文案。</summary>
     public static string FileName => ResourceManager.GetString(nameof(FileName), CultureInfo.CurrentUICulture) ?? nameof(FileName);
@@ -100,20 +94,8 @@ public static class Strings
     /// <summary>“本地端口”输入项标签文案。</summary>
     public static string LocalPort => ResourceManager.GetString(nameof(LocalPort), CultureInfo.CurrentUICulture) ?? nameof(LocalPort);
 
-    /// <summary>“远程地址”输入项标签文案。</summary>
-    public static string RemoteAddress => ResourceManager.GetString(nameof(RemoteAddress), CultureInfo.CurrentUICulture) ?? nameof(RemoteAddress);
-
     /// <summary>“新建隧道”按钮文案。</summary>
     public static string NewTunnel => ResourceManager.GetString(nameof(NewTunnel), CultureInfo.CurrentUICulture) ?? nameof(NewTunnel);
-
-    /// <summary>“活动隧道”列表标题文案。</summary>
-    public static string ActiveTunnels => ResourceManager.GetString(nameof(ActiveTunnels), CultureInfo.CurrentUICulture) ?? nameof(ActiveTunnels);
-
-    /// <summary>命令面板搜索框占位/标题文案。</summary>
-    public static string SearchCommands => ResourceManager.GetString(nameof(SearchCommands), CultureInfo.CurrentUICulture) ?? nameof(SearchCommands);
-
-    /// <summary>“系统监控”面板标题文案。</summary>
-    public static string SystemMonitor => ResourceManager.GetString(nameof(SystemMonitor), CultureInfo.CurrentUICulture) ?? nameof(SystemMonitor);
 
     /// <summary>“网络”分类/面板标题文案。</summary>
     public static string Network => ResourceManager.GetString(nameof(Network), CultureInfo.CurrentUICulture) ?? nameof(Network);
@@ -220,9 +202,6 @@ public static class Strings
     /// <summary>“主机密钥验证”对话框标题文案。</summary>
     public static string HostKeyVerification => ResourceManager.GetString(nameof(HostKeyVerification), CultureInfo.CurrentUICulture) ?? nameof(HostKeyVerification);
 
-    /// <summary>“信任此主机”选项文案。</summary>
-    public static string TrustThisHost => ResourceManager.GetString(nameof(TrustThisHost), CultureInfo.CurrentUICulture) ?? nameof(TrustThisHost);
-
     /// <summary>“浏览密钥文件”按钮文案。</summary>
     public static string BrowseKeyFile => ResourceManager.GetString(nameof(BrowseKeyFile), CultureInfo.CurrentUICulture) ?? nameof(BrowseKeyFile);
 
@@ -246,9 +225,6 @@ public static class Strings
 
     /// <summary>“密钥类型”标签文案。</summary>
     public static string KeyType => ResourceManager.GetString(nameof(KeyType), CultureInfo.CurrentUICulture) ?? nameof(KeyType);
-
-    /// <summary>“信任”按钮文案。</summary>
-    public static string Trust => ResourceManager.GetString(nameof(Trust), CultureInfo.CurrentUICulture) ?? nameof(Trust);
 
     /// <summary>“拒绝”按钮文案。</summary>
     public static string Reject => ResourceManager.GetString(nameof(Reject), CultureInfo.CurrentUICulture) ?? nameof(Reject);
@@ -304,9 +280,6 @@ public static class Strings
 
     /// <summary>“属性”菜单文案。</summary>
     public static string Properties => ResourceManager.GetString(nameof(Properties), CultureInfo.CurrentUICulture) ?? nameof(Properties);
-
-    /// <summary>“修改权限”对话框标题文案。</summary>
-    public static string ChangePermissions => ResourceManager.GetString(nameof(ChangePermissions), CultureInfo.CurrentUICulture) ?? nameof(ChangePermissions);
 
     /// <summary>权限矩阵“所有者”列标签文案。</summary>
     public static string PermissionOwner => ResourceManager.GetString(nameof(PermissionOwner), CultureInfo.CurrentUICulture) ?? nameof(PermissionOwner);

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -25,9 +25,6 @@
   <!-- Auth (7) -->
   <!-- Settings Dialog -->
   <!-- File Browser / SFTP (§6) -->
-  <data name="ActiveTunnels" xml:space="preserve">
-    <value>アクティブなトンネル</value>
-  </data>
   <data name="AddCommand" xml:space="preserve">
     <value>コマンドを追加</value>
   </data>
@@ -105,9 +102,6 @@
   </data>
   <data name="Category" xml:space="preserve">
     <value>カテゴリ</value>
-  </data>
-  <data name="ChangePermissions" xml:space="preserve">
-    <value>権限 (chmod)…</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>タブを閉じる</value>
@@ -556,9 +550,6 @@
   <data name="Monitor_CoreCount" xml:space="preserve">
     <value>{0} 論理コア</value>
   </data>
-  <data name="Monitor_CoreSelected" xml:space="preserve">
-    <value>{0} コア · CPU{1} {2:F0}%</value>
-  </data>
   <data name="Monitor_CoreSelectedLabel" xml:space="preserve">
     <value>{0} コア · {1} {2:F0}%</value>
   </data>
@@ -814,9 +805,6 @@
   <data name="Monitor_TitleFormat" xml:space="preserve">
     <value>システムリソース — {0}</value>
   </data>
-  <data name="Monitor_TopByCpu" xml:space="preserve">
-    <value>CPU 使用率トップ</value>
-  </data>
   <data name="Monitor_TopByMemory" xml:space="preserve">
     <value>メモリ使用量トップ</value>
   </data>
@@ -856,9 +844,6 @@
   <data name="Monitor_WindowSeconds" xml:space="preserve">
     <value>{0} 秒前</value>
   </data>
-  <data name="Monitor_WindowStart" xml:space="preserve">
-    <value>60 秒前</value>
-  </data>
   <data name="Sftp_FileTypeExt" xml:space="preserve">
     <value>{0} ファイル</value>
   </data>
@@ -897,9 +882,6 @@
   </data>
   <data name="KeySvc_AlertChangedAccepted" xml:space="preserve">
     <value>{0} のホストフィンガープリントが変更され、ユーザーが新しいフィンガープリントの永続的な信頼を確認しました:{1}</value>
-  </data>
-  <data name="KeySvc_AlertChangedBlocked" xml:space="preserve">
-    <value>{0} のホストフィンガープリントが known_hosts の記録と一致しないため、接続をブロックしました(中間者攻撃の疑い)。新しいフィンガープリント:{1}</value>
   </data>
   <data name="KeySvc_AlertChangedTrustOnce" xml:space="preserve">
     <value>{0} のホストフィンガープリントが変更され、ユーザーは今回のみ信頼を選択しました(保存されません):{1}</value>
@@ -1202,9 +1184,6 @@
   <data name="Msg_PlaybackTitle" xml:space="preserve">
     <value>再生: {0}({1})</value>
   </data>
-  <data name="Msg_ProxyError" xml:space="preserve">
-    <value>プロキシエラー: プロキシ経由で {0} に接続できません。</value>
-  </data>
   <data name="Msg_ReadKeysFailed" xml:space="preserve">
     <value>鍵の読み込みに失敗しました: {0}</value>
   </data>
@@ -1276,12 +1255,6 @@
   </data>
   <data name="Msg_TunnelNotConnectedAuto" xml:space="preserve">
     <value>未接続 • トンネルの作成/起動時に自動接続</value>
-  </data>
-  <data name="Msg_TunnelRouteDynamic" xml:space="preserve">
-    <value>{0}:{1} → SOCKS5 プロキシ</value>
-  </data>
-  <data name="Msg_TunnelRouteRemote" xml:space="preserve">
-    <value>サーバー:{0} → {1}:{2}</value>
   </data>
   <data name="Msg_TunnelRunning" xml:space="preserve">
     <value>実行中 • {0}</value>
@@ -1599,9 +1572,6 @@
   <data name="Reject" xml:space="preserve">
     <value>拒否</value>
   </data>
-  <data name="RemoteAddress" xml:space="preserve">
-    <value>リモートアドレス</value>
-  </data>
   <data name="RemoteForward" xml:space="preserve">
     <value>リモート転送</value>
   </data>
@@ -1620,14 +1590,8 @@
   <data name="Search" xml:space="preserve">
     <value>検索</value>
   </data>
-  <data name="SearchCommands" xml:space="preserve">
-    <value>コマンドを検索</value>
-  </data>
   <data name="SelectDownloadFolder" xml:space="preserve">
     <value>保存先フォルダーを選択</value>
-  </data>
-  <data name="ServerGroups" xml:space="preserve">
-    <value>サーバーグループ</value>
   </data>
   <data name="Sessions" xml:space="preserve">
     <value>セッション</value>
@@ -2742,9 +2706,6 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="StatusBar_OpenMonitor" xml:space="preserve">
     <value>リソースモニターを開く</value>
   </data>
-  <data name="StatusBar_Swap" xml:space="preserve">
-    <value>スワップ</value>
-  </data>
   <data name="Svc_Active" xml:space="preserve">
     <value>アクティブ</value>
   </data>
@@ -2819,9 +2780,6 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   </data>
   <data name="Svc_Yesterday" xml:space="preserve">
     <value>昨日</value>
-  </data>
-  <data name="SyncGroup" xml:space="preserve">
-    <value>同期グループ</value>
   </data>
   <data name="SyncSvc_ApiFailed" xml:space="preserve">
     <value>GitHub API リクエストに失敗しました({0}):{1}</value>
@@ -2898,9 +2856,6 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="System" xml:space="preserve">
     <value>システム</value>
   </data>
-  <data name="SystemMonitor" xml:space="preserve">
-    <value>システムモニター</value>
-  </data>
   <data name="Term_NoMatches" xml:space="preserve">
     <value>一致なし</value>
   </data>
@@ -2970,17 +2925,11 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Tree_SessionSettings" xml:space="preserve">
     <value>セッション設定</value>
   </data>
-  <data name="Trust" xml:space="preserve">
-    <value>信頼</value>
-  </data>
   <data name="TrustOnce" xml:space="preserve">
     <value>今回のみ信頼</value>
   </data>
   <data name="TrustPermanently" xml:space="preserve">
     <value>常に信頼</value>
-  </data>
-  <data name="TrustThisHost" xml:space="preserve">
-    <value>このホストを信頼</value>
   </data>
   <data name="Tunnel_AliasLabel" xml:space="preserve">
     <value>エイリアス(任意)</value>
@@ -3454,23 +3403,11 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Trace_ColLoss" xml:space="preserve">
     <value>損失%</value>
   </data>
-  <data name="Trace_ColSent" xml:space="preserve">
-    <value>送信</value>
-  </data>
   <data name="Trace_ColLast" xml:space="preserve">
     <value>直近</value>
   </data>
   <data name="Trace_ColAvg" xml:space="preserve">
     <value>平均</value>
-  </data>
-  <data name="Trace_ColBest" xml:space="preserve">
-    <value>最速</value>
-  </data>
-  <data name="Trace_ColWorst" xml:space="preserve">
-    <value>最遅</value>
-  </data>
-  <data name="Trace_ColStdDev" xml:space="preserve">
-    <value>標準偏差</value>
   </data>
   <data name="Trace_Running" xml:space="preserve">
     <value>トレース中…</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -25,9 +25,6 @@
   <!-- Auth (7) -->
   <!-- Settings Dialog -->
   <!-- File Browser / SFTP (§6) -->
-  <data name="ActiveTunnels" xml:space="preserve">
-    <value>활성 터널</value>
-  </data>
   <data name="AddCommand" xml:space="preserve">
     <value>명령 추가</value>
   </data>
@@ -105,9 +102,6 @@
   </data>
   <data name="Category" xml:space="preserve">
     <value>분류</value>
-  </data>
-  <data name="ChangePermissions" xml:space="preserve">
-    <value>권한 (chmod)…</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>탭 닫기</value>
@@ -556,9 +550,6 @@
   <data name="Monitor_CoreCount" xml:space="preserve">
     <value>논리 코어 {0}개</value>
   </data>
-  <data name="Monitor_CoreSelected" xml:space="preserve">
-    <value>{0} 코어 · CPU{1} {2:F0}%</value>
-  </data>
   <data name="Monitor_CoreSelectedLabel" xml:space="preserve">
     <value>{0} 코어 · {1} {2:F0}%</value>
   </data>
@@ -814,9 +805,6 @@
   <data name="Monitor_TitleFormat" xml:space="preserve">
     <value>시스템 리소스 — {0}</value>
   </data>
-  <data name="Monitor_TopByCpu" xml:space="preserve">
-    <value>CPU 상위 프로세스</value>
-  </data>
   <data name="Monitor_TopByMemory" xml:space="preserve">
     <value>메모리 상위 프로세스</value>
   </data>
@@ -856,9 +844,6 @@
   <data name="Monitor_WindowSeconds" xml:space="preserve">
     <value>{0}초 전</value>
   </data>
-  <data name="Monitor_WindowStart" xml:space="preserve">
-    <value>60초 전</value>
-  </data>
   <data name="Sftp_FileTypeExt" xml:space="preserve">
     <value>{0} 파일</value>
   </data>
@@ -897,9 +882,6 @@
   </data>
   <data name="KeySvc_AlertChangedAccepted" xml:space="preserve">
     <value>{0}의 호스트 지문이 변경되었으며 사용자가 새 지문의 영구 신뢰를 확인했습니다: {1}</value>
-  </data>
-  <data name="KeySvc_AlertChangedBlocked" xml:space="preserve">
-    <value>{0}의 호스트 지문이 known_hosts 기록과 일치하지 않아 연결이 차단되었습니다(중간자 공격 의심). 새 지문: {1}</value>
   </data>
   <data name="KeySvc_AlertChangedTrustOnce" xml:space="preserve">
     <value>{0}의 호스트 지문이 변경되었으며 사용자가 이번만 신뢰를 선택했습니다(저장 안 함): {1}</value>
@@ -1202,9 +1184,6 @@
   <data name="Msg_PlaybackTitle" xml:space="preserve">
     <value>재생: {0}({1})</value>
   </data>
-  <data name="Msg_ProxyError" xml:space="preserve">
-    <value>프록시 오류: 프록시를 통해 {0}에 연결할 수 없습니다.</value>
-  </data>
   <data name="Msg_ReadKeysFailed" xml:space="preserve">
     <value>키 읽기 실패: {0}</value>
   </data>
@@ -1276,12 +1255,6 @@
   </data>
   <data name="Msg_TunnelNotConnectedAuto" xml:space="preserve">
     <value>연결 안 됨 • 터널 생성 또는 시작 시 자동 연결</value>
-  </data>
-  <data name="Msg_TunnelRouteDynamic" xml:space="preserve">
-    <value>{0}:{1} → SOCKS5 프록시</value>
-  </data>
-  <data name="Msg_TunnelRouteRemote" xml:space="preserve">
-    <value>서버:{0} → {1}:{2}</value>
   </data>
   <data name="Msg_TunnelRunning" xml:space="preserve">
     <value>실행 중 • {0}</value>
@@ -1599,9 +1572,6 @@
   <data name="Reject" xml:space="preserve">
     <value>거부</value>
   </data>
-  <data name="RemoteAddress" xml:space="preserve">
-    <value>원격 주소</value>
-  </data>
   <data name="RemoteForward" xml:space="preserve">
     <value>원격 포워딩</value>
   </data>
@@ -1620,14 +1590,8 @@
   <data name="Search" xml:space="preserve">
     <value>검색</value>
   </data>
-  <data name="SearchCommands" xml:space="preserve">
-    <value>명령 검색</value>
-  </data>
   <data name="SelectDownloadFolder" xml:space="preserve">
     <value>저장 위치 선택</value>
-  </data>
-  <data name="ServerGroups" xml:space="preserve">
-    <value>서버 그룹</value>
   </data>
   <data name="Sessions" xml:space="preserve">
     <value>세션</value>
@@ -2742,9 +2706,6 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="StatusBar_OpenMonitor" xml:space="preserve">
     <value>리소스 모니터 열기</value>
   </data>
-  <data name="StatusBar_Swap" xml:space="preserve">
-    <value>스왑</value>
-  </data>
   <data name="Svc_Active" xml:space="preserve">
     <value>활성</value>
   </data>
@@ -2819,9 +2780,6 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   </data>
   <data name="Svc_Yesterday" xml:space="preserve">
     <value>어제</value>
-  </data>
-  <data name="SyncGroup" xml:space="preserve">
-    <value>동기화 그룹</value>
   </data>
   <data name="SyncSvc_ApiFailed" xml:space="preserve">
     <value>GitHub API 요청 실패({0}): {1}</value>
@@ -2898,9 +2856,6 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="System" xml:space="preserve">
     <value>시스템</value>
   </data>
-  <data name="SystemMonitor" xml:space="preserve">
-    <value>시스템 모니터</value>
-  </data>
   <data name="Term_NoMatches" xml:space="preserve">
     <value>일치 항목 없음</value>
   </data>
@@ -2970,17 +2925,11 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Tree_SessionSettings" xml:space="preserve">
     <value>세션 설정</value>
   </data>
-  <data name="Trust" xml:space="preserve">
-    <value>신뢰</value>
-  </data>
   <data name="TrustOnce" xml:space="preserve">
     <value>이번만 신뢰</value>
   </data>
   <data name="TrustPermanently" xml:space="preserve">
     <value>항상 신뢰</value>
-  </data>
-  <data name="TrustThisHost" xml:space="preserve">
-    <value>이 호스트 신뢰</value>
   </data>
   <data name="Tunnel_AliasLabel" xml:space="preserve">
     <value>별칭 (선택)</value>
@@ -3454,23 +3403,11 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Trace_ColLoss" xml:space="preserve">
     <value>손실%</value>
   </data>
-  <data name="Trace_ColSent" xml:space="preserve">
-    <value>보냄</value>
-  </data>
   <data name="Trace_ColLast" xml:space="preserve">
     <value>최근</value>
   </data>
   <data name="Trace_ColAvg" xml:space="preserve">
     <value>평균</value>
-  </data>
-  <data name="Trace_ColBest" xml:space="preserve">
-    <value>최고</value>
-  </data>
-  <data name="Trace_ColWorst" xml:space="preserve">
-    <value>최악</value>
-  </data>
-  <data name="Trace_ColStdDev" xml:space="preserve">
-    <value>표준편차</value>
   </data>
   <data name="Trace_Running" xml:space="preserve">
     <value>추적 중…</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -70,9 +70,6 @@
   <data name="Monitor_CoreCount" xml:space="preserve">
     <value>{0} logical cores</value>
   </data>
-  <data name="Monitor_CoreSelected" xml:space="preserve">
-    <value>{0} cores · CPU{1} {2:F0}%</value>
-  </data>
   <data name="Monitor_CoreSelectedLabel" xml:space="preserve">
     <value>{0} cores · {1} {2:F0}%</value>
   </data>
@@ -328,9 +325,6 @@
   <data name="Monitor_TitleFormat" xml:space="preserve">
     <value>System Resources — {0}</value>
   </data>
-  <data name="Monitor_TopByCpu" xml:space="preserve">
-    <value>Top processes by CPU</value>
-  </data>
   <data name="Monitor_TopByMemory" xml:space="preserve">
     <value>Top processes by memory</value>
   </data>
@@ -370,9 +364,6 @@
   <data name="Monitor_WindowSeconds" xml:space="preserve">
     <value>{0}s ago</value>
   </data>
-  <data name="Monitor_WindowStart" xml:space="preserve">
-    <value>60s ago</value>
-  </data>
   <data name="Ready" xml:space="preserve">
     <value>Ready</value>
   </data>
@@ -382,9 +373,6 @@
   </data>
   <data name="RecentConnections" xml:space="preserve">
     <value>Recent Connections</value>
-  </data>
-  <data name="ServerGroups" xml:space="preserve">
-    <value>Server Groups</value>
   </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
@@ -410,9 +398,6 @@
   </data>
   <data name="StatusBar_OpenMonitor" xml:space="preserve">
     <value>Open resource monitor</value>
-  </data>
-  <data name="SyncGroup" xml:space="preserve">
-    <value>Sync Group</value>
   </data>
   <!-- File Browser (7) -->
   <data name="FileName" xml:space="preserve">
@@ -458,22 +443,10 @@
   <data name="LocalPort" xml:space="preserve">
     <value>Local Port</value>
   </data>
-  <data name="RemoteAddress" xml:space="preserve">
-    <value>Remote Address</value>
-  </data>
   <data name="NewTunnel" xml:space="preserve">
     <value>New Tunnel</value>
   </data>
-  <data name="ActiveTunnels" xml:space="preserve">
-    <value>Active Tunnels</value>
-  </data>
   <!-- Quick Commands (5) -->
-  <data name="SearchCommands" xml:space="preserve">
-    <value>Search Commands</value>
-  </data>
-  <data name="SystemMonitor" xml:space="preserve">
-    <value>System Monitor</value>
-  </data>
   <data name="Network" xml:space="preserve">
     <value>Network</value>
   </data>
@@ -603,9 +576,6 @@
   <data name="HostKeyVerification" xml:space="preserve">
     <value>Host Key Verification</value>
   </data>
-  <data name="TrustThisHost" xml:space="preserve">
-    <value>Trust This Host</value>
-  </data>
   <!-- Settings Dialog -->
   <data name="BrowseKeyFile" xml:space="preserve">
     <value>Browse...</value>
@@ -630,9 +600,6 @@
   </data>
   <data name="KeyType" xml:space="preserve">
     <value>Key Type</value>
-  </data>
-  <data name="Trust" xml:space="preserve">
-    <value>Trust</value>
   </data>
   <data name="Reject" xml:space="preserve">
     <value>Reject</value>
@@ -706,9 +673,6 @@
   </data>
   <data name="Properties" xml:space="preserve">
     <value>Properties</value>
-  </data>
-  <data name="ChangePermissions" xml:space="preserve">
-    <value>Permissions (chmod)…</value>
   </data>
   <data name="PermissionOwner" xml:space="preserve">
     <value>Owner</value>
@@ -1155,9 +1119,6 @@ If this keeps happening, close any other VelaShell windows and try again.</value
   <data name="KeySvc_AlertChangedAccepted" xml:space="preserve">
     <value>Host fingerprint of {0} changed; the user confirmed permanent trust of the new fingerprint: {1}</value>
   </data>
-  <data name="KeySvc_AlertChangedBlocked" xml:space="preserve">
-    <value>Host fingerprint of {0} does not match the known_hosts record; the connection was blocked (possible man-in-the-middle). New fingerprint: {1}</value>
-  </data>
   <data name="KeySvc_AlertChangedTrustOnce" xml:space="preserve">
     <value>Host fingerprint of {0} changed; the user chose to trust it this time only (not saved): {1}</value>
   </data>
@@ -1414,9 +1375,6 @@ Paste anyway?</value>
   <data name="Msg_PlaybackTitle" xml:space="preserve">
     <value>Playback: {0} ({1})</value>
   </data>
-  <data name="Msg_ProxyError" xml:space="preserve">
-    <value>Proxy error: cannot connect to {0} through the proxy.</value>
-  </data>
   <data name="Msg_ReadKeysFailed" xml:space="preserve">
     <value>Failed to read keys: {0}</value>
   </data>
@@ -1488,12 +1446,6 @@ Paste anyway?</value>
   </data>
   <data name="Msg_TunnelNotConnectedAuto" xml:space="preserve">
     <value>Not connected • connects automatically when a tunnel is created or started</value>
-  </data>
-  <data name="Msg_TunnelRouteDynamic" xml:space="preserve">
-    <value>{0}:{1} → SOCKS5 proxy</value>
-  </data>
-  <data name="Msg_TunnelRouteRemote" xml:space="preserve">
-    <value>Server:{0} → {1}:{2}</value>
   </data>
   <data name="Msg_TunnelRunning" xml:space="preserve">
     <value>Running • {0}</value>
@@ -2833,9 +2785,6 @@ Overwrite it?</value>
   <data name="Sidebar_ToggleSection" xml:space="preserve">
     <value>Collapse or expand this section</value>
   </data>
-  <data name="StatusBar_Swap" xml:space="preserve">
-    <value>Swap</value>
-  </data>
   <data name="Svc_Active" xml:space="preserve">
     <value>Active</value>
   </data>
@@ -3455,23 +3404,11 @@ Overwrite it?</value>
   <data name="Trace_ColLoss" xml:space="preserve">
     <value>Loss%</value>
   </data>
-  <data name="Trace_ColSent" xml:space="preserve">
-    <value>Sent</value>
-  </data>
   <data name="Trace_ColLast" xml:space="preserve">
     <value>Last</value>
   </data>
   <data name="Trace_ColAvg" xml:space="preserve">
     <value>Avg</value>
-  </data>
-  <data name="Trace_ColBest" xml:space="preserve">
-    <value>Best</value>
-  </data>
-  <data name="Trace_ColWorst" xml:space="preserve">
-    <value>Worst</value>
-  </data>
-  <data name="Trace_ColStdDev" xml:space="preserve">
-    <value>StDev</value>
   </data>
   <data name="Trace_Running" xml:space="preserve">
     <value>Tracing…</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -174,9 +174,6 @@
   <data name="Monitor_CoreCount" xml:space="preserve">
     <value>{0} 个逻辑核心</value>
   </data>
-  <data name="Monitor_CoreSelected" xml:space="preserve">
-    <value>{0} 核 · 已选 CPU{1} {2:F0}%</value>
-  </data>
   <data name="Monitor_CoreSelectedLabel" xml:space="preserve">
     <value>{0} 核 · 已选 {1} {2:F0}%</value>
   </data>
@@ -432,9 +429,6 @@
   <data name="Monitor_TitleFormat" xml:space="preserve">
     <value>系统资源监控 — {0}</value>
   </data>
-  <data name="Monitor_TopByCpu" xml:space="preserve">
-    <value>CPU 占用最高进程</value>
-  </data>
   <data name="Monitor_TopByMemory" xml:space="preserve">
     <value>占用最高进程</value>
   </data>
@@ -474,9 +468,6 @@
   <data name="Monitor_WindowSeconds" xml:space="preserve">
     <value>{0} 秒前</value>
   </data>
-  <data name="Monitor_WindowStart" xml:space="preserve">
-    <value>60 秒前</value>
-  </data>
   <data name="Ready" xml:space="preserve">
     <value>就绪</value>
   </data>
@@ -485,9 +476,6 @@
   </data>
   <data name="RecentConnections" xml:space="preserve">
     <value>最近连接</value>
-  </data>
-  <data name="ServerGroups" xml:space="preserve">
-    <value>服务器分组</value>
   </data>
   <data name="Settings" xml:space="preserve">
     <value>设置</value>
@@ -512,9 +500,6 @@
   </data>
   <data name="StatusBar_OpenMonitor" xml:space="preserve">
     <value>打开资源监视器</value>
-  </data>
-  <data name="SyncGroup" xml:space="preserve">
-    <value>同步组</value>
   </data>
   <data name="FileName" xml:space="preserve">
     <value>文件名</value>
@@ -558,20 +543,8 @@
   <data name="LocalPort" xml:space="preserve">
     <value>本地端口</value>
   </data>
-  <data name="RemoteAddress" xml:space="preserve">
-    <value>远程地址</value>
-  </data>
   <data name="NewTunnel" xml:space="preserve">
     <value>新建隧道</value>
-  </data>
-  <data name="ActiveTunnels" xml:space="preserve">
-    <value>活动隧道</value>
-  </data>
-  <data name="SearchCommands" xml:space="preserve">
-    <value>搜索命令</value>
-  </data>
-  <data name="SystemMonitor" xml:space="preserve">
-    <value>系统监控</value>
   </data>
   <data name="Network" xml:space="preserve">
     <value>网络</value>
@@ -697,9 +670,6 @@
   <data name="HostKeyVerification" xml:space="preserve">
     <value>主机密钥验证</value>
   </data>
-  <data name="TrustThisHost" xml:space="preserve">
-    <value>信任此主机</value>
-  </data>
   <data name="BrowseKeyFile" xml:space="preserve">
     <value>浏览...</value>
   </data>
@@ -723,9 +693,6 @@
   </data>
   <data name="KeyType" xml:space="preserve">
     <value>密钥类型</value>
-  </data>
-  <data name="Trust" xml:space="preserve">
-    <value>信任</value>
   </data>
   <data name="Reject" xml:space="preserve">
     <value>拒绝</value>
@@ -798,9 +765,6 @@
   </data>
   <data name="Properties" xml:space="preserve">
     <value>属性</value>
-  </data>
-  <data name="ChangePermissions" xml:space="preserve">
-    <value>权限 (chmod)…</value>
   </data>
   <data name="PermissionOwner" xml:space="preserve">
     <value>所有者</value>
@@ -1246,9 +1210,6 @@
   <data name="KeySvc_AlertChangedAccepted" xml:space="preserve">
     <value>{0} 的主机指纹已变更,用户确认永久信任新指纹:{1}</value>
   </data>
-  <data name="KeySvc_AlertChangedBlocked" xml:space="preserve">
-    <value>{0} 的主机指纹与 known_hosts 记录不符,连接已被阻断(疑似中间人)。新指纹:{1}</value>
-  </data>
   <data name="KeySvc_AlertChangedTrustOnce" xml:space="preserve">
     <value>{0} 的主机指纹已变更,用户选择仅本次信任(不落盘):{1}</value>
   </data>
@@ -1505,9 +1466,6 @@
   <data name="Msg_PlaybackTitle" xml:space="preserve">
     <value>回放: {0}({1})</value>
   </data>
-  <data name="Msg_ProxyError" xml:space="preserve">
-    <value>代理错误：无法通过代理连接到 {0}。</value>
-  </data>
   <data name="Msg_ReadKeysFailed" xml:space="preserve">
     <value>读取密钥失败:{0}</value>
   </data>
@@ -1579,12 +1537,6 @@
   </data>
   <data name="Msg_TunnelNotConnectedAuto" xml:space="preserve">
     <value>未连接 • 创建或启动隧道时自动连接</value>
-  </data>
-  <data name="Msg_TunnelRouteDynamic" xml:space="preserve">
-    <value>{0}:{1} → SOCKS5 代理</value>
-  </data>
-  <data name="Msg_TunnelRouteRemote" xml:space="preserve">
-    <value>服务器:{0} → {1}:{2}</value>
   </data>
   <data name="Msg_TunnelRunning" xml:space="preserve">
     <value>运行中 • {0}</value>
@@ -2924,9 +2876,6 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Sidebar_ToggleSection" xml:space="preserve">
     <value>折叠或展开此区域</value>
   </data>
-  <data name="StatusBar_Swap" xml:space="preserve">
-    <value>Swap</value>
-  </data>
   <data name="Svc_Active" xml:space="preserve">
     <value>活跃</value>
   </data>
@@ -3546,23 +3495,11 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Trace_ColLoss" xml:space="preserve">
     <value>丢包%</value>
   </data>
-  <data name="Trace_ColSent" xml:space="preserve">
-    <value>已发</value>
-  </data>
   <data name="Trace_ColLast" xml:space="preserve">
     <value>最近</value>
   </data>
   <data name="Trace_ColAvg" xml:space="preserve">
     <value>平均</value>
-  </data>
-  <data name="Trace_ColBest" xml:space="preserve">
-    <value>最快</value>
-  </data>
-  <data name="Trace_ColWorst" xml:space="preserve">
-    <value>最慢</value>
-  </data>
-  <data name="Trace_ColStdDev" xml:space="preserve">
-    <value>标准差</value>
   </data>
   <data name="Trace_Running" xml:space="preserve">
     <value>追踪中…</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -25,9 +25,6 @@
   <!-- Auth (7) -->
   <!-- Settings Dialog -->
   <!-- File Browser / SFTP (§6) -->
-  <data name="ActiveTunnels" xml:space="preserve">
-    <value>作用中的隧道</value>
-  </data>
   <data name="AddCommand" xml:space="preserve">
     <value>新增命令</value>
   </data>
@@ -105,9 +102,6 @@
   </data>
   <data name="Category" xml:space="preserve">
     <value>分類</value>
-  </data>
-  <data name="ChangePermissions" xml:space="preserve">
-    <value>權限 (chmod)…</value>
   </data>
   <data name="CloseTab" xml:space="preserve">
     <value>關閉分頁</value>
@@ -556,9 +550,6 @@
   <data name="Monitor_CoreCount" xml:space="preserve">
     <value>{0} 個邏輯核心</value>
   </data>
-  <data name="Monitor_CoreSelected" xml:space="preserve">
-    <value>{0} 核 · 已選 CPU{1} {2:F0}%</value>
-  </data>
   <data name="Monitor_CoreSelectedLabel" xml:space="preserve">
     <value>{0} 核 · 已選 {1} {2:F0}%</value>
   </data>
@@ -814,9 +805,6 @@
   <data name="Monitor_TitleFormat" xml:space="preserve">
     <value>系統資源監控 — {0}</value>
   </data>
-  <data name="Monitor_TopByCpu" xml:space="preserve">
-    <value>CPU 佔用最高處理程序</value>
-  </data>
   <data name="Monitor_TopByMemory" xml:space="preserve">
     <value>佔用最高處理程序</value>
   </data>
@@ -856,9 +844,6 @@
   <data name="Monitor_WindowSeconds" xml:space="preserve">
     <value>{0} 秒前</value>
   </data>
-  <data name="Monitor_WindowStart" xml:space="preserve">
-    <value>60 秒前</value>
-  </data>
   <data name="Sftp_FileTypeExt" xml:space="preserve">
     <value>{0} 檔案</value>
   </data>
@@ -897,9 +882,6 @@
   </data>
   <data name="KeySvc_AlertChangedAccepted" xml:space="preserve">
     <value>{0} 的主機指紋已變更,使用者確認永久信任新指紋:{1}</value>
-  </data>
-  <data name="KeySvc_AlertChangedBlocked" xml:space="preserve">
-    <value>{0} 的主機指紋與 known_hosts 記錄不符,連線已被阻斷(疑似中間人)。新指紋:{1}</value>
   </data>
   <data name="KeySvc_AlertChangedTrustOnce" xml:space="preserve">
     <value>{0} 的主機指紋已變更,使用者選擇僅本次信任(不落盤):{1}</value>
@@ -1202,9 +1184,6 @@
   <data name="Msg_PlaybackTitle" xml:space="preserve">
     <value>重播: {0}({1})</value>
   </data>
-  <data name="Msg_ProxyError" xml:space="preserve">
-    <value>代理錯誤：無法透過代理連線到 {0}。</value>
-  </data>
   <data name="Msg_ReadKeysFailed" xml:space="preserve">
     <value>讀取金鑰失敗:{0}</value>
   </data>
@@ -1276,12 +1255,6 @@
   </data>
   <data name="Msg_TunnelNotConnectedAuto" xml:space="preserve">
     <value>未連線 • 建立或啟動隧道時自動連線</value>
-  </data>
-  <data name="Msg_TunnelRouteDynamic" xml:space="preserve">
-    <value>{0}:{1} → SOCKS5 代理</value>
-  </data>
-  <data name="Msg_TunnelRouteRemote" xml:space="preserve">
-    <value>伺服器:{0} → {1}:{2}</value>
   </data>
   <data name="Msg_TunnelRunning" xml:space="preserve">
     <value>執行中 • {0}</value>
@@ -1599,9 +1572,6 @@
   <data name="Reject" xml:space="preserve">
     <value>拒絕</value>
   </data>
-  <data name="RemoteAddress" xml:space="preserve">
-    <value>遠端位址</value>
-  </data>
   <data name="RemoteForward" xml:space="preserve">
     <value>遠端轉發</value>
   </data>
@@ -1620,14 +1590,8 @@
   <data name="Search" xml:space="preserve">
     <value>搜尋</value>
   </data>
-  <data name="SearchCommands" xml:space="preserve">
-    <value>搜尋命令</value>
-  </data>
   <data name="SelectDownloadFolder" xml:space="preserve">
     <value>選擇儲存位置</value>
-  </data>
-  <data name="ServerGroups" xml:space="preserve">
-    <value>伺服器群組</value>
   </data>
   <data name="Sessions" xml:space="preserve">
     <value>工作階段</value>
@@ -2742,9 +2706,6 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="StatusBar_OpenMonitor" xml:space="preserve">
     <value>開啟資源監視器</value>
   </data>
-  <data name="StatusBar_Swap" xml:space="preserve">
-    <value>Swap</value>
-  </data>
   <data name="Svc_Active" xml:space="preserve">
     <value>活躍</value>
   </data>
@@ -2819,9 +2780,6 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   </data>
   <data name="Svc_Yesterday" xml:space="preserve">
     <value>昨天</value>
-  </data>
-  <data name="SyncGroup" xml:space="preserve">
-    <value>同步群組</value>
   </data>
   <data name="SyncSvc_ApiFailed" xml:space="preserve">
     <value>GitHub API 請求失敗({0}):{1}</value>
@@ -2898,9 +2856,6 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="System" xml:space="preserve">
     <value>系統</value>
   </data>
-  <data name="SystemMonitor" xml:space="preserve">
-    <value>系統監控</value>
-  </data>
   <data name="Term_NoMatches" xml:space="preserve">
     <value>無相符項</value>
   </data>
@@ -2970,17 +2925,11 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Tree_SessionSettings" xml:space="preserve">
     <value>工作階段設定</value>
   </data>
-  <data name="Trust" xml:space="preserve">
-    <value>信任</value>
-  </data>
   <data name="TrustOnce" xml:space="preserve">
     <value>僅信任本次</value>
   </data>
   <data name="TrustPermanently" xml:space="preserve">
     <value>永久信任</value>
-  </data>
-  <data name="TrustThisHost" xml:space="preserve">
-    <value>信任此主機</value>
   </data>
   <data name="Tunnel_AliasLabel" xml:space="preserve">
     <value>別名(可選)</value>
@@ -3454,23 +3403,11 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Trace_ColLoss" xml:space="preserve">
     <value>遺失%</value>
   </data>
-  <data name="Trace_ColSent" xml:space="preserve">
-    <value>已送出</value>
-  </data>
   <data name="Trace_ColLast" xml:space="preserve">
     <value>最近</value>
   </data>
   <data name="Trace_ColAvg" xml:space="preserve">
     <value>平均</value>
-  </data>
-  <data name="Trace_ColBest" xml:space="preserve">
-    <value>最快</value>
-  </data>
-  <data name="Trace_ColWorst" xml:space="preserve">
-    <value>最慢</value>
-  </data>
-  <data name="Trace_ColStdDev" xml:space="preserve">
-    <value>標準差</value>
   </data>
   <data name="Trace_Running" xml:space="preserve">
     <value>追蹤中…</value>

--- a/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
+++ b/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
@@ -50,7 +50,7 @@ public class LocalizationTests : IDisposable
         CultureInfo.CurrentUICulture = new("en");
         var service = new LocalizationService();
         Assert.AreEqual("Quick Connect", service.GetString("QuickConnect"));
-        Assert.AreEqual("Server Groups", service.GetString("ServerGroups"));
+        Assert.AreEqual("Recent Connections", service.GetString("RecentConnections"));
         Assert.AreEqual("Disconnect", service.GetString("Disconnect"));
     }
 
@@ -60,7 +60,7 @@ public class LocalizationTests : IDisposable
         CultureInfo.CurrentUICulture = new("zh-CN");
         var service = new LocalizationService();
         Assert.AreEqual("快速连接", service.GetString("QuickConnect"));
-        Assert.AreEqual("服务器分组", service.GetString("ServerGroups"));
+        Assert.AreEqual("最近连接", service.GetString("RecentConnections"));
         Assert.AreEqual("断开", service.GetString("Disconnect"));
     }
 
@@ -101,7 +101,6 @@ public class LocalizationTests : IDisposable
         CultureInfo.CurrentUICulture = new("en");
         Assert.IsFalse(string.IsNullOrEmpty(Strings.QuickConnect));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.RecentConnections));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.ServerGroups));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Settings));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Notifications));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.NewTab));
@@ -109,7 +108,6 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Search));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Copy));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Split));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SyncGroup));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.FileName));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Size));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Permissions));
@@ -120,11 +118,7 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.LocalForward));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.RemoteForward));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.LocalPort));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.RemoteAddress));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.NewTunnel));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.ActiveTunnels));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SearchCommands));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SystemMonitor));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Network));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Docker));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Custom));
@@ -152,7 +146,6 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Host));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Port));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.HostKeyVerification));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.TrustThisHost));
     }
 
     [TestMethod]
@@ -161,7 +154,6 @@ public class LocalizationTests : IDisposable
         CultureInfo.CurrentUICulture = new("zh-CN");
         Assert.IsFalse(string.IsNullOrEmpty(Strings.QuickConnect));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.RecentConnections));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.ServerGroups));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Settings));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Notifications));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.NewTab));
@@ -169,7 +161,6 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Search));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Copy));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Split));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SyncGroup));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.FileName));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Size));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Permissions));
@@ -180,11 +171,7 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.LocalForward));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.RemoteForward));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.LocalPort));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.RemoteAddress));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.NewTunnel));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.ActiveTunnels));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SearchCommands));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.SystemMonitor));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Network));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Docker));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Custom));
@@ -212,7 +199,6 @@ public class LocalizationTests : IDisposable
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Host));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.Port));
         Assert.IsFalse(string.IsNullOrEmpty(Strings.HostKeyVerification));
-        Assert.IsFalse(string.IsNullOrEmpty(Strings.TrustThisHost));
     }
 
     /// <summary>

--- a/tests/VelaShell.Tests/Localization/UnusedLocalizedKeyTests.cs
+++ b/tests/VelaShell.Tests/Localization/UnusedLocalizedKeyTests.cs
@@ -1,0 +1,134 @@
+using System.Collections;
+using System.Globalization;
+using System.Resources;
+using System.Text.RegularExpressions;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.Tests.Localization;
+
+/// <summary>
+/// 资源里不该留下没人引用的键。
+/// </summary>
+/// <remarks>
+/// 与 <see cref="LocalizedKeyUsageTests" /> 正好相反的方向:那条查「引用了但没定义」(界面显示英文键名),
+/// 这条查「定义了但没人引用」。后者不会让界面出错,所以没有任何自然反馈会暴露它 ——
+/// 只会让五个 resx 一路膨胀:每加一条死键,翻译方就要多译五份、审校多看五处,
+/// 而删掉一段界面时对应的文案几乎不会有人记得回来清。2026-08-13 首次清理时,
+/// 1253 个键里有 14 个已经没有任何引用(含两条被 Tunnel_Route* 取代后遗留的旧键)。
+///
+/// 判定用法时刻意放宽:任何 .cs / .axaml 文件里出现该键名(哪怕只是同名标识符)都算命中。
+/// 宁可漏掉几个死键,也不能把还在用的键判死 —— 后者会在 <see cref="ResourceManager" /> 取不到时
+/// 静默回退成键名,直接显示到用户脸上。
+/// </remarks>
+[TestClass]
+[TestCategory("i18n")]
+public partial class UnusedLocalizedKeyTests
+{
+    /// <summary>
+    /// 运行期拼出来的键,静态扫描必然看不见,按前缀豁免。
+    /// 新增此类用法时必须同步登记在这里,并写清拼接点在哪。
+    /// </summary>
+    private static readonly string[] ComposedKeyPrefixes =
+    [
+        // PluginManagerViewModel.StatusText:Strings.Get($"PluginState_{descriptor.State}")
+        "PluginState_"
+    ];
+
+    /// <summary>
+    /// 字面量与标记里的裸词,用作「这个键还有人提」的宽松证据。
+    /// 长度不设下限:首版写成至少三个字符,结果两字母的 <c>OK</c> 键永远扫不到,
+    /// 被当成死键删掉后 MessageDialog 立刻编译不过 —— 短键正是最容易被漏判的那一类。
+    /// </summary>
+    [GeneratedRegex(@"[A-Za-z][A-Za-z0-9_]*")]
+    private static partial Regex Word { get; }
+
+    [TestMethod]
+    public void EveryResourceKey_IsReferencedSomewhere()
+    {
+        HashSet<string> referenced = ReferencedWords();
+        List<string> orphans = [.. DefinedKeys()
+            .Where(key => !referenced.Contains(key))
+            .Where(key => !ComposedKeyPrefixes.Any(prefix => key.StartsWith(prefix, StringComparison.Ordinal)))
+            .Order(StringComparer.Ordinal)];
+
+        Assert.IsEmpty(orphans,
+                       "以下资源键已无人引用,请连同五个 resx 一起删掉(确属运行期拼接的,登记到 ComposedKeyPrefixes):\n" +
+                       string.Join("\n", orphans.Select(key => $"  {key}")));
+    }
+
+    /// <summary>中性(英文)资源里已定义的全部键。</summary>
+    private static HashSet<string> DefinedKeys()
+    {
+        var manager = new ResourceManager("VelaShell.Core.Resources.Strings", typeof(Strings).Assembly);
+        ResourceSet neutral = manager.GetResourceSet(CultureInfo.InvariantCulture, true, false)!;
+        var keys = neutral.Cast<DictionaryEntry>().Select(entry => (string)entry.Key).ToHashSet(StringComparer.Ordinal);
+        Assert.IsNotEmpty(keys, "中性资源为空,后面的比对就没意义了。");
+        return keys;
+    }
+
+    /// <summary>
+    /// 源码(src 与 plugins)里出现过的全部单词。Strings.cs 例外:
+    /// 强类型访问器自身的声明不算引用,否则一条没人调用的属性会把对应的键一直养着。
+    /// </summary>
+    private static HashSet<string> ReferencedWords()
+    {
+        var words = new HashSet<string>(StringComparer.Ordinal);
+        int scanned = 0;
+        foreach (string file in SourceFiles())
+        {
+            if (Path.GetFileName(file) == "Strings.cs")
+            {
+                continue;
+            }
+            scanned++;
+            foreach (Match match in Word.Matches(File.ReadAllText(file)))
+            {
+                words.Add(match.Value);
+            }
+        }
+
+        // 没有这道下限,扫描路径一旦失效(挪目录、改布局)就会一个词都扫不到,
+        // 于是「全部键都没人引用」——一条本该守门的测试反过来把整份资源判死。
+        Assert.IsGreaterThanOrEqualTo(200, scanned,
+                                      $"只扫到 {scanned} 个源码文件,远低于预期 —— 扫描八成失效了。");
+        return words;
+    }
+
+    private static IEnumerable<string> SourceFiles()
+    {
+        string root = RepositoryRoot();
+        foreach (string area in (string[])["src", "plugins"])
+        {
+            string dir = Path.Combine(root, area);
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+            foreach (string file in Directory.EnumerateFiles(dir, "*.*", SearchOption.AllDirectories))
+            {
+                if (file.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ||
+                    file.EndsWith(".axaml", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                        !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                    {
+                        yield return file;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>从测试输出目录向上找到仓库根(以 VelaShell.slnx 为锚)。</summary>
+    private static string RepositoryRoot()
+    {
+        for (string? dir = AppContext.BaseDirectory; dir is not null; dir = Directory.GetParent(dir)?.FullName)
+        {
+            if (File.Exists(Path.Combine(dir, "VelaShell.slnx")))
+            {
+                return dir;
+            }
+        }
+        throw new InvalidOperationException("未能从测试输出目录向上定位到仓库根(找不到 VelaShell.slnx)。");
+    }
+}


### PR DESCRIPTION
本次变更删除了大量未被引用的本地化资源键及其多语言翻译，并同步移除相关 C# 访问器属性。调整了 LocalizationTests，去除对已删除键的断言和引用，确保测试与资源文件一致。新增 UnusedLocalizedKeyTests.cs，自动检测资源文件中未被源码引用的“死键”，防止资源膨胀和冗余，提升资源维护效率。