### PR TITLE
优化RpcConnection关闭流程，避免主动关闭异常

### DIFF
--- a/plugin-sdk/VelaShell.PluginSdk/Rpc/RpcConnection.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Rpc/RpcConnection.cs
@@ -145,7 +145,11 @@ public sealed class RpcConnection : IAsyncDisposable
                     throw new IOException($"Invalid RPC frame length {length}.");
                 }
                 byte[] body = new byte[length];
-                await TryFillAsync(body, allowCleanEndOfStream: false).ConfigureAwait(false);
+                // false = 本端正在关闭(帧读到一半),此时 body 是半截的,不能拿去反序列化。
+                if (!await TryFillAsync(body, allowCleanEndOfStream: false).ConfigureAwait(false))
+                {
+                    return;
+                }
                 RpcMessage? message = JsonSerializer.Deserialize<RpcMessage>(body, JsonOptions);
                 if (message is null)
                 {
@@ -166,17 +170,34 @@ public sealed class RpcConnection : IAsyncDisposable
 
     /// <summary>
     /// 读满缓冲区。帧边界上的 0 字节(对端干净关闭)在 <paramref name="allowCleanEndOfStream" />
-    /// 时返回 false;帧中途 EOF 是协议破损,抛 <see cref="IOException" />。
+    /// 时返回 false;本端主动关闭同样返回 false;帧中途 EOF 是协议破损,抛 <see cref="IOException" />。
     /// </summary>
+    /// <remarks>
+    /// 这里【刻意不把 <c>_lifetime.Token</c> 传给 ReadAsync】。传了的话,
+    /// <see cref="DisposeAsync" /> 取消令牌会把待决的读撕成 OperationCanceledException ——
+    /// 虽然被读循环的 catch 吞掉、退出码照样是 0,但每次停用插件/退出应用都在调试器里
+    /// 刷一条首发异常,而主动关闭是这条路径上最常规的分支,不该长成异常的样子。
+    /// 实测(字节模式 + PipeOptions.Asynchronous,与 PluginProcessClient 同配置):
+    /// 释放本端流会让待决的 ReadAsync 返回 0 字节,与对端关闭的表现一致,全程无异常。
+    /// 因此收尾改由 <see cref="DisposeAsync" /> 的 <c>_stream.DisposeAsync()</c> 负责,
+    /// 令牌只留给循环条件、请求处理器与限时等待。
+    /// </remarks>
     private async Task<bool> TryFillAsync(Memory<byte> buffer, bool allowCleanEndOfStream)
     {
         int offset = 0;
         while (offset < buffer.Length)
         {
-            int read = await _stream.ReadAsync(buffer[offset..], _lifetime.Token).ConfigureAwait(false);
+            // 关闭是先取消令牌、后释放流:这一句挡住"取消之后还去读已释放的流",
+            // 否则会拿到一条 ObjectDisposedException —— 换个类型的首发异常,等于没治。
+            if (_lifetime.IsCancellationRequested)
+            {
+                return false;
+            }
+            int read = await _stream.ReadAsync(buffer[offset..]).ConfigureAwait(false);
             if (read == 0)
             {
-                if (allowCleanEndOfStream && offset == 0)
+                // 本端正在关闭:流被释放导致的 0 字节不是协议破损,安静收摊。
+                if (_lifetime.IsCancellationRequested || (allowCleanEndOfStream && offset == 0))
                 {
                     return false;
                 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RpcConnectionTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RpcConnectionTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipes;
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Rpc;
@@ -138,6 +139,42 @@ public class RpcConnectionTests
         finally
         {
             await cleanup();
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispose_WithIdleReadLoop_ThrowsNothing()
+    {
+        // 停用插件/退出应用走的就是这条路:读循环正等着下一帧,本端主动关闭连接。
+        // 这是最常规的分支,不该长成异常 —— 曾经把 _lifetime.Token 传给 ReadAsync,
+        // 取消会把待决的读撕成 OperationCanceledException,虽被读循环 catch 吞掉、
+        // 退出码照样是 0,却在每次退出时给调试器刷一条首发异常。
+        (RpcConnection server, RpcConnection client, Func<ValueTask> _) = await ConnectPairAsync();
+        var thrown = new List<Exception>();
+        void Record(object? _, FirstChanceExceptionEventArgs e)
+        {
+            lock (thrown)
+            {
+                thrown.Add(e.Exception);
+            }
+        }
+
+        // 读循环此刻确实在等待读取(而不是尚未起步),否则这条测试会空跑通过。
+        await Task.Delay(200);
+        AppDomain.CurrentDomain.FirstChanceException += Record;
+        try
+        {
+            await client.DisposeAsync();
+            await server.DisposeAsync();
+            await Task.Delay(200); // 给读循环收尾的时间,晚到的异常也要算数
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= Record;
+        }
+        lock (thrown)
+        {
+            Assert.IsEmpty(thrown, $"关闭连接不应抛任何异常,实际抛出:{string.Join(", ", thrown.Select(e => e.GetType().Name))}");
         }
     }
 


### PR DESCRIPTION
本次修改优化了RpcConnection的关闭流程，防止在主动关闭连接时抛出OperationCanceledException异常。主要包括：TryFillAsync读取帧数据时不再传递_lifetime.Token，增加对_lifetime.IsCancellationRequested的判断，主动关闭时直接返回false，避免读取已释放流；若TryFillAsync返回false则直接return，防止反序列化半截数据；更新方法注释，详细说明取消令牌处理和关闭流程逻辑；新增单元测试Dispose_WithIdleReadLoop_ThrowsNothing，确保关闭流程健壮性。