### PR TITLE
升级 AWSSDK.S3 至 4.0.102.3，保持依赖一致性

### DIFF
--- a/plugins/VelaShell.Plugin.S3/VelaShell.Plugin.S3.csproj
+++ b/plugins/VelaShell.Plugin.S3/VelaShell.Plugin.S3.csproj
@@ -20,7 +20,7 @@
          不用 S3 的用户,安装包里不必带这两个各约 1 MB 的程序集,进程里也永不装载它们。
          选它而非自己签 SigV4 的原委见 docs/S3协议插件化设计.md §二:S3 有 116 个操作,
          自己实现只能覆盖很小一角,且每加一个能力都要重做一遍 XML 序列化与错误码映射。 -->
-    <PackageReference Include="AWSSDK.S3" Version="4.0.102.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.102.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <!-- S3 插件的测试要直接构造 AWSSDK 的请求/响应类型(替身客户端与环回服务器都要),
          版本与 plugins/VelaShell.Plugin.S3 保持一致。 -->
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.102.2" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.102.3" />
     <PackageVersion Include="Avalonia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->


### PR DESCRIPTION
将 AWSSDK.S3 包版本从 4.0.102.2 升级到 4.0.102.3，分别更新了 VelaShell.Plugin.S3.csproj 和 Directory.Packages.props 文件，确保依赖项版本一致。