### PR TITLE
侧边栏“最近连接”新增清除按钮及测试

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2688,6 +2688,12 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="ShowHiddenFiles" xml:space="preserve">
     <value>隠しファイルを表示</value>
   </data>
+  <data name="Sidebar_ClearRecent" xml:space="preserve">
+    <value>最近の接続を消去</value>
+  </data>
+  <data name="Sidebar_ClearRecentConfirm" xml:space="preserve">
+    <value>最近の接続履歴をすべて消去します。この操作は取り消せません。続行しますか?</value>
+  </data>
   <data name="Sidebar_Explorer" xml:space="preserve">
     <value>エクスプローラー</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2688,6 +2688,12 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="ShowHiddenFiles" xml:space="preserve">
     <value>숨김 파일 표시</value>
   </data>
+  <data name="Sidebar_ClearRecent" xml:space="preserve">
+    <value>최근 연결 지우기</value>
+  </data>
+  <data name="Sidebar_ClearRecentConfirm" xml:space="preserve">
+    <value>최근 연결 기록을 모두 지웁니다. 이 작업은 취소할 수 없습니다. 계속할까요?</value>
+  </data>
   <data name="Sidebar_Explorer" xml:space="preserve">
     <value>탐색기</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2776,6 +2776,12 @@ Overwrite it?</value>
   <data name="Shell_Cmd" xml:space="preserve">
     <value>Command Prompt (CMD)</value>
   </data>
+  <data name="Sidebar_ClearRecent" xml:space="preserve">
+    <value>Clear Recent Connections</value>
+  </data>
+  <data name="Sidebar_ClearRecentConfirm" xml:space="preserve">
+    <value>This will clear all recent connection records. This action cannot be undone. Continue?</value>
+  </data>
   <data name="Sidebar_Explorer" xml:space="preserve">
     <value>Explorer</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2867,6 +2867,12 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Shell_Cmd" xml:space="preserve">
     <value>命令提示符 (CMD)</value>
   </data>
+  <data name="Sidebar_ClearRecent" xml:space="preserve">
+    <value>清除最近连接</value>
+  </data>
+  <data name="Sidebar_ClearRecentConfirm" xml:space="preserve">
+    <value>将清除全部最近连接记录,此操作不可撤销。确定继续吗?</value>
+  </data>
   <data name="Sidebar_Explorer" xml:space="preserve">
     <value>资源管理器</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2688,6 +2688,12 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="ShowHiddenFiles" xml:space="preserve">
     <value>顯示隱藏檔案</value>
   </data>
+  <data name="Sidebar_ClearRecent" xml:space="preserve">
+    <value>清除最近連線</value>
+  </data>
+  <data name="Sidebar_ClearRecentConfirm" xml:space="preserve">
+    <value>將清除全部最近連線記錄,此操作無法復原。確定要繼續嗎?</value>
+  </data>
   <data name="Sidebar_Explorer" xml:space="preserve">
     <value>資源總管</value>
   </data>

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -148,14 +148,27 @@
                              VerticalAlignment="Center" />
                 </Grid>
               </Button>
-              <Button Grid.Column="3" Background="Transparent" Padding="0"
-                      Width="24" Height="24" CornerRadius="3" Cursor="Hand"
-                      Command="{Binding RecentConnections.RefreshCommand}"
-                      ToolTip.Tip="{loc:Localize Sidebar_RefreshRecent}"
-                      VerticalAlignment="Center">
-                <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.history}"
-                               Foreground="{DynamicResource VelaTextTertiary}" />
-              </Button>
+              <!-- 清除在左、刷新在右。清除是破坏性操作,不直接绑命令 ——
+                   经确认框确认后才执行 ClearCommand(见 ClearRecentConnections_Click)。 -->
+              <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="2"
+                          VerticalAlignment="Center">
+                <Button x:Name="RecentConnectionsClear" Background="Transparent" Padding="0"
+                        Width="24" Height="24" CornerRadius="3" Cursor="Hand"
+                        Click="ClearRecentConnections_Click"
+                        ToolTip.Tip="{loc:Localize Sidebar_ClearRecent}"
+                        VerticalAlignment="Center">
+                  <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.trash-2}"
+                                 Foreground="{DynamicResource VelaTextTertiary}" />
+                </Button>
+                <Button x:Name="RecentConnectionsRefresh" Background="Transparent" Padding="0"
+                        Width="24" Height="24" CornerRadius="3" Cursor="Hand"
+                        Command="{Binding RecentConnections.RefreshCommand}"
+                        ToolTip.Tip="{loc:Localize Sidebar_RefreshRecent}"
+                        VerticalAlignment="Center">
+                  <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.history}"
+                                 Foreground="{DynamicResource VelaTextTertiary}" />
+                </Button>
+              </StackPanel>
             </Grid>
           </Border>
 

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -2,7 +2,9 @@ using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
 using VelaShell.Presentation.ViewModels;
 
 namespace VelaShell.Views;
@@ -239,6 +241,26 @@ public partial class SidebarView : UserControl
         if (sender is Control { DataContext: RecentConnectionItemViewModel item })
         {
             RecentConnectRequested?.Invoke(this, item.Entry);
+        }
+    }
+
+    /// <summary>
+    /// 清除最近连接是破坏性操作(整段连接历史不可恢复):先确认再执行
+    /// (设置审计 §12 破坏性操作需确认,与常规设置页的“清除历史记录”同一处置)。
+    /// </summary>
+    private async void ClearRecentConnections_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null || TopLevel.GetTopLevel(this) is not Window owner)
+        {
+            return;
+        }
+        bool confirmed = await MessageDialog.ConfirmAsync(owner,
+            Strings.Get("Sidebar_ClearRecent"),
+            Strings.Get("Sidebar_ClearRecentConfirm"),
+            danger: true);
+        if (confirmed)
+        {
+            _viewModel.RecentConnections.ClearCommand.Execute().Subscribe();
         }
     }
 }

--- a/tests/VelaShell.Presentation.Tests/ViewModels/RecentConnectionsViewModelTests.cs
+++ b/tests/VelaShell.Presentation.Tests/ViewModels/RecentConnectionsViewModelTests.cs
@@ -1,0 +1,63 @@
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Presentation.ViewModels;
+
+namespace VelaShell.Presentation.Tests.ViewModels;
+
+/// <summary>侧边栏“最近连接”的刷新与清除命令。</summary>
+[TestClass]
+public sealed class RecentConnectionsViewModelTests
+{
+    [TestMethod]
+    public async Task ClearCommand_ClearsStoreAndList()
+    {
+        IRecentConnectionService service = Substitute.For<IRecentConnectionService>();
+        service.GetRecentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+               .Returns([Entry("web-01"), Entry("db-01")]);
+        var vm = new RecentConnectionsViewModel(service);
+        await vm.RefreshAsync();
+        Assert.HasCount(2, vm.Connections);
+
+        await vm.ClearCommand.Execute().FirstAsync();
+
+        await service.Received(1).ClearAsync(Arg.Any<CancellationToken>());
+        Assert.IsEmpty(vm.Connections);
+    }
+
+    /// <summary>清空历史失败时不能把列表也抹掉 —— 界面须继续如实反映存储里还在的记录。</summary>
+    [TestMethod]
+    public async Task ClearCommand_StoreFailure_KeepsList()
+    {
+        IRecentConnectionService service = Substitute.For<IRecentConnectionService>();
+        service.GetRecentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+               .Returns([Entry("web-01")]);
+        service.ClearAsync(Arg.Any<CancellationToken>()).Returns(Task.FromException(new IOException("db locked")));
+        var vm = new RecentConnectionsViewModel(service);
+        await vm.RefreshAsync();
+
+        await vm.ClearCommand.Execute().FirstAsync();
+
+        Assert.HasCount(1, vm.Connections);
+    }
+
+    /// <summary>无历史服务(如设计时/精简装配)时清除是空操作,不能抛。</summary>
+    [TestMethod]
+    public async Task ClearCommand_WithoutService_DoesNotThrow()
+    {
+        var vm = new RecentConnectionsViewModel();
+
+        await vm.ClearCommand.Execute().FirstAsync();
+
+        Assert.IsEmpty(vm.Connections);
+    }
+
+    private static RecentConnectionEntry Entry(string name) =>
+        new()
+        {
+            Name = name,
+            Host = $"{name}.example",
+            Username = "root",
+        };
+}

--- a/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
@@ -273,6 +273,35 @@ public class SidebarQuickCommandsUiTests
         });
     }
 
+    /// <summary>
+    /// 最近连接标题栏的两个动作按钮:清除在左、刷新在右(二者同属一个 StackPanel,
+    /// 因此可直接比较 Bounds.X)。断言落在实际布局上,而不是 XAML 里的书写顺序。
+    /// </summary>
+    [TestMethod]
+    public void RecentConnectionsHeader_ClearButtonSitsLeftOfRefresh()
+    {
+        OnUi(() =>
+        {
+            var view = new SidebarView { DataContext = new SidebarViewModel() };
+            var window = new Window
+            {
+                Width = 260,
+                Height = 464,
+                Content = view,
+            };
+            window.Show();
+            Relayout(window);
+            Button clear = view.FindControl<Button>("RecentConnectionsClear")!;
+            Button refresh = view.FindControl<Button>("RecentConnectionsRefresh")!;
+
+            Assert.IsTrue(clear.IsVisible);
+            Assert.IsGreaterThan(0, clear.Bounds.Width);
+            Assert.AreSame(clear.Parent, refresh.Parent);
+            Assert.IsLessThan(refresh.Bounds.X, clear.Bounds.X);
+            window.Close();
+        });
+    }
+
     private static void Relayout(Window window)
     {
         Dispatcher.UIThread.RunJobs();


### PR DESCRIPTION
为“最近连接”功能添加“清除最近连接”按钮，完善多语言资源文件，支持相关提示和确认对话框。SidebarView.axaml 增加清除按钮及确认逻辑，SidebarView.axaml.cs 实现事件处理。SidebarQuickCommandsUiTests.cs 新增 UI 测试，确保按钮布局正确。新增 RecentConnectionsViewModelTests.cs，覆盖 ClearCommand 的多种行为。