### PR TITLE
升级输入框为 AvaloniaEdit，支持 Markdown 高亮与文件引用

### DIFF
--- a/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteFs.cs
+++ b/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteFs.cs
@@ -67,10 +67,18 @@ public sealed class FakeRemoteFs : IRemoteFsApi
             : null;
     }
 
+    /// <summary>
+    /// <see cref="ListDirectoryAsync" /> 至今被调用了多少次。
+    /// 列目录在真实环境里是一次 SFTP 往返,"敲一个字符列一次"就是卡顿的来源,
+    /// 因此凡是靠缓存/防抖压请求数的功能(如 AI 面板的 <c>@</c> 补全)都拿它来钉行为。
+    /// </summary>
+    public int ListDirectoryCalls { get; private set; }
+
     /// <inheritdoc />
     public Task<IReadOnlyList<RemoteFileEntry>> ListDirectoryAsync(string sessionId, string path,
         CancellationToken cancellationToken = default)
     {
+        ListDirectoryCalls++;
         string normalized = Normalize(path);
         if (StatCore(sessionId, normalized) is not { IsDirectory: true })
         {

--- a/plugins/VelaShell.Plugin.Ai/Chat/FileReference.cs
+++ b/plugins/VelaShell.Plugin.Ai/Chat/FileReference.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace VelaShell.Plugin.Ai.Chat;
 
 /// <summary>
@@ -59,6 +61,153 @@ public static class FileReference
         return true;
     }
 
+    /// <summary>
+    /// 找紧挨着光标【左侧】的那条<b>已完成</b>引用(补全落定后的形态),把它整条当一个不可分的
+    /// "文件块"看待 —— 退格一次删掉整块,而不是一个字符一个字符地啃。
+    /// </summary>
+    /// <remarks>
+    /// 这正是 Claude Code / OpenCode 里选中文件后显示成一枚芯片的交互:块是原子的。
+    /// 除了顺手,它还直接决定性能:啃字符会让每一次退格都变成一次新的 <c>@</c> 目录列举
+    /// (每次都要发 SFTP 请求、并取消上一次),长路径退格因此又卡又刷屏。
+    ///
+    /// "已完成"的判据只有两种形态,和 <c>AcceptCandidate</c> 落笔的形态一一对应:
+    /// <list type="bullet">
+    ///   <item>带闭合引号:<c>@"/var/log/sys log"</c>(可再跟一个尾空格)</item>
+    ///   <item>不带引号、以一个尾空格收尾:<c>@/var/log/syslog␣</c></item>
+    /// </list>
+    /// 还在敲、尚未落定的 token(既没闭引号也没尾空格)不算块 —— 那时退格照常一个字符,
+    /// 用户正在改自己刚打错的那几位。路径同样必须以 <c>/</c> 或 <c>~</c> 开头,
+    /// 于是 <c>@某人 </c> 这类提及不会被整段吞掉。
+    /// </remarks>
+    /// <param name="text">输入框全文。</param>
+    /// <param name="caret">光标位置(块的右边界)。</param>
+    /// <param name="start">块在全文中的起始下标(<c>@</c> 所在处)。</param>
+    /// <returns>光标左侧是否正好是一条已完成引用。</returns>
+    public static bool TryFindCompletedReferenceBefore(string text, int caret, out int start)
+    {
+        start = -1;
+        caret = Math.Clamp(caret, 0, text.Length);
+        // 尾空格属于这块(补全文件时是自动补上的),连它一起删,免得留下一个孤零零的空格
+        int end = caret;
+        bool closedBySpace = end > 0 && text[end - 1] == ' ';
+        if (closedBySpace)
+        {
+            end--;
+        }
+        if (end <= 0)
+        {
+            return false;
+        }
+        bool quoted = text[end - 1] == '"';
+        if (!quoted && !closedBySpace)
+        {
+            return false; // 没闭引号也没收尾空格 = 还在敲这条引用,退格照常一个字符
+        }
+        int scanFrom = quoted ? end - 2 : end - 1;
+        for (int i = scanFrom; i >= 0; i--)
+        {
+            char c = text[i];
+            if (c == '\n')
+            {
+                return false;
+            }
+            if (quoted)
+            {
+                // 引号形态:一路回扫到开引号 @" 为止,中间允许空格
+                if (c == '"')
+                {
+                    return i >= 1 && text[i - 1] == '@' && IsReferenceStart(text, i - 1)
+                        && Accept(text, i - 1, i + 1, end - 1, ref start);
+                }
+                continue;
+            }
+            if (c == '@')
+            {
+                return IsReferenceStart(text, i) && Accept(text, i, i + 1, end, ref start);
+            }
+            if (IsTokenBreak(c))
+            {
+                return false; // 未加引号的路径里不允许空白:那就不是一条引用
+            }
+        }
+        return false;
+
+        // 路径本体(pathStart..pathEnd)必须是绝对路径或 ~ 开头,否则不认
+        static bool Accept(string text, int at, int pathStart, int pathEnd, ref int start)
+        {
+            if (pathEnd <= pathStart)
+            {
+                return false;
+            }
+            char first = text[pathStart];
+            if (first is not ('/' or '~'))
+            {
+                return false;
+            }
+            start = at;
+            return true;
+        }
+    }
+
+    /// <summary><c>@</c> 只有在行首或空白之后才起头一条引用(邮箱、@某人 里的 @ 不算)。</summary>
+    private static bool IsReferenceStart(string text, int at) => at == 0 || char.IsWhiteSpace(text[at - 1]);
+
+    /// <summary>
+    /// <paramref name="index" /> 处是否<b>正好起头</b>一条已完成引用;供输入框把它整段画成一枚芯片。
+    /// </summary>
+    /// <remarks>
+    /// 判据与 <see cref="TryFindCompletedReferenceBefore" /> 同源(闭合引号,或以空白收尾),
+    /// 于是"画成芯片的"和"退格整块删掉的"永远是同一段文字 —— 看得见什么就删掉什么。
+    /// 差别只有一处:<paramref name="length" /> <b>不含</b>那个收尾空白,空格仍是普通文本,
+    /// 光标可以正常停在芯片后面。
+    /// </remarks>
+    /// <param name="text">全文。</param>
+    /// <param name="index">待判定的位置(应当是 <c>@</c>)。</param>
+    /// <param name="length">引用本体长度(<c>@</c> 起,含闭引号,不含收尾空白)。</param>
+    /// <param name="path">引用到的远端路径(不含引号)。</param>
+    public static bool TryFindCompletedReferenceAt(string text, int index, out int length, out string path)
+    {
+        length = 0;
+        path = "";
+        if (index < 0 || index >= text.Length || text[index] != '@' || !IsReferenceStart(text, index))
+        {
+            return false;
+        }
+        int bodyStart = index + 1;
+        int end;
+        if (bodyStart < text.Length && text[bodyStart] == '"')
+        {
+            int close = text.IndexOf('"', bodyStart + 1);
+            if (close < 0)
+            {
+                return false; // 引号还没闭合 = 还在敲
+            }
+            path = text[(bodyStart + 1)..close];
+            end = close + 1;
+        }
+        else
+        {
+            int scan = bodyStart;
+            while (scan < text.Length && !IsTokenBreak(text[scan]))
+            {
+                scan++;
+            }
+            // 未加引号者靠一个收尾空白判定落定;直抵文末说明用户还在敲这一条
+            if (scan >= text.Length || !char.IsWhiteSpace(text[scan]))
+            {
+                return false;
+            }
+            path = text[bodyStart..scan];
+            end = scan;
+        }
+        if (path.Length == 0 || (!path.StartsWith('/') && !path.StartsWith('~')))
+        {
+            return false;
+        }
+        length = end - index;
+        return true;
+    }
+
     /// <summary>把 token 拆成「要列的目录」与「过滤词」;<c>~</c> 与相对路径按工作目录展开。</summary>
     public static (string Directory, string Filter) Split(string token, string workingDirectory)
     {
@@ -117,6 +266,43 @@ public static class FileReference
             }
         }
         return paths;
+    }
+
+    /// <summary>
+    /// 引用在界面上显示的短名:路径末段(目录保留结尾的 <c>/</c>)。
+    /// 输入框里的芯片与消息气泡里的引用都用它,两处看到的必须是同一个名字。
+    /// </summary>
+    public static string DisplayName(string path)
+    {
+        string trimmed = path.TrimEnd('/');
+        if (trimmed.Length == 0)
+        {
+            return "/"; // 根目录:没有末段可取,也别再补一道斜杠
+        }
+        int slash = trimmed.LastIndexOf('/');
+        string name = slash < 0 ? trimmed : trimmed[(slash + 1)..];
+        return path.EndsWith('/') ? name + "/" : name;
+    }
+
+    /// <summary>
+    /// 把文本里每条<b>已完成</b>引用的长路径换成短名(<c>@/root/abc.txt</c> → <c>@abc.txt</c>),
+    /// 供消息气泡显示 —— 用户在输入框里看到的就是短名,发出去后不该突然变回长路径。
+    /// </summary>
+    /// <remarks>送给模型的那份文本不走这里:模型需要完整路径。</remarks>
+    public static string Shorten(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '@' && TryFindCompletedReferenceAt(text, i, out int length, out string path))
+            {
+                builder.Append('@').Append(DisplayName(path));
+                i += length - 1;
+                continue;
+            }
+            builder.Append(text[i]);
+        }
+        return builder.ToString();
     }
 
     /// <summary><c>~</c> 展开为工作目录。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.FilePicker.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.FilePicker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls;
@@ -25,11 +26,40 @@ public partial class ChatPanelView
     /// <summary>候选列表最多显示多少条。</summary>
     private const int MaxCandidates = 50;
 
+    /// <summary>连打时先攒一下再列目录(毫秒):一次停顿只发一次 SFTP 请求。</summary>
+    private const int PickerDebounceMs = 180;
+
+    /// <summary>目录列举结果的缓存寿命(毫秒):够一次连续补全用,又不至于一直看着旧目录。</summary>
+    private const long DirectoryCacheTtlMs = 5000;
+
+    /// <summary>缓存的目录数上限(超了整体清空:补全过程只会用到最近那几个目录)。</summary>
+    private const int MaxCachedDirectories = 32;
+
     private readonly List<RemoteFileEntry> _fileCandidates = [];
+
+    /// <summary>目录列举缓存,键 = 会话 + 目录。仅用于补全期间的过滤,带 TTL。</summary>
+    private readonly Dictionary<(string Session, string Directory), (IReadOnlyList<RemoteFileEntry> Entries, long At)>
+        _directoryCache = [];
+
     private int _fileIndex;
     private int _fileTokenStart = -1;
     private bool _pickerSuspended;
+
+    /// <summary>
+    /// 面板生命周期内唯一的取消源:只在 <see cref="Detach" />(面板真的关了)时取消。
+    /// </summary>
+    /// <remarks>
+    /// 曾经这里是"每敲一个键就取消上一次、另起一个",于是长路径退格时每个字符都要取消一次
+    /// 正在飞的 SFTP 列目录 —— 一次取消要沿十来层异步栈回卷,既刷屏(调试器里每层报一次
+    /// first-chance 异常)又实打实地卡输入。现在改为【代次判废】:新请求只把
+    /// <see cref="_pickerGeneration" /> 加一,旧请求跑完自己发现过期就安静丢弃结果
+    /// (结果仍进缓存,不浪费),不再互相取消。
+    /// </remarks>
     private CancellationTokenSource? _fileCts;
+
+    /// <summary>补全请求代次:只有最新一次的结果准许上屏。</summary>
+    private int _pickerGeneration;
+
     private string? _cwdSessionId;
     private string _cwd = "";
 
@@ -44,10 +74,13 @@ public partial class ChatPanelView
     }
 
     /// <summary>按光标处的 <c>@token</c> 刷新候选列表;不在引用里就收起弹层。</summary>
-    private async Task UpdateFilePickerAsync()
+    /// <param name="immediate">
+    /// 跳过防抖:补全落定后继续下钻目录时用 —— 那是一次明确的用户动作,不该再等一拍。
+    /// </param>
+    private async Task UpdateFilePickerAsync(bool immediate = false)
     {
         string text = InputBox.Text ?? "";
-        int caret = Math.Clamp(InputBox.CaretIndex, 0, text.Length);
+        int caret = Math.Clamp(InputBox.CaretOffset, 0, text.Length);
         if (!FileReference.TryFindToken(text, caret, out int start, out _, out string reference))
         {
             CloseFilePicker();
@@ -59,41 +92,93 @@ public partial class ChatPanelView
             return;
         }
         _fileTokenStart = start;
+        int generation = ++_pickerGeneration;
 
-        _fileCts?.Cancel();
-        _fileCts?.Dispose();
-        _fileCts = new();
+        _fileCts ??= new();
         CancellationToken cancellationToken = _fileCts.Token;
         try
         {
             string cwd = await ResolveWorkingDirectoryAsync(sessionId, cancellationToken);
             (string directory, string filter) = FileReference.Split(reference, cwd);
-            IReadOnlyList<RemoteFileEntry> entries = await _context.RemoteFs
-                .ListDirectoryAsync(sessionId, directory, cancellationToken);
-            if (cancellationToken.IsCancellationRequested)
+
+            // 只是过滤词变了(用户在同一个目录里接着敲文件名)——缓存里就有,本地筛,不碰网络。
+            if (TryGetCachedEntries(sessionId, directory, out IReadOnlyList<RemoteFileEntry>? cached))
             {
+                ShowCandidates(cached, filter, directory);
                 return;
             }
-            _fileCandidates.Clear();
-            _fileCandidates.AddRange(entries
-                .Where(e => filter.Length == 0 || e.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
-                .OrderByDescending(e => e.IsDirectory)
-                .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
-                .Take(MaxCandidates));
-            _fileIndex = 0;
-            RenderFileCandidates(directory);
+            if (!immediate)
+            {
+                // 防抖:连打时每一键都会走到这儿,但只有最后一键能过下面这道代次检查。
+                await Task.Delay(PickerDebounceMs);
+                if (generation != _pickerGeneration)
+                {
+                    return;
+                }
+            }
+            IReadOnlyList<RemoteFileEntry> entries = await _context.RemoteFs
+                .ListDirectoryAsync(sessionId, directory, cancellationToken);
+            CacheEntries(sessionId, directory, entries);
+            if (generation != _pickerGeneration)
+            {
+                return; // 已被后来的输入顶掉:结果留在缓存里,但不上屏
+            }
+            ShowCandidates(entries, filter, directory);
         }
         catch (OperationCanceledException)
         {
-            // 输入还在继续,这次列目录作废
+            // 面板已关闭(Detach):这次列目录作废
         }
         catch (Exception ex)
         {
+            if (generation != _pickerGeneration)
+            {
+                return;
+            }
             _fileCandidates.Clear();
             FileList.Children.Clear();
             FilePopupHeader.Text = $"{_loc["Error"]}: {ex.Message}";
             FilePopup.IsOpen = true;
         }
+    }
+
+    /// <summary>按过滤词筛出候选并上屏(目录在前、同类按名排)。</summary>
+    private void ShowCandidates(IReadOnlyList<RemoteFileEntry> entries, string filter, string directory)
+    {
+        _fileCandidates.Clear();
+        _fileCandidates.AddRange(entries
+            .Where(e => filter.Length == 0 || e.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(e => e.IsDirectory)
+            .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(MaxCandidates));
+        _fileIndex = 0;
+        RenderFileCandidates(directory);
+    }
+
+    private bool TryGetCachedEntries(string sessionId, string directory,
+        [NotNullWhen(true)] out IReadOnlyList<RemoteFileEntry>? entries)
+    {
+        entries = null;
+        if (!_directoryCache.TryGetValue((sessionId, directory), out (IReadOnlyList<RemoteFileEntry> Entries, long At) hit))
+        {
+            return false;
+        }
+        if (Environment.TickCount64 - hit.At > DirectoryCacheTtlMs)
+        {
+            _directoryCache.Remove((sessionId, directory));
+            return false;
+        }
+        entries = hit.Entries;
+        return true;
+    }
+
+    private void CacheEntries(string sessionId, string directory, IReadOnlyList<RemoteFileEntry> entries)
+    {
+        if (_directoryCache.Count >= MaxCachedDirectories)
+        {
+            _directoryCache.Clear();
+        }
+        _directoryCache[(sessionId, directory)] = (entries, Environment.TickCount64);
     }
 
     private void RenderFileCandidates(string directory)
@@ -108,9 +193,9 @@ public partial class ChatPanelView
         }
         FilePopup.IsOpen = true;
         // 弹层不接管键盘:万一它抢到了焦点,立刻还给输入框,否则用户就打不了字了
-        if (!InputBox.IsFocused)
+        if (!InputBox.TextArea.IsFocused)
         {
-            InputBox.Focus();
+            InputBox.TextArea.Focus();
         }
         HighlightCandidate();
     }
@@ -210,7 +295,7 @@ public partial class ChatPanelView
         }
         RemoteFileEntry entry = _fileCandidates[index];
         string text = InputBox.Text ?? "";
-        int caret = Math.Clamp(InputBox.CaretIndex, 0, text.Length);
+        int caret = Math.Clamp(InputBox.CaretOffset, 0, text.Length);
         if (_fileTokenStart >= caret)
         {
             return;
@@ -225,7 +310,7 @@ public partial class ChatPanelView
         try
         {
             InputBox.Text = string.Concat(text.AsSpan(0, _fileTokenStart), replacement, text.AsSpan(caret));
-            InputBox.CaretIndex = _fileTokenStart + replacement.Length;
+            InputBox.CaretOffset = _fileTokenStart + replacement.Length;
         }
         finally
         {
@@ -233,7 +318,7 @@ public partial class ChatPanelView
         }
         if (entry.IsDirectory)
         {
-            _ = UpdateFilePickerAsync(); // 继续下钻
+            _ = UpdateFilePickerAsync(immediate: true); // 继续下钻:用户刚点了确认,别再等防抖
         }
         else
         {
@@ -241,12 +326,94 @@ public partial class ChatPanelView
         }
     }
 
+    /// <summary>
+    /// 收起弹层。只判废在飞的补全请求(代次加一),<b>不</b>取消 <see cref="_fileCts" /> ——
+    /// 那是面板级的,取消掉后面就没得用了;况且每敲一个非引用字符都会走到这里。
+    /// </summary>
     private void CloseFilePicker()
     {
-        _fileCts?.Cancel();
+        _pickerGeneration++;
         FilePopup.IsOpen = false;
         _fileCandidates.Clear();
         _fileTokenStart = -1;
+    }
+
+    /// <summary>
+    /// 退格/删除键落在一条<b>已完成</b>的 <c>@</c> 引用边上时,整块一起删。
+    /// 返回 true 表示这次按键已被接管。
+    /// </summary>
+    /// <remarks>
+    /// 选中的文件在输入框里是一整块(Claude Code / OpenCode 里那枚芯片的等价物),
+    /// 删就整块删:一次退格 = 一次补全刷新(而且刷新后已不在引用里,连目录都不用列),
+    /// 而不是像以前那样一个字符一次、每次都发一趟 SFTP。
+    /// </remarks>
+    private bool HandleReferenceBlockDelete(KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Back or Key.Delete) || e.KeyModifiers != KeyModifiers.None)
+        {
+            return false;
+        }
+        string text = InputBox.Text ?? "";
+        if (text.Length == 0 || InputBox.SelectionLength > 0)
+        {
+            return false; // 有选区时按常规删选区
+        }
+        int caret = Math.Clamp(InputBox.CaretOffset, 0, text.Length);
+        int start, end;
+        if (e.Key == Key.Back)
+        {
+            if (!FileReference.TryFindCompletedReferenceBefore(text, caret, out start))
+            {
+                return false;
+            }
+            end = caret;
+        }
+        else
+        {
+            // 前向删除:光标停在块左边时同样整块删(与退格对称)
+            int blockEnd = FindCompletedReferenceEnd(text, caret);
+            if (blockEnd < 0)
+            {
+                return false;
+            }
+            start = caret;
+            end = blockEnd;
+        }
+        _pickerSuspended = true;
+        try
+        {
+            InputBox.Text = string.Concat(text.AsSpan(0, start), text.AsSpan(end));
+            InputBox.CaretOffset = start;
+        }
+        finally
+        {
+            _pickerSuspended = false;
+        }
+        CloseFilePicker();
+        e.Handled = true;
+        return true;
+    }
+
+    /// <summary>光标处若正好起头一条已完成引用,返回它的右边界(含尾空格);否则 -1。</summary>
+    private static int FindCompletedReferenceEnd(string text, int caret)
+    {
+        if (caret >= text.Length || text[caret] != '@')
+        {
+            return -1;
+        }
+        for (int end = caret + 1; end <= text.Length; end++)
+        {
+            if (FileReference.TryFindCompletedReferenceBefore(text, end, out int start) && start == caret)
+            {
+                // 引号形态先在闭引号处就命中,尾空格属于这块,一并带走
+                return end < text.Length && text[end] == ' ' ? end + 1 : end;
+            }
+            if (end < text.Length && text[end] == '\n')
+            {
+                return -1;
+            }
+        }
+        return -1;
     }
 
     private async Task<string> ResolveWorkingDirectoryAsync(string sessionId, CancellationToken cancellationToken)
@@ -271,23 +438,29 @@ public partial class ChatPanelView
 
     /// <summary>
     /// 把消息里 <c>@</c> 引用的文件读出来附在消息后面(给模型看的那一份)。
-    /// 返回展开后的文本与成功附带的路径;读失败/二进制/超限都以文字说明,不打断发送。
+    /// 返回展开后的文本、成功附带的路径,以及<b>没能读到</b>的路径;读失败/二进制/超限
+    /// 都以文字说明,不打断发送。
     /// </summary>
-    private async Task<(string ModelText, IReadOnlyList<string> Attached)> ResolveAttachmentsAsync(
-        string text, CancellationToken cancellationToken)
+    /// <remarks>
+    /// 单独回报读失败的那几个,是因为气泡里已经用芯片列出了引用的文件(Copilot 的做法),
+    /// 再补一张"已附带 N 个文件"的卡片纯属重复;真正需要提醒用户的只有"这个没读到"。
+    /// </remarks>
+    private async Task<(string ModelText, IReadOnlyList<string> Attached, IReadOnlyList<string> Failed)>
+        ResolveAttachmentsAsync(string text, CancellationToken cancellationToken)
     {
         List<string> references = FileReference.Parse(text);
         if (references.Count == 0)
         {
-            return (text, []);
+            return (text, [], []);
         }
         if (SelectedSessionId is not { } sessionId)
         {
-            return (text + $"\n\n[{_loc["NoSession"]}]", []);
+            return (text + $"\n\n[{_loc["NoSession"]}]", [], references);
         }
         string cwd = await ResolveWorkingDirectoryAsync(sessionId, cancellationToken);
         var builder = new StringBuilder(text);
         var attached = new List<string>();
+        var failed = new List<string>();
         builder.Append("\n\n").Append(_loc["AttachIntro"]);
         foreach (string reference in references.Take(MaxAttachedFiles))
         {
@@ -312,27 +485,26 @@ public partial class ChatPanelView
             catch (Exception ex)
             {
                 builder.Append($"\n\n===== {path} =====\n[{_loc["AttachFailed"]}: {ex.Message}]");
+                failed.Add(path);
             }
         }
         if (references.Count > MaxAttachedFiles)
         {
             builder.Append($"\n\n[{_loc.F("AttachLimit", MaxAttachedFiles)}]");
+            failed.AddRange(references.Skip(MaxAttachedFiles).Select(r => FileReference.Expand(r, cwd)));
         }
-        return (builder.ToString(), attached);
+        return (builder.ToString(), attached, failed);
     }
 
-    /// <summary>在消息流里补一张"已附带 N 个文件"的小卡片。</summary>
-    private void AddAttachmentCard(IReadOnlyList<string> paths)
+    /// <summary>没读到的引用在消息流里补一行提示(读到的已经在气泡的芯片里了,不再重复报)。</summary>
+    private void AddAttachmentFailureNote(IReadOnlyList<string> paths)
     {
         var stack = new StackPanel { Spacing = 2 };
-        stack.Children.Add(new TextBlock { Classes = { "dim" }, Text = _loc.F("AttachedCount", paths.Count) });
-        foreach (string path in paths)
+        stack.Children.Add(new TextBlock
         {
-            var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
-            row.Children.Add(MakeIcon("Icon.file-text", "VelaTextMuted", 11));
-            row.Children.Add(new TextBlock { Classes = { "fileName" }, Text = path });
-            stack.Children.Add(row);
-        }
+            Classes = { "dim" },
+            Text = _loc.F("AttachFailedList", string.Join(", ", paths.Select(FileReference.DisplayName)))
+        });
         MessagesPanel.Children.Add(new Border { Classes = { "toolCard" }, Child = stack });
     }
 

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
@@ -246,7 +246,7 @@ public partial class ChatPanelView
         }
         _inputHistoryIndex = next;
         InputBox.Text = next == -1 ? _inputDraft : _inputHistory[next];
-        InputBox.CaretIndex = InputBox.Text?.Length ?? 0;
+        InputBox.CaretOffset = InputBox.Text?.Length ?? 0;
         return true;
     }
 
@@ -254,7 +254,7 @@ public partial class ChatPanelView
     private bool CaretOnFirstLine()
     {
         string text = InputBox.Text ?? "";
-        int caret = Math.Clamp(InputBox.CaretIndex, 0, text.Length);
+        int caret = Math.Clamp(InputBox.CaretOffset, 0, text.Length);
         return text.AsSpan(0, caret).IndexOf('\n') < 0;
     }
 
@@ -262,7 +262,7 @@ public partial class ChatPanelView
     private bool CaretOnLastLine()
     {
         string text = InputBox.Text ?? "";
-        int caret = Math.Clamp(InputBox.CaretIndex, 0, text.Length);
+        int caret = Math.Clamp(InputBox.CaretOffset, 0, text.Length);
         return text.AsSpan(caret).IndexOf('\n') < 0;
     }
 

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.InputEditor.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.InputEditor.cs
@@ -1,0 +1,195 @@
+using System.Xml;
+using Avalonia.Controls;
+using Avalonia.Media;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Highlighting;
+using AvaloniaEdit.Highlighting.Xshd;
+using AvaloniaEdit.Rendering;
+using VelaShell.Plugin.Ai.Chat;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// 聊天输入框(AvaloniaEdit)的接线:Markdown 着色 + 把已落定的 <c>@</c> 引用画成一枚
+/// 只写文件名的主题色芯片。
+/// </summary>
+/// <remarks>
+/// 输入框是编辑器而不是 <c>TextBox</c>,就是为了这两件事 —— Avalonia 的 TextBox 是纯文本控件,
+/// 既不能让某一段变色,也不能让"显示的字"和"实际的值"不一样。这里两者都要:
+/// 用户可能直接在输入框里写 Markdown(该看得出结构),而 <c>@/root/abc.txt</c> 这种长路径
+/// 平铺出来又吵又占地方,应当收成 <c>@abc.txt</c>。
+///
+/// 关键约定:<b>文档里存的始终是全路径</b>。芯片只是渲染层的事,发送、附件展开、历史回溯
+/// 全都照旧读 <see cref="AvaloniaEdit.TextEditor.Text" />,一行都不用改。
+/// </remarks>
+public partial class ChatPanelView
+{
+    /// <summary>本插件自带的 Markdown 着色定义(整个进程加载一次,不注册进全局管理器)。</summary>
+    private static IHighlightingDefinition? _markdownDefinition;
+
+    /// <summary>把着色与芯片接到输入框上;主题切换时重上色。</summary>
+    private void SetUpInputEditor()
+    {
+        InputBox.SyntaxHighlighting = LoadMarkdownDefinition();
+        ApplyInputHighlightPalette();
+        InputBox.TextArea.TextView.ElementGenerators.Add(new FileReferenceChipGenerator());
+        InputBox.TextArea.TextView.LineTransformers.Add(new FileReferenceChipColorizer(this));
+        ActualThemeVariantChanged += (_, _) => ApplyInputHighlightPalette();
+    }
+
+    /// <summary>加载(并缓存)自带的 Markdown 着色定义;失败就不上色,输入框照常能用。</summary>
+    private IHighlightingDefinition? LoadMarkdownDefinition()
+    {
+        if (_markdownDefinition is not null)
+        {
+            return _markdownDefinition;
+        }
+        try
+        {
+            using Stream? stream = typeof(ChatPanelView).Assembly
+                .GetManifestResourceStream("VelaShell.Plugin.Ai.Ui.MarkdownInput.xshd");
+            if (stream is null)
+            {
+                return null;
+            }
+            using var reader = XmlReader.Create(stream);
+            return _markdownDefinition = HighlightingLoader.Load(reader, HighlightingManager.Instance);
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Warn($"Markdown highlighting for the input box is off: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>按当前主题令牌给各命名颜色上色(令牌缺席时退到一组中性色,不至于没颜色可用)。</summary>
+    private void ApplyInputHighlightPalette()
+    {
+        if (InputBox.SyntaxHighlighting is not { } definition)
+        {
+            return;
+        }
+        Paint(definition, "Heading", "VelaAccent", Color.FromRgb(0xBD, 0x93, 0xF9));
+        Paint(definition, "Bold", "VelaTextPrimary", Color.FromRgb(0xF8, 0xF8, 0xF2));
+        Paint(definition, "Italic", "VelaTextSecondary", Color.FromRgb(0xB0, 0xB8, 0xD6));
+        Paint(definition, "InlineCode", "VelaShellCyan", Color.FromRgb(0x8B, 0xE9, 0xFD));
+        Paint(definition, "CodeFence", "VelaShellCyan", Color.FromRgb(0x8B, 0xE9, 0xFD));
+        Paint(definition, "Quote", "VelaTextTertiary", Color.FromRgb(0x62, 0x72, 0xA4));
+        Paint(definition, "ListMarker", "VelaAccent", Color.FromRgb(0xBD, 0x93, 0xF9));
+        Paint(definition, "Link", "VelaShellBlue", Color.FromRgb(0xBD, 0x93, 0xF9));
+        // 着色是按行缓存的,换色后要让可视行重建一次,否则要等下一次编辑才生效
+        InputBox.TextArea.TextView.Redraw();
+    }
+
+    /// <summary>给一个命名颜色刷上主题令牌对应的前景色。</summary>
+    private void Paint(IHighlightingDefinition definition, string colorName, string token, Color fallback)
+    {
+        if (definition.GetNamedColor(colorName) is not { } color)
+        {
+            return;
+        }
+        color.Foreground = new SimpleHighlightingBrush(ResolveColor(token, fallback));
+    }
+
+    /// <summary>取一个 Vela* 画刷令牌的颜色;宿主没提供令牌时(如裸测试宿主)用兜底色。</summary>
+    private Color ResolveColor(string token, Color fallback)
+        => ResolveBrush(token, fallback) is ISolidColorBrush brush ? brush.Color : fallback;
+
+    /// <summary>取一个 Vela* 画刷令牌;缺席时退回按兜底色现做一支。</summary>
+    private IBrush ResolveBrush(string token, Color fallback)
+        => this.TryFindResource(token, ActualThemeVariant, out object? value) && value is IBrush brush
+            ? brush
+            : new SolidColorBrush(fallback);
+
+    /// <summary>
+    /// 把文档里已落定的 <c>@/root/abc.txt</c> 整段替换成一枚显示 <c>@abc.txt</c> 的芯片。
+    /// </summary>
+    /// <remarks>
+    /// 用 <see cref="FormattedTextElement" />(把这段文档替换成另一段<b>文本</b>去排版),
+    /// 而不是内联控件:内联控件是"坐在基线上"的,它的高度整个压在基线之上,于是整行被撑高、
+    /// AvaloniaEdit 的光标又按行高画 —— 表现就是一输入内容光标突然变成一根长条
+    /// (实测 15.2 → 24.7)。当文本排版就没有这个问题,而且 OpenCode 的观感本来也是
+    /// "一段彩色文字"而非胶囊。颜色由 <see cref="FileReferenceChipColorizer" /> 上。
+    ///
+    /// 它的 VisualColumnLength 是 1:光标不会落进芯片内部,整枚跨过 —— 与退格整块删除对上,
+    /// 看到的是一枚,删的也是一枚。未落定(还在敲)的 token 不做芯片:那时要看清每个字符。
+    /// </remarks>
+    private sealed class FileReferenceChipGenerator : VisualLineElementGenerator
+    {
+        /// <inheritdoc />
+        public override int GetFirstInterestedOffset(int startOffset)
+        {
+            int endOffset = CurrentContext.VisualLine.LastDocumentLine.EndOffset;
+            for (int offset = startOffset; offset < endOffset; offset++)
+            {
+                if (CurrentContext.Document.GetCharAt(offset) != '@')
+                {
+                    continue;
+                }
+                if (TryRead(offset, out _, out _))
+                {
+                    return offset;
+                }
+            }
+            return -1;
+        }
+
+        /// <inheritdoc />
+        public override VisualLineElement? ConstructElement(int offset)
+        {
+            if (!TryRead(offset, out int length, out string path))
+            {
+                return null;
+            }
+            return new FormattedTextElement("@" + FileReference.DisplayName(path), length);
+        }
+
+        /// <summary>读取 <paramref name="offset" /> 处的引用(按整行取文本,规则与发送/删除同源)。</summary>
+        private bool TryRead(int offset, out int length, out string path)
+        {
+            length = 0;
+            path = "";
+            DocumentLine line = CurrentContext.Document.GetLineByOffset(offset);
+            string text = CurrentContext.Document.GetText(line);
+            if (!FileReference.TryFindCompletedReferenceAt(text, offset - line.Offset, out int len, out string found))
+            {
+                return false;
+            }
+            length = len;
+            path = found;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// 给芯片段上色:强调色文字 + 一层淡强调底,与输入框外的其它 <c>@</c> 引用观感一致。
+    /// </summary>
+    /// <remarks>
+    /// 走 <see cref="DocumentColorizingTransformer" /> 而不是在生成元素时定色:着色器在
+    /// 元素生成之后跑,主题切换后一次 <c>Redraw()</c> 就能重上色,不必重建元素。
+    /// </remarks>
+    private sealed class FileReferenceChipColorizer(ChatPanelView owner) : DocumentColorizingTransformer
+    {
+        /// <inheritdoc />
+        protected override void ColorizeLine(DocumentLine line)
+        {
+            string text = CurrentContext.Document.GetText(line);
+            IBrush foreground = owner.ResolveBrush("VelaAccent", Color.FromRgb(0xBD, 0x93, 0xF9));
+            IBrush background = owner.ResolveBrush("VelaAccentDim", Color.FromArgb(0x30, 0xBD, 0x93, 0xF9));
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (text[i] != '@'
+                    || !FileReference.TryFindCompletedReferenceAt(text, i, out int length, out _))
+                {
+                    continue;
+                }
+                ChangeLinePart(line.Offset + i, line.Offset + i + length, element =>
+                {
+                    element.TextRunProperties.SetForegroundBrush(foreground);
+                    element.TextRunProperties.SetBackgroundBrush(background);
+                });
+                i += length - 1;
+            }
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -1,5 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ae="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
+             xmlns:aee="clr-namespace:AvaloniaEdit.Editing;assembly=AvaloniaEdit"
              xmlns:md="clr-namespace:LiveMarkdown.Avalonia;assembly=LiveMarkdown.Avalonia"
              xmlns:mdm="clr-namespace:LiveMarkdown.Avalonia;assembly=LiveMarkdown.Avalonia.Mermaid"
              x:Class="VelaShell.Plugin.Ai.Ui.ChatPanelView">
@@ -25,6 +27,9 @@
     <!-- LiveMarkdown 自带样式必须先并进来,后面的皮肤覆盖才压得住(Avalonia 同优先级按声明顺序,后者胜)。 -->
     <StyleInclude Source="avares://LiveMarkdown.Avalonia/Styles.axaml" />
     <StyleInclude Source="avares://LiveMarkdown.Avalonia.Mermaid/Styles.axaml" />
+    <!-- 输入框(AvaloniaEdit)的控件模板:宿主 App.axaml 里也并了一份,但插件不能假定
+         装载方一定并过 —— 自己带上,面板在哪儿都能正常成型。 -->
+    <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
 
     <Style Selector="TextBlock.dim">
       <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
@@ -130,27 +135,43 @@
     <Style Selector="Border.inputWrap:focus-within">
       <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
     </Style>
-    <Style Selector="Border.inputWrap TextBox">
+    <!-- 输入框是 AvaloniaEdit(要的是 Markdown 高亮与 @ 引用芯片这类内联富文本,
+         纯 TextBox 给不了)。外层 Border.inputWrap 继续承担边框/焦点态,编辑器本身去壳:
+         透明底、无边框,内边距给在编辑器上(它的模板会把 Padding 传给内部滚动区)。 -->
+    <Style Selector="Border.inputWrap ae|TextEditor">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
       <Setter Property="CornerRadius" Value="0" />
       <Setter Property="MinHeight" Value="0" />
       <Setter Property="Padding" Value="10,7" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiFont}" />
       <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
     </Style>
-    <Style Selector="Border.inputWrap TextBox /template/ Border#PART_BorderElement">
+    <Style Selector="Border.inputWrap ae|TextEditor /template/ Border">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
     </Style>
-    <Style Selector="Border.inputWrap TextBox:pointerover /template/ Border#PART_BorderElement">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="0" />
+    <!-- 用户气泡里的文件引用芯片(输入框内那段引用是编辑器自己上色的,见 InputEditor.cs;
+         两处取同一对令牌,观感一致)。 -->
+    <Style Selector="Border.refChip">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Padding" Value="5,1" />
+      <Setter Property="Margin" Value="0,0,4,0" />
+      <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
-    <Style Selector="Border.inputWrap TextBox:focus /template/ Border#PART_BorderElement">
+    <Style Selector="TextBlock.refChipText">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+    </Style>
+
+    <!-- 选区随主题令牌(编辑器默认是硬编码的黑白)。 -->
+    <Style Selector="Border.inputWrap aee|TextArea">
+      <Setter Property="SelectionBrush" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="SelectionForeground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="SelectionCornerRadius" Value="2" />
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="0" />
     </Style>
 
     <!-- ===== LiveMarkdown 皮肤 =====
@@ -400,7 +421,18 @@
             </StackPanel>
           </Border>
         </Popup>
-        <TextBox x:Name="InputBox" AcceptsReturn="True" TextWrapping="Wrap" MaxHeight="120" />
+        <!-- 编辑器没有占位提示,拿一个不吃命中测试的 TextBlock 叠上去,由代码后置随文本显隐。 -->
+        <Panel>
+          <ae:TextEditor x:Name="InputBox"
+                         WordWrap="True"
+                         MaxHeight="120"
+                         ShowLineNumbers="False"
+                         HorizontalScrollBarVisibility="Disabled"
+                         VerticalScrollBarVisibility="Auto" />
+          <TextBlock x:Name="InputPlaceholder" Classes="dim"
+                     Margin="12,8" IsHitTestVisible="False"
+                     VerticalAlignment="Top" />
+        </Panel>
         <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,5,0" VerticalAlignment="Bottom" Height="34">
           <Button x:Name="SendButton" Theme="{DynamicResource VelaAccentPillButtonTheme}"
                   Height="24" Padding="10,0" VerticalAlignment="Center">

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -83,7 +83,12 @@ public partial class ChatPanelView : UserControl
         ChatScroll.ScrollChanged += OnChatScrollChanged;
         NewChatButton.Click += (_, _) => StartNewChat();
         InputBox.AddHandler(KeyDownEvent, OnInputKeyDown, RoutingStrategies.Tunnel);
-        InputBox.TextChanged += (_, _) => OnInputTextChanged();
+        InputBox.TextChanged += (_, _) =>
+        {
+            InputPlaceholder.IsVisible = InputBox.Document.TextLength == 0;
+            OnInputTextChanged();
+        };
+        SetUpInputEditor();
         FilePopup.PlacementTarget = InputWrap;
         SettingsToggle.IsCheckedChanged += (_, _) => OnViewToggled(SettingsToggle, PanelView.Settings);
         HistoryToggle.IsCheckedChanged += (_, _) =>
@@ -131,7 +136,10 @@ public partial class ChatPanelView : UserControl
         try
         {
             _cts?.Cancel();
+            // 面板级取消源:补全请求之间靠代次判废,只有面板真的关了才在这里取消
             _fileCts?.Cancel();
+            _fileCts?.Dispose();
+            _fileCts = null;
         }
         catch
         {
@@ -193,7 +201,7 @@ public partial class ChatPanelView : UserControl
         ToolTip.SetTip(HistoryToggle, _loc["History"]);
         ClearHistoryButton.Content = _loc["ClearHistory"];
         HistoryHeader.Text = _loc["HistoryHeader"];
-        InputBox.PlaceholderText = _loc["InputPlaceholder"];
+        InputPlaceholder.Text = _loc["InputPlaceholder"];
         SendText.Text = _loc["Send"];
         StopText.Text = _loc["Stop"];
         // 代码块头部按钮的提示藏在 LiveMarkdown 的 ControlTemplate 里,只能经 DynamicResource 灌进去
@@ -379,6 +387,11 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void OnInputKeyDown(object? sender, KeyEventArgs e)
     {
+        // 已完成的 @ 引用是一整块:退格/删除整块带走(见 HandleReferenceBlockDelete)
+        if (HandleReferenceBlockDelete(e))
+        {
+            return;
+        }
         if (FilePopup.IsOpen && HandleFilePickerKey(e))
         {
             return;
@@ -480,13 +493,13 @@ public partial class ChatPanelView : UserControl
         AssistantBubble? bubble = null;
         try
         {
-            // @ 引用的远端文件在这里展开:气泡里仍显示用户原文,只有送给模型的那份带文件内容。
-            (string modelText, IReadOnlyList<string> attached) = fromUser
+            // @ 引用的远端文件在这里展开:气泡里显示的是短名芯片,只有送给模型的那份带完整路径与文件内容。
+            (string modelText, IReadOnlyList<string> _, IReadOnlyList<string> unreadable) = fromUser
                 ? await ResolveAttachmentsAsync(text, token)
-                : (text, []);
-            if (attached.Count > 0)
+                : (text, [], []);
+            if (unreadable.Count > 0)
             {
-                AddAttachmentCard(attached);
+                AddAttachmentFailureNote(unreadable);
             }
             _history.Add(new ChatMessage(ChatRole.User, modelText));
             await PersistAsync("user", text);
@@ -692,7 +705,7 @@ public partial class ChatPanelView : UserControl
         _inputHistoryIndex = -1;
         StatusText.Text = "";
         SetActiveView(PanelView.Chat);
-        InputBox.Focus();
+        InputBox.TextArea.Focus();
     }
 
     // ---------- 审批交互 ----------
@@ -742,12 +755,52 @@ public partial class ChatPanelView : UserControl
 
     // ---------- 气泡构建 ----------
 
+    /// <summary>
+    /// 用户气泡:与 VSCode 里 GitHub Copilot 的提问块一致 —— 引用到的文件先以芯片列出,
+    /// 正文按 Markdown 渲染(与助手气泡同一套渲染器)。
+    /// </summary>
+    /// <remarks>
+    /// 两处刻意与输入框保持一致:①正文里的 <c>@</c> 引用显示成短名(<c>@abc.txt</c>),
+    /// 不再把 <c>@/root/abc.txt</c> 这种长路径原样铺出来 —— 用户在输入框里看到的就是短名,
+    /// 发出去后不该突然变回长路径;②用户自己写的 Markdown 该渲染出来,而不是显示源码。
+    /// 送给模型的那份文本不受影响(仍是带完整路径的原文,见 ResolveAttachmentsAsync)。
+    /// </remarks>
     private void AddUserBubble(string text)
     {
         var stack = new StackPanel();
         stack.Children.Add(new TextBlock { Classes = { "roleHeader" }, Text = _loc["You"] });
-        stack.Children.Add(new SelectableTextBlock { Classes = { "body" }, Text = text });
+
+        List<string> references = FileReference.Parse(text);
+        if (references.Count > 0)
+        {
+            var chips = new WrapPanel { Margin = new(0, 0, 0, 4) };
+            foreach (string path in references)
+            {
+                chips.Children.Add(BuildReferenceChip(path));
+            }
+            stack.Children.Add(chips);
+        }
+
+        var body = new MarkdownSegment(this);
+        body.Append(FileReference.Shorten(text));
+        stack.Children.Add(body.Host);
         MessagesPanel.Children.Add(new Border { Classes = { "msg", "userMsg" }, Child = stack });
+    }
+
+    /// <summary>一枚文件引用芯片(与输入框里那段彩色引用同色同名,悬停给全路径)。</summary>
+    private Border BuildReferenceChip(string path)
+    {
+        var row = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 4 };
+        row.Children.Add(MakeIcon("Icon.file", "VelaAccent", 10));
+        row.Children.Add(new TextBlock
+        {
+            Classes = { "refChipText" },
+            Text = FileReference.DisplayName(path),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+        });
+        var chip = new Border { Classes = { "refChip" }, Child = row };
+        ToolTip.SetTip(chip, path);
+        return chip;
     }
 
     private static string Truncate(string text, int max)

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -69,6 +69,7 @@ public sealed class Loc(string locale)
         ["AttachedCount"] = ["Attached {0} file(s)", "已附带 {0} 个文件", "已附帶 {0} 個檔案", "{0} 個のファイルを添付", "파일 {0}개 첨부됨"],
         ["AttachBinary"] = ["binary file — not attached; ask the agent to inspect it with a command instead", "二进制文件,未附带;可让 Agent 用命令查看", "二進位檔案,未附帶;可讓 Agent 用命令檢視", "バイナリファイルのため添付しません。コマンドで確認してください", "바이너리 파일이라 첨부하지 않았습니다. 명령으로 확인하세요"],
         ["AttachFailed"] = ["could not be read", "读取失败", "讀取失敗", "読み取りに失敗", "읽지 못했습니다"],
+        ["AttachFailedList"] = ["Could not read: {0}", "读取失败:{0}", "讀取失敗:{0}", "読み取れませんでした: {0}", "읽지 못했습니다: {0}"],
         ["AttachLimit"] = ["only the first {0} files were attached", "只附带了前 {0} 个文件", "只附帶了前 {0} 個檔案", "最初の {0} 件のみ添付しました", "처음 {0}개 파일만 첨부했습니다"],
         ["Send"] = ["Send", "发送", "傳送", "送信", "전송"],
         ["Stop"] = ["Stop", "停止", "停止", "停止", "중지"],

--- a/plugins/VelaShell.Plugin.Ai/Ui/MarkdownInput.xshd
+++ b/plugins/VelaShell.Plugin.Ai/Ui/MarkdownInput.xshd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  聊天输入框的 Markdown 着色(AvaloniaEdit 的 xshd)。
+
+  刻意自带一份、而不是拿 HighlightingManager 里内置的 "MarkDown":那是<b>进程级共享单例</b>,
+  插件去改它的颜色会连带改掉宿主远端编辑器里的同一份定义。这份只在本插件里加载,不注册进管理器。
+
+  颜色一律留空,由 ChatPanelView.ApplyInputHighlightPalette() 在运行时按 Vela* 主题令牌上色,
+  并随主题切换重上一次 —— 这样深浅色都不用维护两份规则。
+-->
+<SyntaxDefinition name="VelaAiMarkdownInput" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+
+  <Color name="Heading" fontWeight="bold" />
+  <Color name="Bold" fontWeight="bold" />
+  <Color name="Italic" fontStyle="italic" />
+  <Color name="InlineCode" />
+  <Color name="CodeFence" />
+  <Color name="Quote" fontStyle="italic" />
+  <Color name="ListMarker" />
+  <Color name="Link" />
+
+  <RuleSet>
+    <!-- 围栏代码块:跨行,整段一个色 -->
+    <Span color="CodeFence" multiline="true">
+      <Begin>```</Begin>
+      <End>```</End>
+    </Span>
+
+    <!-- 标题 / 引用 / 列表标记都是行首语法(xshd 的规则逐行匹配,^ 即行首) -->
+    <Rule color="Heading">^[ ]{0,3}\#{1,6}[ \t].*$</Rule>
+    <Rule color="Quote">^[ ]{0,3}&gt;.*$</Rule>
+    <Rule color="ListMarker">^[ \t]*([*+\-]|\d+[.)])(?=[ \t])</Rule>
+
+    <!-- 行内:反引号代码、粗体、斜体、链接 -->
+    <Rule color="InlineCode">`[^`\n]+`</Rule>
+    <!-- 反向引用用具名组:xshd 会把每条规则的正则再包一层组,编号引用(\1)会错位失效。
+         具名组用 (?'x'…)/\k'x' 这种写法,免得 XML 里满屏 &lt; 转义。 -->
+    <Rule color="Bold">(?'bold'\*\*|__)(?=\S)(.+?)(?&lt;=\S)\k'bold'</Rule>
+    <Rule color="Italic">(?&lt;![*_\w])(?'em'[*_])(?=\S)([^*_\n]+?)(?&lt;=\S)\k'em'(?![*_\w])</Rule>
+    <Rule color="Link">!?\[[^\]\n]*\]\([^)\n]*\)</Rule>
+  </RuleSet>
+
+</SyntaxDefinition>

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -11,10 +11,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- 输入框的 Markdown 着色定义。EmbeddedResource 而非 AvaloniaResource:
+         HighlightingLoader 要的是普通 Stream(与宿主 Syntax/*.xshd 的处置一致)。 -->
+    <EmbeddedResource Include="Ui\MarkdownInput.xshd" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- SDK 由宿主统一提供(共享契约程序集),不随插件输出复制。 -->
     <ProjectReference Include="..\..\plugin-sdk\VelaShell.PluginSdk\VelaShell.PluginSdk.csproj" Private="false" ExcludeAssets="runtime" />
     <!-- 仅编译期引用 Avalonia,运行时由装载方共享同一套(版本须与宿主一致)。 -->
     <PackageReference Include="Avalonia" Version="12.1.1" ExcludeAssets="runtime" />
+    <!-- 输入框是 AvaloniaEdit(Markdown 高亮 + @ 引用芯片,纯 TextBox 给不了内联富文本)。
+         程序集名 AvaloniaEdit 命中 PluginAssemblyLoadContext 的 SharedPrefixes("Avalonia"),
+         运行时一律回落到装载方那份,故此处同样只要编译期引用。
+         注意:因此本插件必须进程内装载(plugin.json 未声明 isolated)—— 隔离宿主进程里
+         没有 AvaloniaEdit,回落会找不到程序集。 -->
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" ExcludeAssets="runtime" />
     <!-- AI 栈(用户决策 2026-08-10):Microsoft.Extensions.AI 抽象 + 各家官方 SDK,
          统一到 IChatClient;Agent 循环用 FunctionInvokingChatClient。
          这些依赖随插件目录分发,由插件 ALC 按 deps.json 隔离解析,与宿主互不干扰。 -->

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <!-- AI 面板的输入框(与 src 的 CPM 同版):测试宿主要扮演"装载方"提供这份程序集。 -->
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="ReactiveUI.Testing" Version="24.1.0" />
   </ItemGroup>
 </Project>

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
@@ -4,6 +4,9 @@ using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using AvaloniaEdit;
+using AvaloniaEdit.Rendering;
+using LiveMarkdown.Avalonia;
 using VelaShell.Plugin.Ai.Chat;
 using VelaShell.Plugin.Ai.Configuration;
 using VelaShell.Plugin.Ai.Ui;
@@ -35,8 +38,11 @@ public sealed class ChatPanelViewUiTests
         return (window, panel);
     }
 
-    /// <summary>面板的初始化是 fire-and-forget 的异步链,跑几拍调度器让它落定。</summary>
-    private static async Task PumpAsync(int rounds = 20)
+    /// <summary>
+    /// 面板的初始化是 fire-and-forget 的异步链,跑几拍调度器让它落定。
+    /// 默认拍数要盖过 <c>@</c> 补全的防抖(180ms),否则弹层还没来得及开就断言了。
+    /// </summary>
+    private static async Task PumpAsync(int rounds = 60)
     {
         for (int i = 0; i < rounds; i++)
         {
@@ -48,10 +54,29 @@ public sealed class ChatPanelViewUiTests
     private static T Find<T>(ChatPanelView panel, string name) where T : Control
         => panel.GetControl<T>(name);
 
+    /// <summary>
+    /// 在 headless UI 线程上跑一段<b>异步</b>测试体,并把里面的异常/断言失败带回本线程。
+    /// </summary>
+    /// <remarks>
+    /// 千万别直接写 <c>_session.Dispatch(async () =&gt; { … }, ct).GetAwaiter().GetResult()</c>:
+    /// <see cref="HeadlessUnitTestSession" /> <b>没有 <c>Func&lt;Task&gt;</c> 重载</b>,那样会命中
+    /// <c>Dispatch&lt;TResult&gt;(Func&lt;TResult&gt;)</c>,TResult 被推成 <c>Task</c> ——
+    /// 拿回来的是一个<b>从没被等待过的 <c>Task&lt;Task&gt;</c></b>:测试体只跑到第一个 await 就返回,
+    /// 之后的断言全在后台默默地跑、失败也丢了,测试永远"通过"(本文件此前 6 个用例都是如此,
+    /// 2ms 就"跑完"了)。这里让 lambda 带一个返回值,命中 <c>Func&lt;Task&lt;TResult&gt;&gt;</c> 重载,
+    /// 才是真的等到底。
+    /// </remarks>
+    private static void OnUi(Func<Task> body) =>
+        _session.Dispatch(async () =>
+        {
+            await body();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
     [TestMethod]
     public void Panel_Loads_WithoutHostThemeTokens()
     {
-        _session.Dispatch(async () =>
+        OnUi(async () =>
         {
             using var context = new TestPluginContext();
             (Window window, ChatPanelView panel) = await ShowAsync(context);
@@ -63,23 +88,33 @@ public sealed class ChatPanelViewUiTests
                 Assert.IsNotNull(Find<DockPanel>(panel, "HistoryHost"));
                 Assert.IsNotNull(Find<Popup>(panel, "FilePopup"));
                 Assert.IsFalse(Find<Popup>(panel, "FilePopup").IsOpen, "没输入 @ 时文件选择器不该弹出");
-                Assert.IsTrue(Find<ScrollViewer>(panel, "ChatScroll").IsVisible);
                 Assert.IsFalse(Find<DockPanel>(panel, "HistoryHost").IsVisible);
                 Assert.IsTrue(Find<ToggleButton>(panel, "HistoryToggle").IsEnabled,
                     "时序能力可用时历史按钮应可点");
+                // 裸测试宿主里一个供应商都没配,初始化末尾会自己切到设置页(见 InitAsync 的
+                // NoProvider 分支)—— 中间区是设置而不是聊天流,这不是异常,是既定引导路径。
+                Assert.IsTrue(Find<ToggleButton>(panel, "SettingsToggle").IsChecked);
+                Assert.IsFalse(Find<ScrollViewer>(panel, "ChatScroll").IsVisible,
+                    "没有供应商时先请用户去设置页,聊天流让位");
+                // 输入框是 AvaloniaEdit(要 Markdown 着色与 @ 芯片),不是 TextBox
+                Assert.IsNotNull(Find<TextEditor>(panel, "InputBox"));
+                Assert.IsNotNull(Find<TextEditor>(panel, "InputBox").SyntaxHighlighting,
+                    "输入框应挂上 Markdown 着色");
+                Assert.IsTrue(Find<TextBlock>(panel, "InputPlaceholder").IsVisible,
+                    "空输入框要显示占位提示");
             }
             finally
             {
                 panel.Detach();
                 window.Close();
             }
-        }, CancellationToken.None).GetAwaiter().GetResult();
+        });
     }
 
     [TestMethod]
     public void HistoryToggle_SwitchesCentreView_AndListsSavedConversations()
     {
-        _session.Dispatch(async () =>
+        OnUi(async () =>
         {
             using var context = new TestPluginContext();
             var store = new ChatHistoryStore(context);
@@ -100,7 +135,7 @@ public sealed class ChatPanelViewUiTests
                 StackPanel list = Find<StackPanel>(panel, "HistoryList");
                 Assert.HasCount(1, list.Children);
                 Assert.Contains("磁盘满了怎么查?",
-                    list.Children[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? "").ToList());
+                    [.. list.Children[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")]);
 
                 // 再点一次回到聊天流
                 Find<ToggleButton>(panel, "HistoryToggle").IsChecked = false;
@@ -112,13 +147,13 @@ public sealed class ChatPanelViewUiTests
                 panel.Detach();
                 window.Close();
             }
-        }, CancellationToken.None).GetAwaiter().GetResult();
+        });
     }
 
     [TestMethod]
     public void AtSign_OpensRemoteFilePicker_AndEnterInsertsThePath()
     {
-        _session.Dispatch(async () =>
+        OnUi(async () =>
         {
             using var context = new TestPluginContext();
             VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
@@ -129,10 +164,10 @@ public sealed class ChatPanelViewUiTests
             (Window window, ChatPanelView panel) = await ShowAsync(context);
             try
             {
-                TextBox input = Find<TextBox>(panel, "InputBox");
-                input.Focus();
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
                 input.Text = "看看 @/etc/host";
-                input.CaretIndex = input.Text.Length;
+                input.CaretOffset = input.Text.Length;
                 await PumpAsync();
 
                 Popup popup = Find<Popup>(panel, "FilePopup");
@@ -152,13 +187,13 @@ public sealed class ChatPanelViewUiTests
                 panel.Detach();
                 window.Close();
             }
-        }, CancellationToken.None).GetAwaiter().GetResult();
+        });
     }
 
     [TestMethod]
     public void ArrowUp_RecallsPreviouslySentMessages_AndArrowDownRestoresDraft()
     {
-        _session.Dispatch(async () =>
+        OnUi(async () =>
         {
             using var context = new TestPluginContext();
             var store = new ChatHistoryStore(context);
@@ -172,10 +207,10 @@ public sealed class ChatPanelViewUiTests
             (Window window, ChatPanelView panel) = await ShowAsync(context);
             try
             {
-                TextBox input = Find<TextBox>(panel, "InputBox");
-                input.Focus();
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
                 input.Text = "写到一半的草稿";
-                input.CaretIndex = input.Text.Length;
+                input.CaretOffset = input.Text.Length;
                 await PumpAsync(3);
 
                 window.KeyPressQwerty(PhysicalKey.ArrowUp, RawInputModifiers.None);
@@ -196,6 +231,249 @@ public sealed class ChatPanelViewUiTests
                 panel.Detach();
                 window.Close();
             }
-        }, CancellationToken.None).GetAwaiter().GetResult();
+        });
+    }
+
+    /// <summary>
+    /// 同一个目录里继续敲过滤词,不该再发列目录请求 —— 列目录在真机上是一次 SFTP 往返,
+    /// "敲一个字符列一次、还要取消上一次"正是输入卡顿与调试输出刷屏的来源。
+    /// </summary>
+    [TestMethod]
+    public void FilePicker_ListsEachDirectoryOnce_WhileTheFilterKeepsChanging()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hosts", "127.0.0.1"u8.ToArray());
+            context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", "web-01"u8.ToArray());
+            context.FakeRemoteFs.AddFile(session.SessionId, "/etc/passwd", "root:x:0:0"u8.ToArray());
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
+                Type(input, "看看 @/etc/");
+                await PumpAsync();
+
+                Assert.IsTrue(Find<Popup>(panel, "FilePopup").IsOpen);
+                int afterFirstListing = context.FakeRemoteFs.ListDirectoryCalls;
+                Assert.AreEqual(1, afterFirstListing, "进到一个目录只列一次");
+
+                // 逐字符敲过滤词:目录没变,应当纯本地筛,不再碰网络
+                foreach (char c in "hostn")
+                {
+                    Type(input, input.Text + c);
+                    await PumpAsync(3);
+                }
+                await PumpAsync();
+
+                Assert.AreEqual(afterFirstListing, context.FakeRemoteFs.ListDirectoryCalls,
+                    "过滤词变化不该触发新的列目录(同目录结果有缓存)");
+                Assert.HasCount(1, Find<StackPanel>(panel, "FileList").Children,
+                    "过滤仍然生效:hostn 只剩 hostname");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 补全落定的文件引用是一整块(Claude Code / OpenCode 里那枚芯片):
+    /// 一次退格整块删掉,而不是一个字符一个字符地啃回去(啃一次就列一次目录)。
+    /// </summary>
+    [TestMethod]
+    public void Backspace_RemovesTheWholeAcceptedReference_WithoutAnotherListing()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", "web-01"u8.ToArray());
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
+                Type(input, "看看 @/etc/hostname ");
+                await PumpAsync();
+                int listings = context.FakeRemoteFs.ListDirectoryCalls;
+
+                window.KeyPressQwerty(PhysicalKey.Backspace, RawInputModifiers.None);
+                await PumpAsync();
+
+                Assert.AreEqual("看看 ", input.Text, "一次退格删掉整条引用(含补全时补上的尾空格)");
+                Assert.AreEqual("看看 ".Length, input.CaretOffset, "光标落在被删块的起点");
+                Assert.IsFalse(Find<Popup>(panel, "FilePopup").IsOpen);
+                Assert.AreEqual(listings, context.FakeRemoteFs.ListDirectoryCalls,
+                    "退格不该再引发列目录:删完已经不在引用里了");
+
+                // 还在敲、没落定的 token 仍按字符退格(用户在改自己刚打错的那几位)
+                Type(input, "看看 @/etc/hostn");
+                await PumpAsync();
+                window.KeyPressQwerty(PhysicalKey.Backspace, RawInputModifiers.None);
+                await PumpAsync();
+                Assert.AreEqual("看看 @/etc/host", input.Text, "未落定的引用照常一个字符一个字符退");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 落定的 <c>@</c> 引用在输入框里显示成一枚只写文件名的芯片(OpenCode 那种观感),
+    /// 但文档里存的仍是全路径 —— 发送、附件展开都读文档,不受渲染影响。
+    /// </summary>
+    [TestMethod]
+    public void CompletedReference_RendersAsChipShowingOnlyTheFileName()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            context.FakeRemoteFs.AddFile(session.SessionId, "/root/abc.txt", "x"u8.ToArray());
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
+                Type(input, "看看 @/root/abc.txt 这个");
+                await PumpAsync();
+                input.TextArea.TextView.EnsureVisualLines();
+
+                Assert.AreEqual("看看 @/root/abc.txt 这个", input.Text, "文档里仍是全路径");
+                List<FormattedTextElement> chips = ChipsOf(input);
+                Assert.HasCount(1, chips, "落定的引用应被替换成一枚芯片元素");
+                Assert.AreEqual("@/root/abc.txt".Length, chips[0].DocumentLength, "芯片正好覆盖整条引用");
+                Assert.AreEqual(1, chips[0].VisualLength,
+                    "芯片只占一个视觉列:光标整枚跨过,与整块退格的语义一致");
+
+                // 还在敲、没落定的那条不做芯片:那时用户要看清自己敲的每个字符
+                Type(input, "看看 @/root/ab");
+                await PumpAsync(5);
+                input.TextArea.TextView.EnsureVisualLines();
+                Assert.IsEmpty(ChipsOf(input));
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 芯片不能把行撑高:AvaloniaEdit 的光标按所在行的行高画,行一高,光标就变成一根
+    /// 突兀的长条(这正是把芯片从"内联控件"改成"替换文本"的原因)。
+    /// </summary>
+    [TestMethod]
+    public void Chip_DoesNotInflateLineHeight_SoTheCaretStaysNormal()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            context.FakeRemoteFs.AddFile(session.SessionId, "/root/.bashrc", "x"u8.ToArray());
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                TextEditor input = Find<TextEditor>(panel, "InputBox");
+                input.TextArea.Focus();
+
+                Type(input, "为我简单解释下这个文件的内容");
+                await PumpAsync(5);
+                input.TextArea.TextView.EnsureVisualLines();
+                double plain = input.TextArea.TextView.VisualLines[0].Height;
+
+                Type(input, "@/root/.bashrc 为我简单解释下这个文件的内容");
+                await PumpAsync(5);
+                input.TextArea.TextView.EnsureVisualLines();
+                double withChip = input.TextArea.TextView.VisualLines[0].Height;
+
+                Assert.HasCount(1, ChipsOf(input), "前提:这一行确实带一枚芯片");
+                Assert.AreEqual(plain, withChip, 0.01, "带芯片的行与纯文字行必须等高");
+                Assert.AreEqual(plain, input.TextArea.Caret.CalculateCaretRectangle().Height, 0.01,
+                    "光标高度跟着行高走,行不变高光标才正常");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 用户气泡与 VSCode 的 Copilot 对齐:引用的文件以芯片列出(短名 + 全路径提示),
+    /// 正文按 Markdown 渲染,且正文里的引用同样收成短名 —— 与输入框所见一致。
+    /// </summary>
+    [TestMethod]
+    public void UserBubble_ShowsFileChips_AndRendersMarkdown()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            context.FakeRemoteFs.AddFile(session.SessionId, "/root/.bashrc", "export PATH=/usr/bin"u8.ToArray());
+            // 没有供应商时 SendAsync 会直接引导到设置页、不发消息,所以先配一个(不会真去连它:
+            // 本用例只看用户气泡长什么样,后面那半轮请求失败与否都不影响断言)。
+            var provider = new AiProviderConfig { Name = "test", BaseUrl = "http://127.0.0.1:1/v1", Model = "m" };
+            await new AiSettingsStore(context).SaveAsync(new AiSettings
+            {
+                Providers = [provider],
+                ActiveProviderId = provider.Id
+            });
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                panel.SendExternal("@/root/.bashrc 为我**简单**解释下这个文件");
+                await PumpAsync();
+
+                Border bubble = Find<StackPanel>(panel, "MessagesPanel").Children
+                    .OfType<Border>().First(b => b.Classes.Contains("userMsg"));
+
+                List<string> chips = bubble.GetVisualDescendants()
+                    .OfType<Border>()
+                    .Where(b => b.Classes.Contains("refChip"))
+                    .SelectMany(b => b.GetVisualDescendants().OfType<TextBlock>())
+                    .Select(t => t.Text ?? "")
+                    .ToList();
+                Assert.AreSequenceEqual([".bashrc"], chips, "引用的文件以短名芯片列出");
+
+                // 正文走 Markdown 渲染器(而不是一块纯文本),且不再出现长路径
+                Assert.IsNotEmpty(bubble.GetVisualDescendants().OfType<MarkdownRenderer>().ToList(),
+                    "用户正文也该按 Markdown 渲染");
+                List<string> texts = [.. bubble.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")];
+                Assert.IsFalse(texts.Any(t => t.Contains("/root/.bashrc", StringComparison.Ordinal)),
+                    "气泡里不该再出现长路径(输入框里看到的是短名,发出去也该是短名)");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>当前可视行里的引用芯片元素。</summary>
+    private static List<FormattedTextElement> ChipsOf(TextEditor input)
+        => [.. input.TextArea.TextView.VisualLines.SelectMany(l => l.Elements).OfType<FormattedTextElement>()];
+
+    /// <summary>照用户打字那样改写输入框:文本 + 光标落到末尾。</summary>
+    private static void Type(TextEditor input, string text)
+    {
+        input.Text = text;
+        input.CaretOffset = text.Length;
     }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/FileReferenceTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/FileReferenceTests.cs
@@ -38,6 +38,60 @@ public sealed class FileReferenceTests
         Assert.IsFalse(FileReference.TryFindToken("他说\"好\" 之后", 8, out _, out _, out _));
     }
 
+    /// <summary>
+    /// 补全落定后的引用是一整块:退格要整块删。判据 = 闭合引号,或一个收尾空格
+    /// (正是 <c>AcceptCandidate</c> 落笔的两种形态)。
+    /// </summary>
+    [TestMethod]
+    public void TryFindCompletedReferenceBefore_TakesTheWholeAcceptedBlock()
+    {
+        const string plain = "看看 @/var/log/syslog ";
+        Assert.IsTrue(FileReference.TryFindCompletedReferenceBefore(plain, plain.Length, out int start));
+        Assert.AreEqual(3, start, "整块从 @ 起算,尾空格也归这块");
+
+        const string quoted = "读一下 @\"/opt/my app/a.conf\" ";
+        Assert.IsTrue(FileReference.TryFindCompletedReferenceBefore(quoted, quoted.Length, out start));
+        Assert.AreEqual(4, start);
+
+        // 闭引号本身就算落定,尾空格可有可无
+        Assert.IsTrue(FileReference.TryFindCompletedReferenceBefore(quoted.TrimEnd(), quoted.TrimEnd().Length, out _));
+    }
+
+    [TestMethod]
+    public void TryFindCompletedReferenceBefore_LeavesUnfinishedTokensAlone()
+    {
+        // 还在敲(既没闭引号也没尾空格):此时退格该照常一个字符,让用户改自己打错的那几位
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("@/var/log/sys", 13, out _));
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("@\"/opt/my app", 12, out _));
+        // 不是文件引用的 @
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("@someone ", 9, out _));
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("mail@example.com ", 17, out _));
+        // 光标不在块的右边界上
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("@/etc/hosts 然后", 14, out _));
+        // 空白路径
+        Assert.IsFalse(FileReference.TryFindCompletedReferenceBefore("@ ", 2, out _));
+    }
+
+    /// <summary>
+    /// 短名与"正文收短":输入框里的芯片、消息气泡里的引用都用它 —— 两处看到的必须是同一个名字。
+    /// </summary>
+    [TestMethod]
+    public void DisplayName_AndShorten_KeepTheUiConsistentWithTheInputBox()
+    {
+        Assert.AreEqual("abc.txt", FileReference.DisplayName("/root/abc.txt"));
+        Assert.AreEqual(".bashrc", FileReference.DisplayName("/root/.bashrc"));
+        Assert.AreEqual("logs/", FileReference.DisplayName("/var/logs/"), "目录保留结尾的斜杠");
+        Assert.AreEqual("/", FileReference.DisplayName("/"));
+
+        Assert.AreEqual("看看 @abc.txt 这个", FileReference.Shorten("看看 @/root/abc.txt 这个"));
+        Assert.AreEqual("对比 @a.conf 和 @b.conf ",
+            FileReference.Shorten("对比 @/etc/a.conf 和 @\"/opt/my app/b.conf\" "));
+        // 还在敲、没落定的引用不动它:那会儿用户正看着自己敲的字
+        Assert.AreEqual("看看 @/root/ab", FileReference.Shorten("看看 @/root/ab"));
+        // 不是文件引用的 @ 一律原样
+        Assert.AreEqual("@someone 你好", FileReference.Shorten("@someone 你好"));
+    }
+
     [TestMethod]
     public void Split_ResolvesDirectoryAndFilter()
     {

--- a/tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj
+++ b/tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj
@@ -9,6 +9,9 @@
          Popup/资源引用这类"编译得过、运行才炸"的问题才拦得住。 -->
     <PackageReference Include="Avalonia.Headless" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
+    <!-- 输入框是 AvaloniaEdit,而插件只在编译期引用它(运行时按 ALC 规则回落到装载方那份)。
+         测试宿主在这里就扮演"装载方":不摆这一条,面板一构造就是 FileNotFoundException。 -->
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
将聊天面板输入框从原生 TextBox 升级为 AvaloniaEdit，实现 Markdown 语法高亮和 @ 文件引用芯片渲染，提升输入体验和性能。新增 InputEditor 组件，支持主题动态着色和短名芯片显示。优化 FileReference，统一短名提取与显示，删除引用块时避免重复 SFTP 请求。远端目录筛选逻辑优化，减少无效 SFTP 调用，提升流畅度。用户气泡渲染调整，引用文件以短名芯片列出，正文支持 Markdown。补充多项 UI 自动化测试，完善依赖与资源管理，细化样式和本地化文本。