### PR TITLE
升级 VelaSdkVersion 至 1.0.0 并完善发版流程说明

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <!-- 插件 SDK 系列包(VelaShell.PluginSdk / .Testing / .Build、VelaShell.Plugin.Cli、
          VelaShell.Plugin.Templates)的版本。**与宿主版本解耦**:宿主发 1.2.3 不代表插件
          契约变了,插件作者也不该为了跟版本号而重新编译。CI 发包时用 -p:VelaSdkVersion= 覆盖。 -->
-    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.0.0-preview.1</VelaSdkVersion>
+    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.0.0</VelaSdkVersion>
     <!-- 去掉预发布后缀的数字版(AssemblyVersion/FileVersion 不接受后缀)与主版本号。 -->
     <VelaSdkVersionCore>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersion), '-.*$', ''))</VelaSdkVersionCore>
     <VelaSdkMajor>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersionCore), '\..*$', ''))</VelaSdkMajor>

--- a/plugin-sdk/VelaShell.PluginSdk/README.md
+++ b/plugin-sdk/VelaShell.PluginSdk/README.md
@@ -31,3 +31,15 @@
 - **被引用**：`VelaShell.Infrastructure`（能力实现与插件运行时）、`VelaShell.Presentation`（命令桥接）、`VelaShell.PluginHost`（隔离进程）、以及全部插件项目。
 
 > 开发文档见 [docs/plugins/dev-guide.md](../../docs/plugins/dev-guide.md)；能力清单与权限模型见 [07-capability-apis.md](../../docs/plugins/07-capability-apis.md) 与 [06-permission-system.md](../../docs/plugins/06-permission-system.md)。测试替身见 [`VelaShell.PluginSdk.Testing`](../VelaShell.PluginSdk.Testing)。
+
+## 发版
+
+发一次 SDK 的完整步骤
+
+- 改 Directory.Build.props 的 VelaSdkVersion
+- 改 templates/content/velaplugin/.template.config/template.json     的 sdkVersion.defaultValue
+  改 templates/content/velaplugin-ui/.template.config/template.json  同上（破坏性变更还要 +1 VelaPluginApi.Level）
+- 合进 main
+- git tag sdk-v<版本> && git push origin sdk-v<版本>
+
+第 2 步不是可选的 —— VELA1004 会在构建期拦下。想先验一遍不推送,用 workflow_dispatch 勾 dryRun(就是我们刚才跑的那次)。

--- a/templates/content/velaplugin-ui/.template.config/template.json
+++ b/templates/content/velaplugin-ui/.template.config/template.json
@@ -49,7 +49,7 @@
     "sdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.0.0-preview.1",
+      "defaultValue": "1.0.0",
       "replaces": "SDK_VERSION",
       "description": "Version of the VelaShell.PluginSdk.Build package to reference."
     },

--- a/templates/content/velaplugin/.template.config/template.json
+++ b/templates/content/velaplugin/.template.config/template.json
@@ -49,7 +49,7 @@
     "sdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.0.0-preview.1",
+      "defaultValue": "1.0.0",
       "replaces": "SDK_VERSION",
       "description": "Version of the VelaShell.PluginSdk.Build package to reference."
     },


### PR DESCRIPTION
本次提交将 VelaSdkVersion 从 1.0.0-preview.1 升级为 1.0.0，涉及 Directory.Build.props 及两个模板文件（template.json），同步了默认 SDK 版本号。README.md 新增了“发版”流程说明，详细列出发布 SDK 的步骤，并强调了模板版本号同步的重要性。