### PR TITLE
统一关闭窗口提示，简化“SSH 会话”为“会话”

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -920,7 +920,7 @@
     <value>ローカルポート</value>
   </data>
   <data name="Main_CloseConfirmBody" xml:space="preserve">
-    <value>アクティブな SSH セッションがあります。ウィンドウを閉じるとすべて切断されます。終了しますか?</value>
+    <value>アクティブなセッションがあります。ウィンドウを閉じるとすべて切断されます。終了しますか?</value>
   </data>
   <data name="Main_CloseConfirmTitle" xml:space="preserve">
     <value>VelaShell を閉じる</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -920,7 +920,7 @@
     <value>로컬 포트</value>
   </data>
   <data name="Main_CloseConfirmBody" xml:space="preserve">
-    <value>활성 SSH 세션이 있습니다. 창을 닫으면 모든 연결이 끊어집니다. 종료하시겠습니까?</value>
+    <value>활성 세션이 있습니다. 창을 닫으면 모든 연결이 끊어집니다. 종료하시겠습니까?</value>
   </data>
   <data name="Main_CloseConfirmTitle" xml:space="preserve">
     <value>VelaShell 닫기</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1138,7 +1138,7 @@ If this keeps happening, close any other VelaShell windows and try again.</value
     <value>Unknown</value>
   </data>
   <data name="Main_CloseConfirmBody" xml:space="preserve">
-    <value>Active SSH sessions are still running; closing the window will disconnect them all. Quit anyway?</value>
+    <value>Active sessions are still running; closing the window will disconnect them all. Quit anyway?</value>
   </data>
   <data name="Main_CloseConfirmTitle" xml:space="preserve">
     <value>Close VelaShell</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1229,7 +1229,7 @@
     <value>未知</value>
   </data>
   <data name="Main_CloseConfirmBody" xml:space="preserve">
-    <value>仍有活动的 SSH 会话,关闭窗口将断开所有连接。确定退出吗?</value>
+    <value>仍有活动的会话,关闭窗口将断开所有连接。确定退出吗?</value>
   </data>
   <data name="Main_CloseConfirmTitle" xml:space="preserve">
     <value>关闭 VelaShell</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -920,7 +920,7 @@
     <value>本機連接埠</value>
   </data>
   <data name="Main_CloseConfirmBody" xml:space="preserve">
-    <value>仍有使用中的 SSH 工作階段,關閉視窗將中斷所有連線。確定結束嗎?</value>
+    <value>仍有使用中的工作階段,關閉視窗將中斷所有連線。確定結束嗎?</value>
   </data>
   <data name="Main_CloseConfirmTitle" xml:space="preserve">
     <value>關閉 VelaShell</value>


### PR DESCRIPTION
将关闭窗口时的提示信息中的“SSH 会话”统一简化为“会话”，减少对协议类型的限定。已同步更新英文、日文、韩文、简体中文和繁体中文资源文件，确保所有相关提示内容表述一致且更通用。