### PR TITLE
CI:纯 MSBuild 包不再生成空符号包(首发推送被 400 截断)

### DIFF
--- a/plugin-sdk/VelaShell.PluginSdk.Build/VelaShell.PluginSdk.Build.csproj
+++ b/plugin-sdk/VelaShell.PluginSdk.Build/VelaShell.PluginSdk.Build.csproj
@@ -8,6 +8,11 @@
 
     <!-- 本包不含任何程序集,只有 MSBuild 逻辑与 tools/ 下的打包器。 -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- 没有程序集自然也没有 .pdb,而 plugin-sdk/Directory.Build.props 给所有 SDK 包统一开了
+         IncludeSymbols —— 那会生成一个只含 nuspec 的空 .snupkg,nuget.org 收到会直接
+         400 "The package does not contain any symbol (.pdb) files."。首发时正是它把推送
+         拦腰截断(run 32114870350:前四个包已推上去,第五个再没轮到)。本包关掉符号包。 -->
+    <IncludeSymbols>false</IncludeSymbols>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <!-- NU5128:有依赖但无 lib/ 目录。对纯 MSBuild 包是正常形态。 -->


### PR DESCRIPTION
`VelaShell.PluginSdk.Build` 是 `IncludeBuildOutput=false` 的纯 MSBuild 包,不含任何程序集,自然也没有 `.pdb`;而 `plugin-sdk/Directory.Build.props` 给所有 SDK 包统一开了 `IncludeSymbols`,于是它打出一个**只含 nuspec 的空 `.snupkg`**。nuget.org 收到会直接:

```
400 (The package does not contain any symbol (.pdb) files.)
```

[run 32114870350](https://github.com/joesdu/VelaShell/actions/runs/32114870350) 的推送步骤因此被拦腰截断:

```
Created  VelaShell.Plugin.Cli.1.0.0-preview.1.nupkg          ✅
Created  VelaShell.Plugin.Templates.1.0.0-preview.1.nupkg    ✅
Created  VelaShell.PluginSdk.1.0.0-preview.1.nupkg (+snupkg) ✅
Created  VelaShell.PluginSdk.Build.1.0.0-preview.1.nupkg     ✅
BadRequest  VelaShell.PluginSdk.Build...snupkg               ❌ 400,整步失败
         VelaShell.PluginSdk.Testing.1.0.0-preview.1.nupkg   —— 再没轮到
```

本包关掉 `IncludeSymbols`。其余四个包不受影响 —— `VelaShell.PluginSdk` 与 `.Testing` 的 snupkg 里确有 `lib/net11.0/*.pdb`(本地解包核对过)。

重新 pack 该工程验证:产出只剩 `.nupkg`,不再有 `.snupkg`。

重跑后 `--skip-duplicate` 会跳过已推上去的四个,补上 `VelaShell.PluginSdk.Testing`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)