### PR TITLE
修复发布流水线取插件 404:插件仓库标签不带前导 v

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,13 +38,16 @@
   -->
   <PropertyGroup>
     <!-- 随安装包分发的**插件仓库侧**插件(Redis / S3 / Telnet)所在的 velashell-plugins
-         Release 标签,去掉前导 v。它与 src/Directory.Packages.props 里
+         Release 版本。它与 src/Directory.Packages.props 里
          VelaShell.PluginSdk 的版本是两个独立的号 —— 插件仓库有自己的发行版本
          (VelaPluginsVersion),不跟 SDK 走。
          scripts/Fetch-Plugins.ps1 据此下载
-         releases/download/v<版本>/velashell-plugins-<版本>.zip 解进 artifacts/plugins/。
-         包里若含 velashell-ai,取回时会被丢掉 —— 那一份由本仓库自己构建,见脚本注释。 -->
-    <VelaPluginsBundleVersion Condition="'$(VelaPluginsBundleVersion)' == ''">1.4.0</VelaPluginsBundleVersion>
+         releases/download/<标签>/velashell-plugins-<版本>.zip 解进 artifacts/plugins/;
+         插件仓库的标签不带前导 v,脚本两种写法都会试一遍。
+         包里若含 velashell-ai,取回时会被丢掉 —— 那一份由本仓库自己构建,见脚本注释。
+         别退回 1.4.0:那一版的 zip 与 1.4.1 的二进制逐字节相同,但三个 plugin.json 里
+         写的还是 0.1.0,装出来插件管理页会显示 v0.1.0。 -->
+    <VelaPluginsBundleVersion Condition="'$(VelaPluginsBundleVersion)' == ''">1.4.1</VelaPluginsBundleVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/scripts/Fetch-Plugins.ps1
+++ b/scripts/Fetch-Plugins.ps1
@@ -116,14 +116,35 @@ if (-not $Force -and (Test-Path $stampFile) -and (Get-Content -Raw $stampFile).T
 
 $repo = 'joesdu/velashell-plugins'
 $asset = "velashell-plugins-$Version.zip"
-$base = "https://github.com/$repo/releases/download/v$Version"
+# 插件仓库的 Release 标签**不带前导 v**(1.4.1,不是 v1.4.1),与本仓库的体例正好相反 ——
+# 2026-08-22 发 1.3.0 时四个平台的 job 全挂在这一步,就是照本仓库的习惯拼了个 v 出来。
+# 两种写法都试一遍:对面的标签体例是对面的事,这边不该因为它换个前缀就整条发布流水线 404。
+$tagCandidates = @($Version, "v$Version")
 $temp = Join-Path ([IO.Path]::GetTempPath()) ("vela-plugins-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force $temp | Out-Null
 
 try {
     Write-Host "Downloading $asset ..."
     $zipPath = Join-Path $temp $asset
-    Invoke-WebRequest -Uri "$base/$asset" -OutFile $zipPath
+    $base = $null
+    foreach ($tag in $tagCandidates) {
+        $candidate = "https://github.com/$repo/releases/download/$tag"
+        try {
+            Invoke-WebRequest -Uri "$candidate/$asset" -OutFile $zipPath
+            $base = $candidate
+            break
+        } catch {
+            # 失败的尝试可能落下半截文件,清掉再换下一个候选 —— 否则下一轮的
+            # -OutFile 覆盖不彻底时,校验和会对着一份混合内容算。
+            Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+            Write-Host "  tag '$tag': $($_.Exception.Message)"
+        }
+    }
+    if (-not $base) {
+        throw "在 $repo 的 $($tagCandidates -join ' / ') 标签下都找不到 $asset。" +
+              "确认插件仓库已发布该版本(当前 Directory.Build.props 的 VelaPluginsBundleVersion=$Version)," +
+              "或用 -Version 指定一个已存在的版本。"
+    }
 
     # sha256 核对。SHA256SUMS.txt 与 zip 出自同一次流水线运行,取不到就明说 ——
     # 静默跳过校验等于把"下到半截的包"变成用户机器上的启动崩溃。


### PR DESCRIPTION
## 问题

1.3.0 的 Release 流水线四个平台 job 全挂在 `Fetch first-party plugins`：

```
Downloading velashell-plugins-1.4.0.zip ...
Invoke-WebRequest: ... | Not Found
```

`scripts/Fetch-Plugins.ps1` 按本仓库的体例把地址拼成 `releases/download/v1.4.0/`，
而 `joesdu/velashell-plugins` 的标签是裸版本号 `1.4.0`。插件拆出主仓库之后第一次发版就撞上了。

已实测确认：

| URL | 状态 |
|---|---|
| `.../download/v1.4.1/velashell-plugins-1.4.1.zip` | 404 |
| `.../download/1.4.1/velashell-plugins-1.4.1.zip` | 200 |

## 改动

- 取件脚本对**裸标签**与 `v` 前缀两种写法各试一遍（裸标签优先）。失败的尝试先清掉可能落下的半截文件再换下一个候选，两个都不中才报错，并把试过的候选列进错误里。标签体例是插件仓库那边的事，这边不该因为对面改个前缀就整条发布流水线 404。
- pin 从 `1.4.0` 提到 `1.4.1`。两版 zip 的二进制逐字节相同，但 1.4.0 里三个 `plugin.json` 写的还是 `0.1.0`，装出来插件管理页会显示 `v0.1.0` —— 1.4.0 是一次版本号打错的首发，1.4.1 才是修正版。

## 验证

- `pwsh scripts/Fetch-Plugins.ps1 -Force` → 取回 1.4.1，sha256 校验通过，3 个插件解到 `artifacts/plugins/`
- 失败路径：`-Version 9.9.9` 两个候选都试过后报清楚的错，且不破坏已暂存的插件目录
- `dotnet publish -c Release -r win-x64 -p:SelfContained=true` → 发行包 `plugins/` 下四个插件齐全，三个来自分发包的版本号已是 `1.4.1`

同时带上前一个提交的插件管理器安全须知与商店入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pc7ss3axJZteUfeF7AYVj