### PR TITLE
关于页支持精确显示进程与系统架构

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1268,6 +1268,9 @@
   <data name="Msg_UpdateServiceNotAvailable" xml:space="preserve">
     <value>自動更新サービスは未対応です。プロジェクトのリリースページから新しいバージョンを入手してください。</value>
   </data>
+  <data name="SetAbout_ArchEmulated" xml:space="preserve">
+    <value>{0}、{1} 上でエミュレーション実行</value>
+  </data>
   <data name="SetAbout_Checking" xml:space="preserve">
     <value>更新を確認しています…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1268,6 +1268,9 @@
   <data name="Msg_UpdateServiceNotAvailable" xml:space="preserve">
     <value>자동 업데이트 서비스가 아직 연결되지 않았습니다. 프로젝트 릴리스 페이지에서 새 버전을 받으세요.</value>
   </data>
+  <data name="SetAbout_ArchEmulated" xml:space="preserve">
+    <value>{0}, {1}에서 에뮬레이션 실행</value>
+  </data>
   <data name="SetAbout_Checking" xml:space="preserve">
     <value>업데이트를 확인하는 중…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1459,6 +1459,9 @@ Paste anyway?</value>
   <data name="Msg_UpdateServiceNotAvailable" xml:space="preserve">
     <value>Auto-update is not available yet; please get new releases from the project releases page.</value>
   </data>
+  <data name="SetAbout_ArchEmulated" xml:space="preserve">
+    <value>{0}, emulated on {1}</value>
+  </data>
   <data name="SetAbout_Checking" xml:space="preserve">
     <value>Checking for updates…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1550,6 +1550,9 @@
   <data name="Msg_UpdateServiceNotAvailable" xml:space="preserve">
     <value>自动更新服务尚未接入,请前往项目发布页获取新版本。</value>
   </data>
+  <data name="SetAbout_ArchEmulated" xml:space="preserve">
+    <value>{0},在 {1} 上仿真运行</value>
+  </data>
   <data name="SetAbout_Checking" xml:space="preserve">
     <value>正在检查更新…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1268,6 +1268,9 @@
   <data name="Msg_UpdateServiceNotAvailable" xml:space="preserve">
     <value>自動更新服務尚未接入,請前往專案發佈頁取得新版本。</value>
   </data>
+  <data name="SetAbout_ArchEmulated" xml:space="preserve">
+    <value>{0},在 {1} 上模擬執行</value>
+  </data>
   <data name="SetAbout_Checking" xml:space="preserve">
     <value>正在檢查更新…</value>
   </data>

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using ReactiveUI;
 using ReactiveUI.Primitives;
@@ -477,9 +478,28 @@ public class SettingsViewModel : ReactiveObject
     private static string Describe(string displayName, string packageId) =>
         PackageVersions.Of(packageId) is { } version ? $"{displayName} {version}" : displayName;
 
-    /// <summary>关于页显示的操作系统版本与位数。</summary>
+    /// <summary>关于页显示的操作系统版本与架构。</summary>
     public static string AboutOs =>
-        $"{Environment.OSVersion.VersionString} ({(Environment.Is64BitOperatingSystem ? "x64" : "x86")})";
+        $"{Environment.OSVersion.VersionString} ({DescribeArchitecture(RuntimeInformation.ProcessArchitecture, RuntimeInformation.OSArchitecture)})";
+
+    /// <summary>
+    /// 架构显示文本。取真实架构名而非「是不是 64 位」——
+    /// 原先的 <c>Is64BitOperatingSystem ? "x64" : "x86"</c> 会把 arm64 报成 x64、arm 报成 x86。
+    /// </summary>
+    /// <remarks>
+    /// 进程架构与系统架构不一致时两者都显示(如 x64 版跑在 arm64 Windows / Apple Silicon 的仿真层上)。
+    /// 这不是冗余信息:自更新按**进程**架构选产物(见 <see cref="Services.Update.UpdateManifest.CurrentRid" />),
+    /// 装错架构的人会一直留在仿真轨上拿不到原生版本,关于页是最容易看出来的地方。
+    /// 架构名直接取枚举名小写,与 RID 写法一致(X64→x64、Arm64→arm64),
+    /// 于是将来出现的新架构(loongarch64、riscv64…)无需改这里也能正确显示。
+    /// </remarks>
+    internal static string DescribeArchitecture(Architecture process, Architecture os) =>
+        process == os
+            ? Name(os)
+            : Strings.Format("SetAbout_ArchEmulated", Name(process), Name(os));
+
+    private static string Name(Architecture architecture) =>
+        architecture.ToString().ToLowerInvariant();
 
     /// <summary>关于页显示的配置文件所在目录。</summary>
     public static string AboutConfigPath =>
@@ -523,6 +543,18 @@ public class SettingsViewModel : ReactiveObject
             "MIT",
             "https://github.com/IoTSharp/SonnetDB",
             "https://github.com/IoTSharp/SonnetDB/blob/main/LICENSE"
+        ),
+        new(
+            "FluentFTP",
+            "MIT",
+            "https://github.com/robinrodricks/FluentFTP",
+            "https://github.com/robinrodricks/FluentFTP/blob/master/LICENSE.TXT"
+        ),
+        new(
+            "MaxMind.Db",
+            "Apache-2.0",
+            "https://github.com/maxmind/MaxMind-DB-Reader-dotnet",
+            "https://github.com/maxmind/MaxMind-DB-Reader-dotnet/blob/main/LICENSE"
         ),
     ];
 

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
@@ -309,5 +310,45 @@ public class SettingsViewModelTests
         Assert.AreEqual("deploy", result.Username);
         Assert.AreEqual(AuthMethod.PrivateKey, result.AuthMethod);
         Assert.AreEqual("/home/user/.ssh/id_rsa", result.PrivateKeyPath);
+    }
+
+    /// <summary>
+    /// 关于页的架构必须报真实架构名。旧实现是 <c>Is64BitOperatingSystem ? "x64" : "x86"</c>,
+    /// 只答"是不是 64 位"—— arm64 被显示成 x64、arm 被显示成 x86。
+    /// 这里用纯函数逐架构断言,不必真有 ARM 机器才能守住。
+    /// </summary>
+    [TestMethod]
+    [DataRow(Architecture.X64, "x64")]
+    [DataRow(Architecture.X86, "x86")]
+    [DataRow(Architecture.Arm64, "arm64")]
+    [DataRow(Architecture.Arm, "arm")]
+    public void DescribeArchitecture_NativeRun_ShowsRealArchitectureName(
+        Architecture architecture,
+        string expected
+    ) => Assert.AreEqual(expected, SettingsViewModel.DescribeArchitecture(architecture, architecture));
+
+    /// <summary>
+    /// 进程架构与系统架构不一致(x64 版跑在 arm64 的仿真层上)时两者都要显示。
+    /// 自更新按**进程**架构选产物,装错架构的人会一直留在仿真轨上,关于页得看得出来。
+    /// </summary>
+    [TestMethod]
+    public void DescribeArchitecture_Emulated_ShowsBothProcessAndOsArchitecture()
+    {
+        string text = SettingsViewModel.DescribeArchitecture(Architecture.X64, Architecture.Arm64);
+
+        Assert.IsTrue(text.Contains("x64", StringComparison.Ordinal), $"缺进程架构:{text}");
+        Assert.IsTrue(text.Contains("arm64", StringComparison.Ordinal), $"缺系统架构:{text}");
+    }
+
+    /// <summary>关于页整行以当前架构收尾(拼接本身没写错)。</summary>
+    [TestMethod]
+    public void AboutOs_EndsWithCurrentArchitecture()
+    {
+        string architecture = SettingsViewModel.DescribeArchitecture(
+            RuntimeInformation.ProcessArchitecture,
+            RuntimeInformation.OSArchitecture
+        );
+
+        Assert.EndsWith($"({architecture})", SettingsViewModel.AboutOs);
     }
 }

--- a/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SettingsViewUiTests.cs
@@ -10,6 +10,7 @@ using VelaShell.Core.Models;
 using VelaShell.Core.Services;
 using VelaShell.ViewModels;
 using VelaShell.Views;
+using VelaShell.Views.Settings;
 
 namespace VelaShell.Tests.Views;
 
@@ -153,6 +154,59 @@ public class SettingsViewUiTests
         Assert.HasCount(1, snapshots);
         Assert.AreEqual(80, snapshots[0].Appearance.WindowOpacityPercent);
         Assert.AreEqual("left", snapshots[0].Appearance.SidebarPosition);
+    }
+
+    /// <summary>
+    /// 关于页的开源依赖表必须把 <see cref="SettingsViewModel.AboutDependencies" /> 逐条画出来。
+    /// 断言落在**已布局的文本**上而不是集合内容：往 ItemsControl 里加数据是一回事，
+    /// 那些行真的被渲染出来是另一回事（不可见期入列的行会占住高度却画不出来）。
+    /// 名称与许可证一并核对 —— 许可证写错比不写更糟。
+    /// </summary>
+    [TestMethod]
+    public void AboutPage_RendersEveryOpenSourceDependencyRow()
+    {
+        OnUi(async () =>
+        {
+            ISettingsService settings = Substitute.For<ISettingsService>();
+            IThemeService theme = Substitute.For<IThemeService>();
+            settings.GetSettingsAsync().Returns(new AppSettings());
+            var viewModel = new SettingsViewModel(settings, theme);
+            await viewModel.LoadCommand.Execute().FirstAsync();
+            var page = new AboutPage { DataContext = viewModel };
+            var window = new Window
+            {
+                Width = 720,
+                Height = 1400,
+                Content = page,
+            };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            string[] painted =
+            [
+                .. page.GetVisualDescendants()
+                       .OfType<TextBlock>()
+                       .Where(text => text.Bounds.Width > 0 && text.Text is { Length: > 0 })
+                       .Select(text => text.Text!)
+            ];
+            Assert.IsNotEmpty(viewModel.AboutDependencies);
+            foreach (DependencyInfo dependency in viewModel.AboutDependencies)
+            {
+                Assert.Contains(dependency.Name, painted, $"关于页没画出依赖「{dependency.Name}」");
+                Assert.Contains(
+                    dependency.License,
+                    painted,
+                    $"「{dependency.Name}」的许可证没画出来"
+                );
+                Assert.StartsWith("https://", dependency.Url);
+                Assert.StartsWith("https://", dependency.LicenseUrl);
+            }
+            // FTP 与 IP 归属地是随功能一起引入的两个依赖,曾漏登记在册。
+            Assert.Contains("FluentFTP", painted);
+            Assert.Contains("MaxMind.Db", painted);
+            window.Close();
+        });
     }
 
     private static void OnUi(Func<Task> body) =>


### PR DESCRIPTION
新增多语言架构显示，区分 x86/x64/arm/arm64，并在仿真运行时提示。SettingsViewModel 增加 DescribeArchitecture 方法，AboutOs 属性调用该方法。依赖列表新增 FluentFTP、MaxMind.Db。补充 SettingsViewModelTests 单元测试，验证架构显示逻辑和 AboutOs 格式。SettingsViewUiTests 增加 UI 测试，确保依赖项与许可证完整渲染。