### PR TITLE
发行包不再预装插件仓库侧插件,改由用户按需从商店安装

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,15 @@
 #   macOS   x64/arm64 → tar.gz + dmg(未签名/未公证;Unix 可执行位在原生 runner 上保留)
 #   Linux   x64/arm64 → tar.gz
 # 随包分发的插件(plugins/<目录名>/,目录名 = id 把点换成短横,原因见 macOS job 的签名一步)
-# 有两个来源,发行包里的 plugins/ 是它们的并集:
-#   ① AI 插件(velashell.ai)在本仓库 plugins/ 下,随 publish 一起构建;
-#   ② Redis / S3 / Telnet 在第一方插件仓库 joesdu/velashell-plugins,以 Release 资产
-#      velashell-plugins-<版本>.zip 交付,包内布局就是安装包 plugins/ 那一层。
-# 各 job 在 publish 前跑 scripts/Fetch-Plugins.ps1 按根 Directory.Build.props 的
-# VelaPluginsBundleVersion 取回 ② 并校验 sha256,解到 artifacts/plugins/(脚本会丢掉包里
-# 与 ① 重名的目录);publish 期由 src/VelaShell/VelaShell.csproj 的 AddVelaPluginsToPublish
-# 把两边一起登记入包。
-# 哪个插件进包由各插件的 <VelaPluginShip> 把关(示例插件 velashell.hello-world 设为 false,
-# 只作开发范例不进产物)。两个来源都空时发布会直接失败,不会悄悄出一个没插件的包。
-# ⚠️ 发布顺序:**先发工具链的 Release,再发本仓库** —— 反过来的话 ② 取不到资产。
-# 插件是纯托管、无 RID 的产物,一个 zip 吃遍五个平台,各 job 取的是同一份。
+# **只有本仓库 plugins/ 下自建的那些**(当前是 AI 插件 velashell.ai),随 publish 一起构建、
+# 由 src/VelaShell/VelaShell.csproj 的 AddVelaPluginsToPublish 登记入包。
+# 哪个进包由各插件的 <VelaPluginShip> 把关(示例插件 velashell.hello-world 设为 false,
+# 只作开发范例不进产物)。
+# 2026-08-22 起**不再**从第一方插件仓库 joesdu/velashell-plugins 取 Redis / S3 / Telnet 预装:
+# 不是每个人都要连 Redis、开 S3、拨 Telnet,预装等于给所有人塞三份用不上的依赖(光 Redis 与
+# S3 的 SDK 就近 5 MB),还把发布节奏绑在另一个仓库的发版顺序上。它们改由用户按需从插件商店
+# (https://market.easilynet.top)自行安装 —— 插件管理页的安装入口旁就有链接。
+# 联调/本机想要那几个插件时仍可手动跑 scripts/Fetch-Plugins.ps1(见该脚本),流水线不跑它。
 # 另有 build-msix 任务产出商店版 .msixbundle,但它不附加到 Release —— 作为工作流
 # artifact(store-msix)留存,由人工下载后提交 Partner Center。便携版与商店版是同一份二进制,
 # 只是容器不同;应用内自更新在商店版会自动关闭(运行时判定包身份,见 Services/AppPackaging.cs)。
@@ -87,14 +84,6 @@ jobs:
             [Convert]::FromBase64String($env:SNK_B64))
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
-      # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
-      # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
-      # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
-      - name: Fetch first-party plugins
-        shell: pwsh
-        run: ./scripts/Fetch-Plugins.ps1
-
       - name: Publish (win-x64 / win-arm64)
         shell: pwsh
         run: |
@@ -139,14 +128,6 @@ jobs:
             [Convert]::FromBase64String($env:SNK_B64))
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
-      # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
-      # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
-      # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
-      - name: Fetch first-party plugins
-        shell: pwsh
-        run: ./scripts/Fetch-Plugins.ps1
-
       - name: Build MSIX bundle (win-x64 + win-arm64)
         shell: pwsh
         run: |
@@ -198,14 +179,6 @@ jobs:
           sudo rm -rf "$HOME/Library/Android" /usr/local/share/boost
           sudo rm -rf "$HOME/.rustup" "$HOME/.cargo"
           echo "== after =="; df -h /System/Volumes/Data | tail -1
-      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
-      # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
-      # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
-      # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
-      - name: Fetch first-party plugins
-        shell: pwsh
-        run: ./scripts/Fetch-Plugins.ps1
-
       - name: Publish (osx-x64 / osx-arm64)
         run: |
           set -euo pipefail
@@ -285,14 +258,6 @@ jobs:
         run: echo "$SNK_B64" | openssl base64 -A -d > src/VelaShell.snk
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      # 插件仓库侧的第一方插件(Redis / S3 / Telnet)。按根 Directory.Build.props 的
-      # VelaPluginsBundleVersion 取那一版解到 artifacts/plugins/;AI 插件不在其中,
-      # 它在本仓库 plugins/ 下随 publish 一起构建。两边都由 AddVelaPluginsToPublish 登记进 plugins/。
-      # 取不到就直接失败 —— 发行包不接受"插件系统看着在、实则没插件"。
-      - name: Fetch first-party plugins
-        shell: pwsh
-        run: ./scripts/Fetch-Plugins.ps1
-
       - name: Publish (linux-x64 / linux-arm64)
         run: |
           set -euo pipefail

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,14 +37,15 @@
     先发一次插件仓库的 Release 才能联调。详见 plugins/README.md。
   -->
   <PropertyGroup>
-    <!-- 随安装包分发的**插件仓库侧**插件(Redis / S3 / Telnet)所在的 velashell-plugins
-         Release 版本。它与 src/Directory.Packages.props 里
-         VelaShell.PluginSdk 的版本是两个独立的号 —— 插件仓库有自己的发行版本
-         (VelaPluginsVersion),不跟 SDK 走。
+    <!-- **插件仓库侧**插件(Redis / S3 / Telnet)所在的 velashell-plugins Release 版本。
+         它与 src/Directory.Packages.props 里 VelaShell.PluginSdk 的版本是两个独立的号
+         —— 插件仓库有自己的发行版本(VelaPluginsVersion),不跟 SDK 走。
          scripts/Fetch-Plugins.ps1 据此下载
          releases/download/<标签>/velashell-plugins-<版本>.zip 解进 artifacts/plugins/;
          插件仓库的标签不带前导 v,脚本两种写法都会试一遍。
          包里若含 velashell-ai,取回时会被丢掉 —— 那一份由本仓库自己构建,见脚本注释。
+         2026-08-22 起这几个插件**不再随发行包预装**(用户按需从插件商店装),发布流水线
+         也不再跑取件脚本 —— 这个 pin 现在只服务本机开发/联调时手动取件。
          别退回 1.4.0:那一版的 zip 与 1.4.1 的二进制逐字节相同,但三个 plugin.json 里
          写的还是 0.1.0,装出来插件管理页会显示 v0.1.0。 -->
     <VelaPluginsBundleVersion Condition="'$(VelaPluginsBundleVersion)' == ''">1.4.1</VelaPluginsBundleVersion>

--- a/scripts/Fetch-Plugins.ps1
+++ b/scripts/Fetch-Plugins.ps1
@@ -19,6 +19,12 @@
     干净克隆之后不跑这个脚本一样能构建、能跑,只是启动后只有自建的那几个插件;
     `dotnet publish` 在两边都空时才失败 —— 发行包不接受"插件系统看着在、实则没插件"。
 
+    ⚠️ 2026-08-22 起**发布流水线不再跑这个脚本**:Redis / S3 / Telnet 不再随安装包预装
+    (不是每个人都要连 Redis、开 S3、拨 Telnet),改由用户按需从插件商店
+    https://market.easilynet.top 自行安装。这个脚本从此只是**本机开发/联调**的工具:
+    想在自己机器上连同那几个插件一起跑就手动跑一次。跑过之后 artifacts/plugins/ 会一直留着,
+    本机 `dotnet publish` 出来的包会把它们一并打进去 —— 那只影响你自己的产物,不影响正式发行包。
+
 .PARAMETER Version
     要取的插件分发包版本。默认读 Directory.Build.props 的 VelaPluginsBundleVersion。
 

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -107,14 +107,18 @@
 
     ② 第一方插件仓库 joesdu/velashell-plugins(Redis / S3 / Telnet)
        以 Release 资产 velashell-plugins-<版本>.zip 交付,包内布局就是安装包 plugins/ 那一层。
-       本仓库按根 Directory.Build.props 的 VelaPluginsBundleVersion 取那一版,解到
-       artifacts/plugins/ 作为**暂存目录**,构建与发布都从这里取件。
+       解到 artifacts/plugins/ 作为**暂存目录**,构建与发布都从这里取件。
 
-    暂存目录怎么来:
+       ⚠️ 2026-08-22 起②**不再进发行包**:不是每个人都要连 Redis、开 S3、拨 Telnet,
+       预装等于给所有人塞三份用不上的依赖,还把发版绑在另一个仓库的发布顺序上。
+       用户按需从插件商店(https://market.easilynet.top)装。发布流水线已不跑取件脚本,
+       CI 上这个暂存目录压根不存在 —— 下面两个 Target 的 Exists/为空判断因此都会走空分支。
+       这里的机制保留是给**本机**用的:想在自己机器上连同那几个插件一起跑,取回来即可。
+
+    暂存目录怎么来(都是本机手动动作):
       · 日常:pwsh scripts/Fetch-Plugins.ps1      —— 按 pin 的版本下载并校验 sha256
       · 联调:pwsh scripts/Fetch-Plugins.ps1 -FromPluginsRepo <插件仓库路径>
               —— 就地构建那边的插件,不走网络
-      · CI:  发布流水线在 publish 之前跑同一个脚本(见 .github/workflows/release.yml)
     也可以用 -p:VelaPluginsStageDir=<目录> 直接指别处。
     取件脚本会把包里与①重名的插件目录丢掉 —— 同一个 id 出现两份会被 PluginManager 判重。
   -->
@@ -179,15 +183,16 @@
       <Output TaskParameter="TargetOutputs" ItemName="_VelaLocalPluginPayload" />
     </MSBuild>
 
-    <!-- ② 从工具链仓库取回、解在暂存目录里的插件。.bundle-version 是取件脚本的印记,不进包。 -->
+    <!-- ② 本机取回、解在暂存目录里的插件仓库侧插件。CI 上不存在这个目录(流水线不再取件),
+         这一项为空是**正常**的。.bundle-version 是取件脚本的印记,不进包。 -->
     <ItemGroup>
       <_VelaStagedPluginPayload Include="$(VelaPluginsStageDir)\**\*" Exclude="$(VelaPluginsStageDir)\.bundle-version" />
     </ItemGroup>
 
-    <!-- 两边都空会悄无声息地发出一个"插件系统看着在、实则没插件"的包,
-         宁可在这里断掉发布。发布路径不像构建路径那样容忍缺插件。 -->
+    <!-- 一个插件都没有会悄无声息地发出"插件系统看着在、实则没插件"的包,宁可在这里断掉发布。
+         正常路径靠①兜底:②不进发行包之后,这条只会在自建插件也全军覆没时才响。 -->
     <Error Condition="'@(_VelaLocalPluginPayload)' == '' and '@(_VelaStagedPluginPayload)' == ''"
-           Text="发布产物里没有任何插件:plugins/ 下没有 &lt;VelaPluginShip&gt;true&lt;/VelaPluginShip&gt; 的插件工程,插件暂存目录 '$(VelaPluginsStageDir)' 也是空的或不存在。先跑 `pwsh scripts/Fetch-Plugins.ps1` 取回 pin 的那一版($(VelaPluginsBundleVersion)),或用 -p:VelaPluginsStageDir= 指到别处。" />
+           Text="发布产物里没有任何插件:plugins/ 下没有 &lt;VelaPluginShip&gt;true&lt;/VelaPluginShip&gt; 的插件工程,插件暂存目录 '$(VelaPluginsStageDir)' 也是空的或不存在。发行包里的插件本该来自 plugins/ 下的自建工程 —— 先查那边为什么没产出;确实想把插件仓库侧的插件一并打进去,再跑 `pwsh scripts/Fetch-Plugins.ps1`。" />
 
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_VelaLocalPluginPayload)">


### PR DESCRIPTION
承接 #243。

## 为什么

不是每个人都要连 Redis、开 S3、拨 Telnet。预装等于给所有人塞三份用不上的依赖（光 Redis 与 S3 的 SDK 就近 5 MB），还把本仓库的发版绑在插件仓库的发布顺序上 —— 「先发插件仓库、再发主仓库」这条隐性约束正是 1.3.0 挂掉的土壤。

## 改动

- 发布流水线四个 job（windows / msix / macos / linux）的 `Fetch first-party plugins` 一并去掉。发行包里的 `plugins/` 从此只有本仓库自建的那些（当前是 `velashell.ai`）。
- Redis / S3 / Telnet 改由用户按需从插件商店 <https://market.easilynet.top> 安装 —— 插件管理页的安装入口旁已有链接（#243 加的）。
- `scripts/Fetch-Plugins.ps1` 与 `artifacts/plugins/` 暂存机制**保留**，降级为本机开发/联调工具。CI 上那个目录不存在，csproj 里两个 Target 走空分支。
- 「一个插件都没有就断掉发布」的护栏还在，只是现在只靠自建插件兜底；错误文案相应改写，不再叫人去 CI 上跑取件脚本。

## 验证

`-p:VelaPluginsStageDir` 指向不存在的目录跑 win-x64 self-contained publish（CI 的形状）：

- 包内 `plugins/` 只剩 `velashell-ai`，护栏未误触
- 体积 283 MB → 277 MB

两个下游影响已确认无碍：

- 用户从商店装的插件在**用户数据目录**下（`VelaShellStoragePaths.UserPluginDirectory`），不在应用目录里，换版不受影响。
- 老用户升级时更新器只铺 payload、不删 payload 之外的文件，已经装着的那三个插件不会凭空消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pc7ss3axJZteUfeF7AYVj