### PR TITLE
插件信任与收据加密存储及机制强化

### DIFF
--- a/plugin-sdk/VelaShell.PluginSdk/Packaging/VpxContainer.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Packaging/VpxContainer.cs
@@ -131,6 +131,13 @@ public static class VpxContainer
     /// <summary>包扩展名。</summary>
     public const string FileExtension = ".vpx";
 
+    /// <summary>把 Base64 SPKI 公钥转换为可跨工具核对的 SHA-256 指纹。</summary>
+    public static string PublicKeyFingerprint(string publicKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKey);
+        return "SHA256:" + Convert.ToHexStringLower(SHA256.HashData(Convert.FromBase64String(publicKey)));
+    }
+
     /// <summary>单个包允许的最大载荷(512 MB):挡住损坏头部里的天文数字长度。</summary>
     public const long MaxPayloadLength = 512L * 1024 * 1024;
 

--- a/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
@@ -27,6 +27,14 @@ public static class PluginServiceCollectionExtensions
         services.AddSingleton<Plugins.IPluginDataStore>(sp => new Persistence.SonnetDbPluginDataStore(
             sp.GetRequiredService<Persistence.SonnetDbEngine>(),
             sp.GetService<Core.Data.ISecretProtector>()));
+        services.AddSingleton(sp =>
+        {
+            VelaShellStoragePaths paths = sp.GetRequiredService<VelaShellStoragePaths>();
+            return new PluginTrustRepository(
+                sp.GetRequiredService<SonnetDbEngine>(),
+                sp.GetRequiredService<Core.Data.ISecretProtector>(),
+                Path.Combine(paths.RootDirectory, "trusted-plugin-publishers.json"));
+        });
         services.AddSingleton<PluginManager>(sp =>
         {
             VelaShellStoragePaths paths = sp.GetRequiredService<VelaShellStoragePaths>();
@@ -43,7 +51,7 @@ public static class PluginServiceCollectionExtensions
                 DebugPluginIds = DevPluginRootResolver.ResolveDebugPluginIds(),
                 DataRootDirectory = Path.Combine(paths.RootDirectory, "plugin-data"),
                 UserPluginRoot = Path.Combine(paths.RootDirectory, "plugins"),
-                TrustedPublisherStorePath = Path.Combine(paths.RootDirectory, "trusted-plugin-publishers.json"),
+                TrustRepository = sp.GetRequiredService<PluginTrustRepository>(),
                 HostVersion = hostVersion,
                 Connections = sp.GetService<ISshConnectionService>(),
                 Sftp = sp.GetService<ISftpService>(),

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1,8 +1,9 @@
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection;
 using System.Security.Cryptography;
-using System.Text.Json;
+using System.Text;
 using VelaShell.Infrastructure.Plugins.Capabilities;
 using VelaShell.Infrastructure.Plugins.Isolated;
 using VelaShell.PluginSdk;
@@ -25,8 +26,12 @@ namespace VelaShell.Infrastructure.Plugins;
 /// </summary>
 public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposable
 {
-    private readonly HashSet<string> _trustedPackageKeys = LoadTrustedPackageKeys(options);
+    private readonly HashSet<string> _trustedPackageKeys = new(options.TrustedPackageKeys ?? [], StringComparer.Ordinal);
     private readonly Lock _trustedPackageKeysGate = new();
+    private readonly SemaphoreSlim _trustStateGate = new(1, 1);
+    private PluginTrustState? _trustState;
+    private string? _trustLoadError;
+    private bool _trustInitialized;
     private sealed class PluginRuntime
     {
         public required PluginDescriptor Descriptor { get; init; }
@@ -150,6 +155,15 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         await runtime.ActivationGate.WaitAsync().ConfigureAwait(false);
         try
         {
+            if (options.TrustRepository is not null && options.UserPluginRoot is { } userRoot
+                && IsUnder(runtime.Descriptor.Directory, userRoot)
+                && !ValidateInstallReceipt(pluginId, runtime.Descriptor.Directory, out string? receiptError))
+            {
+                runtime.Descriptor.State = PluginState.Invalid;
+                runtime.Descriptor.Error = receiptError;
+                RaiseChanged();
+                return;
+            }
             TryWriteDisabledMarker(runtime.Descriptor.Directory, disabled: false);
             runtime.Descriptor.State = PluginState.Discovered;
             runtime.Descriptor.Error = null;
@@ -222,6 +236,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             options.ProtocolRegistry?.RemovePlugin(pluginId);
             TryDeleteDirectory(runtime.Descriptor.Directory);
             await PurgePluginDataAsync(pluginId).ConfigureAwait(false);
+            await RemoveInstallReceiptAsync(pluginId).ConfigureAwait(false);
             lock (_gate)
             {
                 _plugins.Remove(runtime);
@@ -264,7 +279,8 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         PluginManifest? manifest = null;
         try
         {
-            ExtractPackage(vpxPath, staging, allowUntrustedPackage);
+            await EnsureTrustInitializedAsync(cancellationToken).ConfigureAwait(false);
+            VpxPackageInfo packageInfo = ExtractPackage(vpxPath, staging, allowUntrustedPackage);
             string manifestPath = Path.Combine(staging, PluginManifestReader.FileName);
             if (!File.Exists(manifestPath))
             {
@@ -298,7 +314,18 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             Directory.Move(staging, target);
             staging = target; // 已搬走,finally 不再删
 
-            var runtime = new PluginRuntime { Descriptor = Describe(target, Path.Combine(target, PluginManifestReader.FileName), []) };
+            try
+            {
+                await SaveInstallReceiptAsync(manifest.Id, target, packageInfo, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 没有受保护收据的目录绝不能留下来被下次启动误认为已安装。
+                TryDeleteDirectory(target);
+                throw;
+            }
+
+            var runtime = new PluginRuntime { Descriptor = Describe(target, Path.Combine(target, PluginManifestReader.FileName), [], false) };
             lock (_gate)
             {
                 _plugins.Add(runtime);
@@ -339,13 +366,14 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     /// 打开插件包并安全解包。只认 <c>.vpx</c> 专属容器(魔数 + 摘要 + 可选签名,见
     /// <see cref="VpxContainer" />)—— 改了后缀的 zip 一律拒绝,拒绝原因里带重新打包的办法。
     /// </summary>
-    private void ExtractPackage(string packagePath, string destination, bool allowUntrustedPackage)
+    private VpxPackageInfo ExtractPackage(string packagePath, string destination, bool allowUntrustedPackage)
     {
         // 格式非法(裸 zip / 截断 / 头部损坏 / 根本不是包)在此抛出并带可读原因。
         using Stream payload = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
         CheckSignature(packagePath, info, allowUntrustedPackage);
         using var archive = new ZipArchive(payload, ZipArchiveMode.Read);
         ExtractZipSafely(archive, destination);
+        return info;
     }
 
     /// <summary>
@@ -401,31 +429,60 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     /// <summary>
     /// 把一个签名有效但发布者未知的公钥加入本机信任库。未签名、坏签名或已经可信的包拒绝走此入口。
     /// </summary>
-    public string TrustPackagePublisher(string packagePath)
+    public async Task<string> TrustPackagePublisherAsync(string packagePath, CancellationToken cancellationToken = default)
     {
+        await EnsureTrustInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (options.TrustRepository is not null && _trustState is null)
+        {
+            throw new InvalidOperationException($"Plugin trust store is unavailable: {_trustLoadError ?? "unknown error"}");
+        }
         using Stream _ = VpxContainer.OpenPayload(packagePath, out VpxPackageInfo info);
         if (info.Signature is not { PublicKey: { Length: > 0 } publicKey }
             || GetSignatureState(info) != VpxSignatureState.Untrusted)
         {
             throw new InvalidOperationException("Only a valid package from an unknown publisher can establish publisher trust.");
         }
-        lock (_trustedPackageKeysGate)
+        string fingerprint = VpxContainer.PublicKeyFingerprint(publicKey);
+        await _trustStateGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            bool added = _trustedPackageKeys.Add(publicKey);
+            bool added;
+            lock (_trustedPackageKeysGate)
+            {
+                added = _trustedPackageKeys.Add(publicKey);
+            }
+            TrustedPluginPublisher? publisher = null;
             try
             {
-                SaveTrustedPackageKeys();
+                if (options.TrustRepository is not null && _trustState is not null
+                    && !_trustState.Publishers.Any(p => p.PublicKey == publicKey))
+                {
+                    publisher = new(publicKey, fingerprint, DateTimeOffset.UtcNow);
+                    _trustState.Publishers.Add(publisher);
+                    await options.TrustRepository.SaveAsync(_trustState, cancellationToken).ConfigureAwait(false);
+                }
             }
             catch
             {
+                if (publisher is not null)
+                {
+                    _trustState!.Publishers.Remove(publisher);
+                }
                 if (added)
                 {
-                    _trustedPackageKeys.Remove(publicKey);
+                    lock (_trustedPackageKeysGate)
+                    {
+                        _trustedPackageKeys.Remove(publicKey);
+                    }
                 }
                 throw;
             }
         }
-        return Fingerprint(publicKey)!;
+        finally
+        {
+            _trustStateGate.Release();
+        }
+        return fingerprint;
     }
 
     private VpxSignatureState GetSignatureState(VpxPackageInfo info)
@@ -444,7 +501,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         }
         try
         {
-            return "SHA256:" + Convert.ToHexStringLower(SHA256.HashData(Convert.FromBase64String(publicKey)));
+            return VpxContainer.PublicKeyFingerprint(publicKey);
         }
         catch (FormatException)
         {
@@ -452,41 +509,215 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         }
     }
 
-    private static HashSet<string> LoadTrustedPackageKeys(PluginManagerOptions managerOptions)
+    private async Task EnsureTrustInitializedAsync(CancellationToken cancellationToken)
     {
-        var keys = new HashSet<string>(managerOptions.TrustedPackageKeys ?? [], StringComparer.Ordinal);
-        if (managerOptions.TrustedPublisherStorePath is not { } path || !File.Exists(path))
-        {
-            return keys;
-        }
-        try
-        {
-            foreach (string key in JsonSerializer.Deserialize<string[]>(File.ReadAllText(path)) ?? [])
-            {
-                if (!string.IsNullOrWhiteSpace(key))
-                {
-                    keys.Add(key);
-                }
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
-        {
-            Trace.WriteLine($"[VelaShell] Failed to read trusted plugin publishers: {ex.Message}");
-        }
-        return keys;
-    }
-
-    private void SaveTrustedPackageKeys()
-    {
-        if (options.TrustedPublisherStorePath is not { } path)
+        if (_trustInitialized)
         {
             return;
         }
-        string fullPath = Path.GetFullPath(path);
-        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-        string temporary = fullPath + ".tmp";
-        File.WriteAllText(temporary, JsonSerializer.Serialize(_trustedPackageKeys.Order(StringComparer.Ordinal)));
-        File.Move(temporary, fullPath, overwrite: true);
+        await _trustStateGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_trustInitialized)
+            {
+                return;
+            }
+            if (options.TrustRepository is null)
+            {
+                _trustInitialized = true;
+                return;
+            }
+            try
+            {
+                _trustState = await options.TrustRepository.LoadAsync(cancellationToken).ConfigureAwait(false);
+                lock (_trustedPackageKeysGate)
+                {
+                    foreach (TrustedPluginPublisher publisher in _trustState.Publishers)
+                    {
+                        _trustedPackageKeys.Add(publisher.PublicKey);
+                    }
+                }
+                if (!_trustState.LegacyInstallMigrationCompleted)
+                {
+                    AdoptExistingUserPlugins(_trustState);
+                    _trustState.LegacyInstallMigrationCompleted = true;
+                    await options.TrustRepository.SaveAsync(_trustState, cancellationToken).ConfigureAwait(false);
+                }
+                _trustInitialized = true;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _trustState = null;
+                _trustLoadError = ex.Message;
+                _trustInitialized = true;
+                lock (_trustedPackageKeysGate)
+                {
+                    _trustedPackageKeys.Clear();
+                    foreach (string configuredKey in options.TrustedPackageKeys ?? [])
+                    {
+                        _trustedPackageKeys.Add(configuredKey);
+                    }
+                }
+                Log($"Plugin trust store unavailable; user plugins will be rejected: {ex.Message}");
+            }
+        }
+        finally
+        {
+            _trustStateGate.Release();
+        }
+    }
+
+    private void AdoptExistingUserPlugins(PluginTrustState state)
+    {
+        if (options.UserPluginRoot is not { } root || !Directory.Exists(root))
+        {
+            return;
+        }
+        foreach (string directory in Directory.EnumerateDirectories(root))
+        {
+            string manifestPath = Path.Combine(directory, PluginManifestReader.FileName);
+            if (!File.Exists(manifestPath))
+            {
+                continue;
+            }
+            try
+            {
+                PluginManifest manifest = PluginManifestReader.Load(manifestPath);
+                state.Receipts[manifest.Id] = new(manifest.Id, ComputePluginContentSha256(directory), null, null,
+                    LegacyAdopted: true, DateTimeOffset.UtcNow);
+            }
+            catch (PluginManifestException)
+            {
+                // 原本就无效的遗留目录不建立可信基线，发现阶段仍会给出清单错误。
+            }
+        }
+    }
+
+    private async Task SaveInstallReceiptAsync(
+        string pluginId,
+        string directory,
+        VpxPackageInfo packageInfo,
+        CancellationToken cancellationToken)
+    {
+        if (options.TrustRepository is null)
+        {
+            return;
+        }
+        if (_trustState is null)
+        {
+            throw new InvalidOperationException($"Plugin trust store is unavailable: {_trustLoadError ?? "unknown error"}");
+        }
+        await _trustStateGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            InstalledPluginReceipt? previous = _trustState.Receipts.GetValueOrDefault(pluginId);
+            _trustState.Receipts[pluginId] = new(pluginId, ComputePluginContentSha256(directory),
+                packageInfo.PayloadSha256, packageInfo.Signature?.PublicKey, LegacyAdopted: false, DateTimeOffset.UtcNow);
+            try
+            {
+                await options.TrustRepository.SaveAsync(_trustState, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (previous is null)
+                {
+                    _trustState.Receipts.Remove(pluginId);
+                }
+                else
+                {
+                    _trustState.Receipts[pluginId] = previous;
+                }
+                throw;
+            }
+        }
+        finally
+        {
+            _trustStateGate.Release();
+        }
+    }
+
+    private async Task RemoveInstallReceiptAsync(string pluginId)
+    {
+        if (options.TrustRepository is null || _trustState is null)
+        {
+            return;
+        }
+        await _trustStateGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!_trustState.Receipts.Remove(pluginId, out InstalledPluginReceipt? removed))
+            {
+                return;
+            }
+            try
+            {
+                await options.TrustRepository.SaveAsync(_trustState).ConfigureAwait(false);
+            }
+            catch
+            {
+                _trustState.Receipts[pluginId] = removed;
+                throw;
+            }
+        }
+        finally
+        {
+            _trustStateGate.Release();
+        }
+    }
+
+    private static string ComputePluginContentSha256(string root)
+    {
+        string fullRoot = Path.GetFullPath(root);
+        if ((File.GetAttributes(fullRoot) & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidDataException("Plugin root is a symbolic link.");
+        }
+        var files = new List<string>();
+        var pending = new Stack<string>();
+        pending.Push(fullRoot);
+        while (pending.TryPop(out string? directory))
+        {
+            foreach (string child in Directory.EnumerateDirectories(directory))
+            {
+                if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) != 0)
+                {
+                    throw new InvalidDataException($"Plugin directory contains a symbolic link: {Path.GetRelativePath(fullRoot, child)}");
+                }
+                pending.Push(child);
+            }
+            foreach (string file in Directory.EnumerateFiles(directory))
+            {
+                if (directory == fullRoot && Path.GetFileName(file).Equals(".disabled", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                if ((File.GetAttributes(file) & FileAttributes.ReparsePoint) != 0)
+                {
+                    throw new InvalidDataException($"Plugin directory contains a symbolic link: {Path.GetRelativePath(fullRoot, file)}");
+                }
+                files.Add(file);
+            }
+        }
+
+        using IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        Span<byte> frame = stackalloc byte[8];
+        foreach (string file in files.OrderBy(f => Path.GetRelativePath(fullRoot, f).Replace('\\', '/'), StringComparer.Ordinal))
+        {
+            byte[] path = Encoding.UTF8.GetBytes(Path.GetRelativePath(fullRoot, file).Replace('\\', '/'));
+            BinaryPrimitives.WriteInt32LittleEndian(frame, path.Length);
+            hash.AppendData(frame[..4]);
+            hash.AppendData(path);
+            using FileStream stream = File.OpenRead(file);
+            BinaryPrimitives.WriteInt64LittleEndian(frame, stream.Length);
+            hash.AppendData(frame);
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = stream.Read(buffer)) > 0)
+            {
+                hash.AppendData(buffer.AsSpan(0, read));
+            }
+        }
+        return Convert.ToHexStringLower(hash.GetHashAndReset());
     }
 
     private static void ExtractZipSafely(ZipArchive archive, string destination)
@@ -559,8 +790,11 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     {
         string full = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
         string rootFull = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar);
-        return full.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
-               || string.Equals(full, rootFull, StringComparison.OrdinalIgnoreCase);
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return full.StartsWith(rootFull + Path.DirectorySeparatorChar, comparison)
+               || string.Equals(full, rootFull, comparison);
     }
 
     private static void TryDeleteDirectory(string directory)
@@ -626,6 +860,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         {
             registry.ActivationRequested = ActivateForProtocolAsync;
         }
+        await EnsureTrustInitializedAsync(cancellationToken).ConfigureAwait(false);
         Discover();
         await PurgeUninstalledDataAsync().ConfigureAwait(false);
         List<PluginRuntime> discovered;
@@ -893,7 +1128,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                 {
                     continue;
                 }
-                PluginDescriptor descriptor = Describe(dir, manifestPath, seenIds);
+                PluginDescriptor descriptor = Describe(dir, manifestPath, seenIds, isDev);
                 descriptor.IsDevelopment = isDev;
                 found.Add(new() { Descriptor = descriptor });
             }
@@ -946,7 +1181,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         return runtime is not null && await EnsureActivatedAsync(runtime).ConfigureAwait(false);
     }
 
-    private PluginDescriptor Describe(string dir, string manifestPath, HashSet<string> seenIds)
+    private PluginDescriptor Describe(string dir, string manifestPath, HashSet<string> seenIds, bool isDevelopment)
     {
         PluginManifest manifest;
         try
@@ -964,6 +1199,13 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             descriptor.State = PluginState.Invalid;
             descriptor.Error = $"Duplicate plugin id '{manifest.Id}' (already provided by an earlier plugin root).";
         }
+        else if (!isDevelopment && options.TrustRepository is not null
+                 && options.UserPluginRoot is { } userRoot && IsUnder(dir, userRoot)
+                 && !ValidateInstallReceipt(manifest.Id, dir, out string? receiptError))
+        {
+            descriptor.State = PluginState.Invalid;
+            descriptor.Error = receiptError;
+        }
         else if (File.Exists(Path.Combine(dir, ".disabled")))
         {
             descriptor.State = PluginState.Disabled;
@@ -979,6 +1221,42 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             descriptor.Error = $"Plugin requires host >= {minHost}, current host is {options.HostVersion}.";
         }
         return descriptor;
+    }
+
+    private bool ValidateInstallReceipt(string pluginId, string directory, out string? error)
+    {
+        if (_trustLoadError is not null)
+        {
+            error = $"Plugin trust store is unavailable; refusing to load user plugin ({_trustLoadError}).";
+            return false;
+        }
+        InstalledPluginReceipt? receipt = null;
+        if (_trustState is not null)
+        {
+            _trustState.Receipts.TryGetValue(pluginId, out receipt);
+        }
+        if (receipt is null)
+        {
+            error = "Protected installation receipt is missing. Reinstall this plugin through the plugin manager.";
+            return false;
+        }
+        try
+        {
+            string actual = ComputePluginContentSha256(directory);
+            if (!CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(actual), Encoding.ASCII.GetBytes(receipt.ContentSha256)))
+            {
+                error = "Installed plugin files changed after installation. Reinstall the original package.";
+                return false;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            error = $"Installed plugin files could not be verified: {ex.Message}";
+            return false;
+        }
+        error = null;
+        return true;
     }
 
     /// <summary>宿主版本是否低于要求(数字段比较,忽略预发布后缀;不可解析时不拦)。</summary>

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -42,11 +42,8 @@ public sealed class PluginManagerOptions
     /// </summary>
     public IReadOnlyCollection<string>? TrustedPackageKeys { get; init; }
 
-    /// <summary>
-    /// 用户确认过的发布者公钥存储文件(JSON 字符串数组)。为空时信任仅保留在当前进程;
-    /// 文件只含公钥,不含任何私钥或凭据。
-    /// </summary>
-    public string? TrustedPublisherStorePath { get; init; }
+    /// <summary>受 AES-GCM 完整性保护的发布者信任与安装凭据仓储。</summary>
+    public PluginTrustRepository? TrustRepository { get; init; }
 
     /// <summary>
     /// 是否只安装带受信签名的包。打开后未签名与不受信签名的包都会被拒,不能通过单次授权绕过。

--- a/src/VelaShell.Infrastructure/Plugins/PluginTrustRepository.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginTrustRepository.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using VelaShell.Core.Data;
+using VelaShell.Infrastructure.Persistence;
+
+namespace VelaShell.Infrastructure.Plugins;
+
+/// <summary>受保护的插件发布者信任与安装凭据快照。</summary>
+public sealed class PluginTrustState
+{
+    /// <summary>持久化结构版本。</summary>
+    public int SchemaVersion { get; set; } = 1;
+    /// <summary>是否已经为升级前存在的插件目录建立过一次基线。</summary>
+    public bool LegacyInstallMigrationCompleted { get; set; }
+    /// <summary>用户明确信任的发布者。</summary>
+    public List<TrustedPluginPublisher> Publishers { get; set; } = [];
+    /// <summary>按插件 id 索引的安装内容收据。</summary>
+    public Dictionary<string, InstalledPluginReceipt> Receipts { get; set; } = [with(StringComparer.OrdinalIgnoreCase)];
+}
+
+/// <summary>用户通过独立渠道核对后信任的发布者。</summary>
+public sealed record TrustedPluginPublisher(string PublicKey, string Fingerprint, DateTimeOffset TrustedAtUtc);
+
+/// <summary>安装时对插件目录内容建立的受保护基线。</summary>
+public sealed record InstalledPluginReceipt(
+    string PluginId,
+    string ContentSha256,
+    string? PackageSha256,
+    string? PublisherPublicKey,
+    bool LegacyAdopted,
+    DateTimeOffset InstalledAtUtc);
+
+/// <summary>
+/// 信任状态存入 SonnetDB，但安全边界来自 <see cref="ISecretProtector" /> 的 AES-GCM 认证标签，
+/// 而不是数据库格式本身。密文被替换、截断或改写时解密失败并 fail closed。
+/// </summary>
+public sealed class PluginTrustRepository(
+    SonnetDbEngine engine,
+    ISecretProtector protector,
+    string? legacyJsonPath = null)
+{
+    private const string DocumentId = "plugin_trust_v1";
+    private const string ProtectedPrefix = "enc1:";
+    private sealed record ProtectedDocument(string Payload);
+
+    /// <summary>读取并认证信任状态；任何格式、密文或认证异常都拒绝降级为明文。</summary>
+    public async Task<PluginTrustState> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        string? stored = await engine.WithCollectionAsync(SonnetDbEngine.ConfigCollection,
+            collection => collection.Get(DocumentId)?.Json, cancellationToken).ConfigureAwait(false);
+        if (stored is not null)
+        {
+            ProtectedDocument document = JsonSerializer.Deserialize<ProtectedDocument>(stored)
+                ?? throw new InvalidDataException("Plugin trust document is empty.");
+            if (string.IsNullOrWhiteSpace(document.Payload)
+                || !document.Payload.StartsWith(ProtectedPrefix, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException("Plugin trust document is not authenticated.");
+            }
+            string plaintext = protector.Unprotect(document.Payload)
+                ?? throw new InvalidDataException("Plugin trust document could not be decrypted.");
+            if (plaintext.StartsWith(ProtectedPrefix, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException("Plugin trust document authentication failed.");
+            }
+            try
+            {
+                PluginTrustState loadedState = JsonSerializer.Deserialize<PluginTrustState>(plaintext)
+                                               ?? throw new InvalidDataException("Plugin trust payload is empty.");
+                ValidateAndNormalize(loadedState);
+                return loadedState;
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException("Plugin trust payload is corrupt.", ex);
+            }
+        }
+
+        var state = new PluginTrustState();
+        if (legacyJsonPath is { } path && File.Exists(path))
+        {
+            try
+            {
+                foreach (string key in JsonSerializer.Deserialize<string[]>(await File.ReadAllTextAsync(path, cancellationToken)) ?? [])
+                {
+                    if (string.IsNullOrWhiteSpace(key) || state.Publishers.Any(p => p.PublicKey == key))
+                    {
+                        continue;
+                    }
+                    state.Publishers.Add(new(key, VelaShell.PluginSdk.Packaging.VpxContainer.PublicKeyFingerprint(key), DateTimeOffset.UtcNow));
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or FormatException)
+            {
+                throw new InvalidDataException("Legacy plugin publisher trust file could not be migrated safely.", ex);
+            }
+        }
+        await SaveAsync(state, cancellationToken).ConfigureAwait(false);
+        if (legacyJsonPath is { } oldPath && File.Exists(oldPath))
+        {
+            File.Move(oldPath, oldPath + ".migrated", overwrite: true);
+        }
+        return state;
+    }
+
+    /// <summary>认证加密并原子更新 SonnetDB 中的信任状态文档。</summary>
+    public Task SaveAsync(PluginTrustState state, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ValidateAndNormalize(state);
+        string plaintext = JsonSerializer.Serialize(state);
+        string payload = protector.Protect(plaintext)
+            ?? throw new InvalidOperationException("Secret protector returned null for plugin trust state.");
+        if (!payload.StartsWith(ProtectedPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Plugin trust state was not protected.");
+        }
+        string document = JsonSerializer.Serialize(new ProtectedDocument(payload));
+        return engine.WithCollectionAsync<object?>(SonnetDbEngine.ConfigCollection, collection =>
+        {
+            collection.Upsert(DocumentId, document);
+            return null;
+        }, cancellationToken);
+    }
+
+    private static void ValidateAndNormalize(PluginTrustState state)
+    {
+        if (state.SchemaVersion != 1)
+        {
+            throw new InvalidDataException($"Unsupported plugin trust schema version {state.SchemaVersion}.");
+        }
+        state.Publishers ??= [];
+        state.Receipts = state.Receipts is null
+            ? new(StringComparer.OrdinalIgnoreCase)
+            : new(state.Receipts, StringComparer.OrdinalIgnoreCase);
+        var seenPublishers = new HashSet<string>(StringComparer.Ordinal);
+        foreach (TrustedPluginPublisher publisher in state.Publishers)
+        {
+            string expected;
+            try
+            {
+                expected = VelaShell.PluginSdk.Packaging.VpxContainer.PublicKeyFingerprint(publisher.PublicKey);
+            }
+            catch (FormatException ex)
+            {
+                throw new InvalidDataException("Plugin trust state contains an invalid publisher key.", ex);
+            }
+            if (!seenPublishers.Add(publisher.PublicKey)
+                || !string.Equals(expected, publisher.Fingerprint, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException("Plugin trust state contains inconsistent publisher identity data.");
+            }
+        }
+        foreach ((string id, InstalledPluginReceipt receipt) in state.Receipts)
+        {
+            if (!string.Equals(id, receipt.PluginId, StringComparison.OrdinalIgnoreCase)
+                || !IsSha256(receipt.ContentSha256)
+                || receipt.PackageSha256 is not null && !IsSha256(receipt.PackageSha256))
+            {
+                throw new InvalidDataException($"Plugin trust state contains an invalid installation receipt for '{id}'.");
+            }
+        }
+    }
+
+    private static bool IsSha256(string value) =>
+        value.Length == 64 && value.All(c => c is >= '0' and <= '9' or >= 'a' and <= 'f');
+}

--- a/src/VelaShell/ViewModels/PluginManagerViewModel.cs
+++ b/src/VelaShell/ViewModels/PluginManagerViewModel.cs
@@ -175,8 +175,8 @@ public sealed class PluginManagerViewModel : ReactiveObject, IDisposable
         _manager.InspectPackageTrust(vpxPath);
 
     /// <summary>把已由用户核对的签名发布者加入本机信任库。</summary>
-    public string TrustPackagePublisher(string vpxPath) =>
-        _manager.TrustPackagePublisher(vpxPath);
+    public Task<string> TrustPackagePublisherAsync(string vpxPath) =>
+        _manager.TrustPackagePublisherAsync(vpxPath);
 
     /// <summary>从 .vpx 文件安装。未知来源只能由界面明确确认后单次放行。</summary>
     public async Task InstallFromVpxAsync(string vpxPath, bool allowUntrustedPackage = false)

--- a/src/VelaShell/Views/PluginManagerWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginManagerWindow.axaml.cs
@@ -162,7 +162,7 @@ public partial class PluginManagerWindow : Window
                 }
                 try
                 {
-                    vm.TrustPackagePublisher(path);
+                    await vm.TrustPackagePublisherAsync(path);
                 }
                 catch (Exception ex)
                 {

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Security.Cryptography;
+using VelaShell.Infrastructure.Persistence;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.Plugin.HelloWorld;
 using VelaShell.PluginSdk.Packaging;
@@ -56,12 +57,12 @@ public class PluginInstallUninstallTests
         }
     }
 
-    private PluginManager CreateManager(string? trustedPublisherStorePath = null) => new(new()
+    private PluginManager CreateManager(PluginTrustRepository? trustRepository = null) => new(new()
     {
         PluginRoots = [_appRoot, _userRoot],
         DataRootDirectory = _dataRoot,
         UserPluginRoot = _userRoot,
-        TrustedPublisherStorePath = trustedPublisherStorePath,
+        TrustRepository = trustRepository,
         HostVersion = "1.0.0",
         CommandsFactory = (_, _) => new RecordingCommands(),
         DataStore = _dataStore
@@ -192,28 +193,70 @@ public class PluginInstallUninstallTests
     [TestMethod]
     public async Task TrustPublisher_PersistsKey_AndFuturePackagesInstallWithoutBypass()
     {
-        string trustStore = Path.Combine(_dataRoot, "trusted-publishers.json");
+        using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "trust-db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
         using var publisher = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         string first = BuildSignedVpx(publisher, "acme.signed-one");
 
-        PluginManager manager = CreateManager(trustStore);
+        PluginManager manager = CreateManager(repository);
         await manager.StartAsync();
         PluginPackageTrustInfo before = manager.InspectPackageTrust(first);
         Assert.AreEqual(VpxSignatureState.Untrusted, before.State);
         Assert.StartsWith("SHA256:", before.PublisherFingerprint);
 
-        string fingerprint = manager.TrustPackagePublisher(first);
+        string fingerprint = await manager.TrustPackagePublisherAsync(first);
         Assert.AreEqual(before.PublisherFingerprint, fingerprint);
         Assert.AreEqual(VpxSignatureState.Trusted, manager.InspectPackageSignature(first));
         await manager.InstallFromVpxAsync(first);
         await manager.DisposeAsync();
 
         string second = BuildSignedVpx(publisher, "acme.signed-two");
-        PluginManager restarted = CreateManager(trustStore);
-        Assert.AreEqual(VpxSignatureState.Trusted, restarted.InspectPackageSignature(second));
+        PluginManager restarted = CreateManager(repository);
         await restarted.StartAsync();
+        Assert.AreEqual(VpxSignatureState.Trusted, restarted.InspectPackageSignature(second));
         await restarted.InstallFromVpxAsync(second);
         Assert.Contains(p => p.Id == "acme.signed-two", restarted.Plugins);
+        await restarted.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Restart_ModifiedInstalledPlugin_IsRejectedByProtectedReceipt()
+    {
+        using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "receipt-db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        PluginManager manager = CreateManager(repository);
+        await manager.StartAsync();
+        const string id = "acme.receipt-tamper";
+        await manager.InstallFromVpxAsync(BuildVpx(id), allowUntrustedPackage: true);
+        await manager.DisposeAsync();
+
+        await File.AppendAllTextAsync(Path.Combine(_userRoot, id, "plugin.json"), " ");
+        PluginManager restarted = CreateManager(repository);
+        await restarted.StartAsync();
+
+        PluginDescriptor descriptor = Assert.ContainsSingle(plugin => plugin.Id == id, restarted.Plugins);
+        Assert.AreEqual(PluginState.Invalid, descriptor.State);
+        Assert.Contains("changed after installation", descriptor.Error);
+        await restarted.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Restart_DirectlyDroppedPlugin_IsRejectedWhenReceiptIsMissing()
+    {
+        using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "direct-drop-db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        PluginManager firstRun = CreateManager(repository);
+        await firstRun.StartAsync(); // 完成一次空目录迁移；此后不再自动收养新目录。
+        await firstRun.DisposeAsync();
+
+        const string id = "acme.direct-drop";
+        Directory.Move(StagePlugin(id), Path.Combine(_userRoot, id));
+        PluginManager restarted = CreateManager(repository);
+        await restarted.StartAsync();
+
+        PluginDescriptor descriptor = Assert.ContainsSingle(plugin => plugin.Id == id, restarted.Plugins);
+        Assert.AreEqual(PluginState.Invalid, descriptor.State);
+        Assert.Contains("receipt is missing", descriptor.Error);
         await restarted.DisposeAsync();
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginTrustRepositoryTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginTrustRepositoryTests.cs
@@ -1,0 +1,114 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using VelaShell.Core.Data;
+using VelaShell.Infrastructure.Persistence;
+using VelaShell.Infrastructure.Plugins;
+using VelaShell.PluginSdk.Packaging;
+
+namespace VelaShell.Infrastructure.Tests.Plugins;
+
+internal sealed class TestSecretProtector : ISecretProtector
+{
+    public string? Protect(string? plaintext) => plaintext is null
+        ? null
+        : "enc1:" + Convert.ToBase64String(Encoding.UTF8.GetBytes(plaintext));
+
+    public string? Unprotect(string? ciphertext)
+    {
+        if (ciphertext is null || !ciphertext.StartsWith("enc1:", StringComparison.Ordinal))
+        {
+            return ciphertext;
+        }
+        try
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(ciphertext[5..]));
+        }
+        catch (FormatException)
+        {
+            return ciphertext;
+        }
+    }
+}
+
+[TestClass]
+[TestCategory("Plugins")]
+public sealed class PluginTrustRepositoryTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "velashell-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // SonnetDB 的后台句柄若仍在收尾，临时目录留给系统清理。
+        }
+    }
+
+    [TestMethod]
+    public async Task SaveAndReload_ProtectsTrustStateInSonnetDb()
+    {
+        using var engine = new SonnetDbEngine(Path.Combine(_root, "db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        using var publisher = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        string publicKey = Convert.ToBase64String(publisher.ExportSubjectPublicKeyInfo());
+        var state = new PluginTrustState
+        {
+            LegacyInstallMigrationCompleted = true,
+            Publishers = [new(publicKey, VpxContainer.PublicKeyFingerprint(publicKey), DateTimeOffset.UtcNow)]
+        };
+
+        await repository.SaveAsync(state);
+
+        string stored = (await engine.WithCollectionAsync(SonnetDbEngine.ConfigCollection,
+            collection => collection.Get("plugin_trust_v1")?.Json))!;
+        Assert.DoesNotContain(publicKey, stored, "SonnetDB 文档不应暴露信任公钥或可编辑明文。");
+        Assert.Contains("enc1:", stored);
+        PluginTrustState reloaded = await repository.LoadAsync();
+        Assert.AreEqual(publicKey, Assert.ContainsSingle(reloaded.Publishers).PublicKey);
+    }
+
+    [TestMethod]
+    public async Task Load_TamperedCiphertext_FailsClosed()
+    {
+        using var engine = new SonnetDbEngine(Path.Combine(_root, "db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        await repository.SaveAsync(new PluginTrustState());
+        await engine.WithCollectionAsync<object?>(SonnetDbEngine.ConfigCollection, collection =>
+        {
+            collection.Upsert("plugin_trust_v1", JsonSerializer.Serialize(new { Payload = "enc1:AAAA" }));
+            return null;
+        });
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(() => repository.LoadAsync());
+    }
+
+    [TestMethod]
+    public async Task Load_MigratesLegacyJsonOnce_ThenRemovesItFromActiveUse()
+    {
+        using var publisher = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        string publicKey = Convert.ToBase64String(publisher.ExportSubjectPublicKeyInfo());
+        string legacy = Path.Combine(_root, "trusted-plugin-publishers.json");
+        await File.WriteAllTextAsync(legacy, JsonSerializer.Serialize(new[] { publicKey }));
+        using var engine = new SonnetDbEngine(Path.Combine(_root, "db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector(), legacy);
+
+        PluginTrustState state = await repository.LoadAsync();
+
+        Assert.AreEqual(publicKey, Assert.ContainsSingle(state.Publishers).PublicKey);
+        Assert.IsFalse(File.Exists(legacy));
+        Assert.IsTrue(File.Exists(legacy + ".migrated"));
+    }
+}

--- a/tools/VelaShell.Plugin.Cli/Program.cs
+++ b/tools/VelaShell.Plugin.Cli/Program.cs
@@ -85,7 +85,7 @@ internal static class Program
         Console.WriteLine($"Packed {manifest.Id} v{manifest.Version}");
         Console.WriteLine($"  -> {output}");
         Console.WriteLine($"     payload {info.PayloadLength} bytes, sha256 {info.PayloadSha256}");
-        Console.WriteLine($"     {(info.Signature is null ? "unsigned" : "signed by " + Shorten(info.Signature.PublicKey))}");
+        Console.WriteLine($"     {(info.Signature is null ? "unsigned" : "signed by " + VpxContainer.PublicKeyFingerprint(info.Signature.PublicKey))}");
         return 0;
     }
 
@@ -122,8 +122,9 @@ internal static class Program
         Console.WriteLine($"  flags      {info.Flags}");
         Console.WriteLine($"  payload    {info.PayloadLength} bytes");
         Console.WriteLine($"  sha256     {info.PayloadSha256}");
-        Console.WriteLine($"  signature  {VpxContainer.VerifySignature(info)}"
-                          + (info.Signature is { } s ? $" ({Shorten(s.PublicKey)})" : ""));
+        VpxSignatureState signature = VpxContainer.VerifySignature(info);
+        Console.WriteLine($"  signature  {(signature == VpxSignatureState.Trusted ? "Valid" : signature.ToString())}"
+                          + (info.Signature is { } s ? $" ({VpxContainer.PublicKeyFingerprint(s.PublicKey)})" : ""));
         // 顺带把清单读出来:光有摘要看不出这是哪个插件。
         using Stream payload = VpxContainer.OpenPayload(package);
         using var archive = new ZipArchive(payload, ZipArchiveMode.Read);
@@ -147,7 +148,7 @@ internal static class Program
         using Stream payload = VpxContainer.OpenPayload(package);
         using var archive = new ZipArchive(payload, ZipArchiveMode.Read);
         Directory.CreateDirectory(destination);
-        archive.ExtractToDirectory(destination, overwriteFiles: true);
+        ExtractZipSafely(archive, destination);
         Console.WriteLine($"Unpacked to {destination}");
         return 0;
     }
@@ -163,9 +164,27 @@ internal static class Program
                                    "and packages signed with it can no longer be updated under the same identity).");
         }
         using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
-        File.WriteAllText(path, key.ExportPkcs8PrivateKeyPem());
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(path, key.ExportPkcs8PrivateKeyPem());
+        }
+        else
+        {
+            using var stream = new FileStream(path, new FileStreamOptions
+            {
+                Mode = FileMode.Create,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite
+            });
+            using var writer = new StreamWriter(stream);
+            writer.Write(key.ExportPkcs8PrivateKeyPem());
+        }
+        string publicKey = Convert.ToBase64String(key.ExportSubjectPublicKeyInfo());
         Console.WriteLine($"Private key written to {path}  (keep it secret, keep it backed up)");
-        Console.WriteLine($"Public key (base64 SPKI): {Convert.ToBase64String(key.ExportSubjectPublicKeyInfo())}");
+        Console.WriteLine($"Public key (base64 SPKI): {publicKey}");
+        Console.WriteLine($"Fingerprint: {VpxContainer.PublicKeyFingerprint(publicKey)}");
         return 0;
     }
 
@@ -192,7 +211,7 @@ internal static class Program
             VpxContainer.Write(destination, source, new() { SigningKey = key });
         }
         Console.WriteLine($"Signed {output}");
-        Console.WriteLine($"  public key: {Convert.ToBase64String(key.ExportSubjectPublicKeyInfo())}");
+        Console.WriteLine($"  fingerprint: {VpxContainer.PublicKeyFingerprint(Convert.ToBase64String(key.ExportSubjectPublicKeyInfo()))}");
         return 0;
     }
 
@@ -206,38 +225,20 @@ internal static class Program
         using (Stream _ = VpxContainer.OpenPayload(package, out info))
         {
         }
-        string[] trusted = options.Get("--key", "-k") is { } key ? [key] : [];
-        VpxSignatureState state = VpxContainer.VerifySignature(info, trusted);
+        string? expectedKey = options.Get("--key", "-k");
+        VpxSignatureState state = expectedKey is null
+            ? VpxContainer.VerifySignature(info)
+            : VpxContainer.VerifySignature(info, [expectedKey]);
         Console.WriteLine($"payload  OK ({info.PayloadLength} bytes, sha256 {info.PayloadSha256})");
-        Console.WriteLine($"signature {state}");
+        Console.WriteLine($"signature {(expectedKey is null && state == VpxSignatureState.Trusted ? "Valid (publisher identity not checked)" : state.ToString())}");
         return state is VpxSignatureState.Invalid or VpxSignatureState.Untrusted ? 1 : 0;
     }
 
-    /// <summary>把 .vpx 装进本机 VelaShell 的用户插件目录(下次启动生效)。</summary>
+    /// <summary>安装必须由宿主完成，确保签名授权和受保护安装收据不可绕过。</summary>
     private static int Install(string[] args)
     {
-        string package = RequirePackagePath(args);
-        using Stream payload = VpxContainer.OpenPayload(package);
-        using var archive = new ZipArchive(payload, ZipArchiveMode.Read);
-        if (archive.GetEntry(PluginManifestReader.FileName) is not { } entry)
-        {
-            throw new CliException("The package has no plugin.json at its root.");
-        }
-        PluginManifest manifest;
-        using (StreamReader reader = new(entry.Open()))
-        {
-            manifest = PluginManifestReader.Parse(reader.ReadToEnd());
-        }
-        string target = Path.Combine(UserPluginRoot, manifest.Id);
-        if (Directory.Exists(target))
-        {
-            Directory.Delete(target, recursive: true);
-        }
-        Directory.CreateDirectory(target);
-        archive.ExtractToDirectory(target, overwriteFiles: true);
-        Console.WriteLine($"Installed {manifest.Id} v{manifest.Version} to {target}");
-        Console.WriteLine("Restart VelaShell (or use the plugin manager page) to load it.");
-        return 0;
+        _ = RequirePackagePath(args);
+        throw new CliException("Direct CLI installation is disabled because it would bypass publisher approval and the protected installation receipt. Install the package from VelaShell's plugin manager; use `dev-link` only for development builds.");
     }
 
     /// <summary>把一个插件输出目录登记进 / 移出 plugins.dev.txt(开发期挂载)。</summary>
@@ -299,8 +300,6 @@ internal static class Program
     private static string DataRoot => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "VelaShell");
 
-    private static string UserPluginRoot => Path.Combine(DataRoot, "plugins");
-
     private static PluginManifest LoadManifest(string directory)
     {
         string manifestPath = Path.Combine(directory, PluginManifestReader.FileName);
@@ -352,7 +351,52 @@ internal static class Program
         return key;
     }
 
-    private static string Shorten(string value) => value.Length <= 24 ? value : value[..12] + "..." + value[^8..];
+    private const int MaxUnpackEntries = 10_000;
+    private const long MaxUnpackedBytes = 512L * 1024 * 1024;
+
+    private static void ExtractZipSafely(ZipArchive archive, string destination)
+    {
+        if (archive.Entries.Count > MaxUnpackEntries)
+        {
+            throw new CliException($"Package contains too many entries ({archive.Entries.Count}; limit {MaxUnpackEntries}).");
+        }
+        string root = Path.GetFullPath(destination + Path.DirectorySeparatorChar);
+        StringComparison pathComparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        long remaining = MaxUnpackedBytes;
+        byte[] buffer = new byte[64 * 1024];
+        foreach (ZipArchiveEntry entry in archive.Entries)
+        {
+            if (((entry.ExternalAttributes >> 16) & 0xF000) == 0xA000)
+            {
+                throw new CliException($"Package contains a symbolic link: {entry.FullName}");
+            }
+            string target = Path.GetFullPath(Path.Combine(destination, entry.FullName));
+            if (!target.StartsWith(root, pathComparison))
+            {
+                throw new CliException($"Package entry escapes the destination: {entry.FullName}");
+            }
+            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
+            {
+                Directory.CreateDirectory(target);
+                continue;
+            }
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            using Stream source = entry.Open();
+            using FileStream output = File.Create(target);
+            int read;
+            while ((read = source.Read(buffer)) > 0)
+            {
+                remaining -= read;
+                if (remaining < 0)
+                {
+                    throw new CliException($"Package expands beyond the {MaxUnpackedBytes / (1024 * 1024)} MB limit.");
+                }
+                output.Write(buffer, 0, read);
+            }
+        }
+    }
 
     private static void Error(string message) => Console.Error.WriteLine($"error: {message}");
 
@@ -381,7 +425,7 @@ internal static class Program
           keygen                Create a P-256 signing key pair
               -o, --output      Key file path (default: velashell-plugin-key.pem)
                   --force       Overwrite an existing key file
-          install <pkg.vpx>     Unpack into this machine's VelaShell plugin folder
+          install <pkg.vpx>     Disabled: install through VelaShell to record trust securely
           dev-link [dir]        Register a plugin output directory for development
           dev-unlink [dir]      Remove such a registration
 


### PR DESCRIPTION
实现插件发布者信任与安装收据的 AES-GCM 加密存储，统一由 PluginTrustRepository 管理，弃用 JSON 文件并支持数据迁移。插件安装、卸载、信任操作均更新受保护状态，安装生成内容哈希收据并启动校验，防止篡改与绕过。禁止 CLI 直装插件，强制走宿主流程。完善单元测试，增强依赖注入与 API，优化 ZIP 解包安全性，控制台输出统一公钥指纹。全面提升插件信任体系安全性与健壮性。