### PR TITLE
增强插件信任与安全机制，优化用户体验

### DIFF
--- a/plugin-sdk/VelaShell.PluginSdk/Packaging/VpxContainer.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Packaging/VpxContainer.cs
@@ -26,7 +26,7 @@ public enum VpxSignatureState
     /// <summary>包未签名。</summary>
     Unsigned,
 
-    /// <summary>签名有效,且公钥在信任集合内(未提供信任集合时,任何有效签名都算 <see cref="Trusted" />)。</summary>
+    /// <summary>签名有效且公钥在信任集合内;未要求来源判定时也表示纯验签成功。</summary>
     Trusted,
 
     /// <summary>签名有效,但公钥不在信任集合内(自签名包)。</summary>
@@ -276,7 +276,8 @@ public static class VpxContainer
 
     /// <summary>
     /// 校验包尾签名。<paramref name="trustedPublicKeys" /> 为 Base64 的 SPKI 公钥集合;
-    /// 传空集合表示"只验签名本身有效性,不判来源",此时有效签名返回 <see cref="VpxSignatureState.Trusted" />。
+    /// 参数省略(<see langword="null" />)表示只校验签名完整性、不判来源;显式传入空集合表示
+    /// 当前没有可信发布者,有效自签名返回 <see cref="VpxSignatureState.Untrusted" />。
     /// </summary>
     /// <param name="info">包头信息(须来自 <see cref="ReadInfo" /> 或 <see cref="OpenPayload(string, out VpxPackageInfo)" />)。</param>
     /// <param name="trustedPublicKeys">受信公钥集合(Base64 SPKI)。</param>
@@ -304,7 +305,7 @@ public static class VpxContainer
         {
             return VpxSignatureState.Invalid;
         }
-        return trustedPublicKeys is not { Count: > 0 }
+        return trustedPublicKeys is null
                || trustedPublicKeys.Contains(block.PublicKey, StringComparer.Ordinal)
             ? VpxSignatureState.Trusted
             : VpxSignatureState.Untrusted;

--- a/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
@@ -187,10 +187,7 @@ public sealed class McpManager(IPluginContext context) : IAsyncDisposable
     {
         if (server.Transport == McpTransportType.Http)
         {
-            if (!Uri.TryCreate(server.Url.Trim(), UriKind.Absolute, out Uri? endpoint))
-            {
-                throw new InvalidOperationException("Invalid MCP server URL.");
-            }
+            Uri endpoint = ValidateHttpEndpoint(server.Url);
             Dictionary<string, string> headers = McpConfigParser.ParseHeaderLines(server.Headers);
             return new HttpClientTransport(new HttpClientTransportOptions
             {
@@ -245,9 +242,29 @@ public sealed class McpManager(IPluginContext context) : IAsyncDisposable
                 name = name.Length + suffix.Length > 64 ? name[..(64 - suffix.Length)] + suffix : $"{name}{suffix}";
             }
             McpClientTool named = tool.WithName(name);
-            bool readOnly = tool.ProtocolTool.Annotations?.ReadOnlyHint == true;
-            sink.Add(readOnly ? named : new ApprovalGatedFunction(named, DisplayName(server), this));
+            // readOnlyHint 是远端服务器自己给出的建议性元数据,不能作为安全边界。恶意服务器
+            // 完全可以把删除/上传工具伪装成只读;所有 MCP 工具统一经过本地审批策略。
+            sink.Add(new ApprovalGatedFunction(named, DisplayName(server), this));
         }
+    }
+
+    /// <summary>
+    /// HTTP MCP 端点只允许 HTTPS。为本机开发保留 loopback HTTP;鉴权请求头绝不能经普通
+    /// 局域网 HTTP 明文发送。其它 URI scheme 也拒绝,避免 SDK 对非网络 URI 的意外解释。
+    /// </summary>
+    internal static Uri ValidateHttpEndpoint(string? value)
+    {
+        if (!Uri.TryCreate(value?.Trim(), UriKind.Absolute, out Uri? endpoint)
+            || (endpoint.Scheme != Uri.UriSchemeHttps && endpoint.Scheme != Uri.UriSchemeHttp))
+        {
+            throw new InvalidOperationException("Invalid MCP server URL. Use an absolute HTTPS URL.");
+        }
+        if (endpoint.Scheme == Uri.UriSchemeHttp && !endpoint.IsLoopback)
+        {
+            throw new InvalidOperationException(
+                "Insecure MCP server URL. HTTP is allowed only for localhost; use HTTPS for remote servers.");
+        }
+        return endpoint;
     }
 
     private static string DisplayName(McpServerConfig server)
@@ -275,8 +292,7 @@ public sealed class McpManager(IPluginContext context) : IAsyncDisposable
     {
         protected override async ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
         {
-            // 只读放行只认得内置的 run_command;MCP 这边不做猜测 —— 服务器自己声明的
-            // readOnlyHint 已经在 CollectTools 里筛过一遍,能走到这儿的都是可能改状态的。
+            // MCP 的 readOnlyHint 来自远端,只能用于展示,不能据此跳过本地审批。
             if (owner.Approval != ApprovalMode.Bypass)
             {
                 if (owner.ApprovalHandler is not { } handler)

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -487,6 +487,15 @@ public class TerminalBehaviorOptions : ObservableOptions
         set => Set(ref field, value);
     } = "system";
 
+    /// <summary>
+    /// 允许远端程序通过 OSC 52 写入本机剪贴板。默认关闭,避免不可信终端输出实施剪贴板投毒。
+    /// </summary>
+    public bool AllowRemoteClipboardWrite
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
     /// <summary>后台标签收到响铃时是否闪烁标签提示。</summary>
     public bool TabFlashAlert
     {

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1475,6 +1475,12 @@
   <data name="Profile_TestSuccess" xml:space="preserve">
     <value>接続テストに成功しました</value>
   </data>
+  <data name="Profile_CopyErrorTip" xml:space="preserve">
+    <value>エラーメッセージをコピー</value>
+  </data>
+  <data name="Profile_ErrorCopied" xml:space="preserve">
+    <value>コピーしました</value>
+  </data>
   <data name="Profile_Title" xml:space="preserve">
     <value>新規接続</value>
   </data>
@@ -3729,4 +3735,19 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Plugin_TestUnavailable" xml:space="preserve">
     <value>この接続タイプはここではテストできません。「接続」を押してください。プラグインがパネル上に実際の結果を表示します。</value>
   </data>
+  <data name="SetTerm_RemoteClipboard" xml:space="preserve">
+    <value>リモートからのクリップボード書き込みを許可（OSC 52）</value>
+  </data>
+  <data name="SetTerm_RemoteClipboardDesc" xml:space="preserve">
+    <value>既定では無効です。端末出力がローカルのクリップボードを書き換えられるため、信頼できるホストでのみ有効にしてください。</value>
+  </data>
+  <data name="PluginManager_UntrustedTitle" xml:space="preserve"><value>信頼されていないプラグイン</value></data>
+  <data name="PluginManager_UnsignedWarning" xml:space="preserve"><value>「{0}」は署名されていません。プラグインはユーザー権限でコードを実行できます。配布元を信頼できる場合のみインストールしてください。</value></data>
+  <data name="PluginManager_UntrustedWarning" xml:space="preserve"><value>「{0}」の署名は有効ですが、このデバイスでは発行元が信頼されていません。続行する前に、作者の公式サイトや GitHub など別の経路で公開鍵のフィンガープリントを確認してください：
+
+{1}
+
+信頼すると、同じ鍵で署名された今後のパッケージも信頼されます。プラグインはユーザー権限でコードを実行できます。</value></data>
+  <data name="PluginManager_InstallAnyway" xml:space="preserve"><value>続行してインストール</value></data>
+  <data name="PluginManager_TrustAndInstall" xml:space="preserve"><value>発行元を信頼してインストール</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1475,6 +1475,12 @@
   <data name="Profile_TestSuccess" xml:space="preserve">
     <value>연결 테스트 성공</value>
   </data>
+  <data name="Profile_CopyErrorTip" xml:space="preserve">
+    <value>오류 메시지 복사</value>
+  </data>
+  <data name="Profile_ErrorCopied" xml:space="preserve">
+    <value>복사됨</value>
+  </data>
   <data name="Profile_Title" xml:space="preserve">
     <value>새 연결</value>
   </data>
@@ -3729,4 +3735,19 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Plugin_TestUnavailable" xml:space="preserve">
     <value>이 연결 유형은 여기서 테스트할 수 없습니다. 「연결」을 누르면 플러그인이 패널에 실제 결과를 표시합니다.</value>
   </data>
+  <data name="SetTerm_RemoteClipboard" xml:space="preserve">
+    <value>원격 클립보드 쓰기 허용(OSC 52)</value>
+  </data>
+  <data name="SetTerm_RemoteClipboardDesc" xml:space="preserve">
+    <value>기본적으로 꺼져 있습니다. 터미널 출력이 로컬 클립보드를 바꿀 수 있으므로 신뢰할 수 있는 호스트에서만 사용하세요.</value>
+  </data>
+  <data name="PluginManager_UntrustedTitle" xml:space="preserve"><value>신뢰할 수 없는 플러그인 패키지</value></data>
+  <data name="PluginManager_UnsignedWarning" xml:space="preserve"><value>"{0}"에 서명이 없습니다. 플러그인은 사용자 권한으로 코드를 실행할 수 있으므로 출처를 신뢰하는 경우에만 설치하세요.</value></data>
+  <data name="PluginManager_UntrustedWarning" xml:space="preserve"><value>"{0}"의 서명은 유효하지만 이 장치에서 게시자를 신뢰하지 않습니다. 계속하기 전에 작성자의 공식 사이트나 GitHub 등 별도 경로에서 공개 키 지문을 확인하세요:
+
+{1}
+
+신뢰하면 같은 키로 서명된 이후 패키지도 신뢰됩니다. 플러그인은 사용자 권한으로 코드를 실행할 수 있습니다.</value></data>
+  <data name="PluginManager_InstallAnyway" xml:space="preserve"><value>계속 설치</value></data>
+  <data name="PluginManager_TrustAndInstall" xml:space="preserve"><value>게시자를 신뢰하고 설치</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1609,6 +1609,12 @@ Paste anyway?</value>
   <data name="Profile_TestSuccess" xml:space="preserve">
     <value>Connection test succeeded</value>
   </data>
+  <data name="Profile_CopyErrorTip" xml:space="preserve">
+    <value>Copy error message</value>
+  </data>
+  <data name="Profile_ErrorCopied" xml:space="preserve">
+    <value>Copied</value>
+  </data>
   <data name="Profile_Title" xml:space="preserve">
     <value>New Connection</value>
   </data>
@@ -3730,4 +3736,19 @@ Overwrite it?</value>
   <data name="Plugin_TestUnavailable" xml:space="preserve">
     <value>This connection type cannot be tested here. Use Connect — its plugin reports the real result on the panel.</value>
   </data>
+  <data name="SetTerm_RemoteClipboard" xml:space="preserve">
+    <value>Allow remote clipboard writes (OSC 52)</value>
+  </data>
+  <data name="SetTerm_RemoteClipboardDesc" xml:space="preserve">
+    <value>Off by default. Enable only for trusted hosts; terminal output can otherwise replace your local clipboard.</value>
+  </data>
+  <data name="PluginManager_UntrustedTitle" xml:space="preserve"><value>Untrusted plugin package</value></data>
+  <data name="PluginManager_UnsignedWarning" xml:space="preserve"><value>"{0}" is not signed. Plugins can execute code with your account permissions. Install only if you trust its source.</value></data>
+  <data name="PluginManager_UntrustedWarning" xml:space="preserve"><value>"{0}" has a valid signature, but its publisher is not trusted on this device. Verify this public-key fingerprint through the author's official channel before continuing:
+
+{1}
+
+Trusting it will also trust future packages signed by the same key. Plugins can execute code with your account permissions.</value></data>
+  <data name="PluginManager_InstallAnyway" xml:space="preserve"><value>Install anyway</value></data>
+  <data name="PluginManager_TrustAndInstall" xml:space="preserve"><value>Trust publisher and install</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1700,6 +1700,12 @@
   <data name="Profile_TestSuccess" xml:space="preserve">
     <value>连接测试成功</value>
   </data>
+  <data name="Profile_CopyErrorTip" xml:space="preserve">
+    <value>复制错误信息</value>
+  </data>
+  <data name="Profile_ErrorCopied" xml:space="preserve">
+    <value>已复制</value>
+  </data>
   <data name="Profile_Title" xml:space="preserve">
     <value>新建连接</value>
   </data>
@@ -3821,4 +3827,19 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Plugin_TestUnavailable" xml:space="preserve">
     <value>这种连接类型没法在这里测试。直接按「连接」——它的插件会在面板上给出真实结果。</value>
   </data>
+  <data name="SetTerm_RemoteClipboard" xml:space="preserve">
+    <value>允许远端写入剪贴板（OSC 52）</value>
+  </data>
+  <data name="SetTerm_RemoteClipboardDesc" xml:space="preserve">
+    <value>默认关闭。仅对可信主机开启，否则终端输出可以替换本机剪贴板内容。</value>
+  </data>
+  <data name="PluginManager_UntrustedTitle" xml:space="preserve"><value>不受信任的插件包</value></data>
+  <data name="PluginManager_UnsignedWarning" xml:space="preserve"><value>“{0}”没有签名。插件能以你的账户权限执行代码，请仅在信任其来源时安装。</value></data>
+  <data name="PluginManager_UntrustedWarning" xml:space="preserve"><value>“{0}”的签名有效，但此设备尚不信任其发布者。继续前请通过作者官网、GitHub 等独立渠道核对公钥指纹：
+
+{1}
+
+信任后，同一密钥签署的后续包也会自动可信。插件能以你的账户权限执行代码。</value></data>
+  <data name="PluginManager_InstallAnyway" xml:space="preserve"><value>仍然安装</value></data>
+  <data name="PluginManager_TrustAndInstall" xml:space="preserve"><value>信任发布者并安装</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1475,6 +1475,12 @@
   <data name="Profile_TestSuccess" xml:space="preserve">
     <value>連線測試成功</value>
   </data>
+  <data name="Profile_CopyErrorTip" xml:space="preserve">
+    <value>複製錯誤訊息</value>
+  </data>
+  <data name="Profile_ErrorCopied" xml:space="preserve">
+    <value>已複製</value>
+  </data>
   <data name="Profile_Title" xml:space="preserve">
     <value>新增連線</value>
   </data>
@@ -3729,4 +3735,19 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Plugin_TestUnavailable" xml:space="preserve">
     <value>這種連線類型沒法在這裡測試。直接按「連線」——它的外掛會在面板上給出真實結果。</value>
   </data>
+  <data name="SetTerm_RemoteClipboard" xml:space="preserve">
+    <value>允許遠端寫入剪貼簿（OSC 52）</value>
+  </data>
+  <data name="SetTerm_RemoteClipboardDesc" xml:space="preserve">
+    <value>預設關閉。僅對可信任主機開啟，否則終端輸出可以取代本機剪貼簿內容。</value>
+  </data>
+  <data name="PluginManager_UntrustedTitle" xml:space="preserve"><value>不受信任的外掛套件</value></data>
+  <data name="PluginManager_UnsignedWarning" xml:space="preserve"><value>「{0}」沒有簽章。外掛能以你的帳戶權限執行程式碼，請僅在信任其來源時安裝。</value></data>
+  <data name="PluginManager_UntrustedWarning" xml:space="preserve"><value>「{0}」的簽章有效，但此裝置尚不信任其發行者。繼續前請透過作者官網、GitHub 等獨立管道核對公鑰指紋：
+
+{1}
+
+信任後，同一密鑰簽署的後續套件也會自動可信。外掛能以你的帳戶權限執行程式碼。</value></data>
+  <data name="PluginManager_InstallAnyway" xml:space="preserve"><value>仍要安裝</value></data>
+  <data name="PluginManager_TrustAndInstall" xml:space="preserve"><value>信任發行者並安裝</value></data>
 </root>

--- a/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class PluginServiceCollectionExtensions
                 DebugPluginIds = DevPluginRootResolver.ResolveDebugPluginIds(),
                 DataRootDirectory = Path.Combine(paths.RootDirectory, "plugin-data"),
                 UserPluginRoot = Path.Combine(paths.RootDirectory, "plugins"),
+                TrustedPublisherStorePath = Path.Combine(paths.RootDirectory, "trusted-plugin-publishers.json"),
                 HostVersion = hostVersion,
                 Connections = sp.GetService<ISshConnectionService>(),
                 Sftp = sp.GetService<ISftpService>(),

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
 using VelaShell.Infrastructure.Plugins.Capabilities;
 using VelaShell.Infrastructure.Plugins.Isolated;
 using VelaShell.PluginSdk;
@@ -23,6 +25,8 @@ namespace VelaShell.Infrastructure.Plugins;
 /// </summary>
 public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposable
 {
+    private readonly HashSet<string> _trustedPackageKeys = LoadTrustedPackageKeys(options);
+    private readonly Lock _trustedPackageKeysGate = new();
     private sealed class PluginRuntime
     {
         public required PluginDescriptor Descriptor { get; init; }
@@ -239,7 +243,10 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     /// </summary>
     /// <exception cref="InvalidOperationException">无用户插件目录、清单校验失败或签名策略拒绝。</exception>
     /// <exception cref="VpxFormatException">包不是合法的 <c>.vpx</c> 容器,或已损坏/被篡改。</exception>
-    public async Task<string> InstallFromVpxAsync(string vpxPath, CancellationToken cancellationToken = default)
+    public async Task<string> InstallFromVpxAsync(
+        string vpxPath,
+        bool allowUntrustedPackage = false,
+        CancellationToken cancellationToken = default)
     {
         if (options.UserPluginRoot is not { } userRoot)
         {
@@ -257,7 +264,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         PluginManifest? manifest = null;
         try
         {
-            ExtractPackage(vpxPath, staging);
+            ExtractPackage(vpxPath, staging, allowUntrustedPackage);
             string manifestPath = Path.Combine(staging, PluginManifestReader.FileName);
             if (!File.Exists(manifestPath))
             {
@@ -332,11 +339,11 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     /// 打开插件包并安全解包。只认 <c>.vpx</c> 专属容器(魔数 + 摘要 + 可选签名,见
     /// <see cref="VpxContainer" />)—— 改了后缀的 zip 一律拒绝,拒绝原因里带重新打包的办法。
     /// </summary>
-    private void ExtractPackage(string packagePath, string destination)
+    private void ExtractPackage(string packagePath, string destination, bool allowUntrustedPackage)
     {
         // 格式非法(裸 zip / 截断 / 头部损坏 / 根本不是包)在此抛出并带可读原因。
         using Stream payload = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
-        CheckSignature(packagePath, info);
+        CheckSignature(packagePath, info, allowUntrustedPackage);
         using var archive = new ZipArchive(payload, ZipArchiveMode.Read);
         ExtractZipSafely(archive, destination);
     }
@@ -345,9 +352,9 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     /// 签名闸。坏签名一律拒绝(哪怕没开强制签名)—— 签名对不上意味着内容被动过,
     /// 这比"未签名"严重得多,不该因为策略宽松就放行。
     /// </summary>
-    private void CheckSignature(string packagePath, VpxPackageInfo info)
+    private void CheckSignature(string packagePath, VpxPackageInfo info, bool allowUntrustedPackage)
     {
-        VpxSignatureState state = VpxContainer.VerifySignature(info, options.TrustedPackageKeys);
+        VpxSignatureState state = GetSignatureState(info);
         string name = Path.GetFileName(packagePath);
         switch (state)
         {
@@ -357,15 +364,129 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             case VpxSignatureState.Untrusted when options.RequireTrustedPackageSignature:
                 throw new InvalidOperationException(
                     $"'{name}' is signed by an unknown publisher and this host only installs packages from trusted keys.");
+            case VpxSignatureState.Untrusted when !allowUntrustedPackage:
+                throw new InvalidOperationException(
+                    $"'{name}' is signed by an unknown publisher. Explicit approval is required to install it.");
             case VpxSignatureState.Unsigned when options.RequireTrustedPackageSignature:
                 throw new InvalidOperationException(
-                    $"'{name}' is not signed and this host only installs signed packages.");
+                    $"'{name}' is not signed and this host only installs packages from trusted keys.");
+            case VpxSignatureState.Unsigned when !allowUntrustedPackage:
+                throw new InvalidOperationException(
+                    $"'{name}' is not signed. Explicit approval is required to install it.");
             case VpxSignatureState.Trusted:
                 Log($"Package '{name}' carries a trusted signature.");
                 break;
             default:
                 break;
         }
+    }
+
+    /// <summary>
+    /// 校验容器摘要并返回发布者信任状态,供交互安装入口在落盘前显示准确警告。
+    /// 坏包会像正式安装一样抛出 <see cref="VpxFormatException" />。
+    /// </summary>
+    public VpxSignatureState InspectPackageSignature(string packagePath)
+    {
+        using Stream _ = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
+        return GetSignatureState(info);
+    }
+
+    /// <summary>读取包签名及可供用户通过独立渠道核对的 SHA-256 公钥指纹。</summary>
+    public PluginPackageTrustInfo InspectPackageTrust(string packagePath)
+    {
+        using Stream _ = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
+        return new(GetSignatureState(info), Fingerprint(info.Signature?.PublicKey));
+    }
+
+    /// <summary>
+    /// 把一个签名有效但发布者未知的公钥加入本机信任库。未签名、坏签名或已经可信的包拒绝走此入口。
+    /// </summary>
+    public string TrustPackagePublisher(string packagePath)
+    {
+        using Stream _ = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
+        if (info.Signature is not { PublicKey: { Length: > 0 } publicKey }
+            || GetSignatureState(info) != VpxSignatureState.Untrusted)
+        {
+            throw new InvalidOperationException("Only a valid package from an unknown publisher can establish publisher trust.");
+        }
+        lock (_trustedPackageKeysGate)
+        {
+            bool added = _trustedPackageKeys.Add(publicKey);
+            try
+            {
+                SaveTrustedPackageKeys();
+            }
+            catch
+            {
+                if (added)
+                {
+                    _trustedPackageKeys.Remove(publicKey);
+                }
+                throw;
+            }
+        }
+        return Fingerprint(publicKey)!;
+    }
+
+    private VpxSignatureState GetSignatureState(VpxPackageInfo info)
+    {
+        lock (_trustedPackageKeysGate)
+        {
+            return VpxContainer.VerifySignature(info, _trustedPackageKeys);
+        }
+    }
+
+    private static string? Fingerprint(string? publicKey)
+    {
+        if (string.IsNullOrWhiteSpace(publicKey))
+        {
+            return null;
+        }
+        try
+        {
+            return "SHA256:" + Convert.ToHexStringLower(SHA256.HashData(Convert.FromBase64String(publicKey)));
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static HashSet<string> LoadTrustedPackageKeys(PluginManagerOptions managerOptions)
+    {
+        var keys = new HashSet<string>(managerOptions.TrustedPackageKeys ?? [], StringComparer.Ordinal);
+        if (managerOptions.TrustedPublisherStorePath is not { } path || !File.Exists(path))
+        {
+            return keys;
+        }
+        try
+        {
+            foreach (string key in JsonSerializer.Deserialize<string[]>(File.ReadAllText(path)) ?? [])
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    keys.Add(key);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            Trace.WriteLine($"[VelaShell] Failed to read trusted plugin publishers: {ex.Message}");
+        }
+        return keys;
+    }
+
+    private void SaveTrustedPackageKeys()
+    {
+        if (options.TrustedPublisherStorePath is not { } path)
+        {
+            return;
+        }
+        string fullPath = Path.GetFullPath(path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        string temporary = fullPath + ".tmp";
+        File.WriteAllText(temporary, JsonSerializer.Serialize(_trustedPackageKeys.Order(StringComparer.Ordinal)));
+        File.Move(temporary, fullPath, overwrite: true);
     }
 
     private static void ExtractZipSafely(ZipArchive archive, string destination)

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -37,14 +37,19 @@ public sealed class PluginManagerOptions
     public string? UserPluginRoot { get; init; }
 
     /// <summary>
-    /// 受信的包签名公钥(Base64 SPKI)。为空表示不做来源判定 —— 此时任何**有效**签名都算受信,
-    /// 但签名对不上的包依然被拒(那是篡改,不是来源问题)。
+    /// 受信的包签名公钥(Base64 SPKI)。为空表示没有可信发布者;有效自签名包仍属于不受信来源,
+    /// 必须由安装入口取得用户的单次明确授权。
     /// </summary>
     public IReadOnlyCollection<string>? TrustedPackageKeys { get; init; }
 
     /// <summary>
-    /// 是否只安装带受信签名的包(默认否:第一方/自装插件场景信任即安装,见蓝图 10 的分期决策)。
-    /// 打开后未签名与不受信签名的包都会被拒。
+    /// 用户确认过的发布者公钥存储文件(JSON 字符串数组)。为空时信任仅保留在当前进程;
+    /// 文件只含公钥,不含任何私钥或凭据。
+    /// </summary>
+    public string? TrustedPublisherStorePath { get; init; }
+
+    /// <summary>
+    /// 是否只安装带受信签名的包。打开后未签名与不受信签名的包都会被拒,不能通过单次授权绕过。
     /// </summary>
     public bool RequireTrustedPackageSignature { get; init; }
 

--- a/src/VelaShell.Infrastructure/Plugins/PluginPackageTrustInfo.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginPackageTrustInfo.cs
@@ -1,0 +1,6 @@
+using VelaShell.PluginSdk.Packaging;
+
+namespace VelaShell.Infrastructure.Plugins;
+
+/// <summary>插件包发布者信任状态及其可人工核对的公钥指纹。</summary>
+public sealed record PluginPackageTrustInfo(VpxSignatureState State, string? PublisherFingerprint);

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -12,7 +12,7 @@ namespace VelaShell.Terminal.Emulation;
 public sealed class TerminalEmulator : IVtActions
 {
     /// <summary>OSC 52 载荷上限(base64 解码后),防远端滥发撑爆剪贴板。</summary>
-    private const int MaxOsc52Bytes = 1024 * 1024;
+    private const int MaxOsc52Bytes = 64 * 1024;
 
     // 字符集:G0..G3 指定,GL/GR 调用,单字符移位。
     private readonly bool[] _decGraphics = new bool[4]; // true => DEC 特殊图形
@@ -76,6 +76,12 @@ public sealed class TerminalEmulator : IVtActions
 
     /// <summary>当前光标行(从 0 开始)。</summary>
     public int CursorY => Screen.CursorY;
+
+    /// <summary>
+    /// 是否接受 OSC 52 远端剪贴板写入。默认关闭:终端输出属于不可信输入,只有用户显式开启后
+    /// tmux/vim 等远端 yank 才能改写本机剪贴板。
+    /// </summary>
+    public bool AllowOsc52ClipboardWrite { get; set; }
 
     /// <summary>备用屏缓冲区处于活动状态(DECSET 1047/1049)时为 true。</summary>
     public bool IsAlternateScreen { get; private set; }
@@ -453,7 +459,9 @@ public sealed class TerminalEmulator : IVtActions
                 break;
             case 52:
                 // 形如 52;c;<base64>(c/p/s… 选区种类一律当系统剪贴板处理)。
-                if (p.Count > 2 && p[2] is { Length: > 0 } payload && payload != "?" && payload.Length <= MaxOsc52Bytes / 3 * 4 + 4)
+                if (AllowOsc52ClipboardWrite
+                    && p.Count > 2 && p[2] is { Length: > 0 } payload
+                    && payload != "?" && payload.Length <= MaxOsc52Bytes / 3 * 4 + 4)
                 {
                     try
                     {

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -256,6 +256,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <summary>BEL 处理:"system"(蜂鸣)、"none"(静默)或 "visual"(屏幕闪烁)。</summary>
     public string BellMode { get; set; } = "system";
 
+    /// <summary>允许远端通过 OSC 52 写入本机剪贴板;默认关闭。</summary>
+    public bool AllowRemoteClipboardWrite
+    {
+        get => Emulator.AllowOsc52ClipboardWrite;
+        set => Emulator.AllowOsc52ClipboardWrite = value;
+    }
+
     /// <summary>
     /// 左侧栏显示每行的收行时间 <c>[HH:mm:ss]</c>(设置 → 终端 / 侧栏右键)。与 <see cref="ShowLineNumber" />
     /// 等相互独立。任一侧栏部件开启都会占用左侧宽度(减少可用列数,PTY 随之改列宽)。

--- a/src/VelaShell/Services/Update/UpdateApplier.cs
+++ b/src/VelaShell/Services/Update/UpdateApplier.cs
@@ -49,6 +49,8 @@ public sealed class UpdateApplier(string applicationDirectory)
 
     private const string PayloadDirectoryName = "payload";
     private const string BackupDirectoryName = "backup";
+    internal const int MaxUpdateEntries = 20_000;
+    internal const long MaxUpdateUnpackedBytes = 2L * 1024 * 1024 * 1024;
 
     /// <summary>外置换版进程临时目录的保留时长;超过此年龄的遗留目录在启动时清扫。</summary>
     private static readonly TimeSpan UpdaterDirectoryMaxAge = TimeSpan.FromHours(6);
@@ -511,16 +513,36 @@ public sealed class UpdateApplier(string applicationDirectory)
             EnsureInsideApplicationDirectory(rel, entry.FullName);
             if (byPath.TryAdd(rel, entry))
             {
+                if (order.Count >= MaxUpdateEntries)
+                {
+                    throw new InvalidDataException(
+                        $"Update package contains too many files (limit {MaxUpdateEntries}).");
+                }
                 order.Add(rel);
-                required += entry.Length;
+                try
+                {
+                    required = checked(required + entry.Length);
+                }
+                catch (OverflowException ex)
+                {
+                    throw new InvalidDataException("Update package declares an invalid unpacked size.", ex);
+                }
+                if (required > MaxUpdateUnpackedBytes)
+                {
+                    throw new InvalidDataException(
+                        $"Update package exceeds the {MaxUpdateUnpackedBytes}-byte unpacked-size limit.");
+                }
             }
         }
         EnsureDiskSpace(required);
+        long remainingBudget = MaxUpdateUnpackedBytes;
         foreach (string rel in order)
         {
             string destination = Path.Combine(PayloadDirectory, rel);
             Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
-            byPath[rel].ExtractToFile(destination, true);
+            using Stream source = byPath[rel].Open();
+            using FileStream target = File.Create(destination);
+            remainingBudget -= CopyWithBudget(source, target, remainingBudget, rel);
         }
         return order;
     }
@@ -536,10 +558,12 @@ public sealed class UpdateApplier(string applicationDirectory)
         {
             throw new NotSupportedException($"Unsupported update package format: {archivePath}");
         }
-        // 压缩包大小的 4 倍是个保守的解压后估算;真解爆了也只是 payload 写失败,应用目录不受影响。
-        EnsureDiskSpace(new FileInfo(archivePath).Length * 4);
+        // 这里只做早期空间提示;真正的安全边界是下方按实际写出字节递减的总预算。
+        long compressedBytes = new FileInfo(archivePath).Length;
+        EnsureDiskSpace(compressedBytes > long.MaxValue / 4 ? long.MaxValue : compressedBytes * 4);
         List<string> entries = [];
         HashSet<string> seen = [with(StringComparer.OrdinalIgnoreCase)];
+        long remainingBudget = MaxUpdateUnpackedBytes;
         using FileStream file = File.OpenRead(archivePath);
         using GZipStream gzip = new(file, CompressionMode.Decompress);
         using TarReader tar = new(gzip);
@@ -555,12 +579,47 @@ public sealed class UpdateApplier(string applicationDirectory)
             {
                 continue;
             }
+            if (entries.Count >= MaxUpdateEntries)
+            {
+                throw new InvalidDataException(
+                    $"Update package contains too many files (limit {MaxUpdateEntries}).");
+            }
             string destination = Path.Combine(PayloadDirectory, rel);
             Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
-            entry.ExtractToFile(destination, true);
+            using (FileStream target = File.Create(destination))
+            {
+                remainingBudget -= CopyWithBudget(
+                    entry.DataStream ?? Stream.Null, target, remainingBudget, rel);
+            }
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(destination, entry.Mode);
+            }
             entries.Add(rel);
         }
         return entries;
+    }
+
+    /// <summary>
+    /// 按实际解压出的字节计费,不信任 zip/tar 头部声明。返回本条目写出的字节数。
+    /// </summary>
+    internal static long CopyWithBudget(Stream source, Stream destination, long remainingBudget, string entryName)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(remainingBudget);
+        byte[] buffer = new byte[81920];
+        long written = 0;
+        int read;
+        while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            if (written > remainingBudget - read)
+            {
+                throw new InvalidDataException(
+                    $"Update package exceeds the {MaxUpdateUnpackedBytes}-byte unpacked-size limit while extracting '{entryName}'.");
+            }
+            destination.Write(buffer, 0, read);
+            written += read;
+        }
+        return written;
     }
 
     /// <summary>
@@ -584,7 +643,7 @@ public sealed class UpdateApplier(string applicationDirectory)
         {
             return;
         }
-        long required = payloadBytes * 2;
+        long required = payloadBytes > long.MaxValue / 2 ? long.MaxValue : payloadBytes * 2;
         if (available < required)
         {
             throw new IOException(

--- a/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
@@ -34,6 +34,12 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
 
     private readonly IConnectionWorkflowService? _connectionWorkflowService;
 
+    /// <summary>复制成功回执(「已复制」)的停留时长。</summary>
+    private static readonly TimeSpan CopyFeedbackDuration = TimeSpan.FromSeconds(2);
+
+    /// <summary>回执退回的定时器句柄;连点时先取消上一个。</summary>
+    private IDisposable? _copyFeedbackReset;
+
     private readonly Guid _profileId;
     private readonly ISessionRepository? _sessionRepository;
     private AuthMethod _authMethod = AuthMethod.Password;
@@ -191,6 +197,7 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
         ConnectCommand = ReactiveCommand.CreateFromTask(ConnectAsync, canExecute);
         CancelCommand = ReactiveCommand.Create(() => (SessionProfile?)null);
         TestConnectionCommand = ReactiveCommand.CreateFromTask(TestConnectionAsync, canExecute);
+        CopyErrorCommand = ReactiveCommand.CreateFromTask(CopyErrorAsync, this.WhenAnyValue(x => x.ErrorMessage, message => !string.IsNullOrWhiteSpace(message)));
         SelectConnectionTypeCommand = ReactiveCommand.Create<ConnectionType>(SelectConnectionType);
         SelectPluginProtocolCommand = ReactiveCommand.CreateFromTask<string>(SelectPluginProtocolAsync);
         // 表单是插件异步装载出来的,字段进集合的那一刻就得带上当前的折叠状态 ——
@@ -498,7 +505,20 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
         {
             this.RaiseAndSetIfChanged(ref field, value);
             this.RaisePropertyChanged(nameof(HasFeedback));
+            this.RaisePropertyChanged(nameof(HasError));
+            // 换了一条错误(或清空)就收回上一条的「已复制」:那句回执是对具体那段文本说的。
+            ErrorCopied = false;
         }
+    }
+
+    /// <summary>是否有可复制的错误信息 —— 复制按钮据此出现。</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+
+    /// <summary>刚复制过错误信息;按钮短暂显示「已复制」,随后自己退回。</summary>
+    public bool ErrorCopied
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
     /// <summary>最近一次连接测试结果;null 表示尚未测试,变更时同步刷新 <see cref="ShowTestSuccess" />。</summary>
@@ -604,6 +624,15 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
 
     /// <summary>连接测试命令;不落库,仅探测能否连通并回填结果。</summary>
     public ReactiveCommand<RxVoid, RxVoid> TestConnectionCommand { get; }
+
+    /// <summary>
+    /// 复制当前错误信息到剪贴板。连接失败的原因常是一长串服务端原文(认证链、
+    /// 主机密钥指纹、栈顶异常),要拿去搜索或贴给同事,靠眼睛照抄不现实。
+    /// </summary>
+    public ReactiveCommand<RxVoid, RxVoid> CopyErrorCommand { get; }
+
+    /// <summary>写系统剪贴板的回调;由视图注入(视图模型层拿不到 TopLevel)。</summary>
+    public Func<string, Task>? CopyToClipboard { get; set; }
 
     /// <summary>浏览私钥文件命令;由视图层挂接文件选择对话框。</summary>
     public ReactiveCommand<RxVoid, RxVoid> BrowseKeyFileCommand { get; }
@@ -755,6 +784,24 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
         {
             EndBusy();
         }
+    }
+
+    /// <summary>
+    /// 把错误信息原文送进剪贴板,并在按钮上留一句「已复制」的回执 ——
+    /// 没有回执就分不清"复制成功了"和"按钮没反应",用户只会再点两下。
+    /// 回执 <see cref="CopyFeedbackDuration" /> 后自动退回;连点时先取消上一个定时器,
+    /// 否则第二次点完会立刻被第一次的定时器把提示抹掉。
+    /// </summary>
+    private async Task CopyErrorAsync()
+    {
+        if (CopyToClipboard is not { } copy || ErrorMessage is not { Length: > 0 } message)
+        {
+            return;
+        }
+        await copy(message).ConfigureAwait(true);
+        ErrorCopied = true;
+        _copyFeedbackReset?.Dispose();
+        _copyFeedbackReset = DispatcherTimer.RunOnce(() => ErrorCopied = false, CopyFeedbackDuration);
     }
 
     /// <summary>
@@ -1143,6 +1190,7 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
     public void Dispose()
     {
         _protocolRegistry?.Changed -= OnProtocolsChanged;
+        _copyFeedbackReset?.Dispose();
     }
 
     /// <summary>把注册表里的协议页签同步到界面(打开对话框时调用)。</summary>

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -3644,6 +3644,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
         control.CursorStyle = behavior.CursorStyle;
         control.CursorBlink = behavior.CursorBlink;
         control.BellMode = behavior.BellMode;
+        control.AllowRemoteClipboardWrite = behavior.AllowRemoteClipboardWrite;
         control.ScrollOnOutput = behavior.ScrollOnOutput;
         control.ShowLineTimestamp = behavior.ShowLineTimestamp;
         control.ShowLineNumber = behavior.ShowLineNumber;

--- a/src/VelaShell/ViewModels/PluginManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/PluginManagerViewModel.cs
@@ -170,12 +170,20 @@ public sealed class PluginManagerViewModel : ReactiveObject, IDisposable
         }
     }
 
-    /// <summary>从 .vpx 文件安装。成功/失败经 <see cref="Notice" /> 反馈。</summary>
-    public async Task InstallFromVpxAsync(string vpxPath)
+    /// <summary>校验插件包并返回发布者信任状态与公钥指纹。</summary>
+    public PluginPackageTrustInfo InspectPackageTrust(string vpxPath) =>
+        _manager.InspectPackageTrust(vpxPath);
+
+    /// <summary>把已由用户核对的签名发布者加入本机信任库。</summary>
+    public string TrustPackagePublisher(string vpxPath) =>
+        _manager.TrustPackagePublisher(vpxPath);
+
+    /// <summary>从 .vpx 文件安装。未知来源只能由界面明确确认后单次放行。</summary>
+    public async Task InstallFromVpxAsync(string vpxPath, bool allowUntrustedPackage = false)
     {
         try
         {
-            string id = await _manager.InstallFromVpxAsync(vpxPath).ConfigureAwait(false);
+            string id = await _manager.InstallFromVpxAsync(vpxPath, allowUntrustedPackage).ConfigureAwait(false);
             SetNotice(Strings.Format("PluginManager_Installed", id));
         }
         catch (Exception ex)

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -81,6 +81,23 @@
       <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
       <Setter Property="FontWeight" Value="Medium" />
     </Style>
+    <!-- 错误信息旁的「复制」小按钮:比页脚按钮矮一圈,免得抢走测试/保存的分量 -->
+    <Style Selector="Button.copy-chip">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="Height" Value="24" />
+      <Setter Property="Padding" Value="8,0" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="VerticalAlignment" Value="Top" />
+    </Style>
+    <Style Selector="Button.copy-chip:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+    </Style>
     <!-- 协议标签页 -->
     <Style Selector="Border.proto-tab">
       <Setter Property="Height" Value="32" />
@@ -472,9 +489,37 @@
               BorderThickness="0,1,0,0"
               BorderBrush="{DynamicResource VelaBorderPrimary}">
         <StackPanel Spacing="4">
-          <TextBlock Text="{Binding ErrorMessage}"
-                     IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                     Foreground="#FF6B6B" FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap" />
+          <!-- 失败原因常是一长串服务端原文(认证链、主机密钥指纹、栈顶异常):
+               给它配一个复制按钮,用户才拿得走去搜索或贴给同事 —— 照着屏幕抄不现实。
+               按钮与文案同排、钉在顶端:错误可能好几行,贴顶才不会随行数上下跑。 -->
+          <Grid ColumnDefinitions="*,Auto"
+                IsVisible="{Binding HasError}">
+            <TextBlock Grid.Column="0" Text="{Binding ErrorMessage}"
+                       Foreground="#FF6B6B" FontSize="{DynamicResource VelaFontSize11}" TextWrapping="Wrap"
+                       VerticalAlignment="Center" />
+            <Button Grid.Column="1" x:Name="CopyErrorButton" Classes="copy-chip"
+                    Margin="12,0,0,0"
+                    Command="{Binding CopyErrorCommand}"
+                    ToolTip.Tip="{loc:Localize Profile_CopyErrorTip}"
+                    ToolTip.Placement="Top">
+              <!-- 两态叠放而不是换文字:同宽同位,复制完按钮不会跳一下 -->
+              <Panel>
+                <StackPanel Orientation="Horizontal" Spacing="5" IsVisible="{Binding !ErrorCopied}">
+                  <PathIcon Width="11" Height="11"
+                            Data="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                            Foreground="{DynamicResource VelaTextSecondary}" />
+                  <TextBlock Text="{loc:Localize Copy}" VerticalAlignment="Center" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="5" IsVisible="{Binding ErrorCopied}">
+                  <PathIcon Width="11" Height="11"
+                            Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                            Foreground="{DynamicResource VelaAccent}" />
+                  <TextBlock Text="{loc:Localize Profile_ErrorCopied}" VerticalAlignment="Center"
+                             Foreground="{DynamicResource VelaAccent}" />
+                </StackPanel>
+              </Panel>
+            </Button>
+          </Grid>
           <TextBlock Text="{loc:Localize Profile_TestSuccess}"
                      IsVisible="{Binding ShowTestSuccess}"
                      Foreground="{DynamicResource VelaAccent}" FontSize="{DynamicResource VelaFontSize11}" />

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -218,6 +219,9 @@ public partial class ConnectionProfileView : Window
         ApplyScreenBounds(preferCurrentScreen: true);
         ClampToWorkingArea();
         ApplyProtoTabFocusAdorner();
+        // 剪贴板挂在 TopLevel 上,视图模型层够不着,由视图注入。赋值幂等:
+        // 窗口重开也只是覆盖同一个委托,不会像事件订阅那样越接越多。
+        viewModel.CopyToClipboard = CopyToClipboardAsync;
         // 协议切换只改按钮前景色、不触发布局,滑动下划线必须由 VM 属性变化驱动。
         // 直接盯 ConnectionType 本身,而不是逐个列举 IsXxxSelected —— 后者每加一个协议
         // 都要回来补一项,漏掉就表现为「下划线停在上一个页签」。
@@ -270,6 +274,15 @@ public partial class ConnectionProfileView : Window
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
             BeginMoveDrag(e);
+        }
+    }
+
+    /// <summary>把文本写进系统剪贴板;拿不到剪贴板(无 TopLevel)时静默跳过。</summary>
+    private async Task CopyToClipboardAsync(string text)
+    {
+        if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+        {
+            await clipboard.SetTextAsync(text);
         }
     }
 

--- a/src/VelaShell/Views/PluginManagerWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginManagerWindow.axaml.cs
@@ -5,7 +5,9 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using VelaShell.Core.Resources;
+using VelaShell.Infrastructure.Plugins;
 using VelaShell.ViewModels;
+using VelaShell.PluginSdk.Packaging;
 
 namespace VelaShell.Views;
 
@@ -122,7 +124,54 @@ public partial class PluginManagerWindow : Window
         });
         if (files is [{ } file] && file.TryGetLocalPath() is { } path)
         {
-            await vm.InstallFromVpxAsync(path);
+            PluginPackageTrustInfo trust;
+            try
+            {
+                trust = vm.InspectPackageTrust(path);
+            }
+            catch
+            {
+                // 让统一安装路径生成本地化错误提示(损坏摘要/错误格式等)。
+                await vm.InstallFromVpxAsync(path);
+                return;
+            }
+            bool allowUntrusted = false;
+            if (trust.State == VpxSignatureState.Unsigned)
+            {
+                allowUntrusted = await MessageDialog.ConfirmAsync(this,
+                    Strings.Get("PluginManager_UntrustedTitle"),
+                    Strings.Format("PluginManager_UnsignedWarning", Path.GetFileName(path)),
+                    confirmText: Strings.Get("PluginManager_InstallAnyway"),
+                    danger: true);
+                if (!allowUntrusted)
+                {
+                    return;
+                }
+            }
+            else if (trust.State == VpxSignatureState.Untrusted)
+            {
+                bool trustPublisher = await MessageDialog.ConfirmAsync(this,
+                    Strings.Get("PluginManager_UntrustedTitle"),
+                    Strings.Format("PluginManager_UntrustedWarning",
+                        Path.GetFileName(path), trust.PublisherFingerprint ?? "(unavailable)"),
+                    confirmText: Strings.Get("PluginManager_TrustAndInstall"),
+                    danger: true);
+                if (!trustPublisher)
+                {
+                    return;
+                }
+                try
+                {
+                    vm.TrustPackagePublisher(path);
+                }
+                catch (Exception ex)
+                {
+                    await MessageDialog.ShowMessageAsync(this,
+                        Strings.Get("PluginManager_UntrustedTitle"), ex.Message, MessageDialogKind.Error);
+                    return;
+                }
+            }
+            await vm.InstallFromVpxAsync(path, allowUntrusted);
         }
     }
 

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -129,6 +129,13 @@
       </StackPanel>
       <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.TabFlashAlert}" VerticalAlignment="Center" />
     </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_RemoteClipboard}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_RemoteClipboardDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.AllowRemoteClipboardWrite}" VerticalAlignment="Center" />
+    </Grid>
 
     <Border Classes="sep" />
 

--- a/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/ModelSerializationTests.cs
@@ -373,11 +373,13 @@ public class ModelSerializationTests
             TerminalFont = "Fira Code",
             TerminalFontSize = 18,
             ScrollbackLines = 20000,
-            DefaultPort = 2222
+            DefaultPort = 2222,
+            TerminalBehavior = new() { AllowRemoteClipboardWrite = true }
         };
         string json = JsonSerializer.Serialize(original, _options);
         AppSettings? deserialized = JsonSerializer.Deserialize<AppSettings>(json, _options);
         Assert.AreEqual(JsonSerializer.Serialize(original, _options),
             JsonSerializer.Serialize(deserialized, _options));
+        Assert.IsTrue(deserialized!.TerminalBehavior.AllowRemoteClipboardWrite);
     }
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Security.Cryptography;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.Plugin.HelloWorld;
 using VelaShell.PluginSdk.Packaging;
@@ -55,11 +56,12 @@ public class PluginInstallUninstallTests
         }
     }
 
-    private PluginManager CreateManager() => new(new()
+    private PluginManager CreateManager(string? trustedPublisherStorePath = null) => new(new()
     {
         PluginRoots = [_appRoot, _userRoot],
         DataRootDirectory = _dataRoot,
         UserPluginRoot = _userRoot,
+        TrustedPublisherStorePath = trustedPublisherStorePath,
         HostVersion = "1.0.0",
         CommandsFactory = (_, _) => new RecordingCommands(),
         DataStore = _dataStore
@@ -103,7 +105,7 @@ public class PluginInstallUninstallTests
         await manager.StartAsync();
         string vpx = BuildVpx();
 
-        string id = await manager.InstallFromVpxAsync(vpx);
+        string id = await manager.InstallFromVpxAsync(vpx, allowUntrustedPackage: true);
         Assert.AreEqual("acme.packaged", id);
         PluginDescriptor descriptor = manager.Plugins.Single(p => p.Id == id);
         Assert.AreEqual(PluginState.Active, descriptor.State, descriptor.Error);
@@ -118,7 +120,7 @@ public class PluginInstallUninstallTests
     {
         PluginManager manager = CreateManager();
         await manager.StartAsync();
-        string id = await manager.InstallFromVpxAsync(BuildVpx());
+        string id = await manager.InstallFromVpxAsync(BuildVpx(), allowUntrustedPackage: true);
 
         Assert.IsTrue(await manager.UninstallAsync(id));
         Assert.DoesNotContain(p => p.Id == id, manager.Plugins);
@@ -163,6 +165,58 @@ public class PluginInstallUninstallTests
         await manager.DisposeAsync();
     }
 
+    private static string BuildSignedVpx(ECDsa signingKey, string id = "acme.signed")
+    {
+        string stage = StagePlugin(id);
+        string vpx = stage + ".vpx";
+        VpxContainer.Pack(stage, vpx, new VpxPackOptions { SigningKey = signingKey });
+        return vpx;
+    }
+
+    [TestMethod]
+    public async Task InstallFromVpx_UnsignedPackage_RequiresExplicitApproval()
+    {
+        PluginManager manager = CreateManager();
+        await manager.StartAsync();
+        string package = BuildVpx("acme.unsigned");
+
+        InvalidOperationException ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => manager.InstallFromVpxAsync(package));
+
+        Assert.Contains("Explicit approval", ex.Message);
+        Assert.AreEqual(VpxSignatureState.Unsigned, manager.InspectPackageSignature(package));
+        Assert.DoesNotContain(p => p.Id == "acme.unsigned", manager.Plugins);
+        await manager.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task TrustPublisher_PersistsKey_AndFuturePackagesInstallWithoutBypass()
+    {
+        string trustStore = Path.Combine(_dataRoot, "trusted-publishers.json");
+        using var publisher = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        string first = BuildSignedVpx(publisher, "acme.signed-one");
+
+        PluginManager manager = CreateManager(trustStore);
+        await manager.StartAsync();
+        PluginPackageTrustInfo before = manager.InspectPackageTrust(first);
+        Assert.AreEqual(VpxSignatureState.Untrusted, before.State);
+        Assert.StartsWith("SHA256:", before.PublisherFingerprint);
+
+        string fingerprint = manager.TrustPackagePublisher(first);
+        Assert.AreEqual(before.PublisherFingerprint, fingerprint);
+        Assert.AreEqual(VpxSignatureState.Trusted, manager.InspectPackageSignature(first));
+        await manager.InstallFromVpxAsync(first);
+        await manager.DisposeAsync();
+
+        string second = BuildSignedVpx(publisher, "acme.signed-two");
+        PluginManager restarted = CreateManager(trustStore);
+        Assert.AreEqual(VpxSignatureState.Trusted, restarted.InspectPackageSignature(second));
+        await restarted.StartAsync();
+        await restarted.InstallFromVpxAsync(second);
+        Assert.Contains(p => p.Id == "acme.signed-two", restarted.Plugins);
+        await restarted.DisposeAsync();
+    }
+
     [TestMethod]
     public async Task InstallFromVpx_TamperedPackage_IsRejected()
     {
@@ -203,7 +257,8 @@ public class PluginInstallUninstallTests
             VpxContainer.Write(destination, payload);
         }
 
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => manager.InstallFromVpxAsync(vpx));
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => manager.InstallFromVpxAsync(vpx, allowUntrustedPackage: true));
         await manager.DisposeAsync();
     }
 
@@ -212,9 +267,9 @@ public class PluginInstallUninstallTests
     {
         PluginManager manager = CreateManager();
         await manager.StartAsync();
-        await manager.InstallFromVpxAsync(BuildVpx("acme.dup"));
+        await manager.InstallFromVpxAsync(BuildVpx("acme.dup"), allowUntrustedPackage: true);
         // 覆盖安装同 id:不抛,替换。
-        string id = await manager.InstallFromVpxAsync(BuildVpx("acme.dup"));
+        string id = await manager.InstallFromVpxAsync(BuildVpx("acme.dup"), allowUntrustedPackage: true);
         Assert.ContainsSingle(p => p.Id == "acme.dup", manager.Plugins);
         Assert.AreEqual(PluginState.Active, manager.Plugins.Single(p => p.Id == id).State);
         await manager.DisposeAsync();

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/VpxContainerTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/VpxContainerTests.cs
@@ -168,7 +168,8 @@ public class VpxContainerTests
 
         string publicKey = Convert.ToBase64String(key.ExportSubjectPublicKeyInfo());
         Assert.AreEqual(VpxSignatureState.Trusted, VpxContainer.VerifySignature(info, [publicKey]));
-        Assert.AreEqual(VpxSignatureState.Trusted, VpxContainer.VerifySignature(info), "不给信任集合时,有效签名即算受信");
+        Assert.AreEqual(VpxSignatureState.Trusted, VpxContainer.VerifySignature(info), "省略信任集合时只做密码学验签");
+        Assert.AreEqual(VpxSignatureState.Untrusted, VpxContainer.VerifySignature(info, []), "显式空信任库不能把自签名当可信发布者");
     }
 
     [TestMethod]

--- a/tests/VelaShell.Plugin.Ai.Tests/McpConfigTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/McpConfigTests.cs
@@ -1,4 +1,5 @@
 using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Agent;
 using VelaShell.PluginSdk.Testing;
 
 namespace VelaShell.Plugin.Ai.Tests;
@@ -63,6 +64,20 @@ public sealed class McpConfigTests
         Assert.AreEqual("mcp", McpConfigParser.SanitizeToolPrefix("  "));
         Assert.AreEqual("mcp", McpConfigParser.SanitizeToolPrefix("!!!"));
         Assert.AreEqual(24, McpConfigParser.SanitizeToolPrefix(new string('x', 60)).Length);
+    }
+
+    [TestMethod]
+    public void HttpEndpoint_RequiresHttps_ExceptForLoopbackDevelopment()
+    {
+        Assert.AreEqual("https://example.com/mcp", McpManager.ValidateHttpEndpoint("https://example.com/mcp").ToString());
+        Assert.AreEqual("http://localhost:3000/mcp", McpManager.ValidateHttpEndpoint("http://localhost:3000/mcp").ToString());
+        Assert.AreEqual("http://127.0.0.1:3000/mcp", McpManager.ValidateHttpEndpoint("http://127.0.0.1:3000/mcp").ToString());
+
+        InvalidOperationException plainHttp = Assert.ThrowsExactly<InvalidOperationException>(
+            () => McpManager.ValidateHttpEndpoint("http://example.com/mcp"));
+        Assert.Contains("HTTPS", plainHttp.Message);
+        Assert.ThrowsExactly<InvalidOperationException>(() => McpManager.ValidateHttpEndpoint("file:///tmp/mcp"));
+        Assert.ThrowsExactly<InvalidOperationException>(() => McpManager.ValidateHttpEndpoint("not a url"));
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalEmulatorTests.cs
@@ -259,11 +259,25 @@ public class TerminalEmulatorTests
     public void Osc52_SetClipboard_RaisesClipboardWriteRequested()
     {
         TerminalEmulator e = New();
+        e.AllowOsc52ClipboardWrite = true;
         string? clipboard = null;
         e.ClipboardWriteRequested += text => clipboard = text;
         string payload = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello 世界"));
         Feed(e, $"\x1b]52;c;{payload}\x07");
         Assert.AreEqual("hello 世界", clipboard);
+    }
+
+    [TestMethod]
+    public void Osc52_IsIgnoredByDefault_ForSecurity()
+    {
+        TerminalEmulator e = New();
+        string? clipboard = null;
+        e.ClipboardWriteRequested += text => clipboard = text;
+        string payload = Convert.ToBase64String(Encoding.UTF8.GetBytes("poisoned"));
+
+        Feed(e, $"\x1b]52;c;{payload}\x07");
+
+        Assert.IsNull(clipboard);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Tests/Services/UpdateApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateApplierTests.cs
@@ -86,6 +86,34 @@ public class UpdateApplierTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
+    public void CopyWithBudget_RejectsActualBytesBeyondLimit()
+    {
+        using var source = new MemoryStream(new byte[9]);
+        using var destination = new MemoryStream();
+
+        InvalidDataException ex = Assert.ThrowsExactly<InvalidDataException>(
+            () => UpdateApplier.CopyWithBudget(source, destination, 8, "bomb.bin"));
+
+        Assert.Contains("bomb.bin", ex.Message);
+        Assert.IsLessThanOrEqualTo(8, destination.Length);
+    }
+
+    [TestMethod]
+    [TestCategory("Update")]
+    public void CopyWithBudget_AllowsContentAtExactLimit()
+    {
+        byte[] content = "12345678"u8.ToArray();
+        using var source = new MemoryStream(content);
+        using var destination = new MemoryStream();
+
+        long written = UpdateApplier.CopyWithBudget(source, destination, content.Length, "app.bin");
+
+        Assert.AreEqual(content.Length, written);
+        Assert.AreSequenceEqual(content, destination.ToArray());
+    }
+
+    [TestMethod]
+    [TestCategory("Update")]
     public void Stage_CorruptPackage_LeavesApplicationIntact_AndNextAttemptStillWorks()
     {
         // 老实现在这里会永久卡死:一次失败留下删不掉的残骸,之后每次升级都在同一处抛异常。

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -295,6 +295,67 @@ public sealed class ConnectionProfileViewModelTests
     }
 
     [TestMethod]
+    public async Task CopyErrorCommand_CopiesFailureText_AndAcknowledgesWithCopiedState()
+    {
+        // 连接失败的原文(认证链、主机密钥指纹、栈顶异常)常常一长串,
+        // 用户要拿去搜索或贴给同事 —— 照着屏幕抄不现实,复制按钮就是为它准备的。
+        IConnectionWorkflowService? workflow = Substitute.For<IConnectionWorkflowService>();
+        workflow.TestConnectionAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+                .Returns(new ConnectionTestResult(false, "Permission denied (publickey,password)."));
+        ConnectionProfileViewModel vm = CreateValidViewModel(workflow);
+        string? copied = null;
+        vm.CopyToClipboard = text =>
+        {
+            copied = text;
+            return Task.CompletedTask;
+        };
+
+        await vm.TestConnectionCommand.Execute().FirstAsync();
+        Assert.IsTrue(vm.HasError, "失败之后必须有可复制的错误信息,按钮才出得来。");
+        Assert.IsFalse(vm.ErrorCopied);
+
+        await vm.CopyErrorCommand.Execute().FirstAsync();
+        Assert.AreEqual("Permission denied (publickey,password).", copied);
+        // 没有这句回执就分不清"复制成功了"和"按钮没反应",用户只会再点两下。
+        Assert.IsTrue(vm.ErrorCopied);
+    }
+
+    [TestMethod]
+    public async Task CopyErrorCommand_IsUnavailable_WhenThereIsNoError()
+    {
+        // 成功那一条没有可复制的内容:命令必须自己灰掉,而不是复制一个空串。
+        IConnectionWorkflowService? workflow = Substitute.For<IConnectionWorkflowService>();
+        workflow.TestConnectionAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+                .Returns(new ConnectionTestResult(true));
+        ConnectionProfileViewModel vm = CreateValidViewModel(workflow);
+
+        Assert.IsFalse(await vm.CopyErrorCommand.CanExecute.FirstAsync());
+        await vm.TestConnectionCommand.Execute().FirstAsync();
+        Assert.IsFalse(vm.HasError);
+        Assert.IsFalse(await vm.CopyErrorCommand.CanExecute.FirstAsync());
+    }
+
+    [TestMethod]
+    public async Task NewError_ClearsPreviousCopiedAcknowledgement()
+    {
+        // 「已复制」是对某一段具体文本说的:换了一条错误还顶着旧回执,
+        // 用户会以为新的这条也已经在剪贴板里了。
+        IConnectionWorkflowService? workflow = Substitute.For<IConnectionWorkflowService>();
+        workflow.TestConnectionAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+                .Returns(new ConnectionTestResult(false, "第一条"), new ConnectionTestResult(false, "第二条"));
+        ConnectionProfileViewModel vm = CreateValidViewModel(workflow);
+        vm.CopyToClipboard = _ => Task.CompletedTask;
+
+        await vm.TestConnectionCommand.Execute().FirstAsync();
+        await vm.CopyErrorCommand.Execute().FirstAsync();
+        Assert.IsTrue(vm.ErrorCopied);
+
+        await vm.TestConnectionCommand.Execute().FirstAsync();
+        Assert.AreEqual("第二条", vm.ErrorMessage);
+        Assert.IsFalse(vm.ErrorCopied);
+    }
+
+    [TestMethod]
     public async Task SaveCommand_CreatesNewGroup_WhenGroupTextIsUnknown()
     {
         // 分组框输入了不存在的分组名:保存时应新建分组落库,并把配置归入该组。

--- a/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectionProfileViewUiTests.cs
@@ -5,9 +5,11 @@ using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Behaviors;
 using VelaShell.Core.Models;
+using VelaShell.Presentation.Services;
 using VelaShell.Security;
 using VelaShell.ViewModels;
 using VelaShell.Views;
@@ -77,6 +79,51 @@ public sealed class ConnectionProfileViewUiTests
 
             // 没有插件协议时,页签集合里不该凭空多出什么。
             Assert.IsEmpty(vm.PluginProtocols);
+            window.Close();
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void CopyErrorButton_AppearsOnlyWithAnError_AndSwitchesToCopiedState()
+    {
+        _session.Dispatch(() =>
+        {
+            IConnectionWorkflowService workflow = Substitute.For<IConnectionWorkflowService>();
+            workflow.TestConnectionAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+                    .Returns(new ConnectionTestResult(false, "Permission denied (publickey,password)."));
+            var vm = new ConnectionProfileViewModel(connectionWorkflowService: workflow)
+            {
+                Host = "prod.example.com",
+                Username = "root",
+                Password = SecureStringConvert.FromPlaintext("secret")
+            };
+            var window = new ConnectionProfileView { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Button copyButton = window.GetVisualDescendants()
+                .OfType<Button>()
+                .Single(button => button.Name == "CopyErrorButton");
+            // 没出错时反馈条整条不占位置,复制按钮自然也不该露出来。
+            Assert.IsFalse(copyButton.IsEffectivelyVisible);
+
+            vm.TestConnectionCommand.Execute().Subscribe();
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsTrue(copyButton.IsEffectivelyVisible, "测试失败后错误信息旁必须出现复制按钮。");
+
+            // 视图在 Opened 里把剪贴板回调注入了 VM;headless 下换成探针,
+            // 断言点击真的走到剪贴板这一步(而不是命令灰着、按了没反应)。
+            string? copied = null;
+            vm.CopyToClipboard = text =>
+            {
+                copied = text;
+                return Task.CompletedTask;
+            };
+            copyButton.Command?.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.AreEqual("Permission denied (publickey,password).", copied);
+            Assert.IsTrue(vm.ErrorCopied);
+
             window.Close();
         }, CancellationToken.None).GetAwaiter().GetResult();
     }


### PR DESCRIPTION
实现插件包发布者信任管理与授权机制，提升插件安装安全性。终端默认禁用 OSC 52 剪贴板写入，需显式开启。连接配置界面支持错误信息一键复制并优化回执提示。MCP 配置强制 HTTPS，限制本地 HTTP。更新包解压增加文件数与字节数限制，防止压缩包攻击。补全多语言本地化，完善相关单元测试。