### PR TITLE
支持 Alt+滚轮快速滚动回滚区，步长为5倍

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -28,6 +28,9 @@ namespace VelaShell.Terminal.Rendering;
 /// </summary>
 public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 {
+    private const int WheelScrollLines = 3;
+    private const int FastWheelScrollMultiplier = 5;
+
     private static readonly ImmutableSolidColorBrush BellFlashBrush = new(
         Color.FromArgb(0x30, 0xFF, 0xFF, 0xFF)
     );
@@ -2524,7 +2527,10 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <summary>字体大小经 Ctrl+滚轮缩放改变时触发,便于宿主持久化。</summary>
     public event Action<double>? FontSizeChanged;
 
-    /// <summary>Ctrl+滚轮缩放字体;否则转发给应用鼠标追踪或滚动回滚区。</summary>
+    /// <summary>
+    /// Ctrl+滚轮缩放字体;否则转发给应用鼠标追踪或滚动回滚区。
+    /// 本地回滚区中按住 Alt 使用五倍步长快速滚动。
+    /// </summary>
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
@@ -2557,7 +2563,10 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 return;
             }
         }
-        int delta = (int)(e.Delta.Y * 3);
+        int multiplier = e.KeyModifiers.HasFlag(KeyModifiers.Alt)
+            ? FastWheelScrollMultiplier
+            : 1;
+        int delta = (int)(e.Delta.Y * WheelScrollLines * multiplier);
         int maxOffset = Emulator.Screen.ScrollbackCount;
         _scrollOffset = Math.Clamp(_scrollOffset + delta, 0, maxOffset);
         InvalidateVisual();

--- a/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
+++ b/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>Issue #212:Alt+滚轮在终端本地回滚区中快速滚动。</summary>
+[TestClass]
+[TestCategory("Input")]
+public sealed class FastWheelScrollTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext _) =>
+        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    [TestMethod]
+    public void AltWheel_ScrollsFiveTimesFartherThanPlainWheel()
+    {
+        (int plain, int fast) result = default;
+        _session
+            .Dispatch(
+                () =>
+                {
+                    var control = new VelaTerminalControl();
+                    var window = new Window
+                    {
+                        Width = 640,
+                        Height = 360,
+                        Content = control,
+                    };
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    var output = new StringBuilder();
+                    for (int i = 0; i < 100; i++)
+                    {
+                        output.Append("line-").Append(i).Append("\r\n");
+                    }
+                    control.Feed(Encoding.UTF8.GetBytes(output.ToString()));
+                    Dispatcher.UIThread.RunJobs();
+                    Assert.IsGreaterThanOrEqualTo(15, control.MaxScrollOffset);
+
+                    Point point = new(100, 100);
+                    window.MouseWheel(point, new(0, 1), RawInputModifiers.None);
+                    result.plain = control.ScrollOffset;
+
+                    control.ScrollOffset = 0;
+                    window.MouseWheel(point, new(0, 1), RawInputModifiers.Alt);
+                    result.fast = control.ScrollOffset;
+                    window.Close();
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None
+            )
+            .GetAwaiter()
+            .GetResult();
+
+        Assert.AreEqual(3, result.plain);
+        Assert.AreEqual(15, result.fast);
+    }
+}


### PR DESCRIPTION
本次为 VelaTerminalControl 增加 Alt+滚轮时回滚区快速滚动功能，步长为普通的五倍（通过 FastWheelScrollMultiplier 实现），普通滚轮步长由 WheelScrollLines 控制。相关逻辑已在 OnPointerWheelChanged 方法实现。新增 FastWheelScrollTests.cs 单元测试，验证 Alt+滚轮滚动距离为普通的五倍，确保功能正确性。