### PR TITLE
修复 #228:左栏区域标题按钮高度不一致

### DIFF
--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -84,8 +84,11 @@
           <Grid RowDefinitions="36,*">
             <Border Grid.Row="0" BorderThickness="0,0,0,1"
                     BorderBrush="{DynamicResource VelaBorderPrimary}" Padding="8,0">
+              <!-- 高度锁 24px 并垂直居中:与同排的 24×24 图标按钮共用同一悬停药丸高度(#228)。
+                   不锁则按钮撑满 36px 行高,悬停时比旁边的图标按钮高出一截。 -->
               <Button x:Name="QuickCommandsToggle"
                       Background="Transparent" Padding="4,0" CornerRadius="3"
+                      Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"
                       HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
                       Click="ToggleQuickCommands_Click" Cursor="Hand"
                       ToolTip.Tip="{loc:Localize Sidebar_ToggleSection}">
@@ -126,8 +129,11 @@
           <Border Grid.Row="0" BorderThickness="0,0,0,1"
                   BorderBrush="{DynamicResource VelaBorderPrimary}" Padding="8,0">
             <Grid ColumnDefinitions="Auto,6,*,Auto">
+              <!-- 同上(#228):锁 24px 高并居中;右侧留 4px,悬停药丸不至于贴住清除按钮。 -->
               <Button x:Name="RecentConnectionsToggle" Grid.Column="0" Grid.ColumnSpan="3"
                       Background="Transparent" Padding="4,0" CornerRadius="3"
+                      Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"
+                      Margin="0,0,4,0"
                       HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
                       Click="ToggleRecentConnections_Click" Cursor="Hand"
                       ToolTip.Tip="{loc:Localize Sidebar_ToggleSection}">

--- a/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
+++ b/tests/VelaShell.Tests/Views/SidebarQuickCommandsUiTests.cs
@@ -445,6 +445,45 @@ public class SidebarQuickCommandsUiTests
         });
     }
 
+    /// <summary>
+    /// 区域标题的折叠按钮与同排图标按钮必须等高(#228)。两者都会画悬停药丸,高度一旦
+    /// 不同,鼠标在标题栏上横向滑过时药丸忽高忽低 —— 报告里正是这个观感。
+    /// </summary>
+    [TestMethod]
+    public void SectionToggleButtons_MatchIconButtonHeight()
+    {
+        OnUi(() =>
+        {
+            IQuickCommandRepository repository = Substitute.For<IQuickCommandRepository>();
+            var runner = new QuickCommandRunnerViewModel(new QuickCommandsViewModel(repository));
+            var viewModel = new SidebarViewModel(quickCommands: runner)
+            {
+                IsQuickCommandsVisible = true,
+            };
+            var view = new SidebarView { DataContext = viewModel };
+            var window = new Window
+            {
+                Width = 280,
+                Height = 700,
+                Content = view,
+            };
+            window.Show();
+            Relayout(window);
+
+            Button clear = view.FindControl<Button>("RecentConnectionsClear")!;
+            Button refresh = view.FindControl<Button>("RecentConnectionsRefresh")!;
+            Button recentToggle = view.FindControl<Button>("RecentConnectionsToggle")!;
+            Button quickToggle = view.FindControl<Button>("QuickCommandsToggle")!;
+
+            double iconHeight = clear.Bounds.Height;
+            Assert.IsGreaterThan(0, iconHeight);
+            Assert.AreEqual(iconHeight, refresh.Bounds.Height);
+            Assert.AreEqual(iconHeight, recentToggle.Bounds.Height, "折叠按钮不应比图标按钮高。");
+            Assert.AreEqual(iconHeight, quickToggle.Bounds.Height, "折叠按钮不应比图标按钮高。");
+            window.Close();
+        });
+    }
+
     private static void Relayout(Window window)
     {
         Dispatcher.UIThread.RunJobs();


### PR DESCRIPTION
Closes #228

## 问题

「最近连接」/「快捷命令」的区域标题折叠按钮此前撑满 36px 行高，而同排的清除/刷新按钮是 24×24。两者都会画悬停药丸，鼠标在标题栏上横向滑过时药丸忽高忽低 —— 报告的两张截图正是这个观感（标题上的药丸明显比铅笔右侧的高一截）。

## 方案

折叠按钮锁 24px 并垂直居中，与图标按钮取齐；右侧留 4px，悬停药丸不至于贴住清除按钮。两个区域标题同改。

## 测试

`SidebarQuickCommandsUiTests.SectionToggleButtons_MatchIconButtonHeight`：headless 布局后比对四个按钮的 `Bounds.Height`。

这条断言特意反向验证过 —— 把修复撤掉重跑会红，不是空断言。

全量：`VelaShell.Tests` 846 通过，构建 0 警告 0 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AApZnutpRHShLn644DeUWq