### PR TITLE
引入 Windows 11 风格滚动条主题及测试

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -300,6 +300,20 @@ The existing SFTP file browser is the primary reusable component for the dual-pa
 - Hover: `VelaBgHover`
 - Disabled: 0.35 opacity
 
+### 5.8 Scrollbars (`Themes/ScrollBarThemes.axaml`, overrides Fluent's `{x:Type ScrollBar}`)
+
+Windows Explorer semantics, both orientations, application-wide (ScrollViewer, lists, AvaloniaEdit, terminal scrollback):
+
+- Lane: 16px, always reserved (`VelaScrollBarSize`) — expanding never shifts layout
+- Idle: 2px thumb hugging the outer edge (`CornerRadius:1`), no track, no arrows — Fluent's resting look, kept as-is
+- Expanded (pointer over the bar, or `AllowAutoHide=false`): `VelaScrollBarTrackFill` lane fades in, chevron buttons fade in at both ends, thumb becomes a 6px **centered** pill (`CornerRadius:3`) — *not* Fluent's full-width block
+- Colors are sampled pixel-for-pixel from a Windows 11 dark scrollbar, not invented: the lane is **one or two steps darker** than the surface it covers (reference: content `#191919`, lane `#171717`), never a lighter band; thumb and arrows are neutral grey `#959595`. Hence `VelaScrollBarTrackFill` = `#232532` dark / `#EDE7D0` light
+- Thumb fill: `VelaScrollBarThumbFill` → `…PointerOver` → `…Pressed`; arrows `VelaScrollBarArrowFill` with `…ButtonBackgroundPointerOver/Pressed` behind them
+- Chevrons use this file's own `VelaScrollBarArrow{Up,Down,Left,Right}` geometries (8×6.4 units, ~1.4px stroke at the 7px render size). Fluent's chevron paths are hairlines drawn for large sizes and turn into a grey smudge below ~12px
+- Transition: 0.1s on thumb padding/corner radius and on track/arrow opacity. Thickness is real layout (padding), never `RenderTransform` scaling — scaling would squash the round cap into an ellipse
+- The thumb control keeps the full 16px width, so the grab area does not shrink with the visible pill
+- Isolated plugin processes (`VelaShell.PluginHost`) intentionally stay on stock Fluent — that host may not reference app assemblies
+
 ---
 
 ## 6. Motion & Interaction

--- a/src/VelaShell/App.axaml
+++ b/src/VelaShell/App.axaml
@@ -26,6 +26,9 @@
                 <ResourceInclude Source="avares://VelaShell.Controls/Themes/VelaShellTokens.axaml" />
                 <ResourceInclude Source="avares://VelaShell.Controls/Themes/Icons.axaml" />
                 <ResourceInclude Source="avares://VelaShell/Themes/ButtonThemes.axaml" />
+                <!-- 滚动条控件主题:覆盖 Fluent 的 {x:Type ScrollBar}(资源查找先于
+                     Application.Styles,故必须放在这里而不是 Styles 里)。 -->
+                <ResourceInclude Source="avares://VelaShell/Themes/ScrollBarThemes.axaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- 界面字体/字号令牌(含整套字号阶梯)在 VelaTokens.axaml 里定义,

--- a/src/VelaShell/Themes/ScrollBarThemes.axaml
+++ b/src/VelaShell/Themes/ScrollBarThemes.axaml
@@ -1,0 +1,363 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="False">
+
+  <!-- ============================== 滚动条(全应用统一) ==============================
+       替换 Fluent 自带的 ScrollBar 控件主题(键就是 {x:Type ScrollBar},放在
+       Application.Resources 里,查找顺序先于 Application.Styles 里的 FluentTheme,
+       于是全应用的横/纵滚动条 —— 含 ScrollViewer、ListBox、AvaloniaEdit、终端回滚条 ——
+       一次生效,各视图不必单独改)。
+
+       改的只有【悬停展开态】,理由:Fluent 展开时把滑块直接铺满整条 16px 滑道(方角实心块),
+       视觉上"鼠标一放上去就变成一根很粗的棒子";Windows(资源管理器)是滑道变深、两端出
+       箭头,而滑块仍是滑道中央一根 6px 的圆头细条。这里按后者做。
+
+       未激活态刻意保持 Fluent 原样:贴外边缘的 2px 细条,不显滑道、不显箭头。
+       两态之间靠 Thumb 的 Padding/CornerRadius 过渡(0.1s),不用 RenderTransform 缩放 ——
+       缩放会把圆角一并压扁成椭圆,而按边距布局能拿到真正的圆头。
+
+       几何(与 Fluent 的 ScrollBarSize=16 对齐,故不改变任何布局占位):
+         滑道 16 → 未激活滑块 2(贴外边缘)→ 展开滑块 6(居中,左右各留 5)。
+
+       尺寸与配色不是估的,是拿 Windows 11 深色滚动条的截图逐像素量的:
+         正文底 #191919 / 滑道 #171717 —— 滑道比正文【暗一两级】,只是一条凹槽的暗示,
+                                          不是一条更亮的带子(这一点最容易做反);
+         滑块 #959595,6px 宽,滑道共 17px(左 6 右 5 的留白,即居中);
+         箭头 #959595,约 6~7px 宽的实心细人字纹。
+       故本主题:滑道取比各深色面板底暗一格的 #232532,滑块/箭头取中性灰 #959595。 -->
+
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Dark">
+      <!-- 滑道底/滑块/箭头三支色是照着 Windows 11 深色滚动条逐像素取的(见文件头注释):
+           滑道并不比正文底更亮,而是【略暗一格】—— 参考图里正文 #191919、滑道 #171717,
+           差一两级,几乎只是一条"凹槽"的暗示;滑块与箭头则是中性灰 #959595。
+           这里的 #232532 相对侧栏 #252734、终端 #282A36 正好也是暗一格的关系。
+           不透明:滚动条是覆盖式的,半透明会让正文文字从滑道里透出来。 -->
+      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#232532" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFill" Color="#959595" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillPointerOver" Color="#B9B9B9" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillPressed" Color="#D6D6D6" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillDisabled" Color="#00000000" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFill" Color="#959595" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFillPointerOver" Color="#E8E8E8" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFillDisabled" Color="#5A5A5A" />
+      <SolidColorBrush x:Key="VelaScrollBarButtonBackgroundPointerOver" Color="#1AFFFFFF" />
+      <SolidColorBrush x:Key="VelaScrollBarButtonBackgroundPressed" Color="#2EFFFFFF" />
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="Light">
+      <!-- 浅色同理:滑道比正文底暗一格(Windows 浅色是白底 #FFFFFF 配 #F0F0F0 滑道),
+           滑块/箭头是中性灰。 -->
+      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#EDE7D0" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFill" Color="#8C8C8C" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillPointerOver" Color="#6B6B6B" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillPressed" Color="#4A4A4A" />
+      <SolidColorBrush x:Key="VelaScrollBarThumbFillDisabled" Color="#00000000" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFill" Color="#5D5D5D" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFillPointerOver" Color="#1F1F1F" />
+      <SolidColorBrush x:Key="VelaScrollBarArrowFillDisabled" Color="#AFAFAF" />
+      <SolidColorBrush x:Key="VelaScrollBarButtonBackgroundPointerOver" Color="#14000000" />
+      <SolidColorBrush x:Key="VelaScrollBarButtonBackgroundPressed" Color="#26000000" />
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
+
+  <!-- 滑道宽 = Fluent 的 ScrollBarSize,别改:终端回滚条等处按这个宽度扣了正文留白。 -->
+  <x:Double x:Key="VelaScrollBarSize">16</x:Double>
+  <!-- 箭头字形按参考图量的:约 6~7px 宽的小人字纹。
+       字形自带一套厚度合适的路径,没沿用 Fluent 那四条 —— 它们是给大尺寸画的发丝线
+       (20 单位宽里只有 1.2 单位粗),缩到 7px 后笔画不足半个像素,渲染出来是灰蒙蒙一团;
+       这里的路径按 8×5.6 的比例画,缩到 7px 正好落在 1px 上,和 Windows 一样是实心细纹。 -->
+  <x:Double x:Key="VelaScrollBarArrowSize">7</x:Double>
+  <StreamGeometry x:Key="VelaScrollBarArrowUp">M 0,6.4 L 4,2.4 L 8,6.4 L 8,4 L 4,0 L 0,4 Z</StreamGeometry>
+  <StreamGeometry x:Key="VelaScrollBarArrowDown">M 0,0 L 4,4 L 8,0 L 8,2.4 L 4,6.4 L 0,2.4 Z</StreamGeometry>
+  <StreamGeometry x:Key="VelaScrollBarArrowLeft">M 4,0 L 0,4 L 4,8 L 6.4,8 L 2.4,4 L 6.4,0 Z</StreamGeometry>
+  <StreamGeometry x:Key="VelaScrollBarArrowRight">M 4,0 L 8,4 L 4,8 L 1.6,8 L 5.6,4 L 1.6,0 Z</StreamGeometry>
+
+  <!-- 右键菜单沿用 Fluent 的文案资源(StringScrollBar*,随 FluentTheme 一起在册):
+       换主题不能顺手把 Windows 滚动条本来就有的"滚动到此处/上一页…"弄丢。 -->
+  <MenuFlyout x:Key="VelaVerticalScrollBarContextFlyout">
+    <MenuItem Header="{DynamicResource StringScrollBarScrollHere}" Command="{Binding $parent[ScrollBar].ScrollHere}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarTop}" Command="{Binding $parent[ScrollBar].ScrollToHome}" />
+    <MenuItem Header="{DynamicResource StringScrollBarBottom}" Command="{Binding $parent[ScrollBar].ScrollToEnd}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarPageUp}" Command="{Binding $parent[ScrollBar].PageUp}" />
+    <MenuItem Header="{DynamicResource StringScrollBarPageDown}" Command="{Binding $parent[ScrollBar].PageDown}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarScrollUp}" Command="{Binding $parent[ScrollBar].LineUp}" />
+    <MenuItem Header="{DynamicResource StringScrollBarScrollDown}" Command="{Binding $parent[ScrollBar].LineDown}" />
+  </MenuFlyout>
+
+  <MenuFlyout x:Key="VelaHorizontalScrollBarContextFlyout">
+    <MenuItem Header="{DynamicResource StringScrollBarScrollHere}" Command="{Binding $parent[ScrollBar].ScrollHere}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarLeftEdge}" Command="{Binding $parent[ScrollBar].ScrollToHome}" />
+    <MenuItem Header="{DynamicResource StringScrollBarRightEdge}" Command="{Binding $parent[ScrollBar].ScrollToEnd}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarPageLeft}" Command="{Binding $parent[ScrollBar].PageLeft}" />
+    <MenuItem Header="{DynamicResource StringScrollBarPageRight}" Command="{Binding $parent[ScrollBar].PageRight}" />
+    <Separator />
+    <MenuItem Header="{DynamicResource StringScrollBarScrollLeft}" Command="{Binding $parent[ScrollBar].LineLeft}" />
+    <MenuItem Header="{DynamicResource StringScrollBarScrollRight}" Command="{Binding $parent[ScrollBar].LineRight}" />
+  </MenuFlyout>
+
+  <!-- 滑块:控件本身始终占满 16px 滑道(抓取区不缩水,和 Windows 一样好抓),
+       可见的那根条子是模板里的 Border,用 Padding 当内缩边距决定它的粗细与位置。
+       粗细/圆角都由 ScrollBar 主题按展开态改写,过渡在这里挂。 -->
+  <ControlTheme x:Key="VelaScrollBarThumb" TargetType="Thumb">
+    <Setter Property="Background" Value="{DynamicResource VelaScrollBarThumbFill}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Margin="{TemplateBinding Padding}" />
+      </ControlTemplate>
+    </Setter>
+    <Setter Property="Transitions">
+      <Transitions>
+        <ThicknessTransition Property="Padding" Duration="0:0:0.1" />
+        <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.1" />
+        <BrushTransition Property="Background" Duration="0:0:0.1" />
+      </Transitions>
+    </Setter>
+
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaScrollBarThumbFillPointerOver}" />
+    </Style>
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="{DynamicResource VelaScrollBarThumbFillPressed}" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="{DynamicResource VelaScrollBarThumbFillDisabled}" />
+    </Style>
+  </ControlTheme>
+
+  <!-- 翻页区(滑块两侧的空白):只负责点击翻页,永远不画东西。 -->
+  <ControlTheme x:Key="VelaScrollBarPageButton" TargetType="RepeatButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}" />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <!-- 两端的箭头按钮:未激活态整体隐形(Opacity 0),展开时随滑道一起淡入。 -->
+  <ControlTheme x:Key="VelaScrollBarLineButton" TargetType="RepeatButton">
+    <Setter Property="Opacity" Value="0" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource VelaScrollBarArrowFill}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
+      </Transitions>
+    </Setter>
+
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaScrollBarButtonBackgroundPointerOver}" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource VelaScrollBarArrowFillPointerOver}" />
+    </Style>
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="{DynamicResource VelaScrollBarButtonBackgroundPressed}" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource VelaScrollBarArrowFillPointerOver}" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource VelaScrollBarArrowFillDisabled}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type ScrollBar}" TargetType="ScrollBar">
+    <Setter Property="MinWidth" Value="{DynamicResource VelaScrollBarSize}" />
+    <Setter Property="MinHeight" Value="{DynamicResource VelaScrollBarSize}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+
+    <Style Selector="^:vertical">
+      <Setter Property="ContextFlyout" Value="{StaticResource VelaVerticalScrollBarContextFlyout}" />
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Grid x:Name="Root">
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}">
+              <Grid RowDefinitions="Auto,*,Auto">
+                <Rectangle x:Name="TrackRect"
+                           Fill="{DynamicResource VelaScrollBarTrackFill}"
+                           Opacity="0"
+                           Grid.RowSpan="3">
+                  <Rectangle.Transitions>
+                    <Transitions>
+                      <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
+                    </Transitions>
+                  </Rectangle.Transitions>
+                </Rectangle>
+
+                <RepeatButton Name="PART_LineUpButton"
+                              Theme="{StaticResource VelaScrollBarLineButton}"
+                              Grid.Row="0"
+                              Focusable="False"
+                              MinWidth="{DynamicResource VelaScrollBarSize}"
+                              Height="{DynamicResource VelaScrollBarSize}"
+                              AutomationProperties.Name="Line up">
+                  <PathIcon Data="{StaticResource VelaScrollBarArrowUp}"
+                            Width="{DynamicResource VelaScrollBarArrowSize}"
+                            Height="{DynamicResource VelaScrollBarArrowSize}" />
+                </RepeatButton>
+
+                <Track Grid.Row="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}"
+                       IsDirectionReversed="True">
+                  <Track.DecreaseButton>
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource VelaScrollBarPageButton}"
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page up" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource VelaScrollBarPageButton}"
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page down" />
+                  </Track.IncreaseButton>
+                  <!-- 未激活:右边缘 2px 细条(16 − 14 内缩);展开态在下面的样式里改写。 -->
+                  <Thumb Theme="{StaticResource VelaScrollBarThumb}"
+                         Width="{DynamicResource VelaScrollBarSize}"
+                         MinHeight="{DynamicResource VelaScrollBarSize}"
+                         Padding="14,0,0,0"
+                         CornerRadius="1"
+                         AutomationProperties.Name="Position" />
+                </Track>
+
+                <RepeatButton Name="PART_LineDownButton"
+                              Theme="{StaticResource VelaScrollBarLineButton}"
+                              Grid.Row="2"
+                              Focusable="False"
+                              MinWidth="{DynamicResource VelaScrollBarSize}"
+                              Height="{DynamicResource VelaScrollBarSize}"
+                              AutomationProperties.Name="Line down">
+                  <PathIcon Data="{StaticResource VelaScrollBarArrowDown}"
+                            Width="{DynamicResource VelaScrollBarArrowSize}"
+                            Height="{DynamicResource VelaScrollBarArrowSize}" />
+                </RepeatButton>
+              </Grid>
+            </Border>
+          </Grid>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:horizontal">
+      <Setter Property="ContextFlyout" Value="{StaticResource VelaHorizontalScrollBarContextFlyout}" />
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Grid x:Name="Root">
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}">
+              <Grid ColumnDefinitions="Auto,*,Auto">
+                <Rectangle x:Name="TrackRect"
+                           Fill="{DynamicResource VelaScrollBarTrackFill}"
+                           Opacity="0"
+                           Grid.ColumnSpan="3">
+                  <Rectangle.Transitions>
+                    <Transitions>
+                      <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
+                    </Transitions>
+                  </Rectangle.Transitions>
+                </Rectangle>
+
+                <RepeatButton Name="PART_LineUpButton"
+                              Theme="{StaticResource VelaScrollBarLineButton}"
+                              Grid.Column="0"
+                              Focusable="False"
+                              MinHeight="{DynamicResource VelaScrollBarSize}"
+                              Width="{DynamicResource VelaScrollBarSize}"
+                              AutomationProperties.Name="Column left">
+                  <PathIcon Data="{StaticResource VelaScrollBarArrowLeft}"
+                            Width="{DynamicResource VelaScrollBarArrowSize}"
+                            Height="{DynamicResource VelaScrollBarArrowSize}" />
+                </RepeatButton>
+
+                <Track Grid.Column="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}">
+                  <Track.DecreaseButton>
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource VelaScrollBarPageButton}"
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page left" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource VelaScrollBarPageButton}"
+                                  Focusable="False"
+                                  AutomationProperties.Name="Page right" />
+                  </Track.IncreaseButton>
+                  <!-- 未激活:下边缘 2px 细条;展开态在下面的样式里改写。 -->
+                  <Thumb Theme="{StaticResource VelaScrollBarThumb}"
+                         Height="{DynamicResource VelaScrollBarSize}"
+                         MinWidth="{DynamicResource VelaScrollBarSize}"
+                         Padding="0,14,0,0"
+                         CornerRadius="1"
+                         AutomationProperties.Name="Position" />
+                </Track>
+
+                <RepeatButton Name="PART_LineDownButton"
+                              Theme="{StaticResource VelaScrollBarLineButton}"
+                              Grid.Column="2"
+                              Focusable="False"
+                              MinHeight="{DynamicResource VelaScrollBarSize}"
+                              Width="{DynamicResource VelaScrollBarSize}"
+                              AutomationProperties.Name="Column right">
+                  <PathIcon Data="{StaticResource VelaScrollBarArrowRight}"
+                            Width="{DynamicResource VelaScrollBarArrowSize}"
+                            Height="{DynamicResource VelaScrollBarArrowSize}" />
+                </RepeatButton>
+              </Grid>
+            </Border>
+          </Grid>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <!-- 展开态(鼠标移到滚动条上/正在拖动):滑道淡入、两端箭头淡入,
+         滑块从贴边 2px 细条变成滑道中央 6px 的圆头条 —— 就是 Windows 的那套。
+         这三条选择器都带激活条件(StyleTrigger 优先级),故能改写模板里内联的默认值。 -->
+    <Style Selector="^[IsExpanded=true] /template/ Rectangle#TrackRect">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="^[IsExpanded=true] /template/ RepeatButton">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="^:vertical[IsExpanded=true] /template/ Thumb">
+      <Setter Property="Padding" Value="5,0" />
+      <Setter Property="CornerRadius" Value="3" />
+    </Style>
+    <Style Selector="^:horizontal[IsExpanded=true] /template/ Thumb">
+      <Setter Property="Padding" Value="0,5" />
+      <Setter Property="CornerRadius" Value="3" />
+    </Style>
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/tests/VelaShell.Tests/Views/ScrollBarStyleTests.cs
+++ b/tests/VelaShell.Tests/Views/ScrollBarStyleTests.cs
@@ -1,0 +1,133 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Headless;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 滚动条的两态方案(Themes/ScrollBarThemes.axaml):未激活 = 贴边细条,悬停展开 = Windows 那套
+/// (滑道 + 两端箭头 + 居中的圆头细滑块),而不是 Fluent 那样把滑块铺满整条滑道。
+/// </summary>
+/// <remarks>
+/// 钉的是【方案】:滑块在两态下的粗细与落位、展开时箭头/滑道要现身。具体像素(16/2/6)写在
+/// 主题里,由眼睛拍板;这里只保证"展开后滑块比滑道窄、且左右对称居中",这正是 Fluent 默认
+/// 主题不满足、也是本次改动的全部目的 —— 换 Avalonia 版本后若模板被顶回默认,这组测试会红。
+///
+/// 展开态用 AllowAutoHide=false 触发(ScrollBar.UpdateIsExpandedState:不许自动隐藏就是常驻展开),
+/// 不模拟指针:Show 之前设好,值就是直接落定的,不会被 0.1s 过渡动画拖成中间值。
+/// </remarks>
+[TestClass]
+[TestCategory("ScrollBarStyle")]
+public sealed class ScrollBarStyleTests
+{
+    /// <summary>滑道宽度(= 主题里的 VelaScrollBarSize)。</summary>
+    private const double BarSize = 16;
+
+    private static HeadlessUnitTestSession _session = null!;
+
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App。
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(ScrollBarStyleTests).Assembly);
+
+    [TestMethod]
+    public void Collapsed_KeepsTheThinLineHuggingTheOuterEdge()
+    {
+        OnUi(() =>
+        {
+            WithScrollBar(Orientation.Vertical, allowAutoHide: true, (bar, thumb) =>
+            {
+                Assert.IsFalse(bar.IsExpanded);
+                // 竖条:左侧内缩 14,只剩右边缘 2px —— 与 Fluent 未激活态一致,这一态刻意不动。
+                Assert.AreEqual(new Thickness(14, 0, 0, 0), thumb.Padding);
+                Assert.IsTrue(ArrowsAndTrack(bar).All(part => part.Opacity == 0),
+                    "未激活态不该露出滑道和两端箭头");
+            });
+
+            WithScrollBar(Orientation.Horizontal, allowAutoHide: true, (_, thumb) =>
+                // 横条:上方内缩 14,细条贴在下边缘。
+                Assert.AreEqual(new Thickness(0, 14, 0, 0), thumb.Padding));
+        });
+    }
+
+    [TestMethod]
+    public void Expanded_ShowsTrackAndArrowsWithACenteredSlimThumb()
+    {
+        OnUi(() =>
+        {
+            WithScrollBar(Orientation.Vertical, allowAutoHide: false, (bar, thumb) =>
+            {
+                Assert.IsTrue(bar.IsExpanded);
+                Assert.IsTrue(ArrowsAndTrack(bar).All(part => part.Opacity == 1),
+                    "展开态要显出滑道与两端箭头(Windows 资源管理器的那套)");
+
+                // 滑块比滑道窄、且左右等宽 —— Fluent 默认是铺满(左右内缩都是 0),那正是要改掉的。
+                Assert.AreEqual(thumb.Padding.Left, thumb.Padding.Right, "展开后的滑块没居中");
+                Assert.IsGreaterThan(0, thumb.Padding.Left, "展开后的滑块仍铺满滑道");
+                Assert.IsLessThan(BarSize / 2, ThumbVisualThickness(thumb, Orientation.Vertical),
+                    "展开后的滑块该明显比滑道细");
+                // 圆头,不是方块。
+                Assert.IsGreaterThan(0, thumb.CornerRadius.TopLeft);
+            });
+
+            WithScrollBar(Orientation.Horizontal, allowAutoHide: false, (_, thumb) =>
+            {
+                Assert.AreEqual(thumb.Padding.Top, thumb.Padding.Bottom, "展开后的滑块没居中");
+                Assert.IsGreaterThan(0, thumb.Padding.Top, "展开后的滑块仍铺满滑道");
+                Assert.IsLessThan(BarSize / 2, ThumbVisualThickness(thumb, Orientation.Horizontal),
+                    "展开后的滑块该明显比滑道细");
+            });
+        });
+    }
+
+    /// <summary>滑块上真正被画出来的那根条子的粗细(模板里的 Border 按 Padding 内缩后剩下的)。</summary>
+    private static double ThumbVisualThickness(Thumb thumb, Orientation orientation) =>
+        orientation == Orientation.Vertical
+            ? BarSize - thumb.Padding.Left - thumb.Padding.Right
+            : BarSize - thumb.Padding.Top - thumb.Padding.Bottom;
+
+    /// <summary>展开时该一起淡入的部件:滑道底 + 两端箭头按钮。</summary>
+    private static IEnumerable<Visual> ArrowsAndTrack(ScrollBar bar) =>
+        bar.GetVisualDescendants()
+           .Where(v => v is Shape { Name: "TrackRect" }
+               or RepeatButton { Name: "PART_LineUpButton" or "PART_LineDownButton" });
+
+    /// <summary>把一条滚动条挂进窗口跑完布局,交给断言;收尾一律关窗。</summary>
+    private static void WithScrollBar(Orientation orientation, bool allowAutoHide, Action<ScrollBar, Thumb> body)
+    {
+        var bar = new ScrollBar
+        {
+            Orientation = orientation,
+            AllowAutoHide = allowAutoHide,
+            Minimum = 0,
+            Maximum = 100,
+            ViewportSize = 10,
+        };
+        var window = new Window { Width = 200, Height = 200, Content = bar };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            body(bar, bar.GetVisualDescendants().OfType<Thumb>().Single());
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(
+            () =>
+            {
+                body();
+                return Task.CompletedTask;
+            },
+            CancellationToken.None
+        ).GetAwaiter().GetResult();
+}

--- a/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
+++ b/tests/VelaShell.Tests/Views/VelaHeadlessApp.cs
@@ -31,6 +31,8 @@ public class VelaHeadlessApp : Application
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/VelaShellTokens.axaml"));
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell.Controls/Themes/Icons.axaml"));
         Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell/Themes/ButtonThemes.axaml"));
+        // 滚动条控件主题:覆盖 Fluent 的 {x:Type ScrollBar},必须在 Resources 里(查找先于 Styles)。
+        Resources.MergedDictionaries.Add(LoadDictionary("avares://VelaShell/Themes/ScrollBarThemes.axaml"));
         // App.axaml 的 ThemeDictionaries:终端调色板(VelaShell*)与资源图表的色阶都在这里,
         // 漏掉它测试里这些画刷全是 null —— 曲线画不出来还一路绿。
         Resources.ThemeDictionaries[ThemeVariant.Dark] = Wrap("avares://VelaShell/Themes/DarkTheme.axaml");


### PR DESCRIPTION
全局替换滚动条样式，统一为 Windows 11 资源管理器风格，支持深浅色、动画过渡、自定义箭头几何，保留 Fluent 右键菜单。新增自动化测试，验证滚动条视觉布局与状态切换，防止主题回退导致的视觉回归。