### PR TITLE
第一方插件迁移至独立仓库并同步更新说明

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 # 随包分发的插件(plugins/<目录名>/,目录名 = id 把点换成短横,原因见 macOS job 的签名一步)
 # 有两个来源,发行包里的 plugins/ 是它们的并集:
 #   ① AI 插件(velashell.ai)在本仓库 plugins/ 下,随 publish 一起构建;
-#   ② Redis / S3 / Telnet 随工具链在 joesdu/velashell-plugin-toolchain,以 Release 资产
+#   ② Redis / S3 / Telnet 在第一方插件仓库 joesdu/velashell-plugins,以 Release 资产
 #      velashell-plugins-<版本>.zip 交付,包内布局就是安装包 plugins/ 那一层。
 # 各 job 在 publish 前跑 scripts/Fetch-Plugins.ps1 按根 Directory.Build.props 的
 # VelaPluginsBundleVersion 取回 ② 并校验 sha256,解到 artifacts/plugins/(脚本会丢掉包里
@@ -87,7 +87,7 @@ jobs:
             [Convert]::FromBase64String($env:SNK_B64))
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 工具链侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
+      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
       # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
       # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
       # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
@@ -139,7 +139,7 @@ jobs:
             [Convert]::FromBase64String($env:SNK_B64))
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 工具链侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
+      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
       # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
       # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
       # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
@@ -198,7 +198,7 @@ jobs:
           sudo rm -rf "$HOME/Library/Android" /usr/local/share/boost
           sudo rm -rf "$HOME/.rustup" "$HOME/.cargo"
           echo "== after =="; df -h /System/Volumes/Data | tail -1
-      # 工具链侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
+      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
       # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
       # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
       # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
@@ -285,7 +285,7 @@ jobs:
         run: echo "$SNK_B64" | openssl base64 -A -d > src/VelaShell.snk
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 工具链侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
+      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
       # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
       # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
       # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,19 +24,24 @@
 
   <!--
     ============================ 随包分发的插件从哪来 ============================
-    插件 SDK、模板、vela-plugin CLI 与 Redis/S3/Telnet/HelloWorld 插件于 2026-08-21 拆到
-    https://github.com/joesdu/velashell-plugin-toolchain
+    插件 SDK、模板、vela-plugin CLI 与 Redis/S3/Telnet/HelloWorld 插件于 2026-08-21 拆出主仓库;
+    2026-08-22 两者又各自独立,现在是两个仓库:
+      https://github.com/joesdu/velashell-plugin-toolchain   SDK 与工具链
+      https://github.com/joesdu/velashell-plugins            第一方插件(Redis / S3 / Telnet / HelloWorld)
     契约程序集(VelaShell.PluginSdk / .Testing)一律走 nuget.org 上的正式包,版本写在
     src/ 与 tests/ 的 Directory.Packages.props 里;那几个插件的二进制走下面这个 Release pin。
 
     **例外:AI 插件(velashell.ai)是本仓库自建的第一方插件**,源码在 plugins/ 下,
     随主程序一起构建、一起发布 —— 它与宿主的耦合最紧(要用宿主的 AvaloniaEdit 作输入框、
     必须进程内装载、Avalonia 版本必须与宿主逐字一致),分在两个仓库时每改一处 UI 都要
-    先发一次工具链 Release 才能联调。详见 plugins/README.md。
+    先发一次插件仓库的 Release 才能联调。详见 plugins/README.md。
   -->
   <PropertyGroup>
-    <!-- 随安装包分发的**工具链侧**插件(Redis / S3 / Telnet)所在的工具链 Release 标签,
-         去掉前导 v。scripts/Fetch-Plugins.ps1 据此下载
+    <!-- 随安装包分发的**插件仓库侧**插件(Redis / S3 / Telnet)所在的 velashell-plugins
+         Release 标签,去掉前导 v。它与 src/Directory.Packages.props 里
+         VelaShell.PluginSdk 的版本是两个独立的号 —— 插件仓库有自己的发行版本
+         (VelaPluginsVersion),不跟 SDK 走。
+         scripts/Fetch-Plugins.ps1 据此下载
          releases/download/v<版本>/velashell-plugins-<版本>.zip 解进 artifacts/plugins/。
          包里若含 velashell-ai,取回时会被丢掉 —— 那一份由本仓库自己构建,见脚本注释。 -->
     <VelaPluginsBundleVersion Condition="'$(VelaPluginsBundleVersion)' == ''">1.4.0</VelaPluginsBundleVersion>

--- a/docs-en/plugins/README.md
+++ b/docs-en/plugins/README.md
@@ -1,17 +1,21 @@
 # VelaShell Plugin System Design Documents
 
-> 📦 **Repository split note (2026-08-21)**: the plugin SDK, `dotnet new` templates, the
-> `vela-plugin` CLI and all first-party plugins moved to
-> [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain).
-> Paths such as `plugin-sdk/…`, `plugins/VelaShell.Plugin.…`, `tools/…`, `templates/…` and
-> `tests/VelaShell.Plugin.*.Tests` that appear on this page (and in blueprints 01–15) now
-> refer to that repository; this one keeps only `src/` (host implementation) and `tests/`
-> (host tests, with plugin fixtures under `tests/fixtures/`).
+> 📦 **Repository split note (2026-08-21, revised 2026-08-22)**: plugin-related code now lives in
+> two repositories — the plugin SDK, `dotnet new` templates and the `vela-plugin` CLI are in
+> [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain);
+> the first-party plugins (Redis / S3 / Telnet and the HelloWorld example) are in
+> [joesdu/velashell-plugins](https://github.com/joesdu/velashell-plugins).
+> On this page (and in blueprints 01–15), `plugin-sdk/…`, `tools/…` and `templates/…` refer to
+> the former; `plugins/VelaShell.Plugin.…` and `tests/VelaShell.Plugin.*.Tests` refer to the latter.
+> **Exception: the AI plugin stays in this repository** (`plugins/VelaShell.Plugin.Ai`, tests in
+> `tests/VelaShell.Plugin.Ai.Tests`) and is built and released with the host — see
+> [plugins/README.md](../../plugins/README.md). Otherwise this repository keeps only `src/`
+> (host implementation) and `tests/` (host tests, with plugin fixtures under `tests/fixtures/`).
 > The conclusions and acceptance evidence are unaffected — only which repository the paths live in.
 
 > Status: **v1 simplified version implemented** (2026-08: dual host modes + full Avalonia UI); documents 01–15 are retained as the **long-term design blueprint** for the complete plugin platform (process isolation, permission system, packaging/distribution/store, etc. will be delivered in phases as needed; the distribution system has been explicitly deferred). Any decision changes made during implementation should be written back to the corresponding document.
 >
-> ⚠️ **The four plugin-author documents moved out with the toolchain** (2026-08-21): `dev-guide.md` / `cli.md` / `publishing.md` / `sdk-reference.md` now live in **[joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain/tree/main/docs-en)**, next to the SDK, templates, CLI and first-party plugins they describe — documentation for plugin authors belongs with the code it documents. What stays here is the **host-side** blueprint.
+> ⚠️ **The four plugin-author documents moved out with the toolchain** (2026-08-21): `dev-guide.md` / `cli.md` / `publishing.md` / `sdk-reference.md` now live in **[joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain/tree/main/docs-en)**, next to the SDK, templates and CLI they describe — documentation for plugin authors belongs with the code it documents. What stays here is the **host-side** blueprint.
 >
 > **To write a plugin, read [dev-guide.md](https://github.com/joesdu/velashell-plugin-toolchain/blob/main/docs-en/dev-guide.md) directly** — it describes the APIs that are actually available today; the interface shapes in the blueprint documents (one process per plugin, Broker, etc.) are not implemented in v1.
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,11 +1,15 @@
 # VelaShell 插件系统设计文档
 
-> 📦 **仓库拆分注记(2026-08-21)**:插件 SDK、`dotnet new` 模板、`vela-plugin` CLI 与
-> 全部第一方插件已迁到
-> [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain)。
-> 本页(以及 01–15 蓝图)里出现的 `plugin-sdk/…`、`plugins/VelaShell.Plugin.…`、
-> `tools/…`、`templates/…`、`tests/VelaShell.Plugin.*.Tests` 等路径,现在都指那个仓库;
-> 主仓库这边只剩 `src/`(宿主实现)与 `tests/`(宿主测试,插件夹具在 `tests/fixtures/`)。
+> 📦 **仓库拆分注记(2026-08-21,2026-08-22 修订)**:插件相关的东西现在分在两个仓库 ——
+> 插件 SDK、`dotnet new` 模板、`vela-plugin` CLI 在
+> [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain);
+> 第一方插件(Redis / S3 / Telnet 与 HelloWorld 示例)在
+> [joesdu/velashell-plugins](https://github.com/joesdu/velashell-plugins)。
+> 本页(以及 01–15 蓝图)里出现的 `plugin-sdk/…`、`tools/…`、`templates/…` 指前者,
+> `plugins/VelaShell.Plugin.…`、`tests/VelaShell.Plugin.*.Tests` 指后者。
+> **例外:AI 插件仍在主仓库**(`plugins/VelaShell.Plugin.Ai`,测试在 `tests/VelaShell.Plugin.Ai.Tests`),
+> 随主程序一起构建发布,理由见 [plugins/README.md](../../plugins/README.md)。
+> 除此之外主仓库只剩 `src/`(宿主实现)与 `tests/`(宿主测试,插件夹具在 `tests/fixtures/`)。
 > 结论与验收证据本身不受影响,仅路径的仓库归属变了。
 
 > 状态:**v1 简化版已实现**(2026-08:双宿主模式 + 完整 Avalonia UI);编号 01–15 的
@@ -15,8 +19,7 @@
 > ⚠️ **面向插件作者的四篇文档已随工具链搬走**(2026-08-21):
 > `dev-guide.md` / `cli.md` / `publishing.md` / `sdk-reference.md` 现在在
 > **[joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain/tree/main/docs)**,
-> 与 SDK、模板、CLI、第一方插件在同一个仓库里 —— 它们描述的是插件作者的世界,
-> 跟着代码走才不会漂。本目录留下的是**宿主侧**的设计蓝图。
+> 与 SDK、模板、CLI 在同一个仓库里 —— 它们描述的是插件作者的世界,跟着代码走才不会漂。本目录留下的是**宿主侧**的设计蓝图。
 >
 > **写插件请直接读
 > [dev-guide.md](https://github.com/joesdu/velashell-plugin-toolchain/blob/main/docs/dev-guide.md)** ——

--- a/docs/plugins/STATUS.md
+++ b/docs/plugins/STATUS.md
@@ -1,10 +1,11 @@
 # 插件系统进度总览
 
 > 📦 **仓库拆分注记(2026-08-21,2026-08-22 修订)**:插件 SDK、`dotnet new` 模板、
-> `vela-plugin` CLI 与 Redis / S3 / Telnet / HelloWorld 插件已迁到
-> [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain)。
-> 本页(以及 01–15 蓝图)里出现的 `plugin-sdk/…`、`tools/…`、`templates/…`、
-> `tests/VelaShell.Plugin.{Redis,S3,Telnet,HelloWorld}.Tests` 等路径,现在都指那个仓库。
+> `vela-plugin` CLI 在 [joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain);
+> Redis / S3 / Telnet / HelloWorld 插件在
+> [joesdu/velashell-plugins](https://github.com/joesdu/velashell-plugins)。
+> 本页(以及 01–15 蓝图)里出现的 `plugin-sdk/…`、`tools/…`、`templates/…` 指前者,
+> `tests/VelaShell.Plugin.{Redis,S3,Telnet,HelloWorld}.Tests` 与那几个插件的源码路径指后者。
 >
 > **例外:AI 插件(`plugins/VelaShell.Plugin.Ai`,测试在 `tests/VelaShell.Plugin.Ai.Tests`)
 > 仍在主仓库**,随主程序一起构建、一起发布 —— 它与宿主是编译期耦合(借宿主的 AvaloniaEdit、

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,10 +6,14 @@
 | --- | --- | --- | --- | --- |
 | [VelaShell.Plugin.Ai](VelaShell.Plugin.Ai/) | `velashell.ai` | 是 | 进程内 | AI 助手：多提供商流式对话 + Agent 模式（读终端/执行命令带审批）+ 自定义 MCP 服务器 |
 
-其余第一方插件（Redis / S3 / Telnet 与 HelloWorld 示例）连同 SDK、模板、`vela-plugin` CLI
-一起住在 **[joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain)**，
+其余第一方插件（Redis / S3 / Telnet 与 HelloWorld 示例）住在
+**[joesdu/velashell-plugins](https://github.com/joesdu/velashell-plugins)**，
 以 Release 资产 `velashell-plugins-<版本>.zip` 交付，由 [`scripts/Fetch-Plugins.ps1`](../scripts/Fetch-Plugins.ps1)
-取回解到 `artifacts/plugins/`。
+取回解到 `artifacts/plugins/`（联调时 `-FromPluginsRepo <插件仓库路径>` 就地构建，不走网络）。
+
+SDK、模板与 `vela-plugin` CLI 则在
+**[joesdu/velashell-plugin-toolchain](https://github.com/joesdu/velashell-plugin-toolchain)**，
+以 NuGet 包交付。三个仓库各管一摊：主程序、SDK 与工具链、第一方插件。
 
 ## 为什么 AI 插件留在主仓库
 

--- a/scripts/Fetch-Plugins.ps1
+++ b/scripts/Fetch-Plugins.ps1
@@ -4,9 +4,10 @@
     取回随安装包分发的第一方插件,解到 artifacts/plugins/。
 
 .DESCRIPTION
-    Redis / S3 / Telnet 插件于 2026-08-21 随工具链搬到独立仓库
-    https://github.com/joesdu/velashell-plugin-toolchain
-    并以 Release 资产 velashell-plugins-<版本>.zip 的形式交付,包内布局就是安装包
+    Redis / S3 / Telnet 插件于 2026-08-21 随工具链搬出主仓库,2026-08-22 又从工具链仓库
+    独立出来,现在住在 https://github.com/joesdu/velashell-plugins
+    (工具链仓库 velashell-plugin-toolchain 从此只管 SDK 与工具链,不再产出插件分发包)。
+    它以 Release 资产 velashell-plugins-<版本>.zip 的形式交付,包内布局就是安装包
     plugins/ 那一层。本脚本按根 Directory.Build.props 里 pin 的 VelaPluginsBundleVersion
     下载那一版,校验 sha256,解到 artifacts/plugins/ —— 构建(F5)与发布都从这个目录取件
     (见 src/VelaShell/VelaShell.csproj 的 VelaPluginsStageDir)。
@@ -21,9 +22,10 @@
 .PARAMETER Version
     要取的插件分发包版本。默认读 Directory.Build.props 的 VelaPluginsBundleVersion。
 
-.PARAMETER FromToolchain
-    改为就地构建本机工具链仓库的插件,不走网络。传工具链仓库的路径,
-    例如 -FromToolchain G:\velashell-plugin-toolchain。改插件时用这条。
+.PARAMETER FromPluginsRepo
+    改为就地构建本机插件仓库的插件,不走网络。传插件仓库的路径,
+    例如 -FromPluginsRepo G:\velashell-plugins。改插件时用这条。
+    别名 -FromToolchain 保留,因为插件曾经确实在工具链仓库里 —— 老命令行不至于突然报错。
 
 .PARAMETER Force
     即使暂存目录已是目标版本也重新取。
@@ -32,12 +34,13 @@
     pwsh scripts/Fetch-Plugins.ps1
 
 .EXAMPLE
-    pwsh scripts/Fetch-Plugins.ps1 -FromToolchain G:\velashell-plugin-toolchain
+    pwsh scripts/Fetch-Plugins.ps1 -FromPluginsRepo G:\velashell-plugins
 #>
 [CmdletBinding()]
 param(
     [string] $Version,
-    [string] $FromToolchain,
+    [Alias('FromToolchain')]
+    [string] $FromPluginsRepo,
     [switch] $Force
 )
 
@@ -80,19 +83,19 @@ function Remove-LocallyBuiltPlugins {
     }
 }
 
-if ($FromToolchain) {
-    $toolchain = (Resolve-Path $FromToolchain).Path
-    $bundleProj = Join-Path $toolchain 'build/PluginBundle.proj'
+if ($FromPluginsRepo) {
+    $pluginsRepo = (Resolve-Path $FromPluginsRepo).Path
+    $bundleProj = Join-Path $pluginsRepo 'build/PluginBundle.proj'
     if (-not (Test-Path $bundleProj)) {
-        throw "在 '$toolchain' 下找不到 build/PluginBundle.proj —— 这个路径是插件工具链仓库吗?"
+        throw "在 '$pluginsRepo' 下找不到 build/PluginBundle.proj —— 这个路径是第一方插件仓库(joesdu/velashell-plugins)吗?"
     }
     Reset-StageDirectory
-    Write-Host "Building first-party plugins from $toolchain ..."
+    Write-Host "Building first-party plugins from $pluginsRepo ..."
     # 用 Release:发行包里就是 Release 产物,联调时也保持一致,免得"本机好好的、发出去炸了"。
     & dotnet build $bundleProj -c Release -t:Bundle -p:BundleDir=$stageDir --nologo
     if ($LASTEXITCODE -ne 0) { throw "PluginBundle.proj 构建失败。" }
     Remove-LocallyBuiltPlugins
-    Set-Content $stampFile "local:$toolchain"
+    Set-Content $stampFile "local:$pluginsRepo"
     Write-Host "Plugins staged at $stageDir (local build)."
     return
 }
@@ -111,7 +114,7 @@ if (-not $Force -and (Test-Path $stampFile) -and (Get-Content -Raw $stampFile).T
     return
 }
 
-$repo = 'joesdu/velashell-plugin-toolchain'
+$repo = 'joesdu/velashell-plugins'
 $asset = "velashell-plugins-$Version.zip"
 $base = "https://github.com/$repo/releases/download/v$Version"
 $temp = Join-Path ([IO.Path]::GetTempPath()) ("vela-plugins-" + [Guid]::NewGuid().ToString('N'))

--- a/scripts/publish-all.ps1
+++ b/scripts/publish-all.ps1
@@ -8,7 +8,7 @@
 #   Linux  x64 / arm64 含运行时 → tar.gz
 # 每份产物内含 plugins/<目录名>/(目录名 = 插件 id 把点换成短横),两个来源:
 #   ① AI 插件(velashell.ai)在本仓库 plugins/ 下,随 publish 一起构建;
-#   ② Redis / S3 / Telnet 随工具链在 joesdu/velashell-plugin-toolchain,以 Release 资产
+#   ② Redis / S3 / Telnet 在第一方插件仓库 joesdu/velashell-plugins,以 Release 资产
 #      velashell-plugins-<版本>.zip 交付 —— 本脚本在 publish 之前跑 scripts/Fetch-Plugins.ps1
 #      按 Directory.Build.props 的 VelaPluginsBundleVersion 取回解到 artifacts/plugins/。
 #   MSBuild 在发布期把两边一起登记入包。哪个插件进包由各插件的 <VelaPluginShip> 把关

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,8 +29,9 @@
          详见 docs/FTP客户端可行性调研.md §4.3。 -->
     <PackageVersion Include="FluentFTP" Version="54.2.0" />
     <!-- 插件契约程序集,由插件工具链仓库(joesdu/velashell-plugin-toolchain)发布到 nuget.org。
-         注意:S3 插件用的 AWSSDK.S3 曾经登记在这里 —— 那个插件在工具链仓库里,
-         版本由它自己写死,别再加回来。plugins/ 下的自建插件不走中央包版本管理
+         注意:S3 插件用的 AWSSDK.S3 曾经登记在这里 —— 那个插件在第一方插件仓库
+         (joesdu/velashell-plugins)里,版本由那边的中央包管理登记,别再加回来。
+         本仓库 plugins/ 下的自建插件(AI)不走中央包版本管理
          (根目录没有 Directory.Packages.props),依赖版本写在各自的 csproj 里。 -->
     <PackageVersion Include="VelaShell.PluginSdk" Version="1.4.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -105,14 +105,14 @@
        AI 插件留在主仓库的原因见 plugins/README.md —— 它与宿主耦合最紧
        (借宿主的 AvaloniaEdit、必须进程内装载、Avalonia 必须逐字同版)。
 
-    ② 工具链仓库 joesdu/velashell-plugin-toolchain(Redis / S3 / Telnet)
+    ② 第一方插件仓库 joesdu/velashell-plugins(Redis / S3 / Telnet)
        以 Release 资产 velashell-plugins-<版本>.zip 交付,包内布局就是安装包 plugins/ 那一层。
        本仓库按根 Directory.Build.props 的 VelaPluginsBundleVersion 取那一版,解到
        artifacts/plugins/ 作为**暂存目录**,构建与发布都从这里取件。
 
     暂存目录怎么来:
       · 日常:pwsh scripts/Fetch-Plugins.ps1      —— 按 pin 的版本下载并校验 sha256
-      · 联调:pwsh scripts/Fetch-Plugins.ps1 -FromToolchain <工具链仓库路径>
+      · 联调:pwsh scripts/Fetch-Plugins.ps1 -FromPluginsRepo <插件仓库路径>
               —— 就地构建那边的插件,不走网络
       · CI:  发布流水线在 publish 之前跑同一个脚本(见 .github/workflows/release.yml)
     也可以用 -p:VelaPluginsStageDir=<目录> 直接指别处。


### PR DESCRIPTION
本次将 Redis/S3/Telnet/HelloWorld 等第一方插件从工具链仓库迁移至独立插件仓库，相关文档、脚本、构建说明、CI 配置等均已同步调整。所有插件来源、构建、分发、联调相关参数、注释、脚本逻辑等已替换为新插件仓库路径和命名（如 Fetch-Plugins.ps1 参数改为 -FromPluginsRepo，保留兼容别名）。文档详细说明三仓库分工，强调 AI 插件仍留主仓库，NuGet 管理说明同步更新。CI/CD、构建脚本、MSBuild 配置等已切换插件来源，确保自动化与本地流程一致，避免开发者和用户混淆插件分发体系。