### PR TITLE
CI:修复 NuGet 流水线,准备 SDK 1.0.0-preview.1 首发

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -18,12 +18,6 @@
 #   NuGet/login 拿本次运行的 GitHub OIDC 令牌去 nuget.org 换一把**短时效**的推送密钥,
 #   用完即弃。密钥不落仓库机密,也就没有"泄漏了要轮换"这件事。
 #
-#   ⚠️ 一次性配置:nuget.org → 账户 → Trusted Publishing 里那条策略的 **Workflow 字段
-#      必须填 `nuget.yml`**(现有那条填的是 `release.yml` —— 那是应用发布流水线,不发包)。
-#      策略校验的是"哪个仓库的哪个工作流文件在跑",文件名对不上就直接拒绝换密钥。
-#      要么把该策略的 Workflow 改成 nuget.yml,要么再建一条指向 nuget.yml 的策略。
-#      仓库变量 `NUGET_USER` 可覆盖账户名(默认 joes_du)。
-#
 # 需要的仓库机密:
 #   STRONG_NAME_KEY   与 release.yml 同一把:Release 下 SDK 程序集要强名称签名,
 #                     否则宿主(已签名)引用不了它。

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -77,8 +77,16 @@ jobs:
           } elseif ('${{ github.event_name }}' -eq 'workflow_dispatch') {
             $version = '${{ inputs.version }}'.TrimStart('v')
           } else {
-            # PR:只是验证能不能打得出来,版本号无所谓,用工程里的默认值加个后缀。
-            $version = "0.0.0-ci.${{ github.run_number }}"
+            # PR:只验"打不打得出来",但版本号**不能瞎编**。模板 template.json 里写死了
+            # 生成工程要引用的 SDK 包版本,templates 工程的 VerifyTemplateSdkVersion 会在
+            # 构建期核对它与 VelaSdkVersion 一致(VELA1004);编一个 0.0.0-ci.N 出来,
+            # templates 包每次 PR 都打不出来。PR 路径不推送,复用仓库当前的默认版本即可。
+            $props = Get-Content -Raw Directory.Build.props
+            $version = [regex]::Match($props, '<VelaSdkVersion[^>]*>([^<]+)</VelaSdkVersion>').Groups[1].Value
+            if ([string]::IsNullOrWhiteSpace($version)) {
+              Write-Error "Could not read VelaSdkVersion from Directory.Build.props"
+              exit 1
+            }
           }
           "version=$version" >> $env:GITHUB_OUTPUT
           "Publishing version $version"
@@ -106,11 +114,20 @@ jobs:
 
       # 打包相关的测试。不跑全量套件:那需要构建整个应用(含 Avalonia headless),
       # 而这条流水线只对包格式、清单规则与开发挂载负责。全量回归在应用侧的流水线里。
+      #
+      # ⚠️ 必须是 Debug,别改回 Release:Release 会打开强名签名(见 src/Directory.Build.props),
+      #    而签名程序集的 InternalsVisibleTo 必须带友元公钥、友元也得用同一把钥匙签名 ——
+      #    测试程序集两条都不满足,所以 src/*.csproj 里的友元声明一律 gated on
+      #    SignAssembly != true。用 Release 跑测试就等于丢掉友元关系,白盒用例引用的宿主
+      #    internal 类型当场 CS0122(只会报第一个:声明期出错后 Roslyn 直接跳过方法体编译,
+      #    后面还有一批同类错误没露面)。这些用例只验包格式与清单规则,与优化级别无关,
+      #    Debug 等价;且 Debug 的 obj/bin 与下面 Pack 的 Release 目录彼此隔离,
+      #    不会把未签名产物混进要发布的包里。
       - name: Test (packaging + manifest + dev roots)
         shell: pwsh
         run: |
           dotnet test tests/VelaShell.Infrastructure.Tests/VelaShell.Infrastructure.Tests.csproj `
-            -c Release --nologo $env:VELA_SIGN_ARGS `
+            -c Debug --nologo `
             --filter "FullyQualifiedName~VpxContainerTests|FullyQualifiedName~PluginManifestReaderTests|FullyQualifiedName~PluginInstallUninstallTests|FullyQualifiedName~DevPluginRootTests"
           if ($LASTEXITCODE -ne 0) { exit 1 }
 


### PR DESCRIPTION
`nuget.yml` 的打包测试步骤用 `-c Release` 跑 `VelaShell.Infrastructure.Tests`,而 Release 会打开强名签名 —— 签名程序集的 `InternalsVisibleTo` 必须带友元公钥、友元也得同一把钥匙签名,测试程序集两条都不满足,所以 `src/*.csproj` 里的友元声明一律 gated on `SignAssembly != true`。结果就是 Release 下友元关系消失,白盒用例引用的宿主 internal 类型当场 CS0122(日志里只露出第一个,声明期出错后 Roslyn 直接跳过方法体编译)。

- 测试步骤改用 `-c Debug`(用例只验包格式/清单规则/开发挂载,与优化级别无关;Debug 的 obj/bin 与 Pack 的 Release 目录彼此隔离,不会把未签名产物混进包里)
- PR 路径的版本号不再编造 `0.0.0-ci.<run_number>` —— 模板 `template.json` 里钉死了 SDK 包版本,`VerifyTemplateSdkVersion` 会核对一致(VELA1004),编出来的版本必然对不上;改为复用 `Directory.Build.props` 里当前的 `VelaSdkVersion`

验证:workflow_dispatch 干跑(run 32106508206)全绿 —— Test / Pack / 模板端到端冒烟全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)