### PR TITLE
统一自绘卡片窗口投影与外边距规范

### DIFF
--- a/src/VelaShell.PluginHost/PluginHostShellWindow.cs
+++ b/src/VelaShell.PluginHost/PluginHostShellWindow.cs
@@ -16,6 +16,20 @@ namespace VelaShell.PluginHost;
 internal sealed class PluginHostShellWindow : Window
 {
     private const double InnerRadius = 7;
+
+    /// <summary>卡片外边距,即投影的画布宽度;与主程序 VelaShadowWindow 的最大延展一致。</summary>
+    private const double CardGutter = 16;
+
+    /// <summary>卡片贴边时(macOS 不透明矩形)的抓取区尺寸,压在内容上故取最小值。</summary>
+    private const double FlushGripEdge = 5,
+        FlushGripCorner = 10;
+
+    /// <summary>
+    /// 卡片投影,与主程序暗色的 VelaShadowWindow 令牌同值(此进程不加载宿主的主题字典,
+    /// 拿不到那个令牌,只能照抄;改一处要记得改另一处)。近处一层压出边缘、远处一层给扩散。
+    /// </summary>
+    private const string CardShadow = "0 2 4 0 #59000000, 0 6 10 0 #A6000000";
+
     private readonly Border _rootCard;
     private readonly Border _titleStrip;
     private readonly Panel _resizeGrips;
@@ -37,11 +51,13 @@ internal sealed class PluginHostShellWindow : Window
 
         _rootCard = new Border
         {
-            Margin = new Thickness(8),
+            // 外边距是投影的画布:透明窗体的投影超出窗口矩形的部分会被直接裁掉,
+            // 故留白必须 ≥ 投影的最大延展(offsetY + blur = 16),与主程序同一口径。
+            Margin = new Thickness(CardGutter),
             CornerRadius = new CornerRadius(8),
             ClipToBounds = true,
             BorderThickness = new Thickness(1),
-            BoxShadow = BoxShadows.Parse("0 8 32 0 #80000000"),
+            BoxShadow = BoxShadows.Parse(CardShadow),
             Child = grid
         };
         Bind(_rootCard, Border.BackgroundProperty, "VelaBgSurface");
@@ -142,35 +158,33 @@ internal sealed class PluginHostShellWindow : Window
     private Panel BuildResizeGrips()
     {
         var panel = new Panel { ZIndex = 200 };
-        AddGrip(panel, "North", WindowEdge.North, StandardCursorType.TopSide, height: 5, hMargin: 10);
-        AddGrip(panel, "South", WindowEdge.South, StandardCursorType.BottomSide, height: 5, hMargin: 10, bottom: true);
-        AddGrip(panel, "West", WindowEdge.West, StandardCursorType.LeftSide, width: 5, vMargin: 10);
-        AddGrip(panel, "East", WindowEdge.East, StandardCursorType.RightSide, width: 5, vMargin: 10, right: true);
+        AddGrip(panel, WindowEdge.North, StandardCursorType.TopSide);
+        AddGrip(panel, WindowEdge.South, StandardCursorType.BottomSide, bottom: true);
+        AddGrip(panel, WindowEdge.West, StandardCursorType.LeftSide, vertical: true);
+        AddGrip(panel, WindowEdge.East, StandardCursorType.RightSide, vertical: true, right: true);
         AddCorner(panel, WindowEdge.NorthWest, StandardCursorType.TopLeftCorner, left: true, top: true);
         AddCorner(panel, WindowEdge.NorthEast, StandardCursorType.TopRightCorner, left: false, top: true);
         AddCorner(panel, WindowEdge.SouthWest, StandardCursorType.BottomLeftCorner, left: true, top: false);
         AddCorner(panel, WindowEdge.SouthEast, StandardCursorType.BottomRightCorner, left: false, top: false);
+        ApplyGripThickness(panel, rounded: true);
         return panel;
     }
 
-    private void AddGrip(Panel panel, string _, WindowEdge edge, StandardCursorType cursor,
-        double width = double.NaN, double height = double.NaN, double hMargin = 0, double vMargin = 0,
-        bool bottom = false, bool right = false)
+    private void AddGrip(Panel panel, WindowEdge edge, StandardCursorType cursor,
+        bool vertical = false, bool bottom = false, bool right = false)
     {
         var border = new Border
         {
+            Tag = edge,
             Background = Brushes.Transparent,
-            Cursor = new Cursor(cursor),
-            Margin = new Thickness(hMargin, vMargin)
+            Cursor = new Cursor(cursor)
         };
-        if (!double.IsNaN(width))
+        if (vertical)
         {
-            border.Width = width;
             border.HorizontalAlignment = right ? HorizontalAlignment.Right : HorizontalAlignment.Left;
         }
-        if (!double.IsNaN(height))
+        else
         {
-            border.Height = height;
             border.VerticalAlignment = bottom ? VerticalAlignment.Bottom : VerticalAlignment.Top;
         }
         border.PointerPressed += (_, e) => BeginResize(edge, e);
@@ -181,8 +195,7 @@ internal sealed class PluginHostShellWindow : Window
     {
         var border = new Border
         {
-            Width = 10,
-            Height = 10,
+            Tag = edge,
             Background = Brushes.Transparent,
             Cursor = new Cursor(cursor),
             HorizontalAlignment = left ? HorizontalAlignment.Left : HorizontalAlignment.Right,
@@ -190,6 +203,39 @@ internal sealed class PluginHostShellWindow : Window
         };
         border.PointerPressed += (_, e) => BeginResize(edge, e);
         panel.Children.Add(border);
+    }
+
+    /// <summary>
+    /// 抓取区厚度跟随卡片形态:圆角态铺满 16px 的投影留白(否则那圈留白看得见点不动),
+    /// 铺满态收回 5px(否则会压在内容上吃掉最靠边控件的点击,比如滚动条)。
+    /// </summary>
+    private static void ApplyGripThickness(Panel grips, bool rounded)
+    {
+        double edge = rounded ? CardGutter : FlushGripEdge;
+        double corner = rounded ? CardGutter + 6 : FlushGripCorner;
+        foreach (Control child in grips.Children)
+        {
+            if (child is not Border { Tag: WindowEdge tag })
+            {
+                continue;
+            }
+            switch (tag)
+            {
+                // 上下边让开四角的宽度,否则角上的抓取区被边压住,拿不到斜向缩放。
+                case WindowEdge.North or WindowEdge.South:
+                    child.Height = edge;
+                    child.Margin = new Thickness(corner, 0);
+                    break;
+                case WindowEdge.West or WindowEdge.East:
+                    child.Width = edge;
+                    child.Margin = new Thickness(0, corner);
+                    break;
+                default:
+                    child.Width = corner;
+                    child.Height = corner;
+                    break;
+            }
+        }
     }
 
     private void OnHeaderPressed(object? sender, PointerPressedEventArgs e)
@@ -246,10 +292,11 @@ internal sealed class PluginHostShellWindow : Window
 
     private void ApplyCardShape(bool rounded)
     {
-        _rootCard.Margin = rounded ? new Thickness(8) : default;
+        _rootCard.Margin = rounded ? new Thickness(CardGutter) : default;
         _rootCard.BorderThickness = rounded ? new Thickness(1) : default;
         _rootCard.CornerRadius = rounded ? new CornerRadius(8) : default;
         _titleStrip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;
+        ApplyGripThickness(_resizeGrips, rounded);
     }
 
     private static void Bind(Control control, AvaloniaProperty property, string resourceKey) =>

--- a/src/VelaShell/Themes/DarkTheme.axaml
+++ b/src/VelaShell/Themes/DarkTheme.axaml
@@ -6,6 +6,12 @@
     <!-- 强调色标记 -->
     <SolidColorBrush x:Key="VelaAccentText" Color="#BD93F9" />
 
+    <!-- 自绘窗体卡片的外投影(#171 层级不清)。透明窗体的投影只能画在窗口矩形之内,
+         超出外边距的部分会被窗口边缘直接裁掉,所以两层的最大延展(offsetY + blur)
+         必须 ≤ 卡片外边距 16:近处一层压出边缘、远处一层给出扩散。
+         调这里的同时要调外边距,否则又变成截断的一块糊影。 -->
+    <BoxShadows x:Key="VelaShadowWindow">0 2 4 0 #59000000, 0 6 10 0 #A6000000</BoxShadows>
+
     <!-- 语义标记 -->
     <SolidColorBrush x:Key="VelaWarning" Color="#FFB86C" />
     <SolidColorBrush x:Key="VelaError"   Color="#FF5555" />

--- a/src/VelaShell/Themes/LightTheme.axaml
+++ b/src/VelaShell/Themes/LightTheme.axaml
@@ -6,6 +6,10 @@
     <!-- 强调色标记(为亮色背景对比度调整) -->
     <SolidColorBrush x:Key="VelaAccentText" Color="#644AC9" />
 
+    <!-- 自绘窗体卡片的外投影,几何与暗色一致(见 DarkTheme 的说明),只把不透明度降一档:
+         同样的纯黑投影压在亮底上会显脏,亮色主题里靠更浅的投影 + 1px 描边区分层级。 -->
+    <BoxShadows x:Key="VelaShadowWindow">0 2 4 0 #26000000, 0 6 10 0 #4D000000</BoxShadows>
+
     <!-- 语义标记 -->
     <SolidColorBrush x:Key="VelaWarning" Color="#846E15" />
     <SolidColorBrush x:Key="VelaError" Color="#CB3A2A" />

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml
@@ -9,7 +9,7 @@
         x:Class="VelaShell.Views.AuthenticationDialogView"
         x:DataType="vm:AuthenticationDialogViewModel"
         Title="{loc:Localize Auth_Title}"
-        Width="420"
+        Width="428"
         SizeToContent="Height"
         CanResize="False"
         WindowDecorations="None"
@@ -78,8 +78,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12">
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16">
     <StackPanel>
 
       <!-- Header -->

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml
@@ -9,7 +9,7 @@
         x:Class="VelaShell.Views.ConnectionDiagnosticsView"
         x:DataType="vm:ConnectionDiagnosticsViewModel"
         Title="{loc:Localize Diag_Title}"
-        Width="760" Height="480"
+        Width="768" Height="488"
         CanResize="False"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -53,8 +53,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12">
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16">
     <DockPanel>
 
       <!-- Header (design diagHeader):可拖动 + 标题/副标题 | 导出/重新检测/关闭 -->

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -10,7 +10,7 @@
         x:Class="VelaShell.Views.ConnectionProfileView"
         x:DataType="vm:ConnectionProfileViewModel"
         Title="{loc:Localize Profile_Title}"
-        Width="500"
+        Width="508"
         SizeToContent="Height"
         CanResize="False"
         WindowDecorations="None"
@@ -142,8 +142,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12">
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16">
     <StackPanel>
 
       <!-- Header: plug 图标 + 标题 + 关闭 -->

--- a/src/VelaShell/Views/HostKeyPromptView.axaml
+++ b/src/VelaShell/Views/HostKeyPromptView.axaml
@@ -10,7 +10,7 @@
         x:Class="VelaShell.Views.HostKeyPromptView"
         x:DataType="vm:HostKeyPromptViewModel"
         Title="{x:Static res:Strings.HostKeyVerification}"
-        Width="484"
+        Width="492"
         SizeToContent="Height"
         CanResize="False"
         ShowInTaskbar="False"
@@ -20,7 +20,7 @@
         WindowStartupLocation="CenterOwner">
 
   <!-- 主机密钥验证(TOFU)。外壳遵循标准弹窗规格:bg-surface 卡片、圆角 8、
-       1px border-secondary、阴影 0 8 32 #80000000、48px 可拖动标题栏 + 52px 按钮栏。 -->
+       1px border-secondary、阴影取 VelaShadowWindow 令牌(随主题深浅)、48px 可拖动标题栏 + 52px 按钮栏。 -->
 
   <Window.Styles>
     <Style Selector="TextBlock.mono">
@@ -75,8 +75,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="48,Auto,52">
 

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml
@@ -10,7 +10,7 @@
         x:Class="VelaShell.Views.LocalPathPickerDialog"
         x:DataType="vm:LocalFilePaneViewModel"
         Title="{loc:Localize Sftp_PickUploadTitle}"
-        Width="640" Height="520"
+        Width="672" Height="552"
         MinWidth="420" MinHeight="320"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -65,11 +65,13 @@
     </Style>
   </Window.Styles>
 
+  <!-- 外边距是投影的画布:此前这里没有外边距,投影整个被窗口边缘裁掉,等于没画(#171)。 -->
   <Border Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
           CornerRadius="8"
-          BoxShadow="0 8 32 0 #80000000">
+          Margin="16"
+          BoxShadow="{DynamicResource VelaShadowWindow}">
     <DockPanel>
 
       <!-- 标题栏(可拖动) -->

--- a/src/VelaShell/Views/MessageDialog.axaml
+++ b/src/VelaShell/Views/MessageDialog.axaml
@@ -5,7 +5,7 @@
         xmlns:pc="using:VelaShell.Controls.Controls"
         mc:Ignorable="d" d:DesignWidth="444" d:DesignHeight="220"
         x:Class="VelaShell.Views.MessageDialog"
-        Width="444"
+        Width="452"
         SizeToContent="Height"
         CanResize="False"
         ShowInTaskbar="False"
@@ -15,7 +15,7 @@
         WindowStartupLocation="CenterOwner">
 
   <!-- 通用消息/确认/输入弹窗。外观遵循设计的标准弹窗规格(如 oNZIM 密码验证弹窗):
-       420px bg-surface 卡片、圆角 8、1px border-secondary 外描边、阴影 0 8 32 #80000000;
+       420px bg-surface 卡片、圆角 8、1px border-secondary 外描边、阴影取 VelaShadowWindow 令牌(随主题深浅);
        48px 标题栏(可拖动) + 内容区 + 52px 按钮栏,分隔线均为 border-primary。 -->
 
   <Window.Styles>
@@ -106,8 +106,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="48,Auto,52">
 

--- a/src/VelaShell/Views/PluginManagerWindow.axaml
+++ b/src/VelaShell/Views/PluginManagerWindow.axaml
@@ -5,8 +5,8 @@
         x:Class="VelaShell.Views.PluginManagerWindow"
         x:DataType="vm:PluginManagerViewModel"
         Icon="/Assets/velashell.ico"
-        Width="660" Height="540"
-        MinWidth="500" MinHeight="380"
+        Width="676" Height="556"
+        MinWidth="516" MinHeight="396"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         WindowStartupLocation="CenterOwner"
@@ -90,11 +90,11 @@
 
   <Panel>
     <Border x:Name="RootCard"
-            Margin="8" CornerRadius="8" ClipToBounds="True"
+            Margin="16" CornerRadius="8" ClipToBounds="True"
             Background="{DynamicResource VelaBgSurface}"
             BorderBrush="{DynamicResource VelaBorderSecondary}"
             BorderThickness="1"
-            BoxShadow="0 8 32 0 #80000000">
+            BoxShadow="{DynamicResource VelaShadowWindow}">
       <Grid RowDefinitions="40,Auto,*">
 
         <!-- 标题栏 -->
@@ -214,14 +214,14 @@
     </Border>
 
     <Panel x:Name="ResizeGrips" ZIndex="200">
-      <Border Tag="North" Height="5" VerticalAlignment="Top" Margin="10,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="South" Height="5" VerticalAlignment="Bottom" Margin="10,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="West" Width="5" HorizontalAlignment="Left" Margin="0,10" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="East" Width="5" HorizontalAlignment="Right" Margin="0,10" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="North" Height="16" VerticalAlignment="Top" Margin="22,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="South" Height="16" VerticalAlignment="Bottom" Margin="22,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="West" Width="16" HorizontalAlignment="Left" Margin="0,22" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="East" Width="16" HorizontalAlignment="Right" Margin="0,22" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
     </Panel>
   </Panel>
 </Window>

--- a/src/VelaShell/Views/PluginManagerWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginManagerWindow.axaml.cs
@@ -163,11 +163,20 @@ public partial class PluginManagerWindow : Window
     {
         if (this.FindControl<Border>("RootCard") is { } card)
         {
-            card.Margin = rounded ? new Thickness(8) : default;
+            card.Margin = rounded ? new Thickness(16) : default;
             card.BorderThickness = rounded ? new Thickness(1) : default;
             card.CornerRadius = rounded ? new CornerRadius(8) : default;
-            card.BoxShadow = rounded ? card.BoxShadow : default;
+            // 铺满态没有外边距,投影只会被整块裁掉,白付一次模糊;圆角态再从令牌取回。
+            // 不能写成 rounded ? card.BoxShadow : default —— 那样最大化清掉之后,
+            // 还原时读到的已经是清掉后的空值,投影一去不返(自身赋值救不回来)。
+            card.BoxShadow =
+                rounded
+                && this.TryFindResource("VelaShadowWindow", out object? shadow)
+                && shadow is BoxShadows shadows
+                    ? shadows
+                    : default;
         }
+        ResizeGripLayout.Apply(ResizeGrips, rounded);
         if (this.FindControl<Border>("TitleBarStrip") is { } strip)
         {
             strip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;

--- a/src/VelaShell/Views/PluginPanelWindow.axaml
+++ b/src/VelaShell/Views/PluginPanelWindow.axaml
@@ -3,8 +3,8 @@
         xmlns:pc="using:VelaShell.Controls.Controls"
         x:Class="VelaShell.Views.PluginPanelWindow"
         Icon="/Assets/velashell.ico"
-        Width="520" Height="420"
-        MinWidth="280" MinHeight="200"
+        Width="536" Height="436"
+        MinWidth="296" MinHeight="216"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         WindowStartupLocation="CenterOwner"
@@ -34,11 +34,11 @@
 
   <Panel>
     <Border x:Name="RootCard"
-            Margin="8" CornerRadius="8" ClipToBounds="True"
+            Margin="16" CornerRadius="8" ClipToBounds="True"
             Background="{DynamicResource VelaBgSurface}"
             BorderBrush="{DynamicResource VelaBorderSecondary}"
             BorderThickness="1"
-            BoxShadow="0 8 32 0 #80000000">
+            BoxShadow="{DynamicResource VelaShadowWindow}">
       <Grid RowDefinitions="40,*">
 
         <Border x:Name="TitleBarStrip" Grid.Row="0"
@@ -85,14 +85,14 @@
     </Border>
 
     <Panel x:Name="ResizeGrips" ZIndex="200">
-      <Border Tag="North" Height="5" VerticalAlignment="Top" Margin="10,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="South" Height="5" VerticalAlignment="Bottom" Margin="10,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="West" Width="5" HorizontalAlignment="Left" Margin="0,10" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="East" Width="5" HorizontalAlignment="Right" Margin="0,10" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="North" Height="16" VerticalAlignment="Top" Margin="22,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="South" Height="16" VerticalAlignment="Bottom" Margin="22,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="West" Width="16" HorizontalAlignment="Left" Margin="0,22" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="East" Width="16" HorizontalAlignment="Right" Margin="0,22" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
     </Panel>
   </Panel>
 </Window>

--- a/src/VelaShell/Views/PluginPanelWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginPanelWindow.axaml.cs
@@ -99,9 +99,10 @@ public partial class PluginPanelWindow : Window
 
     private void ApplyCardShape(bool rounded)
     {
-        RootCard.Margin = rounded ? new Thickness(8) : default;
+        RootCard.Margin = rounded ? new Thickness(16) : default;
         RootCard.BorderThickness = rounded ? new Thickness(1) : default;
         RootCard.CornerRadius = rounded ? new CornerRadius(8) : default;
+        ResizeGripLayout.Apply(ResizeGrips, rounded);
         TitleBarStrip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;
     }
 }

--- a/src/VelaShell/Views/PluginPermissionDialog.axaml
+++ b/src/VelaShell/Views/PluginPermissionDialog.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:pc="using:VelaShell.Controls.Controls"
         x:Class="VelaShell.Views.PluginPermissionDialog"
-        Width="460"
+        Width="468"
         SizeToContent="Height"
         CanResize="False"
         ShowInTaskbar="False"
@@ -52,8 +52,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="48,Auto,Auto">
 

--- a/src/VelaShell/Views/ProcessManagerView.axaml
+++ b/src/VelaShell/Views/ProcessManagerView.axaml
@@ -11,8 +11,8 @@
         x:DataType="vm:ProcessManagerViewModel"
         Icon="/Assets/velashell.ico"
         Title="{loc:Localize Cmd_ProcessManager}"
-        Width="1000" Height="640"
-        MinWidth="880" MinHeight="420"
+        Width="1016" Height="656"
+        MinWidth="896" MinHeight="436"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         WindowStartupLocation="CenterOwner"
@@ -158,13 +158,13 @@
 
   <Panel>
   <Border x:Name="RootCard"
-          Margin="8"
+          Margin="16"
           CornerRadius="8"
           ClipToBounds="True"
           Background="{DynamicResource VelaBgPage}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000">
+          BoxShadow="{DynamicResource VelaShadowWindow}">
   <Grid RowDefinitions="34,Auto,Auto,*,26">
 
     <!-- 标题栏(自绘):按住可拖动,双击最大化/还原。
@@ -507,14 +507,14 @@
        缺了这层窗口就完全不能缩放。铺满整个窗口,正好覆盖卡片外那圈阴影留白。
        最大化时由 code-behind 隐藏。 -->
   <Panel x:Name="ResizeGrips" ZIndex="200">
-    <Border Tag="North" Height="5" VerticalAlignment="Top" Margin="10,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="South" Height="5" VerticalAlignment="Bottom" Margin="10,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="West" Width="5" HorizontalAlignment="Left" Margin="0,10" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="East" Width="5" HorizontalAlignment="Right" Margin="0,10" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="NorthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="NorthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="SouthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="SouthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="North" Height="16" VerticalAlignment="Top" Margin="22,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="South" Height="16" VerticalAlignment="Bottom" Margin="22,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="West" Width="16" HorizontalAlignment="Left" Margin="0,22" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="East" Width="16" HorizontalAlignment="Right" Margin="0,22" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="NorthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="NorthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="SouthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="SouthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
   </Panel>
   </Panel>
 </Window>

--- a/src/VelaShell/Views/ProcessManagerView.axaml.cs
+++ b/src/VelaShell/Views/ProcessManagerView.axaml.cs
@@ -140,9 +140,10 @@ public partial class ProcessManagerView : Window
     /// <param name="rounded">true = 普通态的圆角浮层,false = 铺满的矩形。</param>
     private void ApplyCardShape(bool rounded)
     {
-        RootCard.Margin = rounded ? new Thickness(8) : default;
+        RootCard.Margin = rounded ? new Thickness(16) : default;
         RootCard.BorderThickness = rounded ? new Thickness(1) : default;
         RootCard.CornerRadius = rounded ? new CornerRadius(8) : default;
+        ResizeGripLayout.Apply(ResizeGrips, rounded);
         TitleBarStrip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;
         StatusStrip.CornerRadius = rounded ? new CornerRadius(0, 0, InnerRadius, InnerRadius) : default;
     }

--- a/src/VelaShell/Views/RecordingPlayerView.axaml
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml
@@ -5,8 +5,8 @@
         x:Class="VelaShell.Views.RecordingPlayerView"
         x:DataType="vm:RecordingPlayerViewModel"
         Title="{loc:Localize Recorder_Title}"
-        Width="1200" Height="820"
-        MinWidth="860" MinHeight="600"
+        Width="1208" Height="828"
+        MinWidth="868" MinHeight="608"
         CanResize="True"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -74,8 +74,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="56,*">
 

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml
@@ -7,8 +7,8 @@
         xmlns:loc="using:VelaShell.Localization"
         mc:Ignorable="d" d:DesignWidth="920" d:DesignHeight="640"
         x:Class="VelaShell.Views.RemoteFileEditorView"
-        Width="920" Height="640"
-        MinWidth="520" MinHeight="360"
+        Width="928" Height="648"
+        MinWidth="528" MinHeight="368"
         CanResize="True"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -46,8 +46,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="48,*,32">
 

--- a/src/VelaShell/Views/ResizeGripLayout.cs
+++ b/src/VelaShell/Views/ResizeGripLayout.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace VelaShell.Views;
+
+/// <summary>
+/// 自绘窗体缩放抓取区的尺寸,按卡片当前形态给出。
+/// </summary>
+/// <remarks>
+/// 抓取区必须跟卡片的外边距一起动:外边距是投影的画布,那圈透明留白既不属于卡片、
+/// 也没有别的控件接管,抓取区窄于它就留下一圈"看得见、点不动"的死区;反过来卡片贴边时
+/// (macOS 的不透明矩形)抓取区还按留白宽度铺,就会压在真实内容上吃掉边缘控件的点击
+/// (最靠边的往往正是滚动条)。所以两个值由同一个 <c>rounded</c> 状态决定。
+/// 抓取区的 Border 靠 <c>Tag</c> 标出所在边,与 XAML 里 BeginResizeDrag 用的是同一个标记。
+/// </remarks>
+internal static class ResizeGripLayout
+{
+    /// <summary>卡片带外边距时:抓取区正好铺满 16px 的投影留白。</summary>
+    private const double GutterEdge = 16,
+        GutterCorner = 22;
+
+    /// <summary>卡片贴边时:抓取区压在内容上,只取够用的最小值。</summary>
+    private const double FlushEdge = 5,
+        FlushCorner = 10;
+
+    /// <summary>按卡片形态调整抓取区厚度。</summary>
+    /// <param name="grips">抓取区容器(XAML 里的 ResizeGrips)。</param>
+    /// <param name="rounded">true = 普通态的圆角浮层(有外边距),false = 铺满的矩形。</param>
+    public static void Apply(Panel? grips, bool rounded)
+    {
+        if (grips is null)
+        {
+            return;
+        }
+        double edge = rounded ? GutterEdge : FlushEdge;
+        double corner = rounded ? GutterCorner : FlushCorner;
+        foreach (Control child in grips.Children)
+        {
+            if (child is not Border { Tag: string tag })
+            {
+                continue;
+            }
+            switch (tag)
+            {
+                // 上下边:留出四角的宽度,否则角上的抓取区被边压住,拿不到斜向缩放。
+                case "North" or "South":
+                    child.Height = edge;
+                    child.Margin = new Thickness(corner, 0);
+                    break;
+                case "West" or "East":
+                    child.Width = edge;
+                    child.Margin = new Thickness(0, corner);
+                    break;
+                default:
+                    child.Width = corner;
+                    child.Height = corner;
+                    break;
+            }
+        }
+    }
+}

--- a/src/VelaShell/Views/ResourceMonitorWindow.axaml
+++ b/src/VelaShell/Views/ResourceMonitorWindow.axaml
@@ -12,8 +12,8 @@
         x:DataType="vm:ResourceMonitorWindowViewModel"
         Icon="/Assets/velashell.ico"
         Title="{loc:Localize Monitor_Title}"
-        Width="1280" Height="820"
-        MinWidth="960" MinHeight="620"
+        Width="1296" Height="836"
+        MinWidth="976" MinHeight="636"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         WindowStartupLocation="CenterOwner"
@@ -268,11 +268,11 @@
 
   <Panel>
     <Border x:Name="RootCard"
-            Margin="8" CornerRadius="8" ClipToBounds="True"
+            Margin="16" CornerRadius="8" ClipToBounds="True"
             Background="{DynamicResource VelaBgSurface}"
             BorderBrush="{DynamicResource VelaBorderSecondary}"
             BorderThickness="1"
-            BoxShadow="0 8 32 0 #80000000">
+            BoxShadow="{DynamicResource VelaShadowWindow}">
       <Grid RowDefinitions="56,*">
 
         <!-- ── 头部 ── -->
@@ -1691,14 +1691,14 @@
     </Border>
 
     <Panel x:Name="ResizeGrips" ZIndex="200">
-      <Border Tag="North" Height="5" VerticalAlignment="Top" Margin="10,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="South" Height="5" VerticalAlignment="Bottom" Margin="10,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="West" Width="5" HorizontalAlignment="Left" Margin="0,10" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="East" Width="5" HorizontalAlignment="Right" Margin="0,10" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="NorthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-      <Border Tag="SouthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="North" Height="16" VerticalAlignment="Top" Margin="22,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="South" Height="16" VerticalAlignment="Bottom" Margin="22,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="West" Width="16" HorizontalAlignment="Left" Margin="0,22" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="East" Width="16" HorizontalAlignment="Right" Margin="0,22" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="NorthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+      <Border Tag="SouthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
     </Panel>
   </Panel>
 </Window>

--- a/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
+++ b/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
@@ -122,9 +122,10 @@ public partial class ResourceMonitorWindow : Window
     /// <param name="rounded">true = 普通态圆角浮层,false = 铺满矩形。</param>
     private void ApplyCardShape(bool rounded)
     {
-        RootCard.Margin = rounded ? new Thickness(8) : default;
+        RootCard.Margin = rounded ? new Thickness(16) : default;
         RootCard.BorderThickness = rounded ? new Thickness(1) : default;
         RootCard.CornerRadius = rounded ? new CornerRadius(8) : default;
+        ResizeGripLayout.Apply(ResizeGrips, rounded);
         TitleBarStrip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;
     }
 }

--- a/src/VelaShell/Views/SessionImportView.axaml
+++ b/src/VelaShell/Views/SessionImportView.axaml
@@ -8,7 +8,7 @@
         x:Class="VelaShell.Views.SessionImportView"
         x:DataType="vm:SessionImportViewModel"
         Title="{Binding Title}"
-        Width="560" MaxHeight="660"
+        Width="568" MaxHeight="668"
         SizeToContent="Height"
         CanResize="False"
         WindowDecorations="None"
@@ -55,8 +55,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12">
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16">
     <Grid RowDefinitions="48,Auto,Auto,Auto,*,52">
 
       <!-- Header -->

--- a/src/VelaShell/Views/SettingsView.axaml
+++ b/src/VelaShell/Views/SettingsView.axaml
@@ -10,7 +10,7 @@
         x:Class="VelaShell.Views.SettingsView"
         x:DataType="vm:SettingsViewModel"
         Title="{loc:Localize Settings}"
-        Width="840" Height="740"
+        Width="848" Height="748"
         CanResize="False"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -185,8 +185,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid ColumnDefinitions="200,*">
 

--- a/src/VelaShell/Views/TraceRouteWindow.axaml
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml
@@ -12,8 +12,8 @@
         x:DataType="vm:TraceRouteViewModel"
         Icon="/Assets/velashell.ico"
         Title="{loc:Localize Trace_Title}"
-        Width="940" Height="520"
-        MinWidth="820" MinHeight="360"
+        Width="956" Height="536"
+        MinWidth="836" MinHeight="376"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         WindowStartupLocation="CenterOwner"
@@ -77,11 +77,11 @@
 
   <Panel>
   <Border x:Name="RootCard"
-          Margin="8" CornerRadius="8" ClipToBounds="True"
+          Margin="16" CornerRadius="8" ClipToBounds="True"
           Background="{DynamicResource VelaBgPage}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000">
+          BoxShadow="{DynamicResource VelaShadowWindow}">
     <Grid RowDefinitions="34,Auto,*,26">
 
       <!-- 标题栏 -->
@@ -258,14 +258,14 @@
   </Border>
 
   <Panel x:Name="ResizeGrips" ZIndex="200">
-    <Border Tag="North" Height="5" VerticalAlignment="Top" Margin="10,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="South" Height="5" VerticalAlignment="Bottom" Margin="10,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="West" Width="5" HorizontalAlignment="Left" Margin="0,10" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="East" Width="5" HorizontalAlignment="Right" Margin="0,10" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="NorthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="NorthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="SouthWest" Width="10" Height="10" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
-    <Border Tag="SouthEast" Width="10" Height="10" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="North" Height="16" VerticalAlignment="Top" Margin="22,0" Background="Transparent" Cursor="TopSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="South" Height="16" VerticalAlignment="Bottom" Margin="22,0" Background="Transparent" Cursor="BottomSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="West" Width="16" HorizontalAlignment="Left" Margin="0,22" Background="Transparent" Cursor="LeftSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="East" Width="16" HorizontalAlignment="Right" Margin="0,22" Background="Transparent" Cursor="RightSide" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="NorthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent" Cursor="TopLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="NorthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent" Cursor="TopRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="SouthWest" Width="22" Height="22" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner" PointerPressed="ResizeEdge_PointerPressed" />
+    <Border Tag="SouthEast" Width="22" Height="22" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="ResizeEdge_PointerPressed" />
   </Panel>
   </Panel>
 </Window>

--- a/src/VelaShell/Views/TraceRouteWindow.axaml.cs
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml.cs
@@ -153,9 +153,10 @@ public partial class TraceRouteWindow : Window
     /// <param name="rounded">true = 普通态圆角浮层,false = 铺满矩形。</param>
     private void ApplyCardShape(bool rounded)
     {
-        RootCard.Margin = rounded ? new Thickness(8) : default;
+        RootCard.Margin = rounded ? new Thickness(16) : default;
         RootCard.BorderThickness = rounded ? new Thickness(1) : default;
         RootCard.CornerRadius = rounded ? new CornerRadius(8) : default;
+        ResizeGripLayout.Apply(ResizeGrips, rounded);
         TitleBarStrip.CornerRadius = rounded ? new CornerRadius(InnerRadius, InnerRadius, 0, 0) : default;
         StatusStrip.CornerRadius = rounded ? new CornerRadius(0, 0, InnerRadius, InnerRadius) : default;
     }

--- a/src/VelaShell/Views/TunnelHelpDialog.axaml
+++ b/src/VelaShell/Views/TunnelHelpDialog.axaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d" d:DesignWidth="680" d:DesignHeight="620"
         x:Class="VelaShell.Views.TunnelHelpDialog"
         Title="{loc:Localize TunnelHelp_Title}"
-        Width="680" Height="620"
+        Width="688" Height="628"
         CanResize="False"
         WindowDecorations="None"
         TransparencyLevelHint="Transparent"
@@ -59,8 +59,8 @@
           Background="{DynamicResource VelaBgSurface}"
           BorderBrush="{DynamicResource VelaBorderSecondary}"
           BorderThickness="1"
-          BoxShadow="0 8 32 0 #80000000"
-          Margin="12"
+          BoxShadow="{DynamicResource VelaShadowWindow}"
+          Margin="16"
           ClipToBounds="True">
     <Grid RowDefinitions="48,*,52">
 

--- a/src/VelaShell/Views/Win32WindowChrome.cs
+++ b/src/VelaShell/Views/Win32WindowChrome.cs
@@ -17,7 +17,14 @@ namespace VelaShell.Views;
 /// 可视的系统标题栏和边框没了。WM_NCHITTEST 其余区域一律报 HTCLIENT,否则系统会按
 /// WS_CAPTION 在顶部划出一条非客户带,吞掉自绘标题栏的输入(Avalonia 12 的 extend 模式踩过)。
 ///
-/// 主窗口与任务管理器共用这一套,新的自绘窗体只要调用 <see cref="Attach" /> 即可获得同样的外观。
+/// 光有样式位还不够:WM_NCCALCSIZE 把非客户区裁到零之后,DWM 认为这个窗口没有可投影的框架,
+/// 投影随之消失(#171)。必须再用非零 MARGINS 调 DwmExtendFrameIntoClientArea 把框架"借"回
+/// 客户区,投影才回来 —— 客户区被 Avalonia 全幅不透明绘制盖住,借回来的那 1px 玻璃看不见。
+/// Win11 的圆角再用 DWMWA_WINDOW_CORNER_PREFERENCE 显式钉一次,不依赖系统的默认推断。
+///
+/// 只适用于【不透明】窗体:透明窗体(TransparencyLevelHint=Transparent)会把借回的框架透出来,
+/// 那类窗体照旧用自绘卡片的 BoxShadow(VelaShadowWindow 令牌)拿投影。
+/// 新的自绘不透明窗体只要调用 <see cref="Attach" /> 即可获得同样的外观。
 /// </remarks>
 internal static partial class Win32WindowChrome
 {
@@ -107,6 +114,42 @@ internal static partial class Win32WindowChrome
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER
+            );
+            ApplyDwmFrame(handle.Handle);
+        }
+    }
+
+    /// <summary>
+    /// 把 DWM 框架借 1px 回客户区(拿回投影),并在 Win11 上显式声明圆角。
+    /// </summary>
+    /// <remarks>
+    /// 仅有 WS_THICKFRAME 而在 WM_NCCALCSIZE 里把非客户区裁到零,DWM 会判定此窗口无框架可投影,
+    /// 于是不再合成投影 —— 表现为窗口与桌面/背后窗口糊在一起、分不清层级(#171)。
+    /// DwmExtendFrameIntoClientArea 传非零 MARGINS 即可让 DWM 继续按有框架的窗口处理;
+    /// 借回的 1px 落在客户区最外圈,被 Avalonia 的不透明绘制完全盖住,不产生可见的玻璃边。
+    /// 两个调用都失败即忽略:拿不到投影只是观感回退,不该让窗口打不开。
+    /// </remarks>
+    private static void ApplyDwmFrame(IntPtr hWnd)
+    {
+        const int DWMWA_WINDOW_CORNER_PREFERENCE = 33,
+            DWMWCP_ROUND = 2;
+        var margins = new MARGINS
+        {
+            Left = 1,
+            Right = 1,
+            Top = 1,
+            Bottom = 1,
+        };
+        _ = DwmExtendFrameIntoClientArea(hWnd, in margins);
+        // 圆角属性 Win11(22000+)才认;更低版本会返回 E_INVALIDARG,直接不发。
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+        {
+            int corner = DWMWCP_ROUND;
+            _ = DwmSetWindowAttribute(
+                hWnd,
+                DWMWA_WINDOW_CORNER_PREFERENCE,
+                in corner,
+                sizeof(int)
             );
         }
     }
@@ -213,6 +256,22 @@ internal static partial class Win32WindowChrome
     [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool GetMonitorInfoW(IntPtr hMonitor, ref MONITORINFO info);
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmExtendFrameIntoClientArea(IntPtr hWnd, in MARGINS margins);
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmSetWindowAttribute(IntPtr hWnd, int attribute, in int value, int size);
+
+    /// <summary>DWM 的框架外扩量,字段顺序即 cxLeftWidth/cxRightWidth/cyTopHeight/cyBottomHeight。</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MARGINS
+    {
+        public int Left,
+            Right,
+            Top,
+            Bottom;
+    }
 
     [StructLayout(LayoutKind.Sequential)]
     private struct WINRECT

--- a/tests/VelaShell.Tests/Views/ProcessManagerUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ProcessManagerUiTests.cs
@@ -68,6 +68,30 @@ public sealed class ProcessManagerUiTests
     }
 
     [TestMethod]
+    public void Window_CardShadow_ResolvesFromToken_AndHasRoomToDraw()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+
+            // 投影是这类窗口区分层级的唯一手段(#171),而它有两种"静悄悄失效"的方式:
+            // 令牌名写错 → DynamicResource 解析不到,BoxShadow 静静地空着;外边距不够 →
+            // 投影画在窗口矩形之外被裁掉,画了等于没画。两种都不报错,只是看起来没有阴影。
+            Border card = fixture.Find<Border>("RootCard");
+            Assert.IsGreaterThan(0, card.BoxShadow.Count, "VelaShadowWindow 令牌没解析出投影。");
+
+            double reach = 0;
+            for (int i = 0; i < card.BoxShadow.Count; i++)
+            {
+                BoxShadow shadow = card.BoxShadow[i];
+                reach = Math.Max(reach, Math.Abs(shadow.OffsetY) + shadow.Blur);
+            }
+            Assert.IsGreaterThanOrEqualTo(reach, card.Margin.Bottom,
+                $"卡片外边距 {card.Margin.Bottom} 装不下延展 {reach} 的投影,超出的部分会被窗口边缘裁掉。");
+        });
+    }
+
+    [TestMethod]
     public void Gauges_CarryDistinctColourClasses()
     {
         OnUi(() =>

--- a/tests/VelaShell.Tests/Views/Todo2PixelRegressionTests.cs
+++ b/tests/VelaShell.Tests/Views/Todo2PixelRegressionTests.cs
@@ -84,9 +84,11 @@ public sealed class Todo2PixelRegressionTests
             var limeColors = new Dictionary<string, int>();
             var purpleColors = new Dictionary<string, int>();
             // Fixed protocol strip sample excludes tab text and the selected underline.
-            for (int y = 52; y < 78 && y < height; y++)
+            // 坐标是从窗口左上角量的,故随卡片外边距整体平移:外边距 12 → 16(#171 投影画布)
+            // 之后条带右移下移各 4px,采样窗口不跟着挪就会取到卡片外的空白,一个强调色像素都数不到。
+            for (int y = 56; y < 82 && y < height; y++)
             {
-                for (int x = 72; x < 174 && x < width; x++)
+                for (int x = 76; x < 178 && x < width; x++)
                 {
                     int offset = (y * width + x) * stride;
                     byte blue = Marshal.ReadByte(buffer, offset);


### PR DESCRIPTION
统一所有自绘卡片窗口的 BoxShadow 和外边距为主题令牌和 16px，修复投影被裁剪问题。动态调整缩放抓取区，新增 ResizeGripLayout 辅助类。增强 Win32WindowChrome 支持系统投影，完善 UI 测试并同步修正相关窗口尺寸。