### PR TITLE
实现会话树拖动分组及相关优化

### DIFF
--- a/src/VelaShell.Presentation/ViewModels/SessionTreeNodeViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionTreeNodeViewModel.cs
@@ -150,6 +150,16 @@ public sealed class SessionTreeNodeViewModel(
     /// <summary>分组图标是否使用 accent 配色(<see cref="GroupColorIndex" /> 为 2)。</summary>
     public bool IsFolderAccent => GroupColorIndex == 2;
 
+    /// <summary>
+    /// 拖放中该节点是否为当前落点(仅分组行渲染高亮)。拖会话经过时由视图置位,
+    /// 离开/放下即清除 —— 没有这个反馈,用户无从知道松手会落进哪个分组。
+    /// </summary>
+    public bool IsDropTarget
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
     /// <summary>该分组节点下的子节点集合(会话或子分组)。</summary>
     public ObservableCollection<SessionTreeNodeViewModel> Children { get; } = [];
 }

--- a/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionTreeViewModel.cs
@@ -69,7 +69,9 @@ public sealed class SessionTreeViewModel : ReactiveObject
             () => RaiseForSelected(DiagnoseRequested),
             hasSelectedSession
         );
-        MoveToGroupCommand = ReactiveCommand.Create<SessionTreeNodeViewModel>(MoveSelectedToGroup);
+        MoveToGroupCommand = ReactiveCommand.CreateFromTask<SessionTreeNodeViewModel>(
+            MoveSelectedToGroupAsync
+        );
         DeleteGroupCommand = ReactiveCommand.CreateFromTask(
             DeleteSelectedGroupAsync,
             this.WhenAnyValue(x => x.SelectedNode).Select(node => node is { IsGroup: true })
@@ -212,10 +214,28 @@ public sealed class SessionTreeViewModel : ReactiveObject
         RefreshHasNoSessions();
     }
 
-    /// <summary>把指定会话移动到目标分组并落库;<paramref name="targetGroupId" /> 为 <see cref="Guid.Empty" /> 表示移回树根(未分组)。</summary>
+    /// <summary>
+    /// 把指定会话移动到目标分组;<paramref name="targetGroupId" /> 为 <see cref="Guid.Empty" /> 表示移回树根(未分组)。
+    /// 树的改动是同步的,落库异步跟进(调用方不关心持久化时机时用这个重载)。
+    /// </summary>
     /// <param name="sessionId">要移动的会话标识。</param>
     /// <param name="targetGroupId">目标分组标识;<see cref="Guid.Empty" /> 表示未分组(树根)。</param>
-    public void MoveSessionToGroup(Guid sessionId, Guid targetGroupId)
+    public void MoveSessionToGroup(Guid sessionId, Guid targetGroupId) =>
+        _ = MoveSessionToGroupAsync(sessionId, targetGroupId);
+
+    /// <summary>
+    /// 移动会话到目标分组并落库。源分组因此空掉时连同分组一并删除 —— 分组在本应用里
+    /// 只是会话的容器,空容器既没有可展示的内容,也无法再被拖入(拖放落点是分组行本身),
+    /// 留着只会变成永远清不掉的僵尸目录。
+    /// </summary>
+    /// <remarks>
+    /// 树节点的增删全部排在第一个 await 之前:同步入口 <see cref="MoveSessionToGroup" />
+    /// 靠这一点让界面立即更新,只把持久化留给后台。
+    /// 落库顺序是先存会话、再删分组 —— 反过来的话中途失败会留下一批 GroupId 指向已消失
+    /// 分组的会话,下次加载时它们既不在分组下、也不在树根,等于凭空消失
+    /// (与 <see cref="DeleteSelectedGroupAsync" /> 同一处置)。
+    /// </remarks>
+    public async Task MoveSessionToGroupAsync(Guid sessionId, Guid targetGroupId)
     {
         SessionTreeNodeViewModel? sourceNode = FindSessionNode(
             sessionId,
@@ -225,6 +245,22 @@ public sealed class SessionTreeViewModel : ReactiveObject
         {
             return;
         }
+        // 原地不动直接返回。少了这道判断,“拖回自己所在的分组”会先把节点摘下来、
+        // 把分组判为空而删掉,再往这个已删除的分组里挂回去 —— 会话凭空消失。
+        if ((sourceGroup?.Id ?? Guid.Empty) == targetGroupId)
+        {
+            return;
+        }
+        SessionTreeNodeViewModel? targetGroup = null;
+        if (targetGroupId != Guid.Empty)
+        {
+            targetGroup = Nodes.FirstOrDefault(node => node.IsGroup && node.Id == targetGroupId);
+            if (targetGroup is null)
+            {
+                // 目标分组不存在:整个移动放弃,不能把节点摘下来又挂不回去。
+                return;
+            }
+        }
         if (sourceGroup is not null)
         {
             sourceGroup.Children.Remove(sourceNode);
@@ -233,21 +269,29 @@ public sealed class SessionTreeViewModel : ReactiveObject
         {
             Nodes.Remove(sourceNode);
         }
-        if (targetGroupId == Guid.Empty)
+        if (targetGroup is null)
         {
             // “未分组”落点 = 树根(设计 FrJPu)。
             sourceNode.IsRootLevel = true;
-            Nodes.Add(sourceNode);
+            InsertRootSessionSorted(sourceNode);
         }
         else
         {
-            SessionTreeNodeViewModel? targetGroup = Nodes.FirstOrDefault(node =>
-                node.IsGroup && node.Id == targetGroupId
-            );
-            if (targetGroup is not null)
+            sourceNode.IsRootLevel = false;
+            InsertSorted(targetGroup.Children, sourceNode);
+            // 拖进折叠着的分组时展开一下,否则会话看起来像是"没了"。
+            targetGroup.IsExpanded = true;
+        }
+        bool sourceGroupEmptied = sourceGroup is { Children.Count: 0 };
+        if (sourceGroupEmptied)
+        {
+            Nodes.Remove(sourceGroup!);
+            // GroupNodes 里是同一批分组节点实例(“移动到分组”子菜单绑定它),
+            // 不同步移除的话,菜单里会留下一个指向已删分组的落点。
+            GroupNodes.Remove(sourceGroup!);
+            if (ReferenceEquals(SelectedNode, sourceGroup))
             {
-                sourceNode.IsRootLevel = false;
-                targetGroup.Children.Add(sourceNode);
+                SelectedNode = null;
             }
         }
         if (_sessionCache.TryGetValue(sessionId, out SessionProfile? session))
@@ -255,8 +299,88 @@ public sealed class SessionTreeViewModel : ReactiveObject
             // Guid.Empty 是“未分组”落点:落库必须存 null,否则下次加载时会话会
             // 因找不到分组而从树里消失。
             session.GroupId = targetGroupId == Guid.Empty ? null : targetGroupId;
-            _ = _repository.SaveSessionAsync(session);
+            await _repository.SaveSessionAsync(session);
         }
+        if (sourceGroupEmptied)
+        {
+            await _repository.DeleteGroupAsync(sourceGroup!.Id);
+        }
+    }
+
+    /// <summary>
+    /// 拖放落点解析:把"鼠标松开时所在的节点"翻译成目标分组 Id
+    /// (<see cref="Guid.Empty" /> = 未分组/树根)。放在视图模型里而非视图里,
+    /// 是为了让落点规则可单测 —— 视图只负责找出鼠标下的那个节点。
+    /// </summary>
+    /// <param name="node">鼠标下的节点;树的空白处传 null。</param>
+    public Guid ResolveDropTargetGroupId(SessionTreeNodeViewModel? node) =>
+        node switch
+        {
+            null => Guid.Empty,              // 空白处 = 未分组
+            { IsGroup: true } => node.Id,    // 分组行 = 该分组
+            // 会话行 = 它所在的分组(根级会话即未分组),这样"拖到某台机器上"
+            // 与"拖到它所在的分组上"是一回事,不必精确瞄准分组标题行。
+            _ => FindGroupIdOfSession(node.Id) ?? Guid.Empty
+        };
+
+    /// <summary>
+    /// 落点的显示名,供拖拽时跟随光标的提示标签使用:
+    /// <see cref="Guid.Empty" />(树根)= “未分组”,其余取分组名;
+    /// 分组已不在树上(理论上不该发生)时同样回落到“未分组”,而不是显示一个 Guid。
+    /// </summary>
+    public string DescribeDropTarget(Guid targetGroupId) =>
+        targetGroupId == Guid.Empty
+            ? Strings.Get("Svc_Ungrouped")
+            : Nodes.FirstOrDefault(node => node.IsGroup && node.Id == targetGroupId)?.Name
+              ?? Strings.Get("Svc_Ungrouped");
+
+    /// <summary>返回会话当前所属分组 Id;根级(未分组)为 <see cref="Guid.Empty" />,节点不存在为 null。</summary>
+    public Guid? FindGroupIdOfSession(Guid sessionId)
+    {
+        if (FindSessionNode(sessionId, out SessionTreeNodeViewModel? parentGroup) is null)
+        {
+            return null;
+        }
+        return parentGroup?.Id ?? Guid.Empty;
+    }
+
+    /// <summary>按名称把会话节点插进分组子集合,保持与 <see cref="LoadTreeAsync" /> 一致的排序。</summary>
+    private static void InsertSorted(
+        ObservableCollection<SessionTreeNodeViewModel> children,
+        SessionTreeNodeViewModel node
+    )
+    {
+        int index = 0;
+        while (
+            index < children.Count
+            && string.Compare(children[index].Name, node.Name, StringComparison.OrdinalIgnoreCase) < 0
+        )
+        {
+            index++;
+        }
+        children.Insert(index, node);
+    }
+
+    /// <summary>
+    /// 把会话节点插进树根的未分组区段。根级布局是“全部分组在前、未分组会话在后”
+    /// (见 <see cref="LoadTreeAsync" />),所以先跳过分组节点再按名称排位 ——
+    /// 直接 Add 会让刚移出来的会话固定落在最后,与重新加载后的顺序对不上。
+    /// </summary>
+    private void InsertRootSessionSorted(SessionTreeNodeViewModel node)
+    {
+        int index = 0;
+        while (index < Nodes.Count && Nodes[index].IsGroup)
+        {
+            index++;
+        }
+        while (
+            index < Nodes.Count
+            && string.Compare(Nodes[index].Name, node.Name, StringComparison.OrdinalIgnoreCase) < 0
+        )
+        {
+            index++;
+        }
+        Nodes.Insert(index, node);
     }
 
     /// <summary>宿主上报某配置的连接状态,驱动状态圆点与「活跃/连接中/离线」标签。</summary>
@@ -332,13 +456,13 @@ public sealed class SessionTreeViewModel : ReactiveObject
     private void RefreshHasNoSessions() =>
         HasNoSessions = !Nodes.Any(node => !node.IsGroup || node.Children.Count > 0);
 
-    private void MoveSelectedToGroup(SessionTreeNodeViewModel? targetGroup)
+    private async Task MoveSelectedToGroupAsync(SessionTreeNodeViewModel? targetGroup)
     {
         if (targetGroup is not { IsGroup: true } || SelectedNode is not { IsGroup: false } node)
         {
             return;
         }
-        MoveSessionToGroup(node.Id, targetGroup.Id);
+        await MoveSessionToGroupAsync(node.Id, targetGroup.Id);
     }
 
     private async Task DuplicateSelectedSessionAsync()

--- a/src/VelaShell/Views/SessionTreeView.axaml
+++ b/src/VelaShell/Views/SessionTreeView.axaml
@@ -11,7 +11,12 @@
              x:Class="VelaShell.Views.SessionTreeView"
              x:DataType="vm:SessionTreeViewModel">
 
-  <TreeView ItemsSource="{Binding Nodes}"
+  <Panel>
+
+  <!-- 拖放整棵树接收(AllowDrop 与 DragOver/Drop 处理在代码后台接线):会话行可拖进
+       任意分组行,拖到根级会话或树的空白处 = 移出分组。 -->
+  <TreeView x:Name="SessionTreeRoot"
+            ItemsSource="{Binding Nodes}"
             SelectedItem="{Binding SelectedNode, Mode=TwoWay}"
             Background="Transparent"
             Padding="0,0,0,0">
@@ -46,12 +51,22 @@
         <Setter Property="IsVisible" Value="False" />
       </Style>
 
-      <!-- 分组行 -->
+      <!-- 分组行。描边宽度常驻 1、平时画成透明:拖放高亮只换颜色不换尺寸,
+           否则点亮/熄灭会让行内容左右各挪 1px,拖过去时肉眼就是在抖。 -->
       <Style Selector="Border.group">
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderBrush" Value="Transparent" />
       </Style>
       <Style Selector="Border.group:pointerover">
         <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      </Style>
+
+      <!-- 拖放落点提示:拖着会话经过时,目标分组行以 accent 描边 + 活动底色点亮。
+           落点解析见 SessionTreeView.axaml.cs。 -->
+      <Style Selector="Border.group.droptarget">
+        <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
       </Style>
 
       <!-- 分组文件夹图标配色:按分组顺序 warning/info/accent 轮换(设计 FrJPu)。 -->
@@ -126,12 +141,14 @@
       <TreeDataTemplate ItemsSource="{Binding Children}"
                         x:DataType="vm:SessionTreeNodeViewModel">
 
-        <!-- 分组行 -->
+        <!-- 分组行。Padding 11 + Border.group 样式里常驻的 1px 描边 = 视觉缩进仍是 12,
+             与会话行对齐;描边常驻是为了让拖放高亮只换颜色、不动几何。 -->
         <Panel>
           <Border IsVisible="{Binding IsGroup}"
                   Classes="group"
+                  Classes.droptarget="{Binding IsDropTarget}"
                   Height="30"
-                  Padding="12,0"
+                  Padding="11,0"
                   Cursor="Hand"
                   Tapped="Group_Tapped"
                   PointerPressed="Group_PointerPressed">
@@ -361,5 +378,43 @@
       </TreeDataTemplate>
     </TreeView.ItemTemplate>
   </TreeView>
+
+    <!--
+      拖放叠层。整层 IsHitTestVisible="False" —— 否则叠层自己会成为 DragOver 的命中目标,
+      落点解析永远算到同一个东西上。
+
+      · RootDropZone:落点是“未分组(树根)”时,把整棵树框起来。这里刻意不画插入线 ——
+        移动后的位置是按名称排的(见 SessionTreeViewModel.InsertRootSessionSorted),
+        画一条“插到这两行之间”的线会与实际落位不符,是在骗人。
+      · DragGhost:跟着光标走的半透明标签,直接写明“<会话> → <目标分组>”,
+        这样不必去分辨哪一行被点亮,也能知道松手会落到哪。
+    -->
+    <Border x:Name="RootDropZone"
+            IsVisible="False"
+            IsHitTestVisible="False"
+            Margin="1"
+            CornerRadius="3"
+            BorderThickness="1"
+            BorderBrush="{DynamicResource VelaAccent}" />
+
+    <Canvas x:Name="DragOverlay" IsHitTestVisible="False" ClipToBounds="True">
+      <Border x:Name="DragGhost"
+              IsVisible="False"
+              Padding="8,3"
+              CornerRadius="3"
+              Opacity="0.92"
+              BorderThickness="1"
+              BorderBrush="{DynamicResource VelaAccent}"
+              Background="{DynamicResource VelaBgActive}"
+              BoxShadow="0 2 8 0 #66000000">
+        <TextBlock x:Name="DragGhostText"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize11}"
+                   Foreground="{DynamicResource VelaTextPrimary}"
+                   VerticalAlignment="Center" />
+      </Border>
+    </Canvas>
+
+  </Panel>
 
 </UserControl>

--- a/src/VelaShell/Views/SessionTreeView.axaml.cs
+++ b/src/VelaShell/Views/SessionTreeView.axaml.cs
@@ -1,22 +1,51 @@
 using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using VelaShell.Presentation.ViewModels;
 
 namespace VelaShell.Views;
 
-/// <summary>会话树视图:以分组树形式展示会话,支持展开折叠、双击连接与右键菜单。</summary>
+/// <summary>会话树视图:以分组树形式展示会话,支持展开折叠、双击连接、右键菜单与拖动分组。</summary>
 public partial class SessionTreeView : UserControl
 {
+    /// <summary>
+    /// 会话拖放载荷前缀(与 SFTP 那套 VFTP/VFTPL 同形)。只在本树内自产自销,
+    /// 前缀的作用是别把外部拖进来的文本/文件当成会话节点。
+    /// </summary>
+    private const string SessionDragPrefix = "VSESS|";
+
+    /// <summary>按下到移动超过该像素才算拖拽,避免误触打断双击连接(与文件面板一致)。</summary>
+    private const double DragThreshold = 5;
+
     private SessionTreeViewModel? _viewModel;
+
+    // 拖拽手势状态:按下时记住行与按下事件(DoDragDropAsync 需要原始的 PointerPressedEventArgs)。
+    private SessionTreeNodeViewModel? _dragNode;
+    private PointerPressedEventArgs? _dragPointerArgs;
+    private Point _dragOrigin;
+    private bool _isDragging;
+
+    /// <summary>被拖会话的显示名,拖起时快照下来给幽灵标签用(拖放过程中不再依赖手势状态)。</summary>
+    private string _dragLabel = string.Empty;
 
     /// <summary>初始化会话树视图并加载 XAML 组件。</summary>
     public SessionTreeView()
     {
         InitializeComponent();
         DataContextChanged += OnDataContextChanged;
+
+        // 拖动分组:接收落点在整棵树上(空白处 = 移出分组),发起在会话行上
+        // (Session_PointerPressed 记录起点,移动超过阈值才真正开始拖)。
+        DragDrop.SetAllowDrop(SessionTreeRoot, true);
+        SessionTreeRoot.AddHandler(DragDrop.DragOverEvent, OnTreeDragOver);
+        SessionTreeRoot.AddHandler(DragDrop.DropEvent, OnTreeDrop);
+        SessionTreeRoot.AddHandler(DragDrop.DragLeaveEvent, OnTreeDragLeave);
+        SessionTreeRoot.AddHandler(PointerMovedEvent, OnTreePointerMoved);
+        SessionTreeRoot.AddHandler(PointerReleasedEvent, OnTreePointerReleased, RoutingStrategies.Bubble, true);
     }
 
     private void OnDataContextChanged(object? sender, EventArgs e)
@@ -91,20 +120,226 @@ public partial class SessionTreeView : UserControl
 
     /// <summary>
     /// 右键弹菜单前先选中所指行:菜单里的命令都作用于 SelectedNode,不选中会
-    /// 对着上一次选择的会话执行。
+    /// 对着上一次选择的会话执行。左键则记下拖拽起点(是否真拖由移动阈值决定)。
     /// </summary>
     private void Session_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (!e.GetCurrentPoint(null).Properties.IsRightButtonPressed)
+        if (
+            sender is not Control { DataContext: SessionTreeNodeViewModel { IsGroup: false } node }
+            || DataContext is not SessionTreeViewModel viewModel
+        )
         {
             return;
         }
-        if (
-            sender is Control { DataContext: SessionTreeNodeViewModel { IsGroup: false } node }
-            && DataContext is SessionTreeViewModel viewModel
-        )
+        PointerPointProperties properties = e.GetCurrentPoint(null).Properties;
+        if (properties.IsRightButtonPressed)
         {
             viewModel.SelectedNode = node;
+            return;
+        }
+        if (!properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        _dragNode = node;
+        _dragPointerArgs = e;
+        _dragOrigin = e.GetPosition(this);
+        _isDragging = false;
+    }
+
+    // ── 拖动分组 ────────────────────────────────────────────────
+
+    private void OnTreePointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_isDragging || _dragNode is null || _dragPointerArgs is null)
+        {
+            return;
+        }
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            ResetDragGesture();
+            return;
+        }
+        Point current = e.GetPosition(this);
+        if (
+            Math.Abs(current.X - _dragOrigin.X) < DragThreshold
+            && Math.Abs(current.Y - _dragOrigin.Y) < DragThreshold
+        )
+        {
+            return;
+        }
+        _isDragging = true;
+        _ = StartSessionDragAsync(_dragNode, _dragPointerArgs);
+    }
+
+    private void OnTreePointerReleased(object? sender, PointerReleasedEventArgs e) =>
+        ResetDragGesture();
+
+    private async Task StartSessionDragAsync(
+        SessionTreeNodeViewModel node,
+        PointerPressedEventArgs pointerArgs
+    )
+    {
+        var data = new DataTransfer();
+        var item = new DataTransferItem();
+        item.SetText(SessionDragPrefix + node.Id);
+        data.Add(item);
+        _dragLabel = node.Name;
+        try
+        {
+            await DragDrop.DoDragDropAsync(pointerArgs, data, DragDropEffects.Move);
+        }
+        finally
+        {
+            // 拖拽被取消(Esc/落在窗口外)时同样要收拾干净,否则高亮与幽灵标签会留在屏幕上。
+            ClearDragFeedback();
+            ResetDragGesture();
         }
     }
+
+    private void ResetDragGesture()
+    {
+        _isDragging = false;
+        _dragNode = null;
+        _dragPointerArgs = null;
+    }
+
+    private void OnTreeDragOver(object? sender, DragEventArgs e)
+    {
+        if (
+            TryGetDraggedSessionId(e) is not { } sessionId
+            || DataContext is not SessionTreeViewModel viewModel
+        )
+        {
+            e.DragEffects = DragDropEffects.None;
+            return;
+        }
+        Guid target = viewModel.ResolveDropTargetGroupId(FindNodeAt(e.Source));
+        // 落回原分组等于什么都没发生:直接给"不可放置"光标,免得用户以为拖成功了。
+        bool sameGroup = viewModel.FindGroupIdOfSession(sessionId) == target;
+        e.DragEffects = sameGroup ? DragDropEffects.None : DragDropEffects.Move;
+        ShowDragFeedback(_dragLabel, target, sameGroup, e.GetPosition(DragOverlay));
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// 更新拖拽过程中的三处落点提示:目标分组行点亮、落到未分组时把整棵树框起来、
+    /// 跟随光标的幽灵标签写明“&lt;会话&gt; → &lt;目标&gt;”。
+    /// </summary>
+    /// <remarks>
+    /// 拖放事件在无头测试里造不出来,因此这里是 internal:测试直接调它,验的是真实视觉状态
+    /// (可见性、标签文案、被夹在叠层内的坐标),而不是"我相信 DragOver 会做对"。
+    /// </remarks>
+    /// <param name="draggedName">被拖会话的显示名。</param>
+    /// <param name="targetGroupId">落点分组;<see cref="Guid.Empty" /> 表示未分组(树根)。</param>
+    /// <param name="sameGroup">落点与当前所在分组相同(等于没动),此时只显示会话名、不给落点承诺。</param>
+    /// <param name="position">光标在 <c>DragOverlay</c> 坐标系里的位置。</param>
+    internal void ShowDragFeedback(
+        string draggedName,
+        Guid targetGroupId,
+        bool sameGroup,
+        Point position
+    )
+    {
+        if (DataContext is not SessionTreeViewModel viewModel)
+        {
+            return;
+        }
+        HighlightDropTarget(viewModel, sameGroup ? Guid.Empty : targetGroupId);
+        RootDropZone.IsVisible = !sameGroup && targetGroupId == Guid.Empty;
+        DragGhostText.Text = sameGroup
+            ? draggedName
+            : $"{draggedName} → {viewModel.DescribeDropTarget(targetGroupId)}";
+        DragGhost.IsVisible = true;
+
+        // 先量一次再摆位:标签宽度随文案变,不夹住的话拖到右下角时会被裁掉半截。
+        // 多留 1px:布局取整会把实际排布尺寸再涨到下一个整像素,按 DesiredSize 卡死会正好溢出。
+        const double layoutRoundingSlack = 1;
+        DragGhost.Measure(Size.Infinity);
+        Size ghost = DragGhost.DesiredSize;
+        double maxLeft = Math.Max(
+            0,
+            DragOverlay.Bounds.Width - ghost.Width - layoutRoundingSlack
+        );
+        double maxTop = Math.Max(
+            0,
+            DragOverlay.Bounds.Height - ghost.Height - layoutRoundingSlack
+        );
+        Canvas.SetLeft(DragGhost, Math.Clamp(position.X + 12, 0, maxLeft));
+        Canvas.SetTop(DragGhost, Math.Clamp(position.Y + 16, 0, maxTop));
+    }
+
+    private async void OnTreeDrop(object? sender, DragEventArgs e)
+    {
+        ClearDragFeedback();
+        if (
+            TryGetDraggedSessionId(e) is not { } sessionId
+            || DataContext is not SessionTreeViewModel viewModel
+        )
+        {
+            return;
+        }
+        e.Handled = true;
+        await viewModel.MoveSessionToGroupAsync(
+            sessionId,
+            viewModel.ResolveDropTargetGroupId(FindNodeAt(e.Source))
+        );
+    }
+
+    /// <summary>
+    /// 只有指针真的离开整棵树时才熄灭高亮。
+    /// DragLeave 是路由事件:在树内部跨元素时(行与行之间、行 Border 与里面的文本之间)
+    /// 每次都会冒泡上来,若见一次清一次,就会与紧随其后的 DragOver 交替点亮/熄灭 ——
+    /// 表现为拖着会话在目标分组上移动时持续闪烁。
+    /// </summary>
+    private void OnTreeDragLeave(object? sender, DragEventArgs e)
+    {
+        if (!new Rect(SessionTreeRoot.Bounds.Size).Contains(e.GetPosition(SessionTreeRoot)))
+        {
+            ClearDragFeedback();
+        }
+    }
+
+    /// <summary>点亮目标分组行;<see cref="Guid.Empty" />(未分组/树根)不对应任何行,等同于全部熄灭。</summary>
+    private static void HighlightDropTarget(SessionTreeViewModel viewModel, Guid groupId)
+    {
+        foreach (SessionTreeNodeViewModel node in viewModel.Nodes)
+        {
+            node.IsDropTarget = node.IsGroup && node.Id == groupId;
+        }
+    }
+
+    /// <summary>熄灭全部落点提示(行高亮 + 根落点框 + 幽灵标签)。</summary>
+    internal void ClearDragFeedback()
+    {
+        if (DataContext is SessionTreeViewModel viewModel)
+        {
+            HighlightDropTarget(viewModel, Guid.Empty);
+        }
+        RootDropZone.IsVisible = false;
+        DragGhost.IsVisible = false;
+    }
+
+    /// <summary>从拖放载荷里取出会话 Id;不是本树发出的拖拽则返回 null。</summary>
+    private static Guid? TryGetDraggedSessionId(DragEventArgs e)
+    {
+        string? text = e.DataTransfer.TryGetText();
+        if (text is null || !text.StartsWith(SessionDragPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+        return Guid.TryParse(text[SessionDragPrefix.Length..], out Guid id) ? id : null;
+    }
+
+    /// <summary>
+    /// 找出鼠标下的树节点:从命中的可视元素向上找第一个数据上下文是节点的控件。
+    /// 树的空白处找不到节点,返回 null —— 落点解析(ResolveDropTargetGroupId)把它当作"未分组"。
+    /// </summary>
+    private static SessionTreeNodeViewModel? FindNodeAt(object? source) =>
+        (source as Visual)
+            ?.GetSelfAndVisualAncestors()
+            .OfType<Control>()
+            .Select(control => control.DataContext)
+            .OfType<SessionTreeNodeViewModel>()
+            .FirstOrDefault();
 }

--- a/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SessionTreeViewModelTests.cs
@@ -2,6 +2,7 @@ using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
 using VelaShell.Presentation.ViewModels;
 
 namespace VelaShell.Tests.ViewModels;
@@ -118,14 +119,15 @@ public class SessionTreeViewModelTests
         await _vm.LoadCommand.Execute().FirstAsync();
 
         // Guid.Empty 是“未分组”落点:节点应移到树根,落库 GroupId 为 null。
-        _vm.MoveSessionToGroup(session.Id, Guid.Empty);
-        Assert.IsEmpty(_vm.Nodes[0].Children);
+        // 组内最后一条被移走 → 空分组随之自动删除,树里只剩这条根级会话。
+        await _vm.MoveSessionToGroupAsync(session.Id, Guid.Empty);
         SessionTreeNodeViewModel? rootNode = _vm.Nodes.FirstOrDefault(node =>
             !node.IsGroup && node.Id == session.Id
         );
         Assert.IsNotNull(rootNode);
         Assert.IsTrue(rootNode.IsRootLevel);
         Assert.IsNull(session.GroupId);
+        Assert.DoesNotContain(node => node.IsGroup, _vm.Nodes);
     }
 
     [TestMethod]
@@ -147,6 +149,215 @@ public class SessionTreeViewModelTests
         Assert.HasCount(1, groupNode.Children);
         Assert.IsFalse(groupNode.Children[0].IsRootLevel);
         Assert.AreEqual(group.Id, orphan.GroupId);
+    }
+
+    // ── 拖动分组:移动 + 空分组自动删除 ────────────────────────────
+
+    /// <summary>组内最后一条被拖走 → 空分组连同落库一并删除(“移动到分组”菜单同一条路径)。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_LastMemberLeaves_DeletesEmptiedGroup()
+    {
+        ServerGroup source = CreateGroup("Source", 0);
+        ServerGroup target = CreateGroup("Target", 1);
+        SessionProfile session = CreateSession("WebServer", source.Id);
+        _repository
+            .GetAllGroupsAsync()
+            .Returns(Task.FromResult(new List<ServerGroup> { source, target }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { session }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(session.Id, target.Id);
+
+        await _repository.Received(1).DeleteGroupAsync(source.Id);
+        Assert.DoesNotContain(node => node.Id == source.Id, _vm.Nodes);
+        // “移动到分组”子菜单绑定 GroupNodes,不同步移除会留下指向已删分组的落点。
+        Assert.DoesNotContain(node => node.Id == source.Id, _vm.GroupNodes);
+        Assert.HasCount(1, _vm.Nodes.First(node => node.Id == target.Id).Children);
+        Assert.AreEqual(target.Id, session.GroupId);
+    }
+
+    /// <summary>组里还剩人时不能删组 —— 自动删除只针对被搬空的分组。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_GroupKeepsMembers_IsNotDeleted()
+    {
+        ServerGroup source = CreateGroup("Source", 0);
+        SessionProfile leaving = CreateSession("Leaving", source.Id);
+        SessionProfile staying = CreateSession("Staying", source.Id);
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { source }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { leaving, staying }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(leaving.Id, Guid.Empty);
+
+        await _repository.DidNotReceive().DeleteGroupAsync(Arg.Any<Guid>());
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.Id == source.Id);
+        Assert.HasCount(1, groupNode.Children);
+        Assert.AreEqual("Staying", groupNode.Children[0].Name);
+    }
+
+    /// <summary>
+    /// 拖回自己所在的分组是空操作。少了这道判断会先摘节点、把分组判空删掉,
+    /// 再往已删除的分组里挂回去 —— 会话凭空消失。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_DropOnOwnGroup_IsNoOp()
+    {
+        ServerGroup group = CreateGroup("Production", 0);
+        SessionProfile session = CreateSession("WebServer", group.Id);
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { session }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(session.Id, group.Id);
+
+        await _repository.DidNotReceive().DeleteGroupAsync(Arg.Any<Guid>());
+        await _repository.DidNotReceive().SaveSessionAsync(Arg.Any<SessionProfile>());
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.Id == group.Id);
+        Assert.HasCount(1, groupNode.Children);
+        Assert.AreEqual(group.Id, session.GroupId);
+    }
+
+    /// <summary>根级会话拖到树根(还是未分组)同样是空操作。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_RootSessionToRoot_IsNoOp()
+    {
+        SessionProfile orphan = CreateSession("Orphan");
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup>()));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { orphan }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(orphan.Id, Guid.Empty);
+
+        await _repository.DidNotReceive().SaveSessionAsync(Arg.Any<SessionProfile>());
+        Assert.HasCount(1, _vm.Nodes);
+    }
+
+    /// <summary>目标分组不存在时整个移动放弃,不能把节点摘下来又挂不回去。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_UnknownTargetGroup_KeepsSessionInPlace()
+    {
+        ServerGroup group = CreateGroup("Production", 0);
+        SessionProfile session = CreateSession("WebServer", group.Id);
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { session }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(session.Id, Guid.NewGuid());
+
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.Id == group.Id);
+        Assert.HasCount(1, groupNode.Children);
+        Assert.AreEqual(group.Id, session.GroupId);
+        await _repository.DidNotReceive().DeleteGroupAsync(Arg.Any<Guid>());
+    }
+
+    /// <summary>落点按名称插位,与重新加载后的排序一致(直接 Add 会固定落在末尾)。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_InsertsByName_InTargetAndAtRoot()
+    {
+        ServerGroup target = CreateGroup("Target", 0);
+        SessionProfile alpha = CreateSession("Alpha", target.Id);
+        SessionProfile zulu = CreateSession("Zulu", target.Id);
+        SessionProfile middle = CreateSession("Middle");
+        SessionProfile rootAaa = CreateSession("Aaa");
+        SessionProfile rootZzz = CreateSession("Zzz");
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { target }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(
+                Task.FromResult(new List<SessionProfile> { alpha, zulu, middle, rootAaa, rootZzz })
+            );
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        await _vm.MoveSessionToGroupAsync(middle.Id, target.Id);
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.Id == target.Id);
+        Assert.AreEqual("Alpha", groupNode.Children[0].Name);
+        Assert.AreEqual("Middle", groupNode.Children[1].Name);
+        Assert.AreEqual("Zulu", groupNode.Children[2].Name);
+
+        // 再拖回树根:分组节点始终在前,未分组会话在后并按名称排位。
+        await _vm.MoveSessionToGroupAsync(middle.Id, Guid.Empty);
+        Assert.IsTrue(_vm.Nodes[0].IsGroup);
+        Assert.AreEqual("Aaa", _vm.Nodes[1].Name);
+        Assert.AreEqual("Middle", _vm.Nodes[2].Name);
+        Assert.AreEqual("Zzz", _vm.Nodes[3].Name);
+    }
+
+    /// <summary>拖进折叠着的分组会把它展开,否则会话看起来像是"没了"。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task MoveSessionToGroupAsync_ExpandsCollapsedTargetGroup()
+    {
+        ServerGroup target = CreateGroup("Target", 0);
+        SessionProfile member = CreateSession("Member", target.Id);
+        SessionProfile orphan = CreateSession("Orphan");
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { target }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { member, orphan }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.Id == target.Id);
+        groupNode.IsExpanded = false;
+
+        await _vm.MoveSessionToGroupAsync(orphan.Id, target.Id);
+
+        Assert.IsTrue(groupNode.IsExpanded);
+    }
+
+    /// <summary>落点解析(视图只负责找出鼠标下的节点,规则在这里)。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task ResolveDropTargetGroupId_MapsRowUnderCursorToTargetGroup()
+    {
+        ServerGroup group = CreateGroup("Production", 0);
+        SessionProfile member = CreateSession("Member", group.Id);
+        SessionProfile orphan = CreateSession("Orphan");
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository
+            .GetAllSessionsAsync()
+            .Returns(Task.FromResult(new List<SessionProfile> { member, orphan }));
+        await _vm.LoadCommand.Execute().FirstAsync();
+        SessionTreeNodeViewModel groupNode = _vm.Nodes.First(node => node.IsGroup);
+        SessionTreeNodeViewModel memberNode = groupNode.Children[0];
+        SessionTreeNodeViewModel orphanNode = _vm.Nodes.First(node =>
+            !node.IsGroup && node.Id == orphan.Id
+        );
+
+        // 空白处 = 未分组;分组行 = 该分组;组内会话行 = 它所在的分组;根级会话行 = 未分组。
+        Assert.AreEqual(Guid.Empty, _vm.ResolveDropTargetGroupId(null));
+        Assert.AreEqual(group.Id, _vm.ResolveDropTargetGroupId(groupNode));
+        Assert.AreEqual(group.Id, _vm.ResolveDropTargetGroupId(memberNode));
+        Assert.AreEqual(Guid.Empty, _vm.ResolveDropTargetGroupId(orphanNode));
+    }
+
+    /// <summary>落点名(拖拽时跟随光标的标签用):分组取组名,树根取“未分组”,未知分组不显示 Guid。</summary>
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task DescribeDropTarget_NamesGroupOrUngrouped()
+    {
+        ServerGroup group = CreateGroup("Production", 0);
+        _repository.GetAllGroupsAsync().Returns(Task.FromResult(new List<ServerGroup> { group }));
+        _repository.GetAllSessionsAsync().Returns(Task.FromResult(new List<SessionProfile>()));
+        await _vm.LoadCommand.Execute().FirstAsync();
+
+        Assert.AreEqual("Production", _vm.DescribeDropTarget(group.Id));
+        Assert.AreEqual(Strings.Get("Svc_Ungrouped"), _vm.DescribeDropTarget(Guid.Empty));
+        Assert.AreEqual(Strings.Get("Svc_Ungrouped"), _vm.DescribeDropTarget(Guid.NewGuid()));
     }
 
     [TestMethod]
@@ -271,6 +482,8 @@ public class SessionTreeViewModelTests
         Assert.IsEmpty(sourceGroup.Children);
         Assert.HasCount(1, targetGroup.Children);
         Assert.AreEqual("MoveMe", targetGroup.Children[0].Name);
+        // 源分组被搬空 → 自动删除,树里不再留着它。
+        Assert.DoesNotContain(node => node.Id == sourceGroupId, _vm.Nodes);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
@@ -1,11 +1,15 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using NSubstitute;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
 using VelaShell.Presentation.ViewModels;
 using VelaShell.Views;
 
@@ -271,6 +275,145 @@ public class SidebarQuickCommandsUiTests
             Assert.IsGreaterThan(36, grid.RowDefinitions[2].ActualHeight);
             window.Close();
         });
+    }
+
+    /// <summary>
+    /// 拖动分组的视图侧接线:树接收放置(AllowDrop),分组行随 IsDropTarget 换色,
+    /// 且换色**不改变几何** —— 描边宽度常驻,点亮/熄灭只动颜色。
+    /// 断言落到真实视觉状态(画刷 alpha、行内容位置)而不是只比 VM 的布尔值:
+    /// Classes.droptarget 绑定写错时 VM 照样翻转、界面毫无反应;而描边宽度若跟着变,
+    /// 行内容会左右各挪 1px,拖过去时肉眼就是在抖。
+    /// </summary>
+    [TestMethod]
+    public void SessionTreeGroupRow_HighlightsDropTargetWithoutMovingContent()
+    {
+        OnUi(() =>
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            var viewModel = new SessionTreeViewModel(repository);
+            var groupNode = new SessionTreeNodeViewModel(Guid.NewGuid(), "Production", true);
+            viewModel.Nodes.Add(groupNode);
+            var view = new SessionTreeView { DataContext = viewModel };
+            var window = new Window
+            {
+                Width = 260,
+                Height = 400,
+                Content = view,
+            };
+            window.Show();
+            Relayout(window);
+
+            TreeView tree = view.FindControl<TreeView>("SessionTreeRoot")!;
+            Assert.IsTrue(DragDrop.GetAllowDrop(tree));
+
+            Border row = view.GetVisualDescendants()
+                             .OfType<Border>()
+                             .First(border =>
+                                 border.Classes.Contains("group")
+                                 && ReferenceEquals(border.DataContext, groupNode)
+                             );
+            Rect contentBefore = row.Child!.Bounds;
+            Assert.AreEqual(0, BorderAlpha(row), "平时描边应当是透明的");
+
+            groupNode.IsDropTarget = true;
+            Relayout(window);
+            Assert.IsTrue(row.Classes.Contains("droptarget"));
+            Assert.IsGreaterThan(0, BorderAlpha(row), "落点分组应当点亮 accent 描边");
+            Assert.AreEqual(contentBefore, row.Child!.Bounds, "高亮不得挪动行内容");
+
+            groupNode.IsDropTarget = false;
+            Relayout(window);
+            Assert.AreEqual(0, BorderAlpha(row));
+            Assert.AreEqual(contentBefore, row.Child!.Bounds);
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// 拖拽时的落点提示:幽灵标签写明“会话 → 目标”,落到未分组时整棵树被框起来,
+    /// 且标签始终被夹在叠层内(拖到右下角不会被裁掉半截)。
+    /// 拖放事件在无头后端造不出来,因此直接调视图的 ShowDragFeedback ——
+    /// 验的是真实视觉状态,而不是"相信 DragOver 会做对"。
+    /// </summary>
+    [TestMethod]
+    public void SessionTreeDragFeedback_NamesTargetAndFramesUngroupedDrop()
+    {
+        OnUi(() =>
+        {
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            var viewModel = new SessionTreeViewModel(repository);
+            var groupNode = new SessionTreeNodeViewModel(Guid.NewGuid(), "Production", true);
+            viewModel.Nodes.Add(groupNode);
+            var view = new SessionTreeView { DataContext = viewModel };
+            var window = new Window
+            {
+                Width = 260,
+                Height = 400,
+                Content = view,
+            };
+            window.Show();
+            Relayout(window);
+
+            Canvas overlay = view.FindControl<Canvas>("DragOverlay")!;
+            Border ghost = view.FindControl<Border>("DragGhost")!;
+            TextBlock ghostText = view.FindControl<TextBlock>("DragGhostText")!;
+            Border rootZone = view.FindControl<Border>("RootDropZone")!;
+
+            // 叠层不能参与命中测试,否则落点永远算到它身上。
+            Assert.IsFalse(overlay.IsHitTestVisible);
+            Assert.IsFalse(ghost.IsVisible);
+            Assert.IsFalse(rootZone.IsVisible);
+
+            // 落到分组:标签写明目标,分组行点亮,不画根落点框。
+            view.ShowDragFeedback("WebServer", groupNode.Id, sameGroup: false, new Point(20, 20));
+            Relayout(window);
+            Assert.IsTrue(ghost.IsVisible);
+            Assert.IsTrue(ghostText.Text!.Contains("WebServer", StringComparison.Ordinal));
+            Assert.IsTrue(
+                ghostText.Text!.Contains("Production", StringComparison.Ordinal),
+                $"幽灵标签应写明目标分组,实际:{ghostText.Text}"
+            );
+            Assert.IsTrue(groupNode.IsDropTarget);
+            Assert.IsFalse(rootZone.IsVisible);
+
+            // 落到未分组:框住整棵树,分组行熄灭;坐标越界时标签仍被夹在叠层内。
+            view.ShowDragFeedback("WebServer", Guid.Empty, sameGroup: false, new Point(9999, 9999));
+            Relayout(window);
+            Assert.IsTrue(rootZone.IsVisible);
+            Assert.IsFalse(groupNode.IsDropTarget);
+            Assert.IsTrue(
+                ghostText.Text!.Contains(Strings.Get("Svc_Ungrouped"), StringComparison.Ordinal),
+                $"幽灵标签应写明未分组,实际:{ghostText.Text}"
+            );
+            Assert.IsTrue(
+                Canvas.GetLeft(ghost) + ghost.Bounds.Width <= overlay.Bounds.Width + 0.5,
+                "幽灵标签右边缘越出了叠层"
+            );
+            Assert.IsTrue(
+                Canvas.GetTop(ghost) + ghost.Bounds.Height <= overlay.Bounds.Height + 0.5,
+                $"幽灵标签下边缘越出了叠层:top={Canvas.GetTop(ghost)} h={ghost.Bounds.Height} overlay={overlay.Bounds.Height}"
+            );
+
+            // 落回自己所在的分组 = 没得可动:只显示会话名,不给任何落点承诺。
+            view.ShowDragFeedback("WebServer", groupNode.Id, sameGroup: true, new Point(20, 20));
+            Relayout(window);
+            Assert.AreEqual("WebServer", ghostText.Text);
+            Assert.IsFalse(rootZone.IsVisible);
+            Assert.IsFalse(groupNode.IsDropTarget);
+
+            view.ClearDragFeedback();
+            Relayout(window);
+            Assert.IsFalse(ghost.IsVisible);
+            Assert.IsFalse(rootZone.IsVisible);
+            window.Close();
+        });
+    }
+
+    /// <summary>取行描边画刷的不透明度;画刷解析不到(主题字典没接上)时直接判失败而不是悄悄绿。</summary>
+    private static byte BorderAlpha(Border row)
+    {
+        Assert.IsInstanceOfType<ISolidColorBrush>(row.BorderBrush, "描边画刷未解析");
+        return ((ISolidColorBrush)row.BorderBrush!).Color.A;
     }
 
     /// <summary>


### PR DESCRIPTION
为 SessionTreeView 实现完整拖动分组，支持节点拖放至分组、根或其他会话，自动处理分组高亮、落点提示、分组展开与空分组删除等细节。 SessionTreeNodeViewModel 新增 IsDropTarget 属性用于分组高亮。 SessionTreeViewModel 拆分 MoveSessionToGroup/MoveSessionToGroupAsync，异步处理节点移动、分组删除与持久化，提升 UI 响应性。新增辅助方法保障拖放一致性与可测试性。 SessionTreeView XAML 增加拖放 UI 元素，代码实现拖拽手势、事件处理、落点提示与数据校验，优化拖动体验。 SessionTreeViewModelTests 补充拖动分组相关测试，覆盖多种场景，增强逻辑健壮性。 SidebarQuickCommandsUiTests 新增 UI 测试，确保分组高亮、幽灵标签、根落点框等视觉与交互一致。