### PR TITLE
插件 SDK 升级至 1.1.0，增强远程执行与兼容性

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <!-- 插件 SDK 系列包(VelaShell.PluginSdk / .Testing / .Build、VelaShell.Plugin.Cli、
          VelaShell.Plugin.Templates)的版本。**与宿主版本解耦**:宿主发 1.2.3 不代表插件
          契约变了,插件作者也不该为了跟版本号而重新编译。CI 发包时用 -p:VelaSdkVersion= 覆盖。 -->
-    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.0.1</VelaSdkVersion>
+    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.1.0</VelaSdkVersion>
     <!-- 去掉预发布后缀的数字版(AssemblyVersion/FileVersion 不接受后缀)与主版本号。 -->
     <VelaSdkVersionCore>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersion), '-.*$', ''))</VelaSdkVersionCore>
     <VelaSdkMajor>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersionCore), '\..*$', ''))</VelaSdkMajor>

--- a/docs/plugins/dev-guide.md
+++ b/docs/plugins/dev-guide.md
@@ -227,6 +227,7 @@ vela-plugin dev-unlink bin/Debug/net11.0   # 取消
 | `author` | | 作者,展示在插件管理页(如 `"Joe <joe@example.com>"`,≤128 字符、不许控制字符)。缺省时管理页退回显示 `publisher` |
 | `apiLevel` | | 默认 1;高于宿主支持的代际 → 标记 Incompatible 拒载 |
 | `minHostVersion` | | 要求的最低宿主版本;不满足 → Incompatible |
+| `minSdkVersion` | | 要求的最低**插件 SDK** 版本(如 `1.1.0`);不满足 → Incompatible。**用到了新 SDK 面的插件必须声明它**:`apiLevel` 只在破坏性变更时才动,而新增的接口方法与 DTO 字段不算破坏性 —— 不声明的话老宿主会把插件装上、激活,然后在第一次调用新方法时抛 `MissingMethodException`。SDK 版本与宿主版本刻意解耦,所以 `minHostVersion` 表达不了这件事 |
 | `activationEvents` | | 省略或含 `"onStartup"` = 启动激活;`"onCommand:<命令id>"` / `"onProtocol:<协议id>"` / `"onWorkspace:<连接类型id>"` = **惰性激活**(命中占位命令、或用户选中该页签才装载;须在对应的 `contributes.*` 里声明) |
 | `contributes.commands` | | 声明式命令占位 `[{id,title,category}]`:发现期即进命令面板,id 必须以插件 id 为前缀;激活时插件应 `Register` 同 id 的真实处理器替换占位 |
 | `contributes.protocols` | | 声明式协议页签 `[{id,displayName,defaultPort}]`:发现期即进连接配置页(**不装载程序集**),id 必须等于插件 id 或以其为前缀;设置表单在激活后由 `ProtocolDescriptor` 补齐。要求 `hostMode` 为 `inProcess` |
@@ -358,15 +359,56 @@ await context.RemoteFs.DownloadFileAsync(sid, "/var/log/app.log", localPath, pro
   经 RPC 分块拉取(不支持 Seek)。
 - 进度回调已由宿主节流(≥100ms),放心直接更新状态。
 
-### 5.5 RemoteExec —— 远程一次性命令
+### 5.5 RemoteExec —— 远程命令(一次性 / 流式)
+
+独立 exec 通道:不进用户终端、不污染 shell 历史与环境。两种形态:
+
+**一次性**(探测类命令)——
 
 ```csharp
 ExecResult r = await context.RemoteExec.RunAsync(sid, "docker ps --format json",
     new ExecOptions { Timeout = TimeSpan.FromSeconds(10) }, ct);
+
+if (!r.IsSuccess)                     // 退出码非 0 **不抛异常** —— 命令跑失败是正常结果
+{
+    context.Log.Warn(r.FailureText);  // 优先取 stderr 首行,没有才退回 stdout / 退出码
+}
+Parse(r.Output);                      // stdout 与 stderr 是分开的两条流
 ```
 
-独立 exec 通道:不进用户终端、不污染 shell 历史与环境。默认超时 30s、上限
-10min。适合探测类命令,不适合交互式/长驻进程。
+- 默认超时 30s、上限 10min;超时抛 `TimeoutException`。
+- **`Output` 只含标准输出**;`Error` 是标准错误,`ExitCode` 是退出码 —— 三样都在
+  `ExecResult` 上。别再自己拼 `2>&1; echo $?` 那种哨兵:合并两条流会让解析
+  `--format json` 的代码被一行 `WARNING:` 噎死,而哨兵在用户登录 shell 是 fish/csh 时就崩了。
+
+**流式**(长驻命令:`docker logs -f`、`docker events`、`tail -F`)——
+
+```csharp
+sealed class LineSink(Action<string> onLine) : IProgress<ExecOutput>
+{
+    public void Report(ExecOutput o) => onLine(o.Line);   // 同步转发,顺序即到达顺序
+}
+
+ExecStreamResult done = await context.RemoteExec.StreamAsync(sid,
+    "docker logs -f --tail 200 web",
+    new ExecStreamOptions { Timeout = null },             // null = 不限时,靠取消令牌收尾
+    new LineSink(AppendToView), panelClosedToken);
+```
+
+- 输出**按行**回调,宿主不节流(日志的价值就在于即时);要攒批请自己攒。
+- **别传 `System.Progress<T>`**:它把每次回调 `Post` 到同步上下文或线程池,
+  顺序与线程都不再保证 —— 对进度百分比无所谓,对一屏日志是灾难。
+  宿主是在读行的那个线程上顺序调 `Report` 的,所以只要你的实现是同步的,行序就是保证的。
+- 取消令牌触发 → 宿主给远端进程发 `TERM` 再关通道,方法抛 `OperationCanceledException`;
+  `Timeout` 到点 → 抛 `TimeoutException`。**插件必须持有并触发那个令牌**。
+- 每插件最多 `IRemoteExecApi.MaxConcurrentStreams`(4)条流同时在飞,超了抛
+  `InvalidOperationException`。流不限时且各占一个 SSH 通道,没有上限的话一个忘了取消的
+  插件能把对端的 `MaxSessions` 耗光 —— 那时坏的是用户的连接,不只是这个插件。
+- **隔离模式下"不限时"做不到**:取消令牌不跨进程传播(§6),未指定 `Timeout` 的流会被
+  补上两小时的死线。要即时取消的流式插件请用 `inProcess`。
+
+> 交互式命令(要伪终端、要键盘输入)两者都不适用 —— 那是终端标签的事,
+> 用 `context.Terminal.WriteAsync` 把命令敲进去(需用户授权)。
 
 ### 5.6 Commands —— 命令面板
 
@@ -764,7 +806,7 @@ internal sealed class MyWorkspaceProvider(IPluginContext context) : IWorkspacePr
 | Storage / Log | ✅ KV 经 RPC 落宿主 SonnetDB(插件进程不落本地文件);日志转发宿主并本地 Trace 兜底 |
 | Secrets / Clipboard | ✅ RPC 路由到宿主执行(机密只存宿主侧加密落盘) |
 | 停靠进主窗口标签区 | ❌ **一律独立卡片窗口**(稳定,与主程序统一)。跨进程 dock 嵌入(HWND 收养)与 dock 切标签的 reparenting 有根本张力(卡顿/窗口飘出),**已弃用**;真·dock 标签页请用 inProcess。跨平台稳态方案 = 蓝图 08 共享内存表面(远期) |
-| `CancellationToken` 跨进程传播 | ⚠️ 不传播;以两侧超时兜底(exec 随 `ExecOptions.Timeout`) |
+| `CancellationToken` 跨进程传播 | ⚠️ 不传播;以两侧超时兜底(exec 随 `ExecOptions.Timeout`;流式 exec 未指定 `Timeout` 时补两小时死线,见 §5.5) |
 
 - **选型建议**:第一方/可信插件用默认 `inProcess`(零 IPC 开销、面板可停靠拖拽);
   第三方或实验性插件用 `isolated`(多一个进程换崩溃隔离;面板为独立卡片窗口)。
@@ -793,7 +835,7 @@ public async Task Refresh_ListsContainers()
 
 替身清单:`CollectingLogger`、`InMemoryStorage`、`FakeSessions`、`RecordingProtocols`
 (协议注册,含与宿主一致的 id 前缀校验)、`FakeRemoteFs`
-(内存路径树,语义与真实实现对齐)、`FakeRemoteExec`(脚本化应答)、
+(内存路径树,语义与真实实现对齐)、`FakeRemoteExec`(脚本化应答,含退出码/标准错误与流式逐行)、
 `RecordingCommands`(可 `RunAsync` 驱动命令体)、`TestHostEvents`(Raise 方法)、
 `TestHostInfo`、`FakeUi`(记录面板与惰性内容工厂)、`FakeSecrets`、`FakeClipboard`。
 

--- a/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteExec.cs
+++ b/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteExec.cs
@@ -3,28 +3,95 @@ using VelaShell.PluginSdk.RemoteExec;
 namespace VelaShell.PluginSdk.Testing;
 
 /// <summary>
-/// <see cref="IRemoteExecApi" /> 的测试替身:优先走 <see cref="Handler" />,
-/// 否则按顺序吐出 <see cref="Responses" /> 队列;都没有时返回空输出。
-/// 全部调用记录在 <see cref="Executed" />。
+/// <see cref="IRemoteExecApi" /> 的测试替身:优先走 <see cref="ResultHandler" />,
+/// 其次 <see cref="Handler" />,否则按顺序吐出 <see cref="Responses" /> 队列;
+/// 都没有时返回空输出与退出码 0。全部调用记录在 <see cref="Executed" />。
 /// </summary>
 public sealed class FakeRemoteExec : IRemoteExecApi
 {
-    /// <summary>脚本化应答:(sessionId, command) → 输出。</summary>
+    /// <summary>脚本化应答:(sessionId, command) → 标准输出。退出码按 0、标准错误按空处理。</summary>
     public Func<string, string, string>? Handler { get; set; }
 
-    /// <summary>顺序应答队列(无 <see cref="Handler" /> 时使用)。</summary>
+    /// <summary>
+    /// 完整的脚本化应答:(sessionId, command) → 标准输出 / 标准错误 / 退出码。
+    /// 要测"命令失败了界面怎么说"就用它 —— <see cref="Handler" /> 永远是成功的。
+    /// </summary>
+    public Func<string, string, ExecResult>? ResultHandler { get; set; }
+
+    /// <summary>顺序应答队列(无 <see cref="Handler" /> / <see cref="ResultHandler" /> 时使用)。</summary>
     public Queue<string> Responses { get; } = new();
 
-    /// <summary>全部已执行的 (sessionId, command) 记录。</summary>
+    /// <summary>
+    /// 流式执行的脚本化应答:(sessionId, command) → 要逐行回调的输出。
+    /// 未设置时,流式执行退回复用一次性应答并把它按行拆开回调。
+    /// </summary>
+    public Func<string, string, IEnumerable<ExecOutput>>? StreamHandler { get; set; }
+
+    /// <summary>全部已执行的 (sessionId, command) 记录(含流式)。</summary>
     public List<(string SessionId, string Command)> Executed { get; } = [];
+
+    /// <summary>已发起的流式执行 (sessionId, command) 记录。</summary>
+    public List<(string SessionId, string Command)> Streamed { get; } = [];
 
     /// <inheritdoc />
     public Task<ExecResult> RunAsync(string sessionId, string command, ExecOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         Executed.Add((sessionId, command));
-        string output = Handler?.Invoke(sessionId, command)
-                        ?? (Responses.Count > 0 ? Responses.Dequeue() : "");
-        return Task.FromResult(new ExecResult(output));
+        return Task.FromResult(Respond(sessionId, command));
     }
+
+    /// <inheritdoc />
+    public Task<ExecStreamResult> StreamAsync(string sessionId, string command, ExecStreamOptions? options,
+        IProgress<ExecOutput> output, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        Executed.Add((sessionId, command));
+        Streamed.Add((sessionId, command));
+        long lines = 0;
+        foreach (ExecOutput line in Lines(sessionId, command))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (line.Stream is ExecStream.StandardError && options?.IncludeStandardError is false)
+            {
+                continue;
+            }
+            output.Report(line);
+            lines++;
+        }
+        return Task.FromResult(new ExecStreamResult(0, lines));
+    }
+
+    private ExecResult Respond(string sessionId, string command)
+    {
+        if (ResultHandler is { } detailed)
+        {
+            return detailed(sessionId, command);
+        }
+        string output = Handler?.Invoke(sessionId, command) ?? (Responses.Count > 0 ? Responses.Dequeue() : "");
+        return new(output);
+    }
+
+    private IEnumerable<ExecOutput> Lines(string sessionId, string command)
+    {
+        if (StreamHandler is { } handler)
+        {
+            return handler(sessionId, command);
+        }
+        // 没有专门脚本时复用一次性应答:大多数测试只关心"这些行有没有被逐条送到",
+        // 让它们不必为流式再写一份数据。
+        ExecResult result = Respond(sessionId, command);
+        return
+        [
+            .. Split(result.Output, ExecStream.StandardOutput),
+            .. Split(result.Error, ExecStream.StandardError)
+        ];
+    }
+
+    private static IEnumerable<ExecOutput> Split(string text, ExecStream stream) =>
+        text.Length == 0
+            ? []
+            : text.Replace("\r\n", "\n", StringComparison.Ordinal)
+                  .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                  .Select(line => new ExecOutput(stream, line));
 }

--- a/plugin-sdk/VelaShell.PluginSdk/Manifest/PluginManifest.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Manifest/PluginManifest.cs
@@ -183,6 +183,22 @@ public sealed record PluginManifest
     [JsonPropertyName("minHostVersion")]
     public string? MinHostVersion { get; init; }
 
+    /// <summary>
+    /// 要求的最低**插件 SDK** 版本(可选,如 <c>1.1.0</c>);不满足时插件被标记为不兼容。
+    /// <para>
+    /// 与 <see cref="MinHostVersion" /> 是两回事:SDK 版本与宿主版本**刻意解耦**
+    /// (宿主发 1.2.3 不代表契约变了),所以"我用到了 SDK 1.1 才有的东西"没法用宿主版本表达;
+    /// 也不能靠 <see cref="ApiLevel" /> —— 它只在破坏性变更时才动,而新增的接口方法与
+    /// DTO 字段不算破坏性。
+    /// </para>
+    /// <para>
+    /// 用到了新 SDK 面的插件应当声明它。不声明照样能装,但会在**运行期**撞上
+    /// <c>MissingMethodException</c>,而那比发现期一句"请升级 VelaShell"难查得多。
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("minSdkVersion")]
+    public string? MinSdkVersion { get; init; }
+
     /// <summary>主页/仓库地址(可选)。</summary>
     [JsonPropertyName("homepage")]
     public string? Homepage { get; init; }

--- a/plugin-sdk/VelaShell.PluginSdk/Manifest/PluginManifestReader.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Manifest/PluginManifestReader.cs
@@ -84,6 +84,11 @@ public static partial class PluginManifestReader
             throw new PluginManifestException(
                 $"Invalid minHostVersion '{minHost}': expected semver-style like \"0.1.0\".");
         }
+        if (manifest.MinSdkVersion is { } minSdk && !VersionPattern().IsMatch(minSdk))
+        {
+            throw new PluginManifestException(
+                $"Invalid minSdkVersion '{minSdk}': expected semver-style like \"1.1.0\".");
+        }
         ValidateDisplayText(manifest.Author, "author");
         ValidateDisplayText(manifest.Publisher, "publisher");
         ValidateActivation(manifest);

--- a/plugin-sdk/VelaShell.PluginSdk/RemoteExec/IRemoteExecApi.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/RemoteExec/IRemoteExecApi.cs
@@ -7,18 +7,159 @@ public sealed record ExecOptions
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(30);
 }
 
+/// <summary>输出来自哪条流。</summary>
+public enum ExecStream
+{
+    /// <summary>标准输出。</summary>
+    StandardOutput,
+
+    /// <summary>标准错误。</summary>
+    StandardError
+}
+
+/// <summary>流式执行时回调的一行输出。</summary>
+/// <param name="Stream">这一行来自哪条流。</param>
+/// <param name="Line">一行文本(**不含**行尾换行)。</param>
+public readonly record struct ExecOutput(ExecStream Stream, string Line);
+
+/// <summary>流式执行选项。</summary>
+public sealed record ExecStreamOptions
+{
+    /// <summary>
+    /// 整体超时;<see langword="null" />(默认)表示**不限时**,由取消令牌决定何时收尾。
+    /// <para>
+    /// 与 <see cref="ExecOptions.Timeout" /> 的 10 分钟上限不同:流式执行的正常形态就是
+    /// <c>docker logs -f</c> / <c>tail -F</c> 这类"跑到你不想看为止"的命令,给它一个
+    /// 死线只会让界面在第 10 分钟莫名其妙地断流。代价是插件**必须**持有取消令牌并在
+    /// 不再需要时触发它 —— 宿主同时按 <see cref="IRemoteExecApi.MaxConcurrentStreams" /> 兜底。
+    /// </para>
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
+
+    /// <summary>是否也回调标准错误,默认是。</summary>
+    public bool IncludeStandardError { get; init; } = true;
+}
+
+/// <summary>流式执行的收尾结果。</summary>
+/// <param name="ExitCode">远端进程的退出码。</param>
+/// <param name="Lines">总共回调了多少行。</param>
+public sealed record ExecStreamResult(int ExitCode, long Lines);
+
 /// <summary>远程命令执行结果。</summary>
 /// <param name="Output">命令的标准输出(UTF-8 解码)。</param>
-public sealed record ExecResult(string Output);
+public sealed record ExecResult(string Output)
+{
+    /// <summary>
+    /// 命令的标准错误(UTF-8 解码)。
+    /// <para>
+    /// **单独一条流,不并进 <see cref="Output" />。** 绝大多数命令行工具把错误写在这里
+    /// (<c>docker</c>、<c>systemctl</c>、<c>git</c> 都是),把两条流拌在一起会让解析
+    /// <c>--format json</c> 这类结构化输出的插件被一行警告噎死。
+    /// </para>
+    /// </summary>
+    public string Error { get; init; } = "";
+
+    /// <summary>远端进程的退出码。</summary>
+    public int ExitCode { get; init; }
+
+    /// <summary>退出码为 0。</summary>
+    public bool IsSuccess => ExitCode == 0;
+
+    /// <summary>
+    /// 给人看的一行失败原因:优先取标准错误的第一行非空文本,没有就退回标准输出,
+    /// 再没有就报退出码。用于把失败**如实**呈现到界面上,而不是一句"操作失败"。
+    /// </summary>
+    public string FailureText
+    {
+        get
+        {
+            foreach (string candidate in new[] { Error, Output })
+            {
+                foreach (string line in candidate.Split('\n'))
+                {
+                    string trimmed = line.Trim();
+                    if (trimmed.Length > 0)
+                    {
+                        return trimmed;
+                    }
+                }
+            }
+            return $"exit {ExitCode}";
+        }
+    }
+}
 
 /// <summary>
-/// 远程执行能力:在既有会话上经独立 exec 通道执行一次性命令 ——
+/// 远程执行能力:在既有会话上经独立 exec 通道执行命令 ——
 /// 不进用户终端、不污染用户 shell 历史与环境变量。
-/// 适合探测类命令(<c>docker ps</c>、<c>systemctl status</c> 等);
-/// 交互式或长驻命令不适用。会话无效时抛 <see cref="PluginSessionNotFoundException" />。
+/// 会话无效时抛 <see cref="PluginSessionNotFoundException" />。
+/// <para>
+/// 两种形态:<see cref="RunAsync" /> 跑完拿结果(探测类命令,<c>docker ps</c> /
+/// <c>systemctl status</c>);<see cref="StreamAsync" /> 边跑边按行回调
+/// (<c>docker logs -f</c> / <c>docker events</c> / <c>tail -F</c> 这类长驻命令)。
+/// 交互式命令(要伪终端、要键盘输入的)两者都不适用,那是终端标签的事。
+/// </para>
 /// </summary>
 public interface IRemoteExecApi
 {
-    /// <summary>执行命令并等待完成,返回标准输出。超时抛 <see cref="TimeoutException" />。</summary>
+    /// <summary>
+    /// 同时在飞的流式执行上限(每插件)。超过时 <see cref="StreamAsync" /> 抛
+    /// <see cref="InvalidOperationException" />。
+    /// </summary>
+    /// <remarks>
+    /// 流是不限时的,而每条流占着一个 SSH 通道。没有上限的话,一个忘了取消的插件
+    /// 能在几分钟内把对端的 <c>MaxSessions</c> 耗光 —— 那时坏掉的不是插件,是用户的连接。
+    /// </remarks>
+    public const int MaxConcurrentStreams = 4;
+
+    /// <summary>
+    /// 执行命令并等待完成。超时抛 <see cref="TimeoutException" />。
+    /// <para>
+    /// **不会**因为退出码非 0 而抛异常 —— 命令跑失败是一种正常结果,不是一个异常事件。
+    /// 判成败请看 <see cref="ExecResult.IsSuccess" />。
+    /// </para>
+    /// </summary>
+    /// <param name="sessionId">会话 id。</param>
+    /// <param name="command">命令行。</param>
+    /// <param name="options">执行选项。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    /// <returns>标准输出、标准错误与退出码。</returns>
     Task<ExecResult> RunAsync(string sessionId, string command, ExecOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 流式执行:边跑边把输出**按行**回调,进程结束后返回退出码。
+    /// <para>
+    /// 用于长驻命令。取消令牌触发时宿主向远端进程发 <c>TERM</c> 并关闭通道,
+    /// 方法抛 <see cref="OperationCanceledException" />;
+    /// <see cref="ExecStreamOptions.Timeout" /> 到点则抛 <see cref="TimeoutException" />。
+    /// </para>
+    /// <para>
+    /// <paramref name="output" /> 在**非 UI 线程**被回调,且可能非常频繁
+    /// (宿主不做节流 —— 日志的价值就在于即时);插件自己决定要不要攒批。
+    /// </para>
+    /// <para>
+    /// <b>不要传 <see cref="Progress{T}" />。</b> 宿主是在读行的那个线程上按顺序直接调
+    /// <see cref="IProgress{T}.Report" /> 的,所以**只要你的实现是同步的,行序就是保证的**;
+    /// 而 <see cref="Progress{T}" /> 会把每次回调 <c>Post</c> 到捕获的同步上下文或线程池,
+    /// 既丢掉顺序也可能并发进入 —— 对进度百分比无所谓,对一屏日志则是灾难。
+    /// 请自己写一个直接转发的 <see cref="IProgress{T}" />(几行而已)。
+    /// </para>
+    /// </summary>
+    /// <param name="sessionId">会话 id。</param>
+    /// <param name="command">命令行。</param>
+    /// <param name="options">流式选项;为 null 用默认值(不限时、含标准错误)。</param>
+    /// <param name="output">逐行输出的接收器。</param>
+    /// <param name="cancellationToken">取消令牌(**必须**持有并在不再需要时触发)。</param>
+    /// <returns>退出码与行数。</returns>
+    /// <exception cref="NotSupportedException">宿主实现不支持流式执行时。</exception>
+    Task<ExecStreamResult> StreamAsync(
+        string sessionId,
+        string command,
+        ExecStreamOptions? options,
+        IProgress<ExecOutput> output,
+        CancellationToken cancellationToken = default)
+        // 默认实现只为**源兼容**:第三方的测试替身在 SDK 加了这个方法之后仍然能编译。
+        // 刻意不退化成"跑完再一次性回调" —— 那会让 `docker logs -f` 挂到超时后
+        // 把整段丢掉,一个比"不支持"难查得多的现象。
+        => throw new NotSupportedException("This host does not implement streaming remote execution.");
 }

--- a/plugin-sdk/VelaShell.PluginSdk/Rpc/PluginRpc.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/Rpc/PluginRpc.cs
@@ -27,6 +27,12 @@ public static class PluginRpc
     /// <summary>远程执行。</summary>
     public const string ExecRun = "exec/run";
 
+    /// <summary>远程流式执行(应答为退出码与行数,输出经 <see cref="ExecOutput" /> 通知回流)。</summary>
+    public const string ExecStream = "exec/stream";
+
+    /// <summary>流式执行的输出通知(宿主 → 插件,带 outputToken)。</summary>
+    public const string ExecOutput = "exec/output";
+
     /// <summary>远程文件:列目录。</summary>
     public const string FsList = "fs/list";
 
@@ -211,6 +217,31 @@ public sealed record SessionRef(string SessionId);
 
 /// <summary>远程执行参数。</summary>
 public sealed record ExecRunRequest(string SessionId, string Command, double TimeoutSeconds);
+
+/// <summary>远程流式执行参数。</summary>
+/// <param name="SessionId">会话 id。</param>
+/// <param name="Command">命令行。</param>
+/// <param name="OutputToken">输出通知令牌(宿主按它把行回流给正确的调用点)。</param>
+/// <param name="TimeoutSeconds">超时秒数;<c>0</c> 表示不限时(由插件侧取消驱动)。</param>
+/// <param name="IncludeStandardError">是否也回流标准错误。</param>
+public sealed record ExecStreamRequest(
+    string SessionId,
+    string Command,
+    string OutputToken,
+    double TimeoutSeconds,
+    bool IncludeStandardError);
+
+/// <summary>
+/// 流式执行的输出通知载荷。
+/// </summary>
+/// <param name="OutputToken">对应 <see cref="ExecStreamRequest.OutputToken" />。</param>
+/// <param name="IsStandardError">这一行是否来自标准错误。</param>
+/// <param name="Line">一行文本(不含行尾换行)。</param>
+/// <remarks>
+/// 一行一条通知。看起来很碎,但管道上跑的是长度前缀 + JSON 的轻量帧,而日志的价值
+/// 就在于即时 —— 攒批会让"跟随"变成"每秒抖一下"。真需要攒批的插件自己在回调里攒。
+/// </remarks>
+public sealed record ExecOutputNotification(string OutputToken, bool IsStandardError, string Line);
 
 /// <summary>远程文件通用参数(路径类)。</summary>
 public sealed record FsPathRequest(string SessionId, string Path);

--- a/plugin-sdk/VelaShell.PluginSdk/VelaPluginApi.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/VelaPluginApi.cs
@@ -10,4 +10,20 @@ public static class VelaPluginApi
 {
     /// <summary>当前 SDK 的 apiLevel 代际。</summary>
     public const int Level = 1;
+
+    /// <summary>
+    /// 当前 SDK 的语义版本(<c>主.次.修订</c>)。
+    /// <para>
+    /// apiLevel 只在**破坏性**变更时才动,所以它管不住"只增不改"的那一半:
+    /// SDK 1.1 给 <c>ExecResult</c> 加了标准错误与退出码、给远程执行加了流式形态,
+    /// apiLevel 仍然是 1。一个用了这些新面的插件装到只带 1.0 的老宿主上,清单校验会放行,
+    /// 然后在**运行期**炸出一个 <see cref="MissingMethodException" /> —— 那正是 apiLevel
+    /// 当初要消灭的那种"看不懂的绑定异常",只是它太粗,拦不住这一档。
+    /// </para>
+    /// <para>
+    /// 所以清单上多了一个 <c>minSdkVersion</c>:用到新面的插件声明它,老宿主在**发现期**
+    /// 就干净地标 Incompatible 并说清该升级什么。
+    /// </para>
+    /// </summary>
+    public const string SdkVersion = "1.1.0";
 }

--- a/src/VelaShell.Core/Ssh/ISshClientWrapper.cs
+++ b/src/VelaShell.Core/Ssh/ISshClientWrapper.cs
@@ -44,6 +44,37 @@ public interface ISshClientWrapper : IDisposable
     Task<string> RunCommandAsync(string commandText, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// 在远端主机上执行一次性命令,取回**标准输出、标准错误与退出码**。
+    /// <para>
+    /// 与 <see cref="RunCommandAsync" /> 的区别只在于不丢东西:后者为了调用点简单
+    /// 把标准错误与退出码都扔了,而任何要**如实报告失败**的调用方(插件的远程执行能力
+    /// 就是其一)都需要这两样 —— 没有它们,"命令失败了"和"命令没有输出"长得一模一样。
+    /// </para>
+    /// </summary>
+    /// <param name="commandText">命令行。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    /// <returns>标准输出、标准错误与退出码。</returns>
+    Task<RemoteCommandResult> RunCommandDetailedAsync(string commandText, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 在远端主机上执行命令,并**边跑边按行**回调输出;进程结束后返回退出码。
+    /// <para>
+    /// 用于长驻命令(<c>docker logs -f</c>、<c>tail -F</c>、<c>docker events</c>)。
+    /// 取消令牌触发时向远端进程发 <c>TERM</c> 再关闭通道,而不是干等它自己结束。
+    /// </para>
+    /// </summary>
+    /// <param name="commandText">命令行。</param>
+    /// <param name="includeStandardError">是否也回调标准错误。</param>
+    /// <param name="onLine">逐行回调(参数为「是否来自标准错误」与「行文本」);在 I/O 线程上调用,应快速返回。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    /// <returns>退出码与行数。</returns>
+    Task<RemoteCommandStreamResult> StreamCommandAsync(
+        string commandText,
+        bool includeStandardError,
+        Action<bool, string> onLine,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// 异步建立并启动一条端口转发;返回的句柄负责其停止与清理。
     /// 启动失败时抛出且不留下半挂的监听。
     /// </summary>

--- a/src/VelaShell.Core/Ssh/RemoteCommandResult.cs
+++ b/src/VelaShell.Core/Ssh/RemoteCommandResult.cs
@@ -1,0 +1,22 @@
+namespace VelaShell.Core.Ssh;
+
+/// <summary>
+/// 一次性远端命令的完整结果。
+/// <para>
+/// 库中立类型:<see cref="ISshClientWrapper" /> 的契约不暴露具体 SSH 库的进程类型,
+/// 换底层库时只要能填出这三样就行。
+/// </para>
+/// </summary>
+/// <param name="StandardOutput">标准输出(UTF-8 解码)。</param>
+/// <param name="StandardError">标准错误(UTF-8 解码)。</param>
+/// <param name="ExitCode">退出码。</param>
+public sealed record RemoteCommandResult(string StandardOutput, string StandardError, int ExitCode)
+{
+    /// <summary>退出码为 0。</summary>
+    public bool IsSuccess => ExitCode == 0;
+}
+
+/// <summary>流式远端命令的收尾结果。</summary>
+/// <param name="ExitCode">退出码。</param>
+/// <param name="Lines">总共回调了多少行。</param>
+public sealed record RemoteCommandStreamResult(int ExitCode, long Lines);

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteExecCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteExecCapability.cs
@@ -6,31 +6,83 @@ namespace VelaShell.Infrastructure.Plugins.Capabilities;
 
 /// <summary>
 /// <see cref="IRemoteExecApi" /> 的桥接实现:复用宿主既有连接,经独立 exec 通道执行
-/// (<see cref="ISshClientWrapper.RunCommandAsync" />),不进用户终端、不碰输入串行化队列。
+/// (<see cref="ISshClientWrapper.RunCommandDetailedAsync" />),不进用户终端、不碰输入串行化队列。
+/// <para>
+/// 实例是**按插件**创建的(见 <c>PluginContext</c>),因此
+/// <see cref="IRemoteExecApi.MaxConcurrentStreams" /> 这个并发上限天然就是按插件计的。
+/// </para>
 /// </summary>
 internal sealed class RemoteExecCapability(ISshConnectionService connections) : IRemoteExecApi
 {
     private static readonly TimeSpan MaxTimeout = TimeSpan.FromMinutes(10);
 
+    /// <summary>当前在飞的流式执行条数(每插件)。</summary>
+    private int _activeStreams;
+
     public async Task<ExecResult> RunAsync(string sessionId, string command, ExecOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(command);
-        if (!Guid.TryParse(sessionId, out Guid id) || connections.GetClient(id) is not { IsConnected: true } client)
-        {
-            throw new PluginSessionNotFoundException(sessionId);
-        }
+        ISshClientWrapper client = Resolve(sessionId);
         TimeSpan timeout = options?.Timeout is { } t && t > TimeSpan.Zero && t <= MaxTimeout ? t : TimeSpan.FromSeconds(30);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(timeout);
         try
         {
-            string output = await client.RunCommandAsync(command, cts.Token).ConfigureAwait(false);
-            return new(output);
+            RemoteCommandResult result = await client.RunCommandDetailedAsync(command, cts.Token).ConfigureAwait(false);
+            return new(result.StandardOutput)
+            {
+                Error = result.StandardError,
+                ExitCode = result.ExitCode
+            };
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             throw new TimeoutException($"Remote command timed out after {timeout.TotalSeconds:0}s: {command}");
         }
     }
+
+    public async Task<ExecStreamResult> StreamAsync(string sessionId, string command, ExecStreamOptions? options,
+        IProgress<ExecOutput> output, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(output);
+        ISshClientWrapper client = Resolve(sessionId);
+        // 先占坑再干活:流是不限时的,每条占一个 SSH 通道。忘了取消的插件不该有能力
+        // 把对端的 MaxSessions 耗光 —— 那时坏掉的是用户的连接,不只是这个插件。
+        if (Interlocked.Increment(ref _activeStreams) > IRemoteExecApi.MaxConcurrentStreams)
+        {
+            Interlocked.Decrement(ref _activeStreams);
+            throw new InvalidOperationException(
+                $"This plugin already has {IRemoteExecApi.MaxConcurrentStreams} streaming commands in flight; cancel one before starting another.");
+        }
+        bool includeStandardError = options?.IncludeStandardError ?? true;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (options?.Timeout is { } timeout && timeout > TimeSpan.Zero)
+        {
+            cts.CancelAfter(timeout);
+        }
+        try
+        {
+            RemoteCommandStreamResult result = await client.StreamCommandAsync(
+                command,
+                includeStandardError,
+                (isError, line) => output.Report(new(isError ? ExecStream.StandardError : ExecStream.StandardOutput, line)),
+                cts.Token).ConfigureAwait(false);
+            return new(result.ExitCode, result.Lines);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Streaming remote command timed out: {command}");
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _activeStreams);
+        }
+    }
+
+    private ISshClientWrapper Resolve(string sessionId) =>
+        Guid.TryParse(sessionId, out Guid id) && connections.GetClient(id) is { IsConnected: true } client
+            ? client
+            : throw new PluginSessionNotFoundException(sessionId);
 }

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.RemoteExec;
 using VelaShell.PluginSdk.RemoteFs;
 using VelaShell.PluginSdk.Rpc;
 
@@ -113,6 +114,27 @@ internal sealed class PluginCapabilityRouter : IDisposable
                     ExecRunRequest request = Get<ExecRunRequest>(payload);
                     return await _context.RemoteExec.RunAsync(request.SessionId, request.Command,
                         new() { Timeout = TimeSpan.FromSeconds(request.TimeoutSeconds) }, cancellationToken).ConfigureAwait(false);
+                }
+            case PluginRpc.ExecStream:
+                {
+                    ExecStreamRequest request = Get<ExecStreamRequest>(payload);
+                    // 输出逐行经通知回流(与 fs/progress 同一套 token 机制);应答只带退出码与行数,
+                    // 所以一条跑了一小时的 `docker logs -f` 不会在应答里堆出一个 GB 级的字符串。
+                    Progress<ExecOutput> sink = new(line =>
+                        _ = _rpc.NotifyAsync(PluginRpc.ExecOutput,
+                            new ExecOutputNotification(request.OutputToken, line.Stream is ExecStream.StandardError, line.Line)));
+                    return await _context.RemoteExec.StreamAsync(
+                        request.SessionId,
+                        request.Command,
+                        new()
+                        {
+                            // 取消令牌不跨进程传播(dev-guide §6),所以隔离插件的长驻命令
+                            // 必须靠这个死线收尾 —— 0 表示插件明确要求不限时。
+                            Timeout = request.TimeoutSeconds > 0 ? TimeSpan.FromSeconds(request.TimeoutSeconds) : null,
+                            IncludeStandardError = request.IncludeStandardError
+                        },
+                        sink,
+                        cancellationToken).ConfigureAwait(false);
                 }
             case PluginRpc.FsList:
                 {

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1219,6 +1219,15 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             descriptor.State = PluginState.Incompatible;
             descriptor.Error = $"Plugin requires host >= {minHost}, current host is {options.HostVersion}.";
         }
+        else if (manifest.MinSdkVersion is { } minSdk && IsOlder(VelaPluginApi.SdkVersion, minSdk))
+        {
+            // apiLevel 拦不住这一档:它只在**破坏性**变更时才动,而新增的接口方法 / DTO 字段
+            // 不算破坏性。不在这里拦,插件就会装上、激活、然后在第一次调用新方法时
+            // 抛一个 MissingMethodException —— 正是 apiLevel 当初要消灭的那种异常。
+            descriptor.State = PluginState.Incompatible;
+            descriptor.Error =
+                $"Plugin requires plugin SDK >= {minSdk}, this host ships {VelaPluginApi.SdkVersion}. Update VelaShell.";
+        }
         return descriptor;
     }
 
@@ -1262,7 +1271,18 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     }
 
     /// <summary>宿主版本是否低于要求(数字段比较,忽略预发布后缀;不可解析时不拦)。</summary>
-    private bool IsHostOlderThan(string minHostVersion)
+    private bool IsHostOlderThan(string minHostVersion) => IsOlder(options.HostVersion, minHostVersion);
+
+    /// <summary>
+    /// <paramref name="actual" /> 是否比 <paramref name="required" /> 老。
+    /// 预发布后缀被忽略(<c>1.1.0-beta</c> 视作 <c>1.1.0</c>):把 beta 判成"不够新"
+    /// 会让预览版宿主装不上为它写的插件,而那正是预览版存在的意义。
+    /// 任一侧解析不出版本号就放行 —— 拦下一个只是版本号写得怪的插件,损失大于收益。
+    /// </summary>
+    /// <param name="actual">实际版本。</param>
+    /// <param name="required">要求的最低版本。</param>
+    /// <returns>实际版本更老时为 true。</returns>
+    private static bool IsOlder(string actual, string required)
     {
         static Version? ParseNumeric(string v)
         {
@@ -1273,7 +1293,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             }
             return Version.TryParse(numeric, out Version? parsed) ? parsed : null;
         }
-        return ParseNumeric(options.HostVersion) is { } host && ParseNumeric(minHostVersion) is { } min && host < min;
+        return ParseNumeric(actual) is { } left && ParseNumeric(required) is { } right && left < right;
     }
 
     private async Task ActivateAsync(PluginRuntime runtime, CancellationToken cancellationToken)

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
@@ -242,6 +242,105 @@ public sealed class TmdsSshClientWrapper : ISshClientWrapper
         }
     }
 
+    /// <inheritdoc />
+    public async Task<RemoteCommandResult> RunCommandDetailedAsync(string commandText, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+        try
+        {
+            using RemoteProcess process = await _client
+                .ExecuteAsync(commandText, cancellationToken)
+                .ConfigureAwait(false);
+
+            // 两条流分别读进内存。Tmds 的 ReadToEndAsStringAsync(readStdout, readStderr, ct)
+            // 一次调用同时收两条并各自返回,不会因为一条读空了就把另一条堵住 ——
+            // 自己分两次读才是那个经典的死锁:对端在 stderr 上写满了缓冲区等你读,
+            // 而你在 stdout 上等它写完。
+            (string? standardOutput, string? standardError) = await process
+                .ReadToEndAsStringAsync(readStdout: true, readStderr: true, cancellationToken)
+                .ConfigureAwait(false);
+            int exitCode = await process.GetExitCodeAsync(cancellationToken).ConfigureAwait(false);
+            return new(standardOutput ?? string.Empty, standardError ?? string.Empty, exitCode);
+        }
+        catch (Exception ex) when (ex is SshConnectionException && IsTornDown())
+        {
+            throw new ObjectDisposedException(nameof(TmdsSshClientWrapper), ex);
+        }
+        catch (Exception ex) when (TmdsSshInterop.Translate(ex, cancellationToken) is { } translated)
+        {
+            throw translated;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<RemoteCommandStreamResult> StreamCommandAsync(
+        string commandText,
+        bool includeStandardError,
+        Action<bool, string> onLine,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(onLine);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+        RemoteProcess? process = null;
+        try
+        {
+            process = await _client.ExecuteAsync(commandText, cancellationToken).ConfigureAwait(false);
+            long lines = 0;
+            while (true)
+            {
+                (bool isError, string? line) = await process
+                    .ReadLineAsync(readStdout: true, readStderr: includeStandardError, cancellationToken)
+                    .ConfigureAwait(false);
+                // line == null 表示进程已退出且输出读完 —— 这是**唯一**的正常收尾条件。
+                if (line is null)
+                {
+                    break;
+                }
+                lines++;
+                onLine(isError, line);
+            }
+            int exitCode = await process.GetExitCodeAsync(cancellationToken).ConfigureAwait(false);
+            return new(exitCode, lines);
+        }
+        catch (OperationCanceledException)
+        {
+            // 取消长驻命令时先给远端进程一个 TERM。只 Dispose 通道的话,`docker logs -f`
+            // 那一端要等到写管道被拒才知道该退出 —— 在没有新日志的空闲期,那可能是"永远"。
+            TrySendTerm(process);
+            throw;
+        }
+        catch (Exception ex) when (ex is SshConnectionException && IsTornDown())
+        {
+            throw new ObjectDisposedException(nameof(TmdsSshClientWrapper), ex);
+        }
+        catch (Exception ex) when (TmdsSshInterop.Translate(ex, cancellationToken) is { } translated)
+        {
+            throw translated;
+        }
+        finally
+        {
+            process?.Dispose();
+        }
+    }
+
+    private static void TrySendTerm(RemoteProcess? process)
+    {
+        if (process is null)
+        {
+            return;
+        }
+        try
+        {
+            process.SendSignal("TERM");
+        }
+        catch (Exception)
+        {
+            // 通道可能已经塌了 —— 这只是尽力而为的礼貌收尾,失败不该盖住原来的取消异常。
+        }
+    }
+
     /// <summary>
     /// 在当前连接上异步启动端口转发,返回 <see cref="IPortForwardHandle" />。Tmds.Ssh 的 ForwardToRemoteAsync 只支持远程转发,本地转发被忽略。
     /// </summary>

--- a/src/VelaShell.PluginHost/Program.cs
+++ b/src/VelaShell.PluginHost/Program.cs
@@ -170,6 +170,9 @@ internal static class Program
             case PluginRpc.FsProgress when Deserialize<FsProgressNotification>(payload) is { } progress:
                 context.RemoteFsProxy.OnProgress(progress);
                 break;
+            case PluginRpc.ExecOutput when Deserialize<ExecOutputNotification>(payload) is { } line:
+                context.RemoteExecProxy.OnOutput(line);
+                break;
         }
     }
 

--- a/src/VelaShell.PluginHost/RemoteCapabilities.cs
+++ b/src/VelaShell.PluginHost/RemoteCapabilities.cs
@@ -49,6 +49,21 @@ internal sealed class RpcSessions(RpcConnection rpc) : ISessionsApi
 /// <summary>远程执行能力的 RPC 代理(超时随选项放宽,留 15s 往返余量)。</summary>
 internal sealed class RpcRemoteExec(RpcConnection rpc) : IRemoteExecApi
 {
+    /// <summary>隔离模式下长驻命令的兜底死线。见 <see cref="StreamAsync" /> 的说明。</summary>
+    private static readonly TimeSpan DefaultStreamTimeout = TimeSpan.FromHours(2);
+
+    /// <summary>在途流式执行的输出接收器(outputToken → 回调)。</summary>
+    internal ConcurrentDictionary<string, IProgress<ExecOutput>> OutputSinks { get; } = new();
+
+    /// <summary>宿主输出通知入口。</summary>
+    internal void OnOutput(ExecOutputNotification notification)
+    {
+        if (OutputSinks.TryGetValue(notification.OutputToken, out IProgress<ExecOutput>? sink))
+        {
+            sink.Report(new(notification.IsStandardError ? ExecStream.StandardError : ExecStream.StandardOutput, notification.Line));
+        }
+    }
+
     public async Task<ExecResult> RunAsync(string sessionId, string command, ExecOptions? options = null,
         CancellationToken cancellationToken = default)
     {
@@ -57,6 +72,36 @@ internal sealed class RpcRemoteExec(RpcConnection rpc) : IRemoteExecApi
                    new ExecRunRequest(sessionId, command, execTimeout.TotalSeconds),
                    execTimeout + TimeSpan.FromSeconds(15), cancellationToken).ConfigureAwait(false)
                ?? new("");
+    }
+
+    /// <summary>
+    /// 流式执行的 RPC 代理。
+    /// <para>
+    /// **隔离模式下"不限时"是做不到的**:取消令牌不跨进程传播(dev-guide §6),
+    /// 插件这边取消了,宿主那边的 <c>docker logs -f</c> 不会知道。所以这里给未指定超时的
+    /// 流补上一个两小时的死线 —— 让"忘了取消"最坏也只是浪费两小时一个通道,
+    /// 而不是把它泄漏到宿主退出为止。要真正即时的取消,请用 <c>inProcess</c>。
+    /// </para>
+    /// </summary>
+    public async Task<ExecStreamResult> StreamAsync(string sessionId, string command, ExecStreamOptions? options,
+        IProgress<ExecOutput> output, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        TimeSpan deadline = options?.Timeout is { } t && t > TimeSpan.Zero ? t : DefaultStreamTimeout;
+        string token = Guid.NewGuid().ToString("n");
+        OutputSinks[token] = output;
+        try
+        {
+            return await rpc.RequestAsync<ExecStreamResult>(PluginRpc.ExecStream,
+                       new ExecStreamRequest(sessionId, command, token, deadline.TotalSeconds,
+                           options?.IncludeStandardError ?? true),
+                       deadline + TimeSpan.FromSeconds(15), cancellationToken).ConfigureAwait(false)
+                   ?? new(0, 0);
+        }
+        finally
+        {
+            OutputSinks.TryRemove(token, out _);
+        }
     }
 }
 

--- a/src/VelaShell.PluginHost/RemotePluginContext.cs
+++ b/src/VelaShell.PluginHost/RemotePluginContext.cs
@@ -35,7 +35,9 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
         TimeSeries = new RpcTimeSeries(rpc);
         Sessions = new RpcSessions(rpc);
         RemoteFsProxy = new(rpc);
-        RemoteExec = new RpcRemoteExec(rpc);
+        // 保留具体类型的引用:流式执行的输出经通知回流,Program 要按 token 路由到它。
+        RemoteExecProxy = new(rpc);
+        RemoteExec = RemoteExecProxy;
         CommandsProxy = new(rpc, Log);
         EventsHub = new(Log);
         UiLocal = new(pluginId, Log, rpc);
@@ -122,6 +124,9 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
 
     /// <inheritdoc cref="HostInfo" />
     internal RpcRemoteFs RemoteFsProxy { get; }
+
+    /// <inheritdoc cref="HostInfo" />
+    internal RpcRemoteExec RemoteExecProxy { get; }
 
     /// <inheritdoc cref="HostInfo" />
     internal RpcCommands CommandsProxy { get; }

--- a/templates/content/velaplugin-ui/.template.config/template.json
+++ b/templates/content/velaplugin-ui/.template.config/template.json
@@ -49,7 +49,7 @@
     "sdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.0.1",
+      "defaultValue": "1.1.0",
       "replaces": "SDK_VERSION",
       "description": "Version of the VelaShell.PluginSdk.Build package to reference."
     },

--- a/templates/content/velaplugin/.template.config/template.json
+++ b/templates/content/velaplugin/.template.config/template.json
@@ -49,7 +49,7 @@
     "sdkVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.0.1",
+      "defaultValue": "1.1.0",
       "replaces": "SDK_VERSION",
       "description": "Version of the VelaShell.PluginSdk.Build package to reference."
     },

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginManagerTests.cs
@@ -1,3 +1,4 @@
+using VelaShell.PluginSdk;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.Plugin.HelloWorld;
 
@@ -56,13 +57,18 @@ public class PluginManagerTests
         File.WriteAllText(Path.Combine(_root, "disabled", ".disabled"), "");
         AddPlugin("future", """{ "id": "a.future", "version": "1.0.0", "displayName": "F", "entry": "F.dll", "apiLevel": 99 }""");
         AddPlugin("needs-newer-host", """{ "id": "a.newer", "version": "1.0.0", "displayName": "N", "entry": "N.dll", "minHostVersion": "9.9.9" }""");
+        // apiLevel 只在**破坏性**变更时才动,所以"我用到了 SDK 1.1 新增的接口方法"没法用它表达。
+        // 不拦的话插件会装上、激活,然后在第一次调用新方法时抛 MissingMethodException ——
+        // 正是 apiLevel 当初要消灭的那种异常。
+        AddPlugin("needs-newer-sdk", """{ "id": "a.newsdk", "version": "1.0.0", "displayName": "S", "entry": "S.dll", "minSdkVersion": "9.9.9" }""");
+        AddPlugin("sdk-satisfied", $$"""{ "id": "a.sdkok", "version": "1.0.0", "displayName": "S2", "entry": "S2.dll", "minSdkVersion": "{{VelaPluginApi.SdkVersion}}" }""");
         Directory.CreateDirectory(Path.Combine(_root, "no-manifest")); // 无 plugin.json:直接忽略
 
         var manager = new PluginManager(Options());
         manager.Discover();
         var byId = manager.Plugins.ToDictionary(p => p.Id);
 
-        Assert.HasCount(5, byId);
+        Assert.HasCount(7, byId);
         Assert.AreEqual(PluginState.Discovered, byId["a.ok"].State);
         Assert.AreEqual(PluginState.Invalid, byId["bad-json"].State);
         Assert.IsNotNull(byId["bad-json"].Error);
@@ -71,6 +77,10 @@ public class PluginManagerTests
         Assert.Contains("apiLevel", byId["a.future"].Error);
         Assert.AreEqual(PluginState.Incompatible, byId["a.newer"].State);
         Assert.Contains("9.9.9", byId["a.newer"].Error);
+        Assert.AreEqual(PluginState.Incompatible, byId["a.newsdk"].State);
+        Assert.Contains("SDK", byId["a.newsdk"].Error);
+        // 要求的正是本宿主带的这一版 —— 必须放行,不能把"等于"判成"更老"。
+        Assert.AreEqual(PluginState.Discovered, byId["a.sdkok"].State);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteExecCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteExecCapabilityTests.cs
@@ -1,0 +1,244 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Plugins.Capabilities;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.RemoteExec;
+
+namespace VelaShell.Infrastructure.Tests.Plugins;
+
+/// <summary>
+/// 插件远程执行能力。这一层的契约在 SDK 1.1 才补全(标准错误 + 退出码 + 流式),
+/// 而它决定了插件能不能**如实**报告一条失败的命令 —— 在此之前
+/// "命令失败了"和"命令没有输出"在插件看来完全一样。
+/// </summary>
+[TestClass]
+[TestCategory("Plugins")]
+public class RemoteExecCapabilityTests
+{
+    private static (RemoteExecCapability Capability, ISshClientWrapper Client, string SessionId) NewCapability()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(true);
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        return (new(connections), client, sessionId.ToString());
+    }
+
+    [TestMethod]
+    public async Task RunAsync_CarriesStandardErrorAndExitCodeThrough()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.RunCommandDetailedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(new RemoteCommandResult("", "Error response from daemon: no such container", 1));
+
+        ExecResult result = await capability.RunAsync(sessionId, "docker stop nope");
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(1, result.ExitCode);
+        StringAssert.Contains(result.Error, "no such container");
+        // 标准错误**不并进**标准输出:解析 --format json 的插件会被一行警告噎死。
+        Assert.AreEqual("", result.Output);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_DoesNotThrowOnNonZeroExit()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.RunCommandDetailedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(new RemoteCommandResult("", "boom", 42));
+
+        // 命令跑失败是一种正常结果,不是异常事件 —— 抛出去会逼每个调用点包 try/catch。
+        ExecResult result = await capability.RunAsync(sessionId, "false");
+        Assert.AreEqual(42, result.ExitCode);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_ThrowsSessionNotFoundForUnknownSession()
+    {
+        (RemoteExecCapability capability, _, _) = NewCapability();
+        await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
+            () => capability.RunAsync(Guid.NewGuid().ToString(), "docker ps"));
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_ReportsEachLineWithItsStreamInOrder()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(call =>
+              {
+                  Action<bool, string> onLine = call.Arg<Action<bool, string>>();
+                  onLine(false, "first");
+                  onLine(true, "a warning");
+                  onLine(false, "second");
+                  return Task.FromResult(new RemoteCommandStreamResult(0, 3));
+              });
+
+        SyncProgress<ExecOutput> lines = new();
+        ExecStreamResult result = await capability.StreamAsync(sessionId, "docker logs -f web", null, lines);
+
+        // **行序是契约的一部分**,而它成立的前提是接收器同步转发:宿主就在读行的那个线程上
+        // 顺序调 Report。换成 System.Progress<T> 就会 Post 到线程池,顺序当场没了 ——
+        // 所以这个测试刻意不用它,SDK 的文档里也写明了别用。
+        Assert.AreEqual(3, result.Lines);
+        CollectionAssert.AreEqual(
+            (string[])["first", "a warning", "second"],
+            lines.Items.Select(static l => l.Line).ToArray());
+        Assert.AreEqual(ExecStream.StandardOutput, lines.Items[0].Stream);
+        Assert.AreEqual(ExecStream.StandardError, lines.Items[1].Stream);
+        Assert.AreEqual(ExecStream.StandardOutput, lines.Items[2].Stream);
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_PassesTheStandardErrorPreferenceDown()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult(new RemoteCommandStreamResult(0, 0)));
+
+        await capability.StreamAsync(sessionId, "docker events", new() { IncludeStandardError = false },
+            new SyncProgress<ExecOutput>());
+
+        await client.Received(1).StreamCommandAsync(
+            "docker events", false, Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_RefusesMoreThanTheConcurrencyCap()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        // 挂在**调用方给的**令牌上,而不是测试自己的:那才是真实形态
+        // (`docker logs -f` 一直跑,直到面板关掉、插件取消它)。
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(async call =>
+              {
+                  await Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>()).ConfigureAwait(false);
+                  return new RemoteCommandStreamResult(0, 0);
+              });
+
+        using CancellationTokenSource release = new();
+        List<Task> inFlight = [];
+        for (int i = 0; i < IRemoteExecApi.MaxConcurrentStreams; i++)
+        {
+            inFlight.Add(capability.StreamAsync(sessionId, $"tail -F /var/log/{i}", null, new SyncProgress<ExecOutput>(), release.Token));
+        }
+        await WaitForAsync(() => client.ReceivedCalls().Count(c => c.GetMethodInfo().Name == nameof(ISshClientWrapper.StreamCommandAsync))
+                                 == IRemoteExecApi.MaxConcurrentStreams);
+
+        // 流是不限时的,每条占一个 SSH 通道。没有上限的话,一个忘了取消的插件
+        // 能把对端的 MaxSessions 耗光 —— 坏掉的是用户的连接,不只是这个插件。
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => capability.StreamAsync(sessionId, "one too many", null, new SyncProgress<ExecOutput>()));
+
+        await release.CancelAsync();
+        foreach (Task task in inFlight)
+        {
+            await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => task);
+        }
+
+        // 名额在收尾时归还:取消掉那几条之后应该又能开新的。
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult(new RemoteCommandStreamResult(0, 0)));
+        ExecStreamResult after = await capability.StreamAsync(sessionId, "docker events", null, new SyncProgress<ExecOutput>());
+        Assert.AreEqual(0, after.ExitCode);
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_TranslatesItsOwnDeadlineIntoTimeout()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(async call =>
+              {
+                  await Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>()).ConfigureAwait(false);
+                  return new RemoteCommandStreamResult(0, 0);
+              });
+
+        // 超时是"我给的死线到了",取消是"调用方不要了" —— 两者对调用方的意义不同,
+        // 不该都表现成 OperationCanceledException。
+        await Assert.ThrowsExactlyAsync<TimeoutException>(
+            () => capability.StreamAsync(sessionId, "tail -F /var/log/syslog",
+                new() { Timeout = TimeSpan.FromMilliseconds(80) }, new SyncProgress<ExecOutput>()));
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_PropagatesCallerCancellationAsCancellation()
+    {
+        (RemoteExecCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.StreamCommandAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Action<bool, string>>(), Arg.Any<CancellationToken>())
+              .Returns(async call =>
+              {
+                  await Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>()).ConfigureAwait(false);
+                  return new RemoteCommandStreamResult(0, 0);
+              });
+        using CancellationTokenSource cts = new();
+        Task streaming = capability.StreamAsync(sessionId, "docker logs -f web", null, new SyncProgress<ExecOutput>(), cts.Token);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => streaming);
+    }
+
+    [TestMethod]
+    public async Task StreamAsync_ThrowsSessionNotFoundForUnknownSession()
+    {
+        (RemoteExecCapability capability, _, _) = NewCapability();
+        await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
+            () => capability.StreamAsync(Guid.NewGuid().ToString(), "docker events", null, new SyncProgress<ExecOutput>()));
+    }
+
+    [TestMethod]
+    public void ExecResult_FailureTextPrefersStandardError()
+    {
+        ExecResult failed = new("some stdout noise") { Error = "Error: no such volume\ndetails", ExitCode = 1 };
+        Assert.AreEqual("Error: no such volume", failed.FailureText);
+
+        ExecResult quiet = new("") { Error = "", ExitCode = 7 };
+        Assert.AreEqual("exit 7", quiet.FailureText);
+    }
+
+    /// <summary>
+    /// 同步转发的 <see cref="IProgress{T}" />:<see cref="Report" /> 就在调用线程上执行。
+    /// <para>
+    /// 这正是 SDK 要求插件使用的形态 —— <see cref="Progress{T}" /> 会把回调 Post 出去,
+    /// 顺序与线程都不再保证,而日志流的顺序是它全部的意义。
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">回调载荷类型。</typeparam>
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly List<T> _items = [];
+
+        /// <summary>已收到的载荷(按到达顺序)。</summary>
+        public IReadOnlyList<T> Items
+        {
+            get
+            {
+                lock (_items)
+                {
+                    return [.. _items];
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Report(T value)
+        {
+            lock (_items)
+            {
+                _items.Add(value);
+            }
+        }
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        long deadline = Environment.TickCount64 + timeoutMs;
+        while (!condition() && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+        Assert.IsTrue(condition(), "condition was not met before the timeout");
+    }
+}


### PR DESCRIPTION
本次升级包括：
- 远程执行接口支持标准错误、退出码及流式执行，日志顺序保证，适配长驻命令。
- 插件清单新增 minSdkVersion 字段，提升契约校验与兼容性，防止运行期异常。
- FakeRemoteExec 支持完整模拟，便于插件测试失败与日志流场景。
- 宿主实现流式执行并发上限，防止资源耗尽。
- SSH 封装扩展，支持详细与流式命令执行。
- 插件与宿主间新增流式执行相关 RPC 消息，支持逐行通知、超时与取消。
- 文档与模板同步更新，详细说明新能力及注意事项。
- 补充单元测试，覆盖新能力相关场景，确保契约正确实现。