### PR TITLE
支持同步后刷新会话树，新增事件与测试

### DIFF
--- a/src/VelaShell.Core/Sync/IGistSyncService.cs
+++ b/src/VelaShell.Core/Sync/IGistSyncService.cs
@@ -6,6 +6,12 @@ namespace VelaShell.Core.Sync;
 /// </summary>
 public interface IGistSyncService
 {
+    /// <summary>
+    /// 远端连接配置已成功应用到本地仓储后触发。订阅方可据此刷新会话树等内存视图;
+    /// 事件可能从后台线程触发。
+    /// </summary>
+    event EventHandler? ProfilesApplied;
+
     /// <summary>正在把远端数据应用到本地(此期间的本地保存事件不算“本地改动”,防止拉取后立刻回推)。</summary>
     bool IsApplyingRemote { get; }
 

--- a/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
+++ b/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
@@ -43,6 +43,9 @@ public sealed class GistSyncService(
     /// <summary>是否正在应用远端数据;为 true 时忽略由此触发的本地保存事件,避免拉取后被误判为本地改动而立即回推。</summary>
     public bool IsApplyingRemote { get; private set; }
 
+    /// <inheritdoc />
+    public event EventHandler? ProfilesApplied;
+
     /// <summary>读取持久化的同步配置;不存在时返回默认 <see cref="SyncSettings"/>。</summary>
     public async Task<SyncSettings> GetSyncSettingsAsync(
         CancellationToken cancellationToken = default
@@ -518,7 +521,7 @@ public sealed class GistSyncService(
 
     // ———— 拉取与应用 ————
 
-    private async Task<SyncResult> ApplyRemoteAsync(
+    internal async Task<SyncResult> ApplyRemoteAsync(
         SyncSettings config,
         SyncEnvelope envelope,
         string? remoteVersion,
@@ -635,6 +638,12 @@ public sealed class GistSyncService(
             config.LastLocalChangeAtUtc = null;
         }
         await SaveSyncSettingsAsync(config, cancellationToken).ConfigureAwait(false);
+        if (config.SyncProfiles)
+        {
+            // 仓储已经完整应用远端分组/Profile/隧道后再通知界面。同步通常在后台线程执行,
+            // 订阅方负责封送到自己的 UI 线程。历史版本恢复也复用本路径,因此无需另行接线。
+            ProfilesApplied?.Invoke(this, EventArgs.Empty);
+        }
         return new(
             SyncAction.Pulled,
             true,

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -22,6 +22,7 @@ using VelaShell.Core.Resources;
 using VelaShell.Core.Services;
 using VelaShell.Core.Sftp;
 using VelaShell.Core.Ssh;
+using VelaShell.Core.Sync;
 using VelaShell.Core.Tunnels;
 using VelaShell.Docking;
 using VelaShell.Docking.Model;
@@ -185,7 +186,8 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         IFtpSessionService? ftpSessionService = null,
         IPluginProtocolSessionService? pluginProtocolService = null,
         PluginProtocolRegistry? protocolRegistry = null,
-        PluginWorkspaceLauncher? workspaceLauncher = null
+        PluginWorkspaceLauncher? workspaceLauncher = null,
+        IGistSyncService? gistSyncService = null
     )
     {
         // 注册表可注入(DI 里与插件命令桥共享同一单例);无 UI 单测传 null 时自建。
@@ -214,6 +216,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         _pluginProtocols = pluginProtocolService;
         _protocolRegistry = protocolRegistry;
         _workspaceLauncher = workspaceLauncher;
+        gistSyncService?.ProfilesApplied += OnSyncProfilesApplied;
         // 插件被停用/卸载 → 它名下的工作台文档已无人应答,走正常关闭路径撤掉标签页。
         workspaceLauncher?.SessionAbandoned += OnWorkspaceSessionAbandoned;
         // 新建连接对话框里的「测试」对插件连接类型没法拿 SSH 去试(那只会撞出一个
@@ -1771,6 +1774,17 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         }
         await RefreshPaletteSessionsAsync();
         RevealActiveSessionInSidebar();
+    }
+
+    /// <summary>
+    /// 云同步在后台线程完成 Profile upsert 后刷新所有会话入口。除侧边栏树外还要刷新
+    /// 命令面板的全量会话缓存,否则树已出现新连接而命令面板仍需重启才可搜索到。
+    /// </summary>
+    private void OnSyncProfilesApplied(object? sender, EventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        RxSchedulers.MainThreadScheduler.Schedule(() => _ = RefreshSessionTreeAsync());
     }
 
     /// <summary>BuildPaletteItems 是同步回调,这里预取 session_profiles 全量与分组名。</summary>

--- a/tests/VelaShell.Infrastructure.Tests/Sync/GistSyncServiceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Sync/GistSyncServiceTests.cs
@@ -1,0 +1,61 @@
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sync;
+using VelaShell.Infrastructure.Sync;
+
+namespace VelaShell.Infrastructure.Tests.Sync;
+
+/// <summary>Gist 远端载荷应用后的运行时刷新通知。</summary>
+[TestClass]
+public sealed class GistSyncServiceTests
+{
+    [TestMethod]
+    public async Task ApplyRemoteAsync_WithProfiles_NotifiesAfterRepositoryIsUpdated()
+    {
+        ISettingsService settings = Substitute.For<ISettingsService>();
+        ISessionRepository sessions = Substitute.For<ISessionRepository>();
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        IQuickCommandRepository snippets = Substitute.For<IQuickCommandRepository>();
+        ISecretProtector secrets = Substitute.For<ISecretProtector>();
+        sessions.GetAllSessionsAsync().Returns([]);
+        var service = new GistSyncService(settings, sessions, store, snippets, secrets);
+        SessionProfile profile = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "cloud-server",
+            Host = "cloud.example.com",
+            Username = "root",
+        };
+        bool profileWasSavedWhenNotified = false;
+        service.ProfilesApplied += (_, _) =>
+            profileWasSavedWhenNotified = sessions.ReceivedCalls().Any(call =>
+                call.GetMethodInfo().Name == nameof(ISessionRepository.SaveSessionAsync)
+            );
+
+        SyncResult result = await service.ApplyRemoteAsync(
+            new SyncSettings
+            {
+                SyncAppSettings = false,
+                SyncProfiles = true,
+                SyncSnippets = false,
+            },
+            new SyncEnvelope
+            {
+                Payload = new SyncPayload
+                {
+                    DeviceName = "device-1",
+                    UpdatedAtUtc = DateTime.UtcNow,
+                    Profiles = [profile],
+                },
+            },
+            remoteVersion: "revision-1",
+            CancellationToken.None
+        );
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(SyncAction.Pulled, result.Action);
+        Assert.IsTrue(profileWasSavedWhenNotified, "通知必须发生在连接配置写入仓储之后。");
+        await sessions.Received(1).SaveSessionAsync(profile);
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -5,6 +5,7 @@ using ReactiveUI.Primitives.Concurrency;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Sftp;
+using VelaShell.Core.Sync;
 using VelaShell.Core.Tunnels;
 using VelaShell.Presentation.Commands;
 using VelaShell.Presentation.Services;
@@ -322,6 +323,40 @@ public class MainWindowViewModelTests
         );
 
         Assert.IsTrue(vm.Sidebar.IsQuickCommandsVisible);
+    }
+
+    [TestMethod]
+    [TestCategory("SessionTree")]
+    public async Task SyncProfilesApplied_RefreshesSessionTreeWithoutRestart()
+    {
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        IGistSyncService syncService = Substitute.For<IGistSyncService>();
+        var profiles = new List<SessionProfile>();
+        repository.GetAllGroupsAsync().Returns([]);
+        repository.GetAllSessionsAsync().Returns(_ => [.. profiles]);
+        var vm = new MainWindowViewModel(
+            sessionRepository: repository,
+            gistSyncService: syncService
+        );
+        await vm.InitializeAsync();
+        Assert.IsTrue(vm.Sidebar.SessionTree?.HasNoSessions);
+
+        SessionProfile pulled = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "pulled-server",
+            Host = "pulled.example.com",
+            Username = "root",
+        };
+        profiles.Add(pulled);
+
+        syncService.ProfilesApplied += Raise.Event<EventHandler>(syncService, EventArgs.Empty);
+
+        bool appeared = SpinWait.SpinUntil(
+            () => vm.Sidebar.SessionTree?.Nodes.Any(node => node.Id == pulled.Id) == true,
+            TimeSpan.FromSeconds(5)
+        );
+        Assert.IsTrue(appeared, "云同步拉取的连接应立即出现在会话树中。");
     }
 
     [TestMethod]


### PR DESCRIPTION
新增 IGistSyncService.ProfilesApplied 事件，GistSyncService 在远端配置应用后触发。MainWindowViewModel 订阅该事件并在主线程刷新会话树和命令面板缓存，确保云同步拉取的新连接即时显示。补充相关单元测试，验证事件触发与 UI 刷新逻辑。