### PR TITLE
会话资源管理器支持删除分组及多语言

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2910,6 +2910,15 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Tree_DuplicateConnection" xml:space="preserve">
     <value>接続を複製</value>
   </data>
+  <data name="Tree_DeleteGroup" xml:space="preserve">
+    <value>グループを削除</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirm" xml:space="preserve">
+    <value>グループ「{0}」を削除しますか？中の接続 {1} 件もまとめて削除され、この操作は元に戻せません。</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirmEmpty" xml:space="preserve">
+    <value>空のグループ「{0}」を削除しますか？この操作は元に戻せません。</value>
+  </data>
   <data name="Tree_EditConnection" xml:space="preserve">
     <value>接続を編集</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2910,6 +2910,15 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Tree_DuplicateConnection" xml:space="preserve">
     <value>연결 복제</value>
   </data>
+  <data name="Tree_DeleteGroup" xml:space="preserve">
+    <value>그룹 삭제</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirm" xml:space="preserve">
+    <value>"{0}" 그룹을 삭제하시겠습니까? 그룹 안의 연결 {1}개도 함께 삭제되며 이 작업은 되돌릴 수 없습니다.</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirmEmpty" xml:space="preserve">
+    <value>비어 있는 "{0}" 그룹을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</value>
+  </data>
   <data name="Tree_EditConnection" xml:space="preserve">
     <value>연결 편집</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2968,6 +2968,15 @@ Overwrite it?</value>
   <data name="Tree_DuplicateConnection" xml:space="preserve">
     <value>Duplicate Connection</value>
   </data>
+  <data name="Tree_DeleteGroup" xml:space="preserve">
+    <value>Delete Group</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirm" xml:space="preserve">
+    <value>Delete group "{0}"? The {1} connection(s) inside it will be deleted as well. This cannot be undone.</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirmEmpty" xml:space="preserve">
+    <value>Delete the empty group "{0}"? This cannot be undone.</value>
+  </data>
   <data name="Tree_EditConnection" xml:space="preserve">
     <value>Edit Connection</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3059,6 +3059,15 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Tree_DuplicateConnection" xml:space="preserve">
     <value>复制连接</value>
   </data>
+  <data name="Tree_DeleteGroup" xml:space="preserve">
+    <value>删除分组</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirm" xml:space="preserve">
+    <value>确定要删除分组“{0}”吗？组内的 {1} 个连接会一并删除，此操作不可撤销。</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirmEmpty" xml:space="preserve">
+    <value>确定要删除空分组“{0}”吗？此操作不可撤销。</value>
+  </data>
   <data name="Tree_EditConnection" xml:space="preserve">
     <value>编辑连接</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2910,6 +2910,15 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Tree_DuplicateConnection" xml:space="preserve">
     <value>複製連線</value>
   </data>
+  <data name="Tree_DeleteGroup" xml:space="preserve">
+    <value>刪除分組</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirm" xml:space="preserve">
+    <value>確定要刪除分組「{0}」嗎？群組內的 {1} 個連線會一併刪除，此操作無法復原。</value>
+  </data>
+  <data name="Tree_DeleteGroupConfirmEmpty" xml:space="preserve">
+    <value>確定要刪除空分組「{0}」嗎？此操作無法復原。</value>
+  </data>
   <data name="Tree_EditConnection" xml:space="preserve">
     <value>編輯連線</value>
   </data>

--- a/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
@@ -70,6 +70,10 @@ public sealed class SessionTreeViewModel : ReactiveObject
             hasSelectedSession
         );
         MoveToGroupCommand = ReactiveCommand.Create<SessionTreeNodeViewModel>(MoveSelectedToGroup);
+        DeleteGroupCommand = ReactiveCommand.CreateFromTask(
+            DeleteSelectedGroupAsync,
+            this.WhenAnyValue(x => x.SelectedNode).Select(node => node is { IsGroup: true })
+        );
     }
 
     /// <summary>树的根级节点集合,包含各分组节点及直接挂在根级的未分组会话。</summary>
@@ -125,6 +129,16 @@ public sealed class SessionTreeViewModel : ReactiveObject
 
     /// <summary>把选中的会话移动到指定分组节点(参数为“移动到分组”子菜单项)。</summary>
     public ReactiveCommand<SessionTreeNodeViewModel, RxVoid> MoveToGroupCommand { get; }
+
+    /// <summary>删除选中的分组,连同组内全部连接一并删除(落库 + 移除树节点)。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> DeleteGroupCommand { get; }
+
+    /// <summary>
+    /// 删除分组前的确认回调,由视图提供弹窗;参数是已本地化好的提示语,返回 true 才继续删。
+    /// 与 <c>FileBrowserViewModel.ConfirmDelete</c> 同形:未挂回调(无头宿主/单测)时直接删,
+    /// 界面上则永远挂着——不确认就删掉整组连接是不可接受的。
+    /// </summary>
+    public Func<string, Task<bool>>? ConfirmDeleteGroup { get; set; }
 
     /// <summary>右键“连接”或双击会话时触发,由宿主发起 SSH 连接。</summary>
     public event Action<SessionProfile>? ConnectRequested;
@@ -427,6 +441,44 @@ public sealed class SessionTreeViewModel : ReactiveObject
             node.SyncChannelLetter = letter;
         }
         return node;
+    }
+
+    /// <summary>
+    /// 删除选中的分组:组内连接随分组一并删除(用户在确认框里被明确告知会删掉几条)。
+    /// 落库顺序是先删会话再删分组 —— 反过来的话,中途失败会留下一批 GroupId 指向已消失分组的
+    /// 会话,下次加载时它们既不在分组下、也不在树根,等于凭空消失。
+    /// </summary>
+    private async Task DeleteSelectedGroupAsync()
+    {
+        if (SelectedNode is not { IsGroup: true } group)
+        {
+            return;
+        }
+        List<Guid> memberIds = [.. group.Children.Select(child => child.Id)];
+        if (ConfirmDeleteGroup is not null)
+        {
+            string message = memberIds.Count == 0
+                ? Strings.Format("Tree_DeleteGroupConfirmEmpty", group.Name)
+                : Strings.Format("Tree_DeleteGroupConfirm", group.Name, memberIds.Count);
+            if (!await ConfirmDeleteGroup(message))
+            {
+                return;
+            }
+        }
+        foreach (Guid sessionId in memberIds)
+        {
+            await _repository.DeleteSessionAsync(sessionId);
+            _sessionCache.Remove(sessionId);
+            _statusCache.Remove(sessionId);
+            _syncChannelCache.Remove(sessionId);
+        }
+        await _repository.DeleteGroupAsync(group.Id);
+        Nodes.Remove(group);
+        // GroupNodes 里存的就是同一批分组节点实例(“移动到分组”子菜单绑定它),
+        // 不同步移除的话,菜单里会留下一个指向已删分组的落点。
+        GroupNodes.Remove(group);
+        SelectedNode = null;
+        RefreshHasNoSessions();
     }
 
     private async Task DeleteSelectedSessionAsync()

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -261,6 +261,9 @@ public partial class MainWindow : Window
                             tab.DisconnectCommand.Execute().Subscribe();
                         }
                     });
+
+                // 删除分组会连带删掉组内全部连接,必须先确认(红色危险按钮)。
+                tree.ConfirmDeleteGroup = ConfirmDeleteGroupAsync;
             }
             await vm.InitializeAsync();
         }
@@ -1120,6 +1123,19 @@ public partial class MainWindow : Window
             MessageDialogKind.Warning,
             danger: true);
     }
+
+    /// <summary>
+    /// 删除分组前的确认(资源管理器树右键“删除分组”)。提示语由视图模型按分组名与
+    /// 组内连接数拼好,这里只负责弹窗;确认按钮走 danger 渲染,默认动作是取消。
+    /// </summary>
+    private Task<bool> ConfirmDeleteGroupAsync(string message) =>
+        MessageDialog.ConfirmAsync(this,
+            Strings.Get("Tree_DeleteGroup"),
+            message,
+            Strings.Delete,
+            Strings.Cancel,
+            MessageDialogKind.Warning,
+            danger: true);
 
     /// <summary>指纹按每两字节加冒号分组,便于与服务器端比对。</summary>
     private static string FormatThumbprint(string thumbprint) =>

--- a/src/VelaShell/Views/SessionTreeView.axaml
+++ b/src/VelaShell/Views/SessionTreeView.axaml
@@ -133,7 +133,23 @@
                   Height="30"
                   Padding="12,0"
                   Cursor="Hand"
-                  Tapped="Group_Tapped">
+                  Tapped="Group_Tapped"
+                  PointerPressed="Group_PointerPressed">
+            <Border.ContextMenu>
+              <!-- 分组行的菜单:命令作用于 SelectedNode,右键先选中所指分组
+                   (Group_PointerPressed)。删除是破坏性操作,渲染为 error 色并二次确认。 -->
+              <ContextMenu x:DataType="vm:SessionTreeNodeViewModel">
+                <MenuItem Header="{loc:Localize Tree_DeleteGroup}"
+                          Command="{Binding $parent[TreeView].((vm:SessionTreeViewModel)DataContext).DeleteGroupCommand}"
+                          IsVisible="{Binding IsGroup}"
+                          Foreground="{DynamicResource VelaError}">
+                  <MenuItem.Icon>
+                    <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.trash-2}"
+                                   Foreground="{DynamicResource VelaError}" />
+                  </MenuItem.Icon>
+                </MenuItem>
+              </ContextMenu>
+            </Border.ContextMenu>
             <StackPanel Orientation="Horizontal"
                         Spacing="6"
                         VerticalAlignment="Center">

--- a/src/VelaShell/Views/SessionTreeView.axaml.cs
+++ b/src/VelaShell/Views/SessionTreeView.axaml.cs
@@ -57,6 +57,25 @@ public partial class SessionTreeView : UserControl
         }
     }
 
+    /// <summary>
+    /// 右键分组行时先选中它:分组菜单里的命令同样作用于 SelectedNode。
+    /// 左键不在这里处理 —— 展开/折叠仍走 Group_Tapped,选中交给 TreeView 自己。
+    /// </summary>
+    private void Group_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(null).Properties.IsRightButtonPressed)
+        {
+            return;
+        }
+        if (
+            sender is Control { DataContext: SessionTreeNodeViewModel { IsGroup: true } node }
+            && DataContext is SessionTreeViewModel viewModel
+        )
+        {
+            viewModel.SelectedNode = node;
+        }
+    }
+
     /// <summary>双击会话行直接连接(分组行仅展开/折叠)。</summary>
     private void Session_DoubleTapped(object? sender, TappedEventArgs e)
     {

--- a/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
@@ -431,4 +431,133 @@ public class SessionTreeViewModelTests
         await _vm.DeleteSessionCommand.Execute().FirstAsync();
         Assert.IsTrue(_vm.HasNoSessions);
     }
+
+    // ---- 删除分组(连带删除组内连接) ----
+
+    /// <summary>建一棵「一个分组 + 组内两条连接 + 树根一条未分组连接」的树。</summary>
+    private async Task<(ServerGroup Group, SessionProfile First, SessionProfile Second, SessionProfile Orphan)> LoadGroupWithTwoSessionsAsync()
+    {
+        ServerGroup group = CreateGroup("Production", 0);
+        SessionProfile first = CreateSession("WebServer", group.Id);
+        SessionProfile second = CreateSession("DbServer", group.Id);
+        SessionProfile orphan = CreateSession("Standalone");
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { first, second, orphan }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+        return (group, first, second, orphan);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DeleteGroupCommand_DeletesGroupAndEveryConnectionInside()
+    {
+        (ServerGroup group, SessionProfile first, SessionProfile second, SessionProfile orphan) =
+            await LoadGroupWithTwoSessionsAsync();
+        _vm.ConfirmDeleteGroup = _ => Task.FromResult(true);
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup);
+
+        await _vm.DeleteGroupCommand.Execute().FirstAsync();
+
+        // 组内连接逐条落库删除,分组本身随后删除。
+        await _repository.Received(1).DeleteSessionAsync(first.Id);
+        await _repository.Received(1).DeleteSessionAsync(second.Id);
+        await _repository.Received(1).DeleteGroupAsync(group.Id);
+        // 组外的连接不受影响。
+        await _repository.DidNotReceive().DeleteSessionAsync(orphan.Id);
+        Assert.DoesNotContain(node => node.IsGroup, _vm.Nodes);
+        Assert.ContainsSingle(node => node.Id == orphan.Id, _vm.Nodes);
+        Assert.IsNull(_vm.SelectedNode);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DeleteGroupCommand_WithoutConfirmation_DeletesNothing()
+    {
+        (ServerGroup group, SessionProfile first, _, _) = await LoadGroupWithTwoSessionsAsync();
+        _vm.ConfirmDeleteGroup = _ => Task.FromResult(false);
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup);
+
+        await _vm.DeleteGroupCommand.Execute().FirstAsync();
+
+        await _repository.DidNotReceive().DeleteGroupAsync(Arg.Any<Guid>());
+        await _repository.DidNotReceive().DeleteSessionAsync(Arg.Any<Guid>());
+        Assert.ContainsSingle(node => node.IsGroup && node.Id == group.Id, _vm.Nodes);
+        Assert.HasCount(2, _vm.Nodes.Single(node => node.IsGroup).Children);
+        Assert.IsTrue(_vm.SelectedNode?.IsGroup);
+        Assert.IsNotNull(first);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DeleteGroupCommand_ConfirmationMessage_NamesGroupAndCountsConnections()
+    {
+        (ServerGroup group, _, _, _) = await LoadGroupWithTwoSessionsAsync();
+        string? shown = null;
+        _vm.ConfirmDeleteGroup = message =>
+        {
+            shown = message;
+            return Task.FromResult(false);
+        };
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup);
+
+        await _vm.DeleteGroupCommand.Execute().FirstAsync();
+
+        // 用户必须在点确认前就知道「删的是哪个组」「要连带删掉几条连接」。
+        Assert.IsNotNull(shown);
+        Assert.Contains(group.Name, shown);
+        Assert.Contains("2", shown);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DeleteGroupCommand_RemovesGroupFromMoveToGroupMenu()
+    {
+        (ServerGroup group, _, _, _) = await LoadGroupWithTwoSessionsAsync();
+        _vm.ConfirmDeleteGroup = _ => Task.FromResult(true);
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup);
+
+        await _vm.DeleteGroupCommand.Execute().FirstAsync();
+
+        // 不同步移除的话,「移动到分组」子菜单会留下一个指向已删分组的落点。
+        Assert.DoesNotContain(node => node.Id == group.Id, _vm.GroupNodes);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DeleteGroupCommand_IsDisabled_WhenSelectionIsNotAGroup()
+    {
+        (_, SessionProfile first, _, _) = await LoadGroupWithTwoSessionsAsync();
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup)
+                              .Children.Single(child => child.Id == first.Id);
+
+        Assert.IsFalse(await _vm.DeleteGroupCommand.CanExecute.FirstAsync());
+    }
+
+    [TestMethod]
+    [TestCategory("EdgeCase")]
+    public async Task DeleteGroupCommand_EmptyGroup_UsesEmptyGroupPrompt_AndStillDeletes()
+    {
+        ServerGroup group = CreateGroup("Empty", 0);
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+        await _vm.LoadCommand.Execute().FirstAsync();
+        string? shown = null;
+        _vm.ConfirmDeleteGroup = message =>
+        {
+            shown = message;
+            return Task.FromResult(true);
+        };
+        _vm.SelectedNode = _vm.Nodes.Single(node => node.IsGroup);
+
+        await _vm.DeleteGroupCommand.Execute().FirstAsync();
+
+        // 空分组不该提「组内 0 个连接会被删除」这种话。
+        Assert.IsNotNull(shown);
+        Assert.DoesNotContain("0", shown);
+        await _repository.Received(1).DeleteGroupAsync(group.Id);
+        Assert.IsEmpty(_vm.Nodes);
+        Assert.IsTrue(_vm.HasNoSessions);
+    }
 }

--- a/tests/VelaShell.Tests/Views/SessionTreeGroupMenuUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SessionTreeGroupMenuUiTests.cs
@@ -1,0 +1,84 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Presentation.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 资源管理器树上分组行的右键菜单接线。
+/// </summary>
+/// <remarks>
+/// 视图模型侧的删除逻辑由 <c>SessionTreeViewModelTests</c> 覆盖,这里守的是另一半:
+/// 菜单项确实挂在分组行上、并且真的绑到了 <see cref="SessionTreeViewModel.DeleteGroupCommand" />。
+/// ContextMenu 走的是非编译期校验的反射绑定(<c>$parent[TreeView]</c> 穿弹出层),
+/// 写错了不会有任何编译错误 —— 只会在用户点下去时"菜单点了没反应"。
+/// </remarks>
+[TestClass]
+[TestCategory("SessionTree")]
+public class SessionTreeGroupMenuUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(
+            typeof(SessionTreeGroupMenuUiTests).Assembly
+        );
+
+    [TestMethod]
+    public void GroupRow_ContextMenu_BindsDeleteGroupCommand()
+    {
+        OnUi(async () =>
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            var group = new ServerGroup { Id = Guid.NewGuid(), Name = "Production" };
+            var session = new SessionProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = "WebServer",
+                Host = "web.example.com",
+                Username = "admin",
+                GroupId = group.Id,
+            };
+            repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+            repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile> { session }));
+
+            var viewModel = new SessionTreeViewModel(repository);
+            await viewModel.LoadCommand.Execute().FirstAsync();
+
+            var view = new SessionTreeView { DataContext = viewModel };
+            var window = new Window { Width = 260, Height = 400, Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            Border groupRow = view.GetVisualDescendants()
+                .OfType<Border>()
+                .Single(border => border.Classes.Contains("group")
+                                  && border.DataContext is SessionTreeNodeViewModel { IsGroup: true });
+
+            Assert.IsNotNull(groupRow.ContextMenu, "分组行必须有右键菜单,否则根本没有删除分组的入口。");
+            MenuItem item = groupRow.ContextMenu.Items.OfType<MenuItem>().Single();
+
+            // 打开菜单才会求值绑定:关掉的 ContextMenu 里 Command 恒为 null,直接断言会假通过。
+            groupRow.ContextMenu.Open(groupRow);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreSame(viewModel.DeleteGroupCommand, item.Command,
+                           "分组菜单的删除项必须绑到 DeleteGroupCommand。");
+
+            groupRow.ContextMenu.Close();
+            window.Close();
+        });
+    }
+
+    private static void OnUi(Func<Task> body) =>
+        _session.Dispatch(body, CancellationToken.None).GetAwaiter().GetResult();
+}


### PR DESCRIPTION
本次变更为会话资源管理器树（SessionTree）增加了“删除分组”功能，完善了本地化、多语言支持、视图、视图模型、命令绑定及单元测试。
- 在 Strings.resx 及各语言资源文件中，新增“删除分组”及确认提示的本地化字符串。
- SessionTreeViewModel 新增 DeleteGroupCommand 命令及 ConfirmDeleteGroup 回调，支持删除选中分组及其下所有连接，删除前弹出确认提示。
- SessionTreeView.axaml 增加分组行右键菜单，绑定 DeleteGroupCommand，删除项以危险色渲染。
- SessionTreeView.axaml.cs 新增 Group_PointerPressed 方法，确保右键菜单操作前选中分组。
- MainWindow.axaml.cs 实现 ConfirmDeleteGroupAsync，负责弹出删除分组确认对话框。
- SessionTreeViewModelTests 新增多项测试，覆盖删除分组的各种场景。
- 新增 SessionTreeGroupMenuUiTests，验证分组行右键菜单绑定 DeleteGroupCommand。