### PR TITLE
插件 SDK 新增远程隧道能力，支持二进制流

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <!-- 插件 SDK 系列包(VelaShell.PluginSdk / .Testing / .Build、VelaShell.Plugin.Cli、
          VelaShell.Plugin.Templates)的版本。**与宿主版本解耦**:宿主发 1.2.3 不代表插件
          契约变了,插件作者也不该为了跟版本号而重新编译。CI 发包时用 -p:VelaSdkVersion= 覆盖。 -->
-    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.1.0</VelaSdkVersion>
+    <VelaSdkVersion Condition="'$(VelaSdkVersion)' == ''">1.2.0</VelaSdkVersion>
     <!-- 去掉预发布后缀的数字版(AssemblyVersion/FileVersion 不接受后缀)与主版本号。 -->
     <VelaSdkVersionCore>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersion), '-.*$', ''))</VelaSdkVersionCore>
     <VelaSdkMajor>$([System.Text.RegularExpressions.Regex]::Replace($(VelaSdkVersionCore), '\..*$', ''))</VelaSdkMajor>

--- a/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteTunnel.cs
+++ b/plugin-sdk/VelaShell.PluginSdk.Testing/FakeRemoteTunnel.cs
@@ -1,0 +1,202 @@
+using VelaShell.PluginSdk.RemoteTunnel;
+
+namespace VelaShell.PluginSdk.Testing;
+
+/// <summary>
+/// <see cref="IRemoteTunnelApi" /> 的测试替身:优先走 <see cref="Handler" />,
+/// 其次按顺序吐出 <see cref="Responses" /> 队列;都没有时抛
+/// <see cref="InvalidOperationException" />。
+/// <para>
+/// 刻意**不**在没有脚本时返回一条空流:空流对 <c>HttpClient</c> 而言是"对端立刻断开",
+/// 测试看到的会是一个和被测逻辑无关的 <c>HttpRequestException</c>,
+/// 而不是"你忘了给这条隧道写应答"。
+/// </para>
+/// </summary>
+public sealed class FakeRemoteTunnel : IRemoteTunnelApi
+{
+    private int _active;
+
+    /// <summary>脚本化应答:(sessionId, endpoint) → 双工流。endpoint 形如 <c>unix:/var/run/docker.sock</c> 或 <c>tcp:host:2375</c>。</summary>
+    public Func<string, string, Stream>? Handler { get; set; }
+
+    /// <summary>顺序应答队列(无 <see cref="Handler" /> 时使用)。</summary>
+    public Queue<Stream> Responses { get; } = new();
+
+    /// <summary>全部已打开的 (sessionId, endpoint) 记录。</summary>
+    public List<(string SessionId, string Endpoint)> Opened { get; } = [];
+
+    /// <inheritdoc />
+    public int ActiveTunnels => Volatile.Read(ref _active);
+
+    /// <inheritdoc />
+    public Task<Stream> OpenUnixSocketAsync(string sessionId, string socketPath, TunnelOptions? options = null,
+        CancellationToken cancellationToken = default) => OpenAsync(sessionId, $"unix:{socketPath}");
+
+    /// <inheritdoc />
+    public Task<Stream> OpenTcpAsync(string sessionId, string host, int port, TunnelOptions? options = null,
+        CancellationToken cancellationToken = default) => OpenAsync(sessionId, $"tcp:{host}:{port}");
+
+    private Task<Stream> OpenAsync(string sessionId, string endpoint)
+    {
+        Opened.Add((sessionId, endpoint));
+        Stream inner = Handler?.Invoke(sessionId, endpoint)
+                       ?? (Responses.Count > 0
+                           ? Responses.Dequeue()
+                           : throw new InvalidOperationException(
+                               $"FakeRemoteTunnel has no scripted response for '{endpoint}'. Set Handler or enqueue Responses."));
+        Interlocked.Increment(ref _active);
+        return Task.FromResult<Stream>(new TrackedStream(inner, () => Interlocked.Decrement(ref _active)));
+    }
+
+    /// <summary>
+    /// 造一条"读出固定字节、把写入的字节记下来"的双工流,用于把测试当成一个假 daemon。
+    /// </summary>
+    /// <param name="responseBytes">被测代码读到的字节(读完即 EOF)。</param>
+    public static ScriptedTunnelStream Script(byte[] responseBytes) => new(responseBytes);
+
+    private sealed class TrackedStream(Stream inner, Action onDisposed) : DelegatingStream(inner)
+    {
+        private int _disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                try { base.Dispose(disposing); }
+                finally { onDisposed(); }
+                return;
+            }
+            base.Dispose(disposing);
+        }
+    }
+}
+
+/// <summary>
+/// 一条脚本化的双工流:读出预置字节,写入的内容累积在 <see cref="Written" />。
+/// </summary>
+public sealed class ScriptedTunnelStream(byte[] responseBytes) : Stream
+{
+    private readonly MemoryStream _read = new(responseBytes, writable: false);
+    private readonly MemoryStream _written = new();
+
+    /// <summary>被测代码写进这条隧道的全部字节(即"发给 daemon 的请求")。</summary>
+    public byte[] Written => _written.ToArray();
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => true;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+    }
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => _read.Read(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override int Read(Span<byte> buffer) => _read.Read(buffer);
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => _written.Write(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override void Write(ReadOnlySpan<byte> buffer) => _written.Write(buffer);
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+}
+
+/// <summary>把一切转发给内层流的基类(测试替身用)。</summary>
+public abstract class DelegatingStream(Stream inner) : Stream
+{
+    /// <summary>内层流。</summary>
+    protected Stream Inner { get; } = inner;
+
+    /// <inheritdoc />
+    public override bool CanRead => Inner.CanRead;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => Inner.CanWrite;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override void Flush() => Inner.Flush();
+
+    /// <inheritdoc />
+    public override Task FlushAsync(CancellationToken cancellationToken) => Inner.FlushAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => Inner.Read(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override int Read(Span<byte> buffer) => Inner.Read(buffer);
+
+    /// <inheritdoc />
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => Inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    /// <inheritdoc />
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => Inner.ReadAsync(buffer, cancellationToken);
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => Inner.Write(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override void Write(ReadOnlySpan<byte> buffer) => Inner.Write(buffer);
+
+    /// <inheritdoc />
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => Inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+    /// <inheritdoc />
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        => Inner.WriteAsync(buffer, cancellationToken);
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Inner.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/plugin-sdk/VelaShell.PluginSdk.Testing/TestPluginContext.cs
+++ b/plugin-sdk/VelaShell.PluginSdk.Testing/TestPluginContext.cs
@@ -5,6 +5,7 @@ using VelaShell.PluginSdk.Logging;
 using VelaShell.PluginSdk.Protocols;
 using VelaShell.PluginSdk.RemoteExec;
 using VelaShell.PluginSdk.RemoteFs;
+using VelaShell.PluginSdk.RemoteTunnel;
 using VelaShell.PluginSdk.Secrets;
 using VelaShell.PluginSdk.Sessions;
 using VelaShell.PluginSdk.Storage;
@@ -62,6 +63,9 @@ public sealed class TestPluginContext : IPluginContext, IDisposable
 
     /// <summary>默认远程执行替身。</summary>
     public FakeRemoteExec FakeRemoteExec { get; } = new();
+
+    /// <summary>默认远程隧道替身。</summary>
+    public FakeRemoteTunnel FakeRemoteTunnel { get; } = new();
 
     /// <summary>默认命令替身。</summary>
     public RecordingCommands RecordingCommands { get; } = new();
@@ -142,6 +146,9 @@ public sealed class TestPluginContext : IPluginContext, IDisposable
     /// <inheritdoc cref="IPluginContext.RemoteExec" />
     public IRemoteExecApi RemoteExec { get; init; }
 
+    /// <inheritdoc cref="IPluginContext.RemoteTunnel" />
+    public IRemoteTunnelApi RemoteTunnel { get; init; }
+
     /// <inheritdoc cref="IPluginContext.Commands" />
     public ICommandsApi Commands { get; init; }
 
@@ -178,6 +185,7 @@ public sealed class TestPluginContext : IPluginContext, IDisposable
         Sessions = FakeSessions;
         RemoteFs = FakeRemoteFs;
         RemoteExec = FakeRemoteExec;
+        RemoteTunnel = FakeRemoteTunnel;
         Commands = RecordingCommands;
         Events = HostEvents;
         Ui = FakeUi;

--- a/plugin-sdk/VelaShell.PluginSdk/IPluginContext.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/IPluginContext.cs
@@ -5,6 +5,7 @@ using VelaShell.PluginSdk.Logging;
 using VelaShell.PluginSdk.Protocols;
 using VelaShell.PluginSdk.RemoteExec;
 using VelaShell.PluginSdk.RemoteFs;
+using VelaShell.PluginSdk.RemoteTunnel;
 using VelaShell.PluginSdk.Secrets;
 using VelaShell.PluginSdk.Sessions;
 using VelaShell.PluginSdk.Storage;
@@ -54,6 +55,13 @@ public interface IPluginContext
 
     /// <summary>远程执行能力:在既有会话上执行一次性命令(独立通道,不进用户终端)。</summary>
     IRemoteExecApi RemoteExec { get; }
+
+    /// <summary>
+    /// 远程隧道能力:在既有会话上开一条到远端 unix socket / TCP 端点的**裸字节双工流**。
+    /// 用于承载文本行模型装不下的协议(Docker Engine API 的分块传输与 tar 流等)。
+    /// 仅 <c>inProcess</c> 宿主模式可用,见 <see cref="IRemoteTunnelApi" />。
+    /// </summary>
+    IRemoteTunnelApi RemoteTunnel { get; }
 
     /// <summary>命令能力:向命令面板/菜单注册命令,或执行宿主命令。</summary>
     ICommandsApi Commands { get; }

--- a/plugin-sdk/VelaShell.PluginSdk/RemoteTunnel/IRemoteTunnelApi.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/RemoteTunnel/IRemoteTunnelApi.cs
@@ -1,0 +1,95 @@
+namespace VelaShell.PluginSdk.RemoteTunnel;
+
+/// <summary>打开一条隧道的选项。</summary>
+public sealed record TunnelOptions
+{
+    /// <summary>
+    /// 建立通道的超时,默认 15 秒,上限 2 分钟(宿主强制夹取)。
+    /// <para>
+    /// 只管**建立**:通道一旦建成,读写就由调用方的取消令牌与远端决定,不再有死线 ——
+    /// 隧道的正常形态是 <c>docker events</c> 这种挂着不动的长连接,给它一个总时限
+    /// 只会让界面在第 N 分钟莫名其妙地断流。
+    /// </para>
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(15);
+}
+
+/// <summary>
+/// 远程隧道能力:在既有 SSH 会话上开一条到远端 <b>unix socket</b> 或 <b>TCP 端口</b> 的
+/// 双工字节流(SSH 的 <c>direct-streamlocal@openssh.com</c> / <c>direct-tcpip</c> 通道)。
+/// 会话无效时抛 <see cref="PluginSessionNotFoundException" />。
+/// <para>
+/// <b>为什么不能用 <see cref="RemoteExec.IRemoteExecApi" /> 凑合。</b>
+/// 远程执行的两种形态都是**文本**:<c>RunAsync</c> 把整个输出 UTF-8 解码成一个字符串,
+/// <c>StreamAsync</c> 按 <c>\n</c> 切行回调。而这条隧道要承载的东西 —— Docker Engine API 的
+/// 分块传输、<c>/containers/{id}/archive</c> 的 tar 流、<c>/exec</c> 的 8 字节多路复用帧 ——
+/// 全是二进制:UTF-8 解码会把非法字节换成 U+FFFD(不可逆),按行切分会在 <c>0x0A</c>
+/// 处把一帧劈成两半。凑合的结果不是"慢一点",是**数据静默损坏**。
+/// </para>
+/// <para>
+/// <b>为什么不用本地端口转发。</b> 宿主确实有 <c>StartPortForwardAsync</c>,但它在**本机**
+/// 开一个监听端口 —— 那意味着同机的任何进程都能连上去,而隧道对面是一个 root 等价的
+/// Docker socket。这条 API 只把流交给发起调用的插件,不在本机留下任何可被别人连上的入口。
+/// </para>
+/// <para>
+/// 仅 <c>inProcess</c> 宿主模式可用:返回的是一个活的 <see cref="Stream" />,
+/// 跨进程代理一条裸流除了把每个字节多搬一次之外没有别的效果。隔离进程里调用抛
+/// <see cref="NotSupportedException" />。
+/// </para>
+/// </summary>
+public interface IRemoteTunnelApi
+{
+    /// <summary>
+    /// 同时在飞的隧道上限(每插件)。超过时抛 <see cref="InvalidOperationException" />。
+    /// </summary>
+    /// <remarks>
+    /// 隧道是不限时的,每条占一个 SSH 通道。一个 Docker 面板正常也就是"列表连接池 2~3 条
+    /// + 事件流 1 条 + 每个跟随中的日志/统计各 1 条",16 足够宽松;
+    /// 而没有上限的话,一个漏掉 <c>Dispose</c> 的插件能把对端的通道数吃干净 ——
+    /// 那时坏掉的不是插件,是用户的连接。
+    /// </remarks>
+    public const int MaxConcurrentTunnels = 16;
+
+    /// <summary>当前该插件已打开、尚未释放的隧道条数。</summary>
+    int ActiveTunnels { get; }
+
+    /// <summary>
+    /// 打开一条到远端 unix 域套接字的双工字节流。
+    /// <para>
+    /// 返回的 <see cref="Stream" /> 是**可读可写**的;<see cref="Stream.Dispose()" />
+    /// 关闭 SSH 通道并归还配额 —— 调用方**必须**释放它。
+    /// </para>
+    /// </summary>
+    /// <param name="sessionId">会话 id。</param>
+    /// <param name="socketPath">远端 socket 的绝对路径,如 <c>/var/run/docker.sock</c>。</param>
+    /// <param name="options">选项;为 null 用默认值。</param>
+    /// <param name="cancellationToken">取消令牌(只作用于**建立**阶段)。</param>
+    /// <returns>双工字节流。</returns>
+    /// <exception cref="NotSupportedException">宿主实现不支持隧道(隔离进程模式)时。</exception>
+    Task<Stream> OpenUnixSocketAsync(
+        string sessionId,
+        string socketPath,
+        TunnelOptions? options = null,
+        CancellationToken cancellationToken = default)
+        // 默认实现只为**源兼容**:第三方的测试替身在 SDK 加了这个能力之后仍然能编译。
+        => throw new NotSupportedException("This host does not implement remote tunnels.");
+
+    /// <summary>
+    /// 打开一条到远端 TCP 端点的双工字节流(从**远端主机**的角度解析地址,
+    /// 因此 <c>localhost</c> 指的是远端的环回)。
+    /// </summary>
+    /// <param name="sessionId">会话 id。</param>
+    /// <param name="host">远端可解析的主机名或 IP。</param>
+    /// <param name="port">端口。</param>
+    /// <param name="options">选项;为 null 用默认值。</param>
+    /// <param name="cancellationToken">取消令牌(只作用于**建立**阶段)。</param>
+    /// <returns>双工字节流。</returns>
+    /// <exception cref="NotSupportedException">宿主实现不支持隧道(隔离进程模式)时。</exception>
+    Task<Stream> OpenTcpAsync(
+        string sessionId,
+        string host,
+        int port,
+        TunnelOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("This host does not implement remote tunnels.");
+}

--- a/plugin-sdk/VelaShell.PluginSdk/VelaPluginApi.cs
+++ b/plugin-sdk/VelaShell.PluginSdk/VelaPluginApi.cs
@@ -24,6 +24,13 @@ public static class VelaPluginApi
     /// 所以清单上多了一个 <c>minSdkVersion</c>:用到新面的插件声明它,老宿主在**发现期**
     /// 就干净地标 Incompatible 并说清该升级什么。
     /// </para>
+    /// <para>
+    /// <b>1.2</b> 加了 <see cref="RemoteTunnel.IRemoteTunnelApi" />:到远端 unix socket /
+    /// TCP 端点的**裸字节双工流**。远程执行的两种形态都是文本(整段 UTF-8 解码,或按
+    /// <c>\n</c> 切行回调),而 Docker Engine API 的分块传输、tar 归档流与 exec 的多路复用帧
+    /// 全是二进制 —— 用文本模型承载它们不是"慢一点",是数据静默损坏。同样只增不改,
+    /// apiLevel 仍是 1,靠 <c>minSdkVersion: "1.2.0"</c> 在发现期拦住老宿主。
+    /// </para>
     /// </summary>
-    public const string SdkVersion = "1.1.0";
+    public const string SdkVersion = "1.2.0";
 }

--- a/src/VelaShell.Core/Ssh/ISshClientWrapper.cs
+++ b/src/VelaShell.Core/Ssh/ISshClientWrapper.cs
@@ -79,4 +79,28 @@ public interface ISshClientWrapper : IDisposable
     /// 启动失败时抛出且不留下半挂的监听。
     /// </summary>
     Task<IPortForwardHandle> StartPortForwardAsync(PortForwardRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 在当前连接上开一条到远端 <b>unix 域套接字</b>的双工字节流
+    /// (SSH 的 <c>direct-streamlocal@openssh.com</c> 通道)。
+    /// <para>
+    /// 与 <see cref="StartPortForwardAsync" /> 的区别是**不在本机开监听端口**:
+    /// 流直接交给调用方,同机的其它进程连不上去。对 <c>/var/run/docker.sock</c>
+    /// 这种 root 等价的端点,这个区别不是优化而是前提。
+    /// </para>
+    /// </summary>
+    /// <param name="socketPath">远端 socket 的绝对路径。</param>
+    /// <param name="cancellationToken">取消令牌(只作用于建立阶段)。</param>
+    /// <returns>双工字节流;调用方负责释放。</returns>
+    Task<Stream> OpenUnixConnectionAsync(string socketPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 在当前连接上开一条到远端 TCP 端点的双工字节流(SSH 的 <c>direct-tcpip</c> 通道)。
+    /// 地址从**远端主机**的角度解析,因此 <c>localhost</c> 指远端的环回。
+    /// </summary>
+    /// <param name="host">远端可解析的主机名或 IP。</param>
+    /// <param name="port">端口。</param>
+    /// <param name="cancellationToken">取消令牌(只作用于建立阶段)。</param>
+    /// <returns>双工字节流;调用方负责释放。</returns>
+    Task<Stream> OpenTcpConnectionAsync(string host, int port, CancellationToken cancellationToken = default);
 }

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteTunnelCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/RemoteTunnelCapability.cs
@@ -1,0 +1,161 @@
+using VelaShell.Core.Ssh;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.RemoteTunnel;
+
+namespace VelaShell.Infrastructure.Plugins.Capabilities;
+
+/// <summary>
+/// <see cref="IRemoteTunnelApi" /> 的桥接实现:复用宿主既有连接,开一条
+/// <c>direct-streamlocal@openssh.com</c> / <c>direct-tcpip</c> 通道,把裸流交给插件。
+/// <para>
+/// 实例是**按插件**创建的(见 <c>PluginManager.CreateContext</c>),因此
+/// <see cref="IRemoteTunnelApi.MaxConcurrentTunnels" /> 这个并发上限天然按插件计。
+/// </para>
+/// </summary>
+internal sealed class RemoteTunnelCapability(ISshConnectionService connections) : IRemoteTunnelApi
+{
+    private static readonly TimeSpan MaxConnectTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>当前该插件已打开、尚未释放的隧道条数。</summary>
+    private int _activeTunnels;
+
+    public int ActiveTunnels => Volatile.Read(ref _activeTunnels);
+
+    public Task<Stream> OpenUnixSocketAsync(string sessionId, string socketPath, TunnelOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        return OpenAsync(sessionId, options, cancellationToken,
+            (client, ct) => client.OpenUnixConnectionAsync(socketPath, ct));
+    }
+
+    public Task<Stream> OpenTcpAsync(string sessionId, string host, int port, TunnelOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535);
+        return OpenAsync(sessionId, options, cancellationToken,
+            (client, ct) => client.OpenTcpConnectionAsync(host, port, ct));
+    }
+
+    private async Task<Stream> OpenAsync(string sessionId, TunnelOptions? options,
+        CancellationToken cancellationToken, Func<ISshClientWrapper, CancellationToken, Task<Stream>> open)
+    {
+        ISshClientWrapper client = Resolve(sessionId);
+        // 先占坑再干活:隧道不限时,每条占一个 SSH 通道。一个漏掉 Dispose 的插件
+        // 不该有能力把对端的通道数吃干净 —— 那时坏掉的是用户的连接,不只是这个插件。
+        if (Interlocked.Increment(ref _activeTunnels) > IRemoteTunnelApi.MaxConcurrentTunnels)
+        {
+            Interlocked.Decrement(ref _activeTunnels);
+            throw new InvalidOperationException(
+                $"This plugin already has {IRemoteTunnelApi.MaxConcurrentTunnels} tunnels open; dispose one before opening another.");
+        }
+        TimeSpan connectTimeout = options?.ConnectTimeout is { } t && t > TimeSpan.Zero && t <= MaxConnectTimeout
+            ? t
+            : TimeSpan.FromSeconds(15);
+        try
+        {
+            // 超时只夹**建立**阶段:链接源不能传进流的生命周期,否则第一个到点的
+            // CancelAfter 会在半小时后无声掐掉一条正在跟随的日志流。
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(connectTimeout);
+            Stream stream;
+            try
+            {
+                stream = await open(client, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Opening the tunnel timed out after {connectTimeout.TotalSeconds:0}s.");
+            }
+            return new CountedStream(stream, () => Interlocked.Decrement(ref _activeTunnels));
+        }
+        catch
+        {
+            Interlocked.Decrement(ref _activeTunnels);
+            throw;
+        }
+    }
+
+    private ISshClientWrapper Resolve(string sessionId) =>
+        Guid.TryParse(sessionId, out Guid id) && connections.GetClient(id) is { IsConnected: true } client
+            ? client
+            : throw new PluginSessionNotFoundException(sessionId);
+
+    /// <summary>
+    /// 把配额的归还钉在流的释放上。配额只有在流真正关掉时才回来,而不是"调用返回时" ——
+    /// 后者会让上限形同虚设:插件拿着 100 条活流,计数却是 0。
+    /// </summary>
+    private sealed class CountedStream(Stream inner, Action onDisposed) : Stream
+    {
+        private int _disposed;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => inner.CanWrite;
+        public override bool CanTimeout => inner.CanTimeout;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int ReadTimeout
+        {
+            get => inner.ReadTimeout;
+            set => inner.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => inner.WriteTimeout;
+            set => inner.WriteTimeout = value;
+        }
+
+        public override void Flush() => inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => inner.FlushAsync(cancellationToken);
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => inner.Read(buffer);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => inner.ReadAsync(buffer, cancellationToken);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+        public override void Write(ReadOnlySpan<byte> buffer) => inner.Write(buffer);
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => inner.WriteAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                try { inner.Dispose(); }
+                finally { onDisposed(); }
+            }
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                try { await inner.DisposeAsync().ConfigureAwait(false); }
+                finally { onDisposed(); }
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/VelaShell.Infrastructure/Plugins/PluginContext.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginContext.cs
@@ -6,6 +6,7 @@ using VelaShell.PluginSdk.Logging;
 using VelaShell.PluginSdk.Protocols;
 using VelaShell.PluginSdk.RemoteExec;
 using VelaShell.PluginSdk.RemoteFs;
+using VelaShell.PluginSdk.RemoteTunnel;
 using VelaShell.PluginSdk.Secrets;
 using VelaShell.PluginSdk.Sessions;
 using VelaShell.PluginSdk.Storage;
@@ -30,6 +31,7 @@ internal sealed class PluginContext : IPluginContext, IDisposable
     public required ISessionsApi Sessions { get; init; }
     public required IRemoteFsApi RemoteFs { get; init; }
     public required IRemoteExecApi RemoteExec { get; init; }
+    public required IRemoteTunnelApi RemoteTunnel { get; init; }
     public required ICommandsApi Commands { get; init; }
     public required IHostEvents Events { get; init; }
     public required IUiApi Ui { get; init; }

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -14,6 +14,7 @@ using VelaShell.PluginSdk.Manifest;
 using VelaShell.PluginSdk.Packaging;
 using VelaShell.PluginSdk.RemoteExec;
 using VelaShell.PluginSdk.RemoteFs;
+using VelaShell.PluginSdk.RemoteTunnel;
 using VelaShell.PluginSdk.Sessions;
 
 namespace VelaShell.Infrastructure.Plugins;
@@ -1475,6 +1476,9 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             RemoteExec = options.Connections is { } execConnections
                 ? new RemoteExecCapability(execConnections)
                 : new UnavailableRemoteExec(),
+            RemoteTunnel = options.Connections is { } tunnelConnections
+                ? new RemoteTunnelCapability(tunnelConnections)
+                : new UnavailableRemoteTunnel(),
             Commands = GetOrCreateCommandsApi(runtime),
             Events = new PluginEventHub(log, options.Connections, options.Theme, options.Localization),
             Ui = options.UiFactory?.Invoke(manifest.Id, log) ?? new NullUiApi(log),
@@ -1651,6 +1655,19 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     {
         public Task<ExecResult> RunAsync(string sessionId, string command, ExecOptions? options = null, CancellationToken cancellationToken = default)
             => Task.FromException<ExecResult>(new InvalidOperationException("Remote exec capability is unavailable in this host."));
+    }
+
+    private sealed class UnavailableRemoteTunnel : IRemoteTunnelApi
+    {
+        private static InvalidOperationException Unavailable() => new("Remote tunnel capability is unavailable in this host.");
+
+        public int ActiveTunnels => 0;
+
+        public Task<Stream> OpenUnixSocketAsync(string sessionId, string socketPath, TunnelOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<Stream>(Unavailable());
+
+        public Task<Stream> OpenTcpAsync(string sessionId, string host, int port, TunnelOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<Stream>(Unavailable());
     }
 
     /// <summary>无数据库的宿主上的时序能力:明确报不可用,绝不静默丢数据。</summary>

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
@@ -363,6 +363,44 @@ public sealed class TmdsSshClientWrapper : ISshClientWrapper
     }
 
     /// <summary>
+    /// 在当前连接上开一条到远端 unix 域套接字的双工字节流。
+    /// </summary>
+    public async Task<Stream> OpenUnixConnectionAsync(string socketPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+        try
+        {
+            return await _client.OpenUnixConnectionAsync(socketPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (TmdsSshInterop.Translate(ex, cancellationToken) is { } translated)
+        {
+            throw translated;
+        }
+    }
+
+    /// <summary>
+    /// 在当前连接上开一条到远端 TCP 端点的双工字节流。
+    /// </summary>
+    public async Task<Stream> OpenTcpConnectionAsync(string host, int port, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+        try
+        {
+            return await _client.OpenTcpConnectionAsync(host, port, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (TmdsSshInterop.Translate(ex, cancellationToken) is { } translated)
+        {
+            throw translated;
+        }
+    }
+
+    /// <summary>
     /// 释放当前连接,并将 _client 置 null,不抛出异常。
     /// </summary>
     public void Dispose()

--- a/src/VelaShell.PluginHost/RemotePluginContext.cs
+++ b/src/VelaShell.PluginHost/RemotePluginContext.cs
@@ -85,7 +85,32 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
 
     public PluginSdk.Workspaces.IWorkspacesApi Workspaces { get; } = new IsolatedWorkspaces();
 
+    /// <summary>
+    /// 隧道能力在隔离进程里**不可用**。它交出去的是一条活的 <see cref="Stream" />;
+    /// 跨进程代理一条裸流,除了把每个字节多搬一次、再给它套上一层会断的 RPC 之外
+    /// 得不到任何东西 —— 而隧道恰恰是用来承载"一条连接挂几小时"的流的。
+    /// 明确报不可用,好过给一个语义已经变质的实现。
+    /// </summary>
+    public PluginSdk.RemoteTunnel.IRemoteTunnelApi RemoteTunnel { get; } = new IsolatedRemoteTunnel();
+
     public CancellationToken Shutdown { get; }
+
+    /// <summary>隔离进程的隧道能力退化实现:调用即报不可用。</summary>
+    private sealed class IsolatedRemoteTunnel : PluginSdk.RemoteTunnel.IRemoteTunnelApi
+    {
+        private static NotSupportedException Unsupported() => new(
+            "Remote tunnels require hostMode \"inProcess\": a live byte stream cannot be proxied across processes.");
+
+        public int ActiveTunnels => 0;
+
+        public Task<Stream> OpenUnixSocketAsync(string sessionId, string socketPath,
+            PluginSdk.RemoteTunnel.TunnelOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<Stream>(Unsupported());
+
+        public Task<Stream> OpenTcpAsync(string sessionId, string host, int port,
+            PluginSdk.RemoteTunnel.TunnelOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<Stream>(Unsupported());
+    }
 
     /// <summary>
     /// 隔离进程的工作台能力退化实现:注册即报不可用。原生控件无法跨进程嵌入,

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
@@ -69,6 +69,7 @@ public class EmbedRoutingTests
         Sessions = new FakeSessions(),
         RemoteFs = new FakeRemoteFs(),
         RemoteExec = new FakeRemoteExec(),
+        RemoteTunnel = new FakeRemoteTunnel(),
         Commands = new RecordingCommands(),
         Events = new PluginEventHub(new CollectingLogger(), null, null, null),
         Ui = new FakeUi(),

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
@@ -1,0 +1,233 @@
+using NSubstitute;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Plugins.Capabilities;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.RemoteTunnel;
+
+namespace VelaShell.Infrastructure.Tests.Plugins;
+
+/// <summary>
+/// 插件远程隧道能力(SDK 1.2)。这一层交出去的是一条**裸字节双工流** ——
+/// 它存在的全部理由就是远程执行那套"UTF-8 解码 + 按行切"的模型装不下二进制协议。
+/// 因此这里要钉住的不是"能不能连上",而是:配额算不算得准、超时只夹建立阶段、
+/// 以及流被释放后配额是否真的回来。
+/// </summary>
+[TestClass]
+[TestCategory("Plugins")]
+public class RemoteTunnelCapabilityTests
+{
+    private static (RemoteTunnelCapability Capability, ISshClientWrapper Client, string SessionId) NewCapability()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(true);
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        return (new(connections), client, sessionId.ToString());
+    }
+
+    private static Stream NewStream() => new MemoryStream();
+
+    [TestMethod]
+    public async Task OpenUnixSocketAsync_PassesPathThroughAndReturnsUsableStream()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync("/var/run/docker.sock", Arg.Any<CancellationToken>())
+              .Returns(NewStream());
+
+        await using Stream stream = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+
+        Assert.IsTrue(stream.CanRead);
+        Assert.IsTrue(stream.CanWrite);
+        await client.Received(1).OpenUnixConnectionAsync("/var/run/docker.sock", Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task OpenTcpAsync_PassesHostAndPortThrough()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenTcpConnectionAsync("127.0.0.1", 2375, Arg.Any<CancellationToken>()).Returns(NewStream());
+
+        await using Stream stream = await capability.OpenTcpAsync(sessionId, "127.0.0.1", 2375);
+
+        Assert.IsNotNull(stream);
+        await client.Received(1).OpenTcpConnectionAsync("127.0.0.1", 2375, Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task UnknownSession_ThrowsSessionNotFound()
+    {
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        var capability = new RemoteTunnelCapability(connections);
+
+        await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
+            () => capability.OpenUnixSocketAsync(Guid.NewGuid().ToString(), "/var/run/docker.sock"));
+    }
+
+    [TestMethod]
+    public async Task DisconnectedSession_ThrowsSessionNotFound()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(false);
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        var capability = new RemoteTunnelCapability(connections);
+
+        await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
+            () => capability.OpenUnixSocketAsync(sessionId.ToString(), "/var/run/docker.sock"));
+    }
+
+    [TestMethod]
+    public async Task ActiveTunnels_CountsOpenStreamsAndIsReleasedOnDispose()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(_ => NewStream());
+
+        Assert.AreEqual(0, capability.ActiveTunnels);
+        Stream first = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+        Stream second = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+        Assert.AreEqual(2, capability.ActiveTunnels);
+
+        // 配额钉在流的释放上,而不是"调用返回时" —— 否则上限形同虚设。
+        await first.DisposeAsync();
+        Assert.AreEqual(1, capability.ActiveTunnels);
+        await second.DisposeAsync();
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task DoubleDispose_DoesNotDoubleCountTheRelease()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(_ => NewStream());
+
+        Stream stream = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+        await stream.DisposeAsync();
+        await stream.DisposeAsync();
+        stream.Dispose();
+
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task ExceedingMaxConcurrentTunnels_Throws()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(_ => NewStream());
+
+        List<Stream> open = [];
+        for (int i = 0; i < IRemoteTunnelApi.MaxConcurrentTunnels; i++)
+        {
+            open.Add(await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock"));
+        }
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock"));
+
+        // 被拒绝的那次不能把计数留高,否则关掉一条之后仍然开不出新的。
+        Assert.AreEqual(IRemoteTunnelApi.MaxConcurrentTunnels, capability.ActiveTunnels);
+        foreach (Stream s in open)
+        {
+            await s.DisposeAsync();
+        }
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task FailedOpen_ReleasesTheQuotaItReserved()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns<Stream>(_ => throw new IOException("connect: no such file or directory"));
+
+        await Assert.ThrowsExactlyAsync<IOException>(
+            () => capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock"));
+
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task ConnectTimeout_SurfacesAsTimeoutNotCancellation()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(async call =>
+              {
+                  var ct = call.Arg<CancellationToken>();
+                  await Task.Delay(Timeout.Infinite, ct);
+                  return NewStream();
+              });
+
+        await Assert.ThrowsExactlyAsync<TimeoutException>(
+            () => capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock",
+                new TunnelOptions { ConnectTimeout = TimeSpan.FromMilliseconds(50) }));
+
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task CallerCancellation_SurfacesAsCancellationNotTimeout()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(async call =>
+              {
+                  var ct = call.Arg<CancellationToken>();
+                  await Task.Delay(Timeout.Infinite, ct);
+                  return NewStream();
+              });
+
+        using var cts = new CancellationTokenSource();
+        Task<Stream> pending = capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock",
+            new TunnelOptions { ConnectTimeout = TimeSpan.FromMinutes(1) }, cts.Token);
+        await cts.CancelAsync();
+
+        // 调用方自己取消 ≠ 超时:把它翻译成 TimeoutException 会让上层写出错误的重试策略。
+        try
+        {
+            await pending;
+            Assert.Fail("Expected the pending open to be cancelled.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        Assert.AreEqual(0, capability.ActiveTunnels);
+    }
+
+    [TestMethod]
+    public async Task ReturnedStream_IsNotSeekable()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+              .Returns(_ => NewStream());
+
+        await using Stream stream = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+
+        // 内层可能恰好是个 MemoryStream,但隧道语义上就不是可定位的:
+        // 让它假装可以,只会让调用方写出在真通道上必然失败的代码。
+        Assert.IsFalse(stream.CanSeek);
+        Assert.ThrowsExactly<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        Assert.ThrowsExactly<NotSupportedException>(() => _ = stream.Length);
+    }
+
+    [TestMethod]
+    public async Task ReturnedStream_ReadsAndWritesReachTheInnerStream()
+    {
+        (RemoteTunnelCapability capability, ISshClientWrapper client, string sessionId) = NewCapability();
+        var inner = new MemoryStream();
+        client.OpenUnixConnectionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(inner);
+
+        Stream stream = await capability.OpenUnixSocketAsync(sessionId, "/var/run/docker.sock");
+        byte[] payload = [0x00, 0x0A, 0xFF, 0x80, 0x0D];
+        await stream.WriteAsync(payload);
+        await stream.FlushAsync();
+
+        // 二进制原样到达:这条通道存在的意义就是这些字节不被 UTF-8 与换行动过。
+        CollectionAssert.AreEqual(payload, inner.ToArray());
+        await stream.DisposeAsync();
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
@@ -42,6 +42,7 @@ public class StreamingRoutingTests
             Sessions = new FakeSessions(),
             RemoteFs = remoteFs,
             RemoteExec = new FakeRemoteExec(),
+            RemoteTunnel = new FakeRemoteTunnel(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
             Ui = new FakeUi(),

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
@@ -51,6 +51,7 @@ public class TimeSeriesRoutingTests
             Sessions = new FakeSessions(),
             RemoteFs = new FakeRemoteFs(),
             RemoteExec = new FakeRemoteExec(),
+            RemoteTunnel = new FakeRemoteTunnel(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
             Ui = new FakeUi(),


### PR DESCRIPTION
本次提交引入 IRemoteTunnelApi（SDK 1.2），允许插件在现有 SSH 会话上打开到远端 unix socket 或 TCP 端口的双工流，支持如 Docker API、tar 流等二进制协议，解决 RemoteExec 仅支持文本流的问题。新增接口及配置项，完善插件上下文、宿主实现、测试替身等，支持配额、超时、生命周期管理。ISshClientWrapper 增加连接方法，PluginManager 及测试同步适配。新增单元测试覆盖关键行为，SDK 版本升至 1.2.0，文档同步更新。