### PR TITLE
调整“连接后执行命令”行为及相关文档

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -299,7 +299,7 @@ Core 的中立抽象证明有效——**迁移一行 Core 代码都没改**,改�
 
 **E. 远端任务管理器(07-25)**:SSH 进程管理(`IRemoteProcessService`/`RemoteProcessService`),入口:标题栏"进程管理器"图标。
 
-**F. 文件浏览器跟随终端目录(07-24)**:SFTP 上传按钮右侧 map-pin 开关(`FileBrowserViewModel.FollowTerminal`);终端 cwd 经注入 bash 提示符发 OSC 7,`TerminalEmulator` 解析(`ParseOsc7Path`)→去重→浏览器同步;仅 bash/zsh 有效。
+**F. 文件浏览器跟随终端目录(07-24)**:SFTP 上传按钮右侧 map-pin 开关(`FileBrowserViewModel.FollowTerminal`);终端 cwd 由对端 shell 的提示符发 OSC 7,`TerminalEmulator` 解析(`ParseOsc7Path`)→去重→浏览器同步。注:内置注入的 bash 提示符脚本已撤除(仅 bash 生效、其余 shell 反而出噪声),需要该功能的用户自行在"连接后执行命令"或远端 rc 里上报 OSC 7。
 
 **G. SFTP 传输面板增强(07-27 ~ 07-29)**:框选、批量操作、文件+文件夹混选上传、冲突与历史交互优化;文件传输 toast 面板(`FileTransferView`,浮动活动/历史项,不跨重启持久化)。
 

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -598,8 +598,8 @@ public class TerminalBehaviorOptions : ObservableOptions
     }
 
     /// <summary>
-    /// 连接/重连成功后追加执行的用户初始化命令(空 = 无)。它会被拼接在内置的
-    /// bash 提示符补行脚本之后,一并静默注入远端 shell(回显被抑制,不在终端显示)。
+    /// 连接/重连成功后执行的用户初始化命令(空 = 不注入任何命令)。
+    /// 静默注入远端 shell(回显被抑制,不在终端显示)。
     /// </summary>
     public string StartupCommand
     {

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2407,7 +2407,7 @@
     <value>接続後にコマンドを実行</value>
   </data>
   <data name="SetTerm_StartupCommandDesc" xml:space="preserve">
-    <value>// 接続/再接続後にサイレント実行(ターミナルには表示されません)。内蔵のプロンプト補正スクリプトの後に自動追加されます。空欄の場合は内蔵スクリプトのみ実行</value>
+    <value>// 接続/再接続後にサイレント実行(ターミナルには表示されません)。空欄の場合は何も実行しません</value>
   </data>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>例: cd /var/www</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2407,7 +2407,7 @@
     <value>연결 후 명령 실행</value>
   </data>
   <data name="SetTerm_StartupCommandDesc" xml:space="preserve">
-    <value>// 연결/재연결 후 조용히 실행(터미널에 표시되지 않음)되며 내장 프롬프트 보정 스크립트 뒤에 이어서 실행됩니다. 비워 두면 내장 스크립트만 실행</value>
+    <value>// 연결/재연결 후 조용히 실행(터미널에 표시되지 않음)됩니다. 비워 두면 아무것도 실행하지 않습니다</value>
   </data>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>예: cd /var/www</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2501,7 +2501,7 @@ Paste anyway?</value>
     <value>Run command after connect</value>
   </data>
   <data name="SetTerm_StartupCommandDesc" xml:space="preserve">
-    <value>// Runs silently after connect/reconnect (not echoed in the terminal), appended after the built-in prompt-fix script; leave empty to run only the built-in script</value>
+    <value>// Runs silently after connect/reconnect (not echoed in the terminal); leave empty to run nothing</value>
   </data>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>e.g. cd /var/www</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2592,7 +2592,7 @@
     <value>连接后执行命令</value>
   </data>
   <data name="SetTerm_StartupCommandDesc" xml:space="preserve">
-    <value>// 连接/重连后静默执行(不在终端回显),自动拼接在内置的提示符补行脚本之后;留空则只执行内置脚本</value>
+    <value>// 连接/重连后静默执行(不在终端回显);留空则不执行任何命令</value>
   </data>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>如 cd /var/www</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2407,7 +2407,7 @@
     <value>連線後執行命令</value>
   </data>
   <data name="SetTerm_StartupCommandDesc" xml:space="preserve">
-    <value>// 連線/重連後靜默執行(不在終端機回顯),自動接在內建提示符補行指令碼之後;留空則僅執行內建指令碼</value>
+    <value>// 連線/重連後靜默執行(不在終端機回顯);留空則不執行任何指令</value>
   </data>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>例如 cd /var/www</value>

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -471,7 +471,8 @@ public sealed class TerminalEmulator : IVtActions
                 break;
             case 7:
                 // OSC 7:shell 上报当前工作目录(file://host/path)。用于「文件浏览器跟随终端目录」。
-                // 由 VelaShell 注入的 bash 提示符脚本发出(见 MainWindowViewModel.PromptNewlineFix)。
+                // 由对端 shell 自己发出(常见于 bash/zsh 的 PROMPT_COMMAND、fish 的 fish_prompt);
+                // VelaShell 不再内置注入上报脚本,用户可自行写进"连接后执行命令"或远端 rc 文件。
                 if (p.Count > 1 && ParseOsc7Path(p[1]) is { Length: > 0 } dir)
                 {
                     WorkingDirectoryChanged?.Invoke(dir);

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -196,7 +196,7 @@ public class SshTerminalBridge : IDisposable
     }
 
     /// <summary>
-    /// 程序化注入:直写 PTY,不经终端控件的输入事件。连接初始化命令(提示符补行脚本、
+    /// 程序化注入:直写 PTY,不经终端控件的输入事件。连接初始化命令(用户配置的
     /// 启动命令)必须走这里——若走 WriteInput,注入里的 ESC 字节会把命令补全的行跟踪器
     /// (plan.md #16)打进未知态,SSH 标签的智能建议从连接起就全灭(实测取证)。
     /// </summary>

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -42,45 +42,6 @@ namespace VelaShell.ViewModels;
 /// </summary>
 public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.ITerminalResolver
 {
-    /// <summary>
-    /// bash 提示符补行脚本(内置,静默注入):命令输出末尾无换行时,经 DSR(ESC[6n)
-    /// 查询光标列,不在行首则先补一个换行再画提示符(zsh 的默认行为)。
-    /// </summary>
-    // 函数体末尾的 printf 发 OSC 7(file://主机/当前目录),供「文件浏览器跟随终端目录」(map-pin)读取 shell cwd。
-    //
-    // 整段 bash 代码必须裹在 test -n "$BASH_VERSION" && eval '...' 里:fish 在执行前先解析整行,
-    // 只要行内出现 bash 语法就整行报错并把命令原文糊在屏幕上(用户反馈:
-    // "fish: Unsupported use of '='. In fish, please use 'set PROMPT_COMMAND prompt_nl'"),
-    // 因此"守卫失败就不执行"救不了,代码必须在 fish 眼里只是一个单引号字面量 —— eval 的参数正是如此。
-    // 实测(容器内 bash 5/zsh 5/fish 4.6/dash):非 bash 一律静默,只剩末尾的清行 printf。
-    // 例外是 csh/tcsh:它对未定义变量直接报错("BASH_VERSION: Undefined variable."),
-    // 而任何变量无关的 bash 探测(command -v shopt / readlink /proc/$$/exe)要么在 tcsh 里同样报错,
-    // 要么在 macOS 上失效 —— 登录 shell 是 tcsh 的情况按噪声一行接受。
-    //
-    // 函数体内一律用双引号 + 八进制 \033,不用 $'\e[6n':单引号要在 eval 字符串里转义成 '\'',
-    // 而 DSR 直接由 printf 发出即可,不必走 read -p,顺带省掉转义与子 shell。
-    //
-    // read 必须带 -t 1:对端终端不应答 DSR 时(stdin 被重定向、抢输被别的程序吃掉等)
-    // 无超时的 read 会一直阻塞,表现为每画一次提示符就卡死。
-    //
-    // PROMPT_COMMAND 只追加不覆盖:直接赋值会踢掉用户自己的 starship/direnv/atuin 等钩子。
-    // case 去重让重连时的再次注入不会把 prompt_nl 叠加成多份。
-    //
-    // 整行最后的 printf "\r\033[2K" 是"登录时提示符出现两次"的解药:注入这一行本身要占掉 shell
-    // 的一个提示符周期 —— 登录提示符先画出来(还带上 tty 回显里没被抑制针覆盖的那个前导空格),
-    // 命令执行完 shell 再画一个新的,于是屏幕上并排两行 [root@host ~]#。
-    // 这里在新提示符画出来之前把光标所在的整行擦掉(\r 回到行首 + CSI 2K 清整行),
-    // 旧提示符与残留空格一并消失;随后 prompt_nl 查到光标已在第 1 列,不会再补换行,
-    // 新提示符正好落在被清空的那一行 —— 净效果就是只剩一个提示符,与 WindTerm 等工具一致。
-    // 放在整行末尾(而不是 SendSilentCommand 里)是为了让用户配置的"连接后执行命令"
-    // 接在它后面:先清行,用户命令的输出才从干净的行首开始。
-    // 它在守卫之外,由对端的任意 shell 执行,所以转义只能用八进制 \033 —— \e 是 bash/zsh 扩展,
-    // dash/busybox ash 的 printf 会把它原样打成字面量 "\e[2K"(fish 的 printf 认 \033,实测通过)。
-    private const string PromptNewlineFix =
-        """
-        test -n "$BASH_VERSION" && eval 'prompt_nl() { local c; printf "\033[6n"; IFS="[;" read -t 1 -d R -rs _ _ c; ((c>1)) 2>/dev/null && echo; printf "\033]7;file://%s%s\033\\\\" "$HOSTNAME" "$PWD"; }; case ";$PROMPT_COMMAND;" in *";prompt_nl;"*) ;; *) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}prompt_nl";; esac'; printf "\r\033[2K"
-        """;
-
     /// <summary>RIS(ESC c)完全重置序列:重开会话前清掉旧进程的残留缓冲。</summary>
     private static readonly byte[] RisResetSequence = [0x1B, (byte)'c']; // ESC c
 
@@ -112,10 +73,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     private readonly QuickCommandsViewModel? _quickCommands;
     private readonly QuickCommandRunnerViewModel? _quickCommandRunner;
     private readonly TerminalTargetSelectorViewModel _terminalTargetSelector;
-    private readonly Dictionary<
-        TerminalTabViewModel,
-        IDisposable
-    > _quickCommandTargetSubscriptions = [];
+    private readonly Dictionary<TerminalTabViewModel, IDisposable> _quickCommandTargetSubscriptions = [];
 
     /// <summary>同步输入频道的对等转发中枢(标签右键菜单 → 同步输入)。</summary>
     private readonly SyncInputCoordinator _syncInput = new();
@@ -2265,26 +2223,22 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     }
 
     /// <summary>
-    /// 连接成功后静默注入初始化命令:内置补行脚本 + 用户配置的"连接后执行命令"
-    /// (设置 → 终端 → 会话)拼接为一行,经回显抑制不在终端显示。PTY 输入由内核缓冲,
+    /// 连接成功后静默注入用户配置的"连接后执行命令"(设置 → 终端 → 会话),
+    /// 经回显抑制不在终端显示;未配置则什么都不发。PTY 输入由内核缓冲,
     /// shell 就绪后才会读取,无需等待提示符。
     /// </summary>
+    // 这里曾额外内置一段 bash 提示符补行脚本(prompt_nl + OSC 7 上报 cwd)。
+    // 它只在 bash 下生效,其余 shell(fish/dash/tcsh 等)要么静默无效、要么把命令原文糊在屏幕上,
+    // 收益覆盖不到大多数会话,故整体撤除:需要补行或「文件浏览器跟随终端目录」的用户
+    // 自行把脚本写进"连接后执行命令"或远端 rc 文件即可。
     private static void SendStartupCommand(TerminalTabViewModel tab, AppSettings settings)
     {
-        string? user = settings.TerminalBehavior.StartupCommand.Trim();
-
-        // 旧版本曾把补行脚本作为该设置项的默认值;现已内置,跳过以免重复执行。
-        if (
-            !string.IsNullOrEmpty(user)
-            && user.Contains("PROMPT_COMMAND=prompt_nl", StringComparison.Ordinal)
-        )
+        string user = settings.TerminalBehavior.StartupCommand.Trim();
+        if (user.Length == 0)
         {
-            user = null;
+            return;
         }
-        string payload = string.IsNullOrEmpty(user)
-            ? PromptNewlineFix
-            : PromptNewlineFix + "; " + user;
-        tab.SendSilentCommand(payload);
+        tab.SendSilentCommand(user);
     }
 
     /// <summary>

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -625,7 +625,8 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     /// 把初始化命令注入远端 shell 并静默执行:发送前在桥上装回显抑制器,
     /// 把 PTY 回显的这一行从输出流剥掉,不在界面显示。前导空格让
     /// HISTCONTROL=ignoreboth 不记历史;抑制针 needle 不含该空格(空格太常见,
-    /// 不适合做流匹配锚点),残留的空格与光标位置由命令本身的补行脚本消化。
+    /// 不适合做流匹配锚点)。注入本身要占掉 shell 的一个提示符周期,想让屏幕保持干净
+    /// 可在命令里自行清行(如 printf "\r\033[2K")。
     /// </summary>
     public void SendSilentCommand(string command)
     {


### PR DESCRIPTION
本次变更移除内置 bash 补行脚本，现仅执行用户配置的“连接后执行命令”，未配置则不注入任何命令。同步更新相关代码、注释及多语言资源，界面文案明确说明行为变更。SendStartupCommand 逻辑简化，提升直观性和可控性，兼容性特殊需求交由用户自行配置。