### PR TITLE
状态栏圆环展示插件安装与云同步进度

### DIFF
--- a/docs-en/plugins/STATUS.md
+++ b/docs-en/plugins/STATUS.md
@@ -207,3 +207,86 @@ active, prefetch reads files but never activates, prefetch off leaves no trace;
 `BackgroundActivityServiceTests` (8, including 64 concurrent activities settling back to empty — the
 ring must not spin forever); `StatusBarBackgroundActivityTests` (6, aggregation rules); and one UI
 test, `StatusBar_BackgroundRing_*` (hidden → visible → solid arc → hidden).
+
+## 2026-08-23 (2): more producers on the indicator, build hygiene closed out
+
+The first round of making the ring pay for itself: wire it to the places users actually wait on,
+and turn the plugin-mirroring build target into a real mirror.
+
+### Plugin installation on the ring
+
+`InstallFromVpxAsync` is several seconds of pure waiting — verify signature → extract → SHA-256 the
+whole directory for the install receipt — and until now the UI sat perfectly still
+(`PluginManagerViewModel` only posted a notice once it was over). It now reports per phase: the
+package filename is the subtitle first, swapped for the plugin's display name once the manifest is
+readable. Progress is a coarse ladder rather than a smooth curve: none of these steps offers
+fine-grained callbacks, and rather than invent a smooth fake, the arc jumps a step at a time — every
+jump corresponds to something genuinely finished.
+
+> Note: the plugin store (market.easilynet.top) is a link opened in the browser; the download does
+> not happen in-app. The slow seconds are entirely local — verification, extraction, hashing.
+
+**One thing deliberately not done**: activating right after install re-computes the directory hash
+that `SaveInstallReceiptAsync` just computed. It looks wasteful, but do not pre-seed the verification
+result to skip it — that would carve the window between "receipt written" and "first load" out of
+verification, and all it buys is one hash of a directory that is already in page cache (tens of
+milliseconds). This repository's posture on the plugin trust surface has consistently been to hash
+twice rather than trade a window for that. A comment in the code holds the line against the next
+person who wants to "just optimize this".
+
+### Cloud sync on the ring
+
+The four entry points of `GistSyncService` (sync now / push only / pull only / restore revision) each
+open an indeterminate activity, with the subtitle reusing the label of the identically-named button
+on the settings page (`SetSync_*`, already present in all five languages, nothing new added) — the
+wording a user sees matches the button they pressed. Indeterminate because the whole span is a
+network round trip: there is no meaningful percentage, and the question this activity answers is
+only ever "is it syncing right now?".
+
+Automatic sync has always been silent (startup pull, debounced push after a save, failures never
+interrupt). **"Not interrupting" should not mean "invisible"**: the user's connection profiles are
+being uploaded or overwritten, and that deserves somewhere to show up.
+
+### Build hygiene: the mirroring target actually mirrors now
+
+`CopyVelaPluginsToOutput` (which lays the `artifacts/plugins/` staging directory into the host's
+output) only ever added, never removed, and the files it copied were never recorded in MSBuild's
+clean ledger. Both consequences have genuinely bitten:
+
+- delete a plugin from staging and the copy in the output stays until someone removes it by hand;
+- `dotnet clean` could not remove them (their names were not on the ledger), which shows up as
+  "I cleaned and the plugins are still there".
+
+The fix: the target moved from `AfterTargets="Build"` to `AfterTargets="CopyFilesToOutputDirectory"`
+(ahead of `IncrementalClean`), and its copies are registered as `FileWrites`. Pruning and clean then
+come free from MSBuild's own incremental-clean machinery. One sweep is added on top:
+`IncrementalClean` removes files, so a pruned directory is left behind empty — the sweep removes
+directories with no `plugin.json` (equivalent to empty as far as the host is concerned) so that
+`ls plugins` never shows a plugin name that should have disappeared.
+
+Only this target's copies are registered: the self-built plugin (`velashell-ai`) is laid into the
+same `plugins/` by its own project and is not on this ledger, so it can never be pruned by mistake —
+verified by test.
+
+Evidence (four scenarios, measured): staging mirrors into the output; removing a plugin from staging
+prunes it on the next build; the emptied directory is swept; `dotnet clean` removes the mirrored
+plugins and leaves `velashell-ai` alone. New regressions:
+`InstallFromVpx_ReportsProgressToTheBackgroundLedger_AndClearsIt`,
+`InstallFromVpx_WhenRejected_StillClearsTheBackgroundLedger`,
+`SyncEntryPoints_ReportToTheBackgroundLedger_AndAlwaysClearIt` (all four exits distinguishable and
+each one always cleared).
+
+### Reviewed, and deliberately deferred
+
+- **Warm process pool for isolated plugin hosts**: a full activation cycle measures at roughly one
+  second (process launch plus Avalonia initialization dominate), so the number is real. But
+  `velashell.ai` and `velashell.redis` must both run `inProcess` (the former borrows the host's
+  AvaloniaEdit, the latter hands the host an Avalonia control to dock), so **there is not a single
+  isolated plugin today** — the pool would help nobody. Revisit when third-party isolated plugins
+  actually appear.
+- **ReadyToRun**: publishing uses `-p:SelfContained=true` with **no** `PublishReadyToRun`, so both
+  the app and `VelaShell.PluginHost` JIT cold on the user's machine. Enabling it benefits every user
+  on every launch and would absorb part of the isolated host's cold start without touching the IPC
+  protocol. The cost is 30–50% larger R2R'd assemblies (noticeable under self-contained). **The
+  benefit must be measured**, so it gets its own round: change the configuration, measure cold start
+  on all three platforms, then decide whether the size is worth it.

--- a/docs/plugins/STATUS.md
+++ b/docs/plugins/STATUS.md
@@ -176,3 +176,69 @@ AI / Redis 面板另有 headless 装载与交互测试。
 `BackgroundActivityServiceTests` 8 项(含并发 64 条活动后账本归零 —— 圆环不得一直转);
 `StatusBarBackgroundActivityTests` 6 项(聚合规则);UI 侧 `StatusBar_BackgroundRing_*` 1 项
 (收起 → 出现 → 确定弧 → 收起)。
+
+## 2026-08-23(二):后台活动指示器接入更多生产者,构建卫生收口
+
+圆环落地之后的第一轮"还本":把它接到用户真正会等的地方,并把镜像插件的构建目标改成
+真正的镜像语义。
+
+### 插件安装接入圆环
+
+`InstallFromVpxAsync` 全程是纯等待的几秒 —— 验签 → 解压 → 对整个目录算 SHA256 落安装凭据
+——此前界面上一动不动(`PluginManagerViewModel` 里只有一个"完了给条通知")。现在按阶段上报:
+包文件名先做副标题,清单读出来后换成插件显示名。进度是粗刻度而非平滑曲线:每一步内部
+都拿不到细粒度回调,与其编一个平滑的假进度,不如让弧一段一段地跳 —— 它至少每一跳都对应
+真的完成了一件事。
+
+> 注:插件商店(market.easilynet.top)是浏览器里开的链接,下载不在应用内 ——
+> 慢的那几秒全在本地的验签/解压/哈希上。
+
+**没有做的一件事**:装完随即激活会把 `SaveInstallReceiptAsync` 刚算过的目录哈希再算一遍,
+看着是浪费。但不要预置校验结果去省它 —— 那等于把"落凭据 → 首次装载"之间的窗口排除在
+校验之外,而省下的只是一次热缓存目录的哈希(几十毫秒)。这个仓库对插件信任面的态度一贯是
+宁可多算一遍。代码里留了注释挡住下一个想"顺手优化"的人。
+
+### 云同步接入圆环
+
+`GistSyncService` 的四条出口(立即同步 / 仅推送 / 仅拉取 / 恢复到此版本)各开一条不确定态
+活动,副标题直接复用设置页上同名按钮的文案(`SetSync_*`,五语已有,零新增)——
+用户看到的措辞与他点下去的那个按钮一致。走不确定态是因为整段是网络往返,给不出有意义的
+百分比,而这条活动要回答的问题本来也只有一个:"现在到底有没有在同步"。
+
+自动同步一向静默(启动拉取、保存后防抖推送,失败都不打扰用户)。**"不打扰"不该等于
+"什么都看不见"**:用户的连接配置正在被上传或覆盖,这件事值得有个去处。
+
+### 构建卫生:镜像插件的目标改成真正的镜像
+
+`CopyVelaPluginsToOutput`(把 `artifacts/plugins/` 暂存目录铺进宿主输出)此前只增不减,
+且复制出去的文件没登记进 MSBuild 的清理台账。两个后果都真实咬过人:
+
+- 从暂存目录删掉一个插件,输出里那份能一直留到手动删为止;
+- `dotnet clean` 清不掉它们(台账上没名字),表现是"clean 完插件还在"。
+
+改动:目标从 `AfterTargets="Build"` 挪到 `AfterTargets="CopyFilesToOutputDirectory"`
+(赶在 `IncrementalClean` 之前),并把复制产物登记进 `FileWrites`。于是剪枝与 clean 都由
+MSBuild 自己的增量清理机制免费提供。另加一道扫尾:`IncrementalClean` 剪的是文件,剪空的
+目录会原地留下来 —— 判据用"没有 `plugin.json`"(对宿主而言与空目录等价)把它们一并清掉,
+免得 `ls plugins` 看到一个早该消失的插件名。
+
+只登记本目标复制的文件:自建插件(`velashell-ai`)由插件工程自己铺进同一个 `plugins/`,
+不在这份台账里,因此绝不会被误剪 —— 这一条已实测。
+
+验收(四个场景实测):暂存目录 → 输出的镜像;从暂存目录删掉插件后重建即从输出剪掉;
+剪空的目录被扫掉;`dotnet clean` 能清动镜像出去的插件且不碰 `velashell-ai`。
+新增回归:`InstallFromVpx_ReportsProgressToTheBackgroundLedger_AndClearsIt`、
+`InstallFromVpx_WhenRejected_StillClearsTheBackgroundLedger`、
+`SyncEntryPoints_ReportToTheBackgroundLedger_AndAlwaysClearIt`(四条出口各自可辨且必收干净)。
+
+### 复核过、结论是暂不做的
+
+- **隔离插件的宿主进程预热池**:实测一次完整激活周期约 1 秒(进程拉起 + Avalonia 初始化
+  占大头),数字是真的。但当前 `velashell.ai` 与 `velashell.redis` 都必须 `inProcess`
+  (前者借宿主的 AvaloniaEdit,后者要向宿主交 Avalonia 控件挂进停靠区),**一个隔离插件都没有**
+  —— 这个池子今天谁也帮不上。等生态里真出现第三方隔离插件再做。
+- **ReadyToRun**:发布是 `-p:SelfContained=true` 且**没有** `PublishReadyToRun`,
+  主程序与 `VelaShell.PluginHost` 到用户机器上全靠 JIT 冷启。开了是所有人每次启动都受益,
+  且能顺带吃掉一部分隔离宿主的冷启动、不用动 IPC 协议。代价是 R2R'd 程序集大 30~50%
+  (self-contained 下包体增长可观)。**收益必须实测**,单独开一轮:改配置 → 三平台各测冷启动
+  → 拿数据决定包体值不值。

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.FilePicker.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.FilePicker.cs
@@ -12,7 +12,7 @@ namespace VelaShell.Plugin.Ai.Ui;
 /// <summary>
 /// 聊天面板的 <c>@</c> 文件引用部分:在输入框里键入 <c>@</c> 即列出所选会话的远端目录,
 /// 上下键选择、回车/Tab 确认、目录可继续下钻;发送时把被引用文件的内容随消息一并送给模型。
-/// 读取走 SFTP(<see cref="VelaShell.PluginSdk.RemoteFs.IRemoteFsApi" />),
+/// 读取走 SFTP(<see cref="IRemoteFsApi" />),
 /// 写回/编辑由 Agent 模式的 <c>write_remote_file</c> 工具负责(需审批)。
 /// </summary>
 public partial class ChatPanelView

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -1284,7 +1284,7 @@ public partial class ChatPanelView : UserControl
     /// <summary>套用宿主 ControlTheme(进程内可查;隔离进程缺失时保持默认外观)。</summary>
     private void ApplyThemeResource(Avalonia.Controls.Primitives.TemplatedControl control, string themeKey)
     {
-        if (this.TryFindResource(themeKey, out object? value) && value is Avalonia.Styling.ControlTheme theme)
+        if (this.TryFindResource(themeKey, out object? value) && value is ControlTheme theme)
         {
             control.Theme = theme;
         }

--- a/src/VelaShell.Core/Import/ImportedSession.cs
+++ b/src/VelaShell.Core/Import/ImportedSession.cs
@@ -43,13 +43,13 @@ public sealed class ImportedSession
 
     /// <summary>
     /// FTP / FTPS 的协议专属设置(加密方式等);仅当 <see cref="ConnectionType" /> 为
-    /// <see cref="Models.ConnectionType.FTP" /> 时非空。
+    /// <see cref="ConnectionType.FTP" /> 时非空。
     /// </summary>
     public FtpSettings? FtpSettings { get; init; }
 
     /// <summary>
     /// 插件协议 id;仅当 <see cref="ConnectionType" /> 为
-    /// <see cref="Models.ConnectionType.Plugin" /> 时非空。
+    /// <see cref="ConnectionType.Plugin" /> 时非空。
     /// <para>
     /// 导入器天生就认识外部工具的格式,因此由它把「WinSCP 的 S3 会话」映射到
     /// <c>velashell.s3</c> 这个协议 id;插件没装也照常导入 —— 配置留着,

--- a/src/VelaShell.Core/Processes/RemoteProcessProbe.cs
+++ b/src/VelaShell.Core/Processes/RemoteProcessProbe.cs
@@ -4,7 +4,7 @@ namespace VelaShell.Core.Processes;
 
 /// <summary>
 /// 远端进程列表探针:一条命令取回任务管理器需要的全部数据,以及把输出解析成快照。
-/// 面向 Linux(/proc + procps 的 ps),与 <see cref="Core.Services.SessionMetrics" /> 同样
+/// 面向 Linux(/proc + procps 的 ps),与 <see cref="Services.SessionMetrics" /> 同样
 /// 采用分段标记,任一段探测失败只丢该段,不拖垮整次采样。
 /// </summary>
 public static class RemoteProcessProbe

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3771,4 +3771,5 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="BackgroundTasks" xml:space="preserve"><value>バックグラウンドタスク</value></data>
   <data name="BackgroundTasksIdle" xml:space="preserve"><value>バックグラウンドタスクはありません</value></data>
   <data name="BackgroundTasksCount" xml:space="preserve"><value>バックグラウンドタスク {0} 件</value></data>
+  <data name="Msg_PluginInstalling" xml:space="preserve"><value>プラグインをインストール中</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3771,4 +3771,5 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="BackgroundTasks" xml:space="preserve"><value>백그라운드 작업</value></data>
   <data name="BackgroundTasksIdle" xml:space="preserve"><value>백그라운드 작업 없음</value></data>
   <data name="BackgroundTasksCount" xml:space="preserve"><value>백그라운드 작업 {0}개</value></data>
+  <data name="Msg_PluginInstalling" xml:space="preserve"><value>플러그인 설치 중</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3772,4 +3772,5 @@ Trusting it will also trust future packages signed by the same key. Plugins can 
   <data name="BackgroundTasks" xml:space="preserve"><value>Background tasks</value></data>
   <data name="BackgroundTasksIdle" xml:space="preserve"><value>No background tasks</value></data>
   <data name="BackgroundTasksCount" xml:space="preserve"><value>{0} background tasks</value></data>
+  <data name="Msg_PluginInstalling" xml:space="preserve"><value>Installing plugin</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3863,4 +3863,5 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="BackgroundTasks" xml:space="preserve"><value>后台任务</value></data>
   <data name="BackgroundTasksIdle" xml:space="preserve"><value>暂无后台任务</value></data>
   <data name="BackgroundTasksCount" xml:space="preserve"><value>{0} 项后台任务</value></data>
+  <data name="Msg_PluginInstalling" xml:space="preserve"><value>正在安装插件</value></data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3771,4 +3771,5 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="BackgroundTasks" xml:space="preserve"><value>背景工作</value></data>
   <data name="BackgroundTasksIdle" xml:space="preserve"><value>目前沒有背景工作</value></data>
   <data name="BackgroundTasksCount" xml:space="preserve"><value>{0} 項背景工作</value></data>
+  <data name="Msg_PluginInstalling" xml:space="preserve"><value>正在安裝外掛</value></data>
 </root>

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class InfrastructureServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         // 后台活动账本(状态栏右下角的圆环)。注册在最前面:插件运行时等生产者都要它,
         // 而它自己不依赖任何东西。
-        services.AddSingleton<Core.Services.IBackgroundActivityService, Core.Services.BackgroundActivityService>();
+        services.AddSingleton<IBackgroundActivityService, BackgroundActivityService>();
         services.AddSingleton<VelaShellStoragePaths>();
         services.AddSingleton<SonnetDbEngine>(sp => new(sp.GetRequiredService<VelaShellStoragePaths>()));
         services.AddSingleton<ISecretProtector>(sp => new AesSecretProtector(sp.GetRequiredService<VelaShellStoragePaths>()));
@@ -133,7 +133,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IPluginProtocolSessionService>(sp => sp.GetRequiredService<PluginProtocolFileService>());
         // 工作台连接类型(Redis、MySQL… 由插件提供):界面是插件自己的,所以这里没有数据面要翻译,
         // 只有"解析注册表 → 组装请求 → 翻译异常 → 会话登记"这几件宿主该做的事。
-        services.AddSingleton<PluginWorkspaceLauncher>(sp =>
+        services.AddSingleton(sp =>
         {
             PluginProtocolRegistry registry = sp.GetRequiredService<PluginProtocolRegistry>();
             var launcher = new PluginWorkspaceLauncher(registry);
@@ -151,7 +151,7 @@ public static class InfrastructureServiceCollectionExtensions
             sp.GetRequiredService<FtpFileService>(),
             sp.GetRequiredService<PluginProtocolFileService>(),
             sp.GetRequiredService<PluginProtocolFileService>()));
-        services.AddSingleton<SftpService>(sp =>
+        services.AddSingleton(sp =>
         {
             ISshConnectionService connSvc = sp.GetRequiredService<ISshConnectionService>();
             ISettingsService settings = sp.GetRequiredService<ISettingsService>();
@@ -175,7 +175,9 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IGistSyncService>(sp => new Sync.GistSyncService(
             sp.GetRequiredService<ISettingsService>(), sp.GetRequiredService<ISessionRepository>(),
             sp.GetRequiredService<IAppDataStore>(), sp.GetRequiredService<IQuickCommandRepository>(),
-            sp.GetRequiredService<ISecretProtector>()));
+            sp.GetRequiredService<ISecretProtector>(),
+            // 后台活动账本:自动同步是静默的,至少让状态栏的圆环交代一句"正在同步"。
+            sp.GetService<IBackgroundActivityService>()));
         services.AddSingleton<ISessionMetricsService>(sp =>
             new SessionMetricsService(sp.GetRequiredService<ISshConnectionService>()));
         services.AddSingleton<IRemoteProcessService>(sp =>

--- a/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
@@ -24,8 +24,8 @@ public static class PluginServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         // 插件数据后端:SonnetDB 单集合、按插件 id 命名空间隔离(KV + 机密),卸载整体清除。
-        services.AddSingleton<Plugins.IPluginDataStore>(sp => new Persistence.SonnetDbPluginDataStore(
-            sp.GetRequiredService<Persistence.SonnetDbEngine>(),
+        services.AddSingleton<IPluginDataStore>(sp => new SonnetDbPluginDataStore(
+            sp.GetRequiredService<SonnetDbEngine>(),
             sp.GetService<Core.Data.ISecretProtector>()));
         services.AddSingleton(sp =>
         {
@@ -69,7 +69,7 @@ public static class PluginServiceCollectionExtensions
                 CommandsFactory = sp.GetService<Func<string, IPluginLogger, ICommandsApi>>(),
                 UiFactory = sp.GetService<Func<string, IPluginLogger, IUiApi>>(),
                 ThemeTokensProvider = sp.GetService<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(),
-                DataStore = sp.GetService<Plugins.IPluginDataStore>(),
+                DataStore = sp.GetService<IPluginDataStore>(),
                 SecretProtector = sp.GetService<Core.Data.ISecretProtector>(),
                 Clipboard = sp.GetService<PluginSdk.Clipboard.IClipboardApi>(),
                 EmbedHost = sp.GetService<Plugins.Isolated.IPluginEmbedHost>(),

--- a/src/VelaShell.Infrastructure/Diagnostics/MmdbIpGeolocationService.cs
+++ b/src/VelaShell.Infrastructure/Diagnostics/MmdbIpGeolocationService.cs
@@ -192,9 +192,9 @@ public sealed class MmdbIpGeolocationService : IIpGeolocationService, IDisposabl
     [method: Constructor]
     // MMDB 记录的最小映射:只取落点与名称,不引入厂商专有字段。
     private sealed class MmdbRecord(
-        [MapKey("city")] MmdbIpGeolocationService.MmdbNamed? city,
-        [MapKey("country")] MmdbIpGeolocationService.MmdbCountry? country,
-        [MapKey("location")] MmdbIpGeolocationService.MmdbLocation? location
+        [MapKey("city")] MmdbNamed? city,
+        [MapKey("country")] MmdbCountry? country,
+        [MapKey("location")] MmdbLocation? location
         )
     {
         public MmdbNamed? City { get; } = city;

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -301,16 +301,26 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         string staging = Path.Combine(Path.GetTempPath(), "velashell-vpx", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(staging);
         PluginManifest? manifest = null;
+        // 安装是纯等待的几秒:验签 → 解压 → 对整个目录算哈希落安装凭据。
+        // 用户从商店下完包点"安装"之后,这段时间界面上必须有东西在动。
+        // 进度是按阶段给的粗刻度 —— 每一步内部都拿不到细粒度回调,与其编一个平滑的假进度,
+        // 不如让弧一段一段地跳:它至少每一跳都对应真的完成了一件事。
+        using IBackgroundActivityScope? activity = options.Activity?.Begin(
+            Strings.Get("Msg_PluginInstalling"), Path.GetFileName(vpxPath), progress: 0);
         try
         {
             await EnsureTrustInitializedAsync(cancellationToken).ConfigureAwait(false);
+            activity?.Report(0.1);
             VpxPackageInfo packageInfo = ExtractPackage(vpxPath, staging, allowUntrustedPackage);
+            activity?.Report(0.5);
             string manifestPath = Path.Combine(staging, PluginManifestReader.FileName);
             if (!File.Exists(manifestPath))
             {
                 throw new InvalidOperationException("Package has no plugin.json at its root.");
             }
             manifest = PluginManifestReader.Load(manifestPath); // 坏清单在此抛 PluginManifestException
+            // 清单读出来了,副标题就从包文件名换成插件的显示名 —— 那才是用户认得的东西。
+            activity?.Report(0.55, DisplayNameOf(manifest));
             string entryPath = Path.Combine(staging, manifest.Entry);
             if (!File.Exists(entryPath))
             {
@@ -337,6 +347,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             TryDeleteDirectory(target);
             Directory.Move(staging, target);
             staging = target; // 已搬走,finally 不再删
+            activity?.Report(0.7);
 
             try
             {
@@ -349,8 +360,13 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                 throw;
             }
 
+            activity?.Report(0.9);
             PluginDescriptor installed = Describe(target, Path.Combine(target, PluginManifestReader.FileName), [], false,
                 out bool needsVerification);
+            // 装完随即激活会把 SaveInstallReceiptAsync 刚算过的目录哈希再算一遍。看着是浪费,
+            // 但**不要**在这里预置校验结果去省它:那等于把"落凭据 → 首次装载"之间的窗口
+            // 排除在校验之外,而省下的只是一次热缓存目录的哈希(几十毫秒)。
+            // 这个仓库对插件信任面的态度一贯是宁可多算一遍,别为这点时间换窗口。
             var runtime = new PluginRuntime { Descriptor = installed, NeedsVerification = needsVerification };
             lock (_gate)
             {
@@ -368,6 +384,7 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                     RegisterActivationTriggers(runtime);
                 }
             }
+            activity?.Report(1);
             Log($"Installed plugin '{manifest.Id}' v{manifest.Version} from package.");
         }
         finally
@@ -1318,7 +1335,11 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
 
     /// <summary>面向用户的插件名:清单里的显示名,缺失时退回插件 id。</summary>
     private static string DisplayNameOf(PluginDescriptor descriptor) =>
-        descriptor.Manifest is { DisplayName: { Length: > 0 } name } ? name : descriptor.Id;
+        descriptor.Manifest is { } manifest ? DisplayNameOf(manifest) : descriptor.Id;
+
+    /// <inheritdoc cref="DisplayNameOf(PluginDescriptor)" />
+    private static string DisplayNameOf(PluginManifest manifest) =>
+        manifest is { DisplayName: { Length: > 0 } name } ? name : manifest.Id;
 
     /// <summary>
     /// 空闲巡检(蓝图 04 §资源控制,仅隔离模式):可回收插件连续空闲

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -186,7 +186,7 @@ public sealed class PluginManagerOptions
     /// 后台活动账本(状态栏右下角的圆环据此显示)。缺席时插件加载静默进行,
     /// 行为与引入指示器之前完全一致 —— headless 测试与无界面宿主不受影响。
     /// </summary>
-    public Core.Services.IBackgroundActivityService? Activity { get; init; }
+    public IBackgroundActivityService? Activity { get; init; }
 
     /// <summary>
     /// 是否对惰性等待中的插件做冷启动预读(把程序集抬进操作系统文件缓存)。

--- a/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
@@ -132,12 +132,12 @@ public sealed class PluginProtocolRegistry
     /// 一扇窗口是反过来的依赖方向。
     /// </para>
     /// </summary>
-    public Func<VelaShell.PluginSdk.Workspaces.WorkspaceConnectionProposal, Task<bool>>? ConnectionProposalHandler { get; set; }
+    public Func<WorkspaceConnectionProposal, Task<bool>>? ConnectionProposalHandler { get; set; }
 
     /// <summary>把一条连接提议转交界面层;没有处理器时返回 false。</summary>
     /// <param name="proposal">提议。</param>
     /// <returns>用户是否保存。</returns>
-    public async Task<bool> ProposeConnectionAsync(VelaShell.PluginSdk.Workspaces.WorkspaceConnectionProposal proposal)
+    public async Task<bool> ProposeConnectionAsync(WorkspaceConnectionProposal proposal)
     {
         ArgumentNullException.ThrowIfNull(proposal);
         if (ConnectionProposalHandler is not { } handler)
@@ -190,13 +190,13 @@ public sealed class PluginProtocolRegistry
     /// <summary>登记某插件在清单里声明的协议页签(发现期调用,不碰程序集)。</summary>
     /// <param name="pluginId">插件 id。</param>
     /// <param name="protocols">清单里的协议贡献。</param>
-    public void Declare(string pluginId, IEnumerable<VelaShell.PluginSdk.ProtocolContribution> protocols)
+    public void Declare(string pluginId, IEnumerable<PluginSdk.ProtocolContribution> protocols)
     {
         ArgumentNullException.ThrowIfNull(protocols);
         bool changed = false;
         lock (_gate)
         {
-            foreach (VelaShell.PluginSdk.ProtocolContribution protocol in protocols)
+            foreach (PluginSdk.ProtocolContribution protocol in protocols)
             {
                 // 同 id 先到先得,与插件 id 冲突处置一致:后来者不覆盖已在表里的声明。
                 changed |= _declared.TryAdd(protocol.Id,
@@ -213,7 +213,7 @@ public sealed class PluginProtocolRegistry
     /// <summary>
     /// 把某插件清单里声明的工作台页签登记进注册表(发现期调用,不碰程序集)。
     /// <para>
-    /// 刻意**不**与 <see cref="Declare(string, IEnumerable{VelaShell.PluginSdk.ProtocolContribution})" />
+    /// 刻意**不**与 <see cref="Declare(string, IEnumerable{PluginSdk.ProtocolContribution})" />
     /// 重载同名:两个重载只在集合元素类型上有别,而调用方普遍写
     /// <c>Declare(id, [new() { … }])</c> —— 目标类型化的 <c>new()</c> 在两个候选之间无从推断,
     /// 编译期就是一句二义调用。名字分开,调用点一眼看得出登记的是哪一种。
@@ -221,13 +221,13 @@ public sealed class PluginProtocolRegistry
     /// </summary>
     /// <param name="pluginId">插件 id。</param>
     /// <param name="workspaces">清单里的工作台贡献。</param>
-    public void DeclareWorkspaces(string pluginId, IEnumerable<VelaShell.PluginSdk.WorkspaceContribution> workspaces)
+    public void DeclareWorkspaces(string pluginId, IEnumerable<PluginSdk.WorkspaceContribution> workspaces)
     {
         ArgumentNullException.ThrowIfNull(workspaces);
         bool changed = false;
         lock (_gate)
         {
-            foreach (VelaShell.PluginSdk.WorkspaceContribution workspace in workspaces)
+            foreach (PluginSdk.WorkspaceContribution workspace in workspaces)
             {
                 changed |= _declared.TryAdd(workspace.Id,
                     new(workspace.Id, workspace.DisplayName, workspace.DefaultPort, pluginId, IsReady: false,

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
@@ -294,7 +294,7 @@ public sealed class TmdsSftpClientWrapper(Func<Task<SftpClient>> clientFactory) 
     public Task<SftpEntry?> GetEntryAsync(string path, CancellationToken ct = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return GuardedAsync<SftpEntry?>(async () =>
+        return GuardedAsync(async () =>
         {
             FileEntryAttributes? attrs = await EnsureClient()
                 .GetAttributesAsync(path, true, null, ct).ConfigureAwait(false);

--- a/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
+++ b/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
@@ -18,7 +18,8 @@ public sealed class GistSyncService(
     ISessionRepository sessionRepository,
     IAppDataStore appDataStore,
     IQuickCommandRepository quickCommandRepository,
-    ISecretProtector secretProtector
+    ISecretProtector secretProtector,
+    Core.Services.IBackgroundActivityService? backgroundActivity = null
 ) : IGistSyncService
 {
     private const int CurrentSchemaVersion = 2;
@@ -39,6 +40,23 @@ public sealed class GistSyncService(
 
     /// <summary>同步操作串行化:防止自动推送与手动同步并发互踩。</summary>
     private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <summary>
+    /// 在状态栏右下角的圆环上开一条"同步中"的活动;副标题用设置页上同名按钮的文案
+    /// (仅推送 / 仅拉取 / 立即同步),用户看到的措辞与他点下去的那个按钮一致。
+    /// <para>
+    /// 走不确定态:整段是网络往返,给不出有意义的百分比,而这条活动要回答的问题
+    /// 本来也只有一个 —— "现在到底有没有在同步"。
+    /// </para>
+    /// <para>
+    /// 自动同步一向静默(启动拉取、保存后防抖推送,失败都不打扰用户),但"不打扰"
+    /// 不该等于"什么都看不见":用户的连接配置正在被上传或覆盖,这件事值得有个去处。
+    /// </para>
+    /// </summary>
+    /// <param name="actionKey">设置页动作按钮的资源键。</param>
+    /// <returns>活动句柄;未注入账本时为 <see langword="null" />。</returns>
+    private Core.Services.IBackgroundActivityScope? BeginSyncActivity(string actionKey) =>
+        backgroundActivity?.Begin(Strings.Get("Msg_Syncing"), Strings.Get(actionKey));
 
     /// <summary>是否正在应用远端数据;为 true 时忽略由此触发的本地保存事件,避免拉取后被误判为本地改动而立即回推。</summary>
     public bool IsApplyingRemote { get; private set; }
@@ -109,6 +127,7 @@ public sealed class GistSyncService(
     public async Task<SyncResult> SyncNowAsync(CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        using Core.Services.IBackgroundActivityScope? activity = BeginSyncActivity("SetSync_SyncNow");
         try
         {
             SyncSettings config = await GetSyncSettingsAsync(cancellationToken)
@@ -197,6 +216,7 @@ public sealed class GistSyncService(
     public async Task<SyncResult> PushAsync(CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        using Core.Services.IBackgroundActivityScope? activity = BeginSyncActivity("SetSync_PushOnly");
         try
         {
             SyncSettings config = await GetSyncSettingsAsync(cancellationToken)
@@ -226,6 +246,7 @@ public sealed class GistSyncService(
     public async Task<SyncResult> PullAsync(CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        using Core.Services.IBackgroundActivityScope? activity = BeginSyncActivity("SetSync_PullOnly");
         try
         {
             SyncSettings config = await GetSyncSettingsAsync(cancellationToken)
@@ -345,6 +366,7 @@ public sealed class GistSyncService(
     {
         ArgumentException.ThrowIfNullOrEmpty(version);
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        using Core.Services.IBackgroundActivityScope? activity = BeginSyncActivity("SetSync_RestoreRevision");
         try
         {
             SyncSettings config = await GetSyncSettingsAsync(cancellationToken)

--- a/src/VelaShell.PluginHost/RemoteCapabilities.cs
+++ b/src/VelaShell.PluginHost/RemoteCapabilities.cs
@@ -325,7 +325,7 @@ internal sealed class RemoteEventHub(IPluginLogger log) : IHostEvents
 }
 
 /// <summary>机密能力的 RPC 代理:机密只存宿主侧,值仅在本机管道上瞬时传输。</summary>
-internal sealed class RpcSecrets(RpcConnection rpc) : VelaShell.PluginSdk.Secrets.ISecretsApi
+internal sealed class RpcSecrets(RpcConnection rpc) : PluginSdk.Secrets.ISecretsApi
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
@@ -341,7 +341,7 @@ internal sealed class RpcSecrets(RpcConnection rpc) : VelaShell.PluginSdk.Secret
 }
 
 /// <summary>剪贴板能力的 RPC 代理:经宿主主窗口执行,与进程内语义一致。</summary>
-internal sealed class RpcClipboard(RpcConnection rpc) : VelaShell.PluginSdk.Clipboard.IClipboardApi
+internal sealed class RpcClipboard(RpcConnection rpc) : PluginSdk.Clipboard.IClipboardApi
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
@@ -356,14 +356,14 @@ internal sealed class RpcClipboard(RpcConnection rpc) : VelaShell.PluginSdk.Clip
 /// KV 存储的 RPC 代理:数据落宿主 SonnetDB(按插件 id 命名空间隔离,卸载整体清除),
 /// 隔离进程不落本地文件。
 /// </summary>
-internal sealed class RpcStorage(RpcConnection rpc) : VelaShell.PluginSdk.Storage.IPluginStorage
+internal sealed class RpcStorage(RpcConnection rpc) : PluginSdk.Storage.IPluginStorage
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
-        System.Text.Json.JsonElement? value = await rpc.RequestAsync<System.Text.Json.JsonElement?>(
+        JsonElement? value = await rpc.RequestAsync<JsonElement?>(
             PluginRpc.StorageGet, new StorageKeyRef(key), Timeout, cancellationToken).ConfigureAwait(false);
         return value is { ValueKind: not System.Text.Json.JsonValueKind.Null and not System.Text.Json.JsonValueKind.Undefined } element
             ? element.Deserialize<T>()
@@ -393,12 +393,12 @@ internal sealed class RpcStorage(RpcConnection rpc) : VelaShell.PluginSdk.Storag
 /// 时序能力的 RPC 代理:句柄按 measurement 短名寻址(宿主侧记住已打开的实例),
 /// 数据落宿主 SonnetDB,隔离进程不落本地文件。
 /// </summary>
-internal sealed class RpcTimeSeries(RpcConnection rpc) : VelaShell.PluginSdk.TimeSeries.ITimeSeriesApi
+internal sealed class RpcTimeSeries(RpcConnection rpc) : PluginSdk.TimeSeries.ITimeSeriesApi
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
 
-    public async Task<VelaShell.PluginSdk.TimeSeries.ITimeSeries> OpenAsync(
-        VelaShell.PluginSdk.TimeSeries.TimeSeriesDefinition definition, CancellationToken cancellationToken = default)
+    public async Task<PluginSdk.TimeSeries.ITimeSeries> OpenAsync(
+        PluginSdk.TimeSeries.TimeSeriesDefinition definition, CancellationToken cancellationToken = default)
     {
         VelaShell.PluginSdk.TimeSeries.TimeSeriesValidation.RequireDefinition(definition);
         TimeSeriesNameRef? response = await rpc.RequestAsync<TimeSeriesNameRef>(PluginRpc.TimeSeriesOpen,
@@ -415,24 +415,24 @@ internal sealed class RpcTimeSeries(RpcConnection rpc) : VelaShell.PluginSdk.Tim
             .ConfigureAwait(false);
 
     /// <summary>单个 measurement 的 RPC 句柄。</summary>
-    private sealed class RpcSeries(RpcConnection rpc, string name) : VelaShell.PluginSdk.TimeSeries.ITimeSeries
+    private sealed class RpcSeries(RpcConnection rpc, string name) : PluginSdk.TimeSeries.ITimeSeries
     {
         public string Name => name;
 
-        public Task WriteAsync(VelaShell.PluginSdk.TimeSeries.TimeSeriesPoint point, CancellationToken cancellationToken = default)
+        public Task WriteAsync(PluginSdk.TimeSeries.TimeSeriesPoint point, CancellationToken cancellationToken = default)
             => WriteManyAsync([point], cancellationToken);
 
-        public Task WriteManyAsync(IEnumerable<VelaShell.PluginSdk.TimeSeries.TimeSeriesPoint> points,
+        public Task WriteManyAsync(IEnumerable<PluginSdk.TimeSeries.TimeSeriesPoint> points,
             CancellationToken cancellationToken = default)
             => rpc.RequestAsync<object>(PluginRpc.TimeSeriesWrite,
                 new TimeSeriesWriteRequest(name, [.. points]), Timeout, cancellationToken);
 
-        public async Task<IReadOnlyList<VelaShell.PluginSdk.TimeSeries.TimeSeriesPoint>> QueryAsync(
-            VelaShell.PluginSdk.TimeSeries.TimeSeriesQuery query, CancellationToken cancellationToken = default)
-            => await rpc.RequestAsync<VelaShell.PluginSdk.TimeSeries.TimeSeriesPoint[]>(PluginRpc.TimeSeriesQuery,
+        public async Task<IReadOnlyList<PluginSdk.TimeSeries.TimeSeriesPoint>> QueryAsync(
+            PluginSdk.TimeSeries.TimeSeriesQuery query, CancellationToken cancellationToken = default)
+            => await rpc.RequestAsync<PluginSdk.TimeSeries.TimeSeriesPoint[]>(PluginRpc.TimeSeriesQuery,
                    new TimeSeriesQueryRequest(name, query), Timeout, cancellationToken).ConfigureAwait(false) ?? [];
 
-        public async Task<long> CountAsync(string field, VelaShell.PluginSdk.TimeSeries.TimeSeriesQuery query,
+        public async Task<long> CountAsync(string field, PluginSdk.TimeSeries.TimeSeriesQuery query,
             CancellationToken cancellationToken = default)
             => await rpc.RequestAsync<long>(PluginRpc.TimeSeriesCount,
                 new TimeSeriesCountRequest(name, field, query), Timeout, cancellationToken).ConfigureAwait(false);
@@ -517,7 +517,7 @@ internal sealed class RemoteReadStream(RpcConnection rpc, string streamId, long 
 }
 
 /// <summary>终端能力的 RPC 代理:读取/搜索/回写全部路由到宿主(授权对话框在宿主弹)。</summary>
-internal sealed class RpcTerminal(RpcConnection rpc) : VelaShell.PluginSdk.Terminal.ITerminalApi
+internal sealed class RpcTerminal(RpcConnection rpc) : PluginSdk.Terminal.ITerminalApi
 {
     // 回写可能等用户在对话框上做选择,给足时间。
     private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(30);
@@ -527,13 +527,13 @@ internal sealed class RpcTerminal(RpcConnection rpc) : VelaShell.PluginSdk.Termi
         => await rpc.RequestAsync<string>(PluginRpc.TerminalGetOutput,
                new TerminalGetOutputRequest(sessionId, maxLines), ReadTimeout, cancellationToken).ConfigureAwait(false) ?? "";
 
-    public async Task<IReadOnlyList<VelaShell.PluginSdk.Terminal.TerminalMatch>> SearchOutputAsync(string sessionId,
+    public async Task<IReadOnlyList<PluginSdk.Terminal.TerminalMatch>> SearchOutputAsync(string sessionId,
         string pattern, bool isRegex = false, int maxMatches = 100, CancellationToken cancellationToken = default)
     {
         TerminalMatchDto[] hits = await rpc.RequestAsync<TerminalMatchDto[]>(PluginRpc.TerminalSearch,
             new TerminalSearchRequest(sessionId, pattern, isRegex, maxMatches), ReadTimeout, cancellationToken)
             .ConfigureAwait(false) ?? [];
-        return [.. hits.Select(h => new VelaShell.PluginSdk.Terminal.TerminalMatch(h.Line, h.Text))];
+        return [.. hits.Select(h => new PluginSdk.Terminal.TerminalMatch(h.Line, h.Text))];
     }
 
     public Task WriteAsync(string sessionId, string input, CancellationToken cancellationToken = default)

--- a/src/VelaShell.PluginHost/RemotePluginContext.cs
+++ b/src/VelaShell.PluginHost/RemotePluginContext.cs
@@ -1,4 +1,4 @@
-﻿using VelaShell.PluginSdk;
+using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Commands;
 using VelaShell.PluginSdk.Events;
 using VelaShell.PluginSdk.Logging;
@@ -60,16 +60,16 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
     public IHostInfo Host => HostInfo;
     public IPluginLogger Log { get; }
     public IPluginStorage Storage { get; }
-    public VelaShell.PluginSdk.TimeSeries.ITimeSeriesApi TimeSeries { get; }
+    public PluginSdk.TimeSeries.ITimeSeriesApi TimeSeries { get; }
     public ISessionsApi Sessions { get; }
     public IRemoteFsApi RemoteFs => RemoteFsProxy;
     public IRemoteExecApi RemoteExec { get; }
     public ICommandsApi Commands => CommandsProxy;
     public IHostEvents Events => EventsHub;
     public IUiApi Ui => UiLocal;
-    public VelaShell.PluginSdk.Secrets.ISecretsApi Secrets { get; }
-    public VelaShell.PluginSdk.Clipboard.IClipboardApi Clipboard { get; }
-    public VelaShell.PluginSdk.Terminal.ITerminalApi Terminal { get; }
+    public PluginSdk.Secrets.ISecretsApi Secrets { get; }
+    public PluginSdk.Clipboard.IClipboardApi Clipboard { get; }
+    public PluginSdk.Terminal.ITerminalApi Terminal { get; }
 
     /// <summary>
     /// 协议能力在隔离进程里**不可用**:协议是宿主反向调用插件的高频通道(列目录、流式读、

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -63,23 +63,23 @@ public class App : Application
             .AddSingleton<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(_ =>
                 VelaShell.Services.Plugins.PluginThemeTokens.CollectAsync)
             // 插件剪贴板能力:经主窗口系统剪贴板(隔离插件经 RPC 路由到同一实现)。
-            .AddSingleton<PluginSdk.Clipboard.IClipboardApi>(new VelaShell.Services.Plugins.HostClipboard())
+            .AddSingleton<PluginSdk.Clipboard.IClipboardApi>(new Services.Plugins.HostClipboard())
             // 隔离插件的停靠请求默认回退为独立卡片窗口(跨进程 dock 嵌入与 dock reparenting
             // 有根本张力,已弃用;真·dock 标签页请用 inProcess 模式),故不注册 IPluginEmbedHost。
             // 终端回写授权闸(始终允许持久化到 SonnetDB app_config)+ 授权对话框。
-            .AddSingleton<Infrastructure.Plugins.IPluginPermissionPrompt>(new VelaShell.Services.Plugins.DialogPermissionPrompt())
+            .AddSingleton<Infrastructure.Plugins.IPluginPermissionPrompt>(new Services.Plugins.DialogPermissionPrompt())
             .AddSingleton(sp => new Infrastructure.Plugins.PluginPermissionGate(
                 sp.GetService<IAppDataStore>(),
                 sp.GetService<Infrastructure.Plugins.IPluginPermissionPrompt>()))
             // 插件终端能力:读取/搜索终端缓冲 + 授权回写(经主窗口视图模型解析会话仿真器)。
             .AddSingleton<Func<string, IPluginLogger, PluginSdk.Terminal.ITerminalApi>>(sp =>
-                (pluginId, log) => new VelaShell.Services.Plugins.HostTerminal(pluginId, log,
+                (pluginId, log) => new Services.Plugins.HostTerminal(pluginId, log,
                     () => sp.GetService<MainWindowViewModel>(),
                     sp.GetRequiredService<Infrastructure.Plugins.PluginPermissionGate>()))
             // 插件终端视图能力:出借宿主的终端仿真器(VT 解析 + 屏幕缓冲 + 输入编码),
             // 外观跟随宿主当前的终端设置。仅进程内插件可用 —— 交出去的是活的原生控件。
             .AddSingleton<PluginSdk.TerminalView.ITerminalViewApi>(sp =>
-                new VelaShell.Services.Plugins.PluginTerminalViewApi(
+                new Services.Plugins.PluginTerminalViewApi(
                     () => sp.GetService<MainWindowViewModel>()))
             // 进程内插件运行时(docs/plugins/dev-guide.md)。注册零开销:
             // 发现与激活在主窗口显示后的后台线程进行,不占启动路径。
@@ -110,7 +110,7 @@ public class App : Application
         // 头像、插件)的出站请求;每次请求动态取当前代理设置,保存即生效。
         // SSH / FTP 的代理走各自适配层,同样消费这一个 IProxyResolver。
         VelaShell.Infrastructure.Net.VelaWebProxy.Install(
-            _serviceProvider.GetRequiredService<VelaShell.Core.Net.IProxyResolver>());
+            _serviceProvider.GetRequiredService<Core.Net.IProxyResolver>());
 
         // 本地化字符串的实时重绑定({loc:Localize})跟随 DI 服务(#4)。
         ILocalizationService localization =
@@ -215,7 +215,7 @@ public class App : Application
 
             // 宿主自我登记(~/.velashell/host.json):插件工具链据此找到本机安装、核对版本。
             // 一次文件写入,放后台线程,不占启动路径。
-            if (_serviceProvider?.GetService<VelaShell.Infrastructure.Persistence.VelaShellStoragePaths>() is { } storagePaths)
+            if (_serviceProvider?.GetService<Infrastructure.Persistence.VelaShellStoragePaths>() is { } storagePaths)
             {
                 _ = Task.Run(() => HostRegistrationService.Register(storagePaths));
             }
@@ -223,7 +223,7 @@ public class App : Application
             // 插件运行时:主窗口就绪后在后台线程发现并激活插件(启动路径零阻塞)。
             // VELASHELL_DISABLE_PLUGINS=1 为排障急停开关;停用随 DI 容器释放执行。
             if (Environment.GetEnvironmentVariable("VELASHELL_DISABLE_PLUGINS") != "1"
-                && _serviceProvider?.GetService<VelaShell.Infrastructure.Plugins.PluginManager>() is { } pluginManager)
+                && _serviceProvider?.GetService<Infrastructure.Plugins.PluginManager>() is { } pluginManager)
             {
                 _ = Task.Run(async () =>
                 {

--- a/src/VelaShell/Services/Plugins/PluginThemeTokens.cs
+++ b/src/VelaShell/Services/Plugins/PluginThemeTokens.cs
@@ -18,7 +18,7 @@ internal static class PluginThemeTokens
 {
     /// <summary>在 UI 线程枚举并解析全部 Vela* 令牌(画刷/颜色/数值/字体)。</summary>
     public static Task<IReadOnlyList<ThemeTokenDto>> CollectAsync() =>
-        Dispatcher.UIThread.InvokeAsync<IReadOnlyList<ThemeTokenDto>>(CollectOnUiThread).GetTask();
+        Dispatcher.UIThread.InvokeAsync(CollectOnUiThread).GetTask();
 
     private static IReadOnlyList<ThemeTokenDto> CollectOnUiThread()
     {
@@ -57,7 +57,7 @@ internal static class PluginThemeTokens
                 {
                     CollectKeys(merged, keys);
                 }
-                foreach (KeyValuePair<Avalonia.Styling.ThemeVariant, Avalonia.Controls.IThemeVariantProvider> theme in dictionary.ThemeDictionaries)
+                foreach (KeyValuePair<Avalonia.Styling.ThemeVariant, IThemeVariantProvider> theme in dictionary.ThemeDictionaries)
                 {
                     CollectKeys(theme.Value, keys);
                 }

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -129,14 +129,40 @@
   <!-- 开发内环:把暂存目录镜像进本项目输出的 plugins/,F5 即可装载(自建插件走的是
        plugins/Directory.Build.targets 的 CopyVelaPluginToAppOutput,不经过这里)。
        暂存目录不存在就静默跳过 —— 没取过插件的干净克隆照样能构建、能跑,
-       只是启动后只有自建的那几个插件。发布路径不接受一个插件都没有,见 AddVelaPluginsToPublish。 -->
-  <Target Name="CopyVelaPluginsToOutput" AfterTargets="Build" Condition="Exists('$(VelaPluginsStageDir)')">
+       只是启动后只有自建的那几个插件。发布路径不接受一个插件都没有,见 AddVelaPluginsToPublish。
+
+       挂 CopyFilesToOutputDirectory 而不是 Build,是为了赶在 IncrementalClean 之前 ——
+       下面把复制出去的文件登记进 FileWrites,于是:
+         · `dotnet clean` 能把它们清干净(此前清不掉:Copy 不登记就等于没在清理台账上留名,
+           表现是"clean 完插件还在",很难往构建产物残留上想);
+         · 从暂存目录里删掉一个插件后,下次构建 IncrementalClean 会按上一轮的台账
+           把它从输出里剪掉 —— 此前只增不减,删了源头输出里那份能一直留到手动删为止。
+       只登记本目标复制的文件:自建插件(velashell-ai)由插件工程自己铺进同一个 plugins/,
+       不在这份台账里,因此绝不会被误剪。 -->
+  <Target Name="CopyVelaPluginsToOutput" AfterTargets="CopyFilesToOutputDirectory"
+          Condition="Exists('$(VelaPluginsStageDir)')">
     <ItemGroup>
       <_VelaStagedPluginFile Include="$(VelaPluginsStageDir)\**\*" />
+      <_VelaStagedPluginOutput Include="@(_VelaStagedPluginFile->'$(OutDir)plugins\%(RecursiveDir)%(Filename)%(Extension)')" />
     </ItemGroup>
     <Copy SourceFiles="@(_VelaStagedPluginFile)"
-          DestinationFiles="@(_VelaStagedPluginFile->'$(OutDir)plugins\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(_VelaStagedPluginOutput)"
           SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <FileWrites Include="@(_VelaStagedPluginOutput)" />
+    </ItemGroup>
+    <!-- IncrementalClean 剪的是文件,剪空的目录会原地留下来。留着不影响运行
+         (宿主发现插件要求目录里有 plugin.json,没有就跳过),但 `ls plugins` 看到一个
+         早该消失的插件名会让人以为它还装着 —— 那正是这轮要消灭的困惑。
+         判据用"没有 plugin.json"而不是"目录为空":对宿主而言这两者等价,
+         而前者顺带也清掉了剪剩半截的残骸。 -->
+    <ItemGroup>
+      <_VelaOutputPluginDir Include="$([System.IO.Directory]::GetDirectories('$(OutDir)plugins'))"
+                            Condition="Exists('$(OutDir)plugins')" />
+      <_VelaOrphanPluginDir Include="@(_VelaOutputPluginDir)"
+                            Condition="!Exists('%(Identity)\plugin.json')" />
+    </ItemGroup>
+    <RemoveDir Directories="@(_VelaOrphanPluginDir)" />
   </Target>
 
   <!--

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -45,7 +45,7 @@ namespace VelaShell.ViewModels;
 /// 主窗口视图模型:应用外壳的中枢,统筹终端标签、SSH/本地会话生命周期、停靠工作区、
 /// 侧边栏、状态栏、命令面板、SFTP 文件面板与隧道面板,并串联设置、连接工作流与各项服务。
 /// </summary>
-public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.ITerminalResolver
+public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalResolver
 {
     /// <summary>
     /// bash 提示符目录上报钩子(内置、静默注入):每次提示符出现时发送 OSC 7,
@@ -487,7 +487,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     /// <summary>
     /// 插件终端能力经此按会话 id 解析到仿真器与人类可读标签(<see cref="Services.Plugins.ITerminalResolver" />)。
     /// </summary>
-    (VelaShell.Terminal.ITerminalEmulator Emulator, string Label)? Services.Plugins.ITerminalResolver.Resolve(Guid sessionId)
+    (ITerminalEmulator Emulator, string Label)? Services.Plugins.ITerminalResolver.Resolve(Guid sessionId)
     {
         foreach (TerminalTabViewModel tab in _tabBar.Tabs.OfType<TerminalTabViewModel>())
         {
@@ -3256,7 +3256,7 @@ public class MainWindowViewModel : ReactiveObject, VelaShell.Services.Plugins.IT
     /// <summary>借一个空闲的本地端口号(bind 0 → 读端口 → 放掉)。</summary>
     private static int ReserveLocalPort()
     {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
         listener.Start();
         try
         {

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1230,7 +1230,7 @@ public class SettingsViewModel : ReactiveObject
     private ProxyOptions? _hookedProxy;
 
     /// <summary>Proxy.Type 被直接改动时,同步派生的下拉索引与「参数可编辑」标志。</summary>
-    private void OnProxyItemChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void OnProxyItemChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(ProxyOptions.Type))
         {

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -123,7 +123,7 @@ public partial class ConnectionProfileView : Window
         {
             return;
         }
-        Avalonia.Point origin = target.TranslatePoint(default, ProtoTabsPanel) ?? default;
+        Point origin = target.TranslatePoint(default, ProtoTabsPanel) ?? default;
         (double X, double W) geometry = (Math.Round(origin.X), Math.Round(target.Bounds.Width));
         if (geometry == _protoIndicatorGeometry && ProtoTabIndicator.IsVisible)
         {
@@ -203,7 +203,7 @@ public partial class ConnectionProfileView : Window
         {
             Background = this.FindResource("VelaAccentDim") as IBrush,
             BorderBrush = this.FindResource("VelaAccent") as IBrush,
-            BorderThickness = new Avalonia.Thickness(1),
+            BorderThickness = new Thickness(1),
             IsHitTestVisible = false
         };
         return border;

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -214,7 +214,7 @@ public partial class MainWindow : Window
             // 打开宿主自己的「新建连接」对话框并预填。**插件不能自己写会话库** ——
             // 那是用户数据、凭据也在里面;它只能提议,由用户过一眼再按保存。
             if (Application.Current is App proposalApp
-                && proposalApp.Services?.GetService<VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry>()
+                && proposalApp.Services?.GetService<Infrastructure.Plugins.Protocols.PluginProtocolRegistry>()
                     is { } proposalRegistry)
             {
                 proposalRegistry.ConnectionProposalHandler = ProposeConnectionAsync;
@@ -897,7 +897,7 @@ public partial class MainWindow : Window
     /// <param name="proposal">插件的提议。</param>
     /// <returns>用户是否保存了这条连接。</returns>
     private async Task<bool> ProposeConnectionAsync(
-        VelaShell.PluginSdk.Workspaces.WorkspaceConnectionProposal proposal)
+        PluginSdk.Workspaces.WorkspaceConnectionProposal proposal)
     {
         var profile = new SessionProfile
         {
@@ -964,7 +964,7 @@ public partial class MainWindow : Window
             defaultKeyPath,
             // 协议注册表:连接页据此画出插件协议页签(不装载任何插件程序集),
             // 用户点到某个页签才触发它的惰性激活。
-            app.Services.GetService<VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry>()
+            app.Services.GetService<Infrastructure.Plugins.Protocols.PluginProtocolRegistry>()
         );
         var dialog = new ConnectionProfileView { DataContext = connectionProfileViewModel };
         SessionProfile? profile = await dialog.ShowDialog<SessionProfile?>(this);
@@ -1060,7 +1060,7 @@ public partial class MainWindow : Window
             return;
         }
         IServiceProvider? services = (Application.Current as App)?.Services;
-        IIpGeolocationService? geo = services?.GetService<Core.Diagnostics.IIpGeolocationService>();
+        IIpGeolocationService? geo = services?.GetService<IIpGeolocationService>();
         ISettingsService? settings = services?.GetService<ISettingsService>();
         var viewModel = new TraceRouteViewModel(
             vm.TraceRouteService,

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -68,7 +68,7 @@ public class SftpServiceTests
     [TestMethod]
     public async Task UploadFileAsync_PreserveTimestampsOff_DoesNotTouchRemoteMtime()
     {
-        ISettingsService settings = Substitute.For<VelaShell.Core.Data.ISettingsService>();
+        ISettingsService settings = Substitute.For<ISettingsService>();
         settings.GetSettingsAsync().Returns(new AppSettings { Transfer = { PreserveTimestamps = false } });
         var service = new SftpService(_connectionService, _ => _sftpClient, settings);
         string localPath = Path.Combine(Path.GetTempPath(), $"vela-mtime-{Guid.NewGuid():N}.txt");

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using System.Text.Json;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.Infrastructure.Plugins.Capabilities;
@@ -70,7 +70,7 @@ public class EmbedRoutingTests
         RemoteFs = new FakeRemoteFs(),
         RemoteExec = new FakeRemoteExec(),
         RemoteTunnel = new FakeRemoteTunnel(),
-        TerminalView = new VelaShell.PluginSdk.Testing.FakeTerminalViewApi(),
+        TerminalView = new FakeTerminalViewApi(),
         Commands = new RecordingCommands(),
         Events = new PluginEventHub(new CollectingLogger(), null, null, null),
         Ui = new FakeUi(),

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
@@ -111,14 +111,14 @@ public class LazyActivationTests
         await manager.DisposeAsync();
     }
 
-    private sealed class RecordingDataStore : VelaShell.Infrastructure.Plugins.IPluginDataStore
+    private sealed class RecordingDataStore : IPluginDataStore
     {
         public List<string> Present { get; } = [];
         public List<string> Purged { get; } = [];
 
-        public VelaShell.PluginSdk.Storage.IPluginStorage CreateStorage(string pluginId) => new InMemoryStorage();
-        public VelaShell.PluginSdk.Secrets.ISecretsApi CreateSecrets(string pluginId) => new FakeSecrets();
-        public VelaShell.PluginSdk.TimeSeries.ITimeSeriesApi CreateTimeSeries(string pluginId) => new InMemoryTimeSeries();
+        public PluginSdk.Storage.IPluginStorage CreateStorage(string pluginId) => new InMemoryStorage();
+        public PluginSdk.Secrets.ISecretsApi CreateSecrets(string pluginId) => new FakeSecrets();
+        public PluginSdk.TimeSeries.ITimeSeriesApi CreateTimeSeries(string pluginId) => new InMemoryTimeSeries();
 
         public Task<IReadOnlyList<string>> ListPluginIdsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<string>>([.. Present]);

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Security.Cryptography;
+using VelaShell.Core.Resources;
 using VelaShell.Infrastructure.Persistence;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.PluginSdk.Packaging;
@@ -18,12 +19,12 @@ public class PluginInstallUninstallTests
     private string _dataRoot = null!;
     private RecordingDataStore _dataStore = null!;
 
-    private sealed class RecordingDataStore : VelaShell.Infrastructure.Plugins.IPluginDataStore
+    private sealed class RecordingDataStore : IPluginDataStore
     {
         public List<string> Purged { get; } = [];
-        public VelaShell.PluginSdk.Storage.IPluginStorage CreateStorage(string pluginId) => new InMemoryStorage();
-        public VelaShell.PluginSdk.Secrets.ISecretsApi CreateSecrets(string pluginId) => new FakeSecrets();
-        public VelaShell.PluginSdk.TimeSeries.ITimeSeriesApi CreateTimeSeries(string pluginId) => new InMemoryTimeSeries();
+        public PluginSdk.Storage.IPluginStorage CreateStorage(string pluginId) => new InMemoryStorage();
+        public PluginSdk.Secrets.ISecretsApi CreateSecrets(string pluginId) => new FakeSecrets();
+        public PluginSdk.TimeSeries.ITimeSeriesApi CreateTimeSeries(string pluginId) => new InMemoryTimeSeries();
         public Task<IReadOnlyList<string>> ListPluginIdsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<string>>([]);
         public Task PurgeAsync(string pluginId, CancellationToken cancellationToken = default)
         {
@@ -58,7 +59,8 @@ public class PluginInstallUninstallTests
     }
 
     private PluginManager CreateManager(PluginTrustRepository? trustRepository = null,
-        VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry? protocolRegistry = null) => new(new()
+        Infrastructure.Plugins.Protocols.PluginProtocolRegistry? protocolRegistry = null,
+        Core.Services.IBackgroundActivityService? activity = null) => new(new()
         {
             PluginRoots = [_appRoot, _userRoot],
             DataRootDirectory = _dataRoot,
@@ -67,7 +69,8 @@ public class PluginInstallUninstallTests
             HostVersion = "1.0.0",
             CommandsFactory = (_, _) => new RecordingCommands(),
             DataStore = _dataStore,
-            ProtocolRegistry = protocolRegistry
+            ProtocolRegistry = protocolRegistry,
+            Activity = activity
         });
 
     /// <summary>把夹具插件摊成一个待打包目录(plugin.json + dll)。</summary>
@@ -114,6 +117,57 @@ public class PluginInstallUninstallTests
         Assert.AreEqual(PluginState.Active, descriptor.State, descriptor.Error);
         Assert.IsTrue(File.Exists(Path.Combine(_userRoot, id, "plugin.json")), "应解包进用户插件目录");
         Assert.IsTrue(manager.IsUninstallable(id));
+
+        await manager.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task InstallFromVpx_ReportsProgressToTheBackgroundLedger_AndClearsIt()
+    {
+        // 安装是纯等待的几秒(验签 → 解压 → 全目录哈希落凭据),这段时间状态栏的圆环
+        // 必须转起来;更要紧的是**转完必须停**,否则一次安装会让它一直转到关程序。
+        using var activity = new Core.Services.BackgroundActivityService();
+        var progress = new List<double?>();
+        string? title = null;
+        activity.Changed += () =>
+        {
+            foreach (Core.Services.BackgroundActivitySnapshot snapshot in activity.Activities)
+            {
+                if (snapshot.Title == Strings.Get("Msg_PluginInstalling"))
+                {
+                    title = snapshot.Title;
+                    lock (progress)
+                    {
+                        progress.Add(snapshot.Progress);
+                    }
+                }
+            }
+        };
+        PluginManager manager = CreateManager(activity: activity);
+        await manager.StartAsync();
+
+        await manager.InstallFromVpxAsync(BuildVpx(), allowUntrustedPackage: true);
+
+        Assert.AreEqual(Strings.Get("Msg_PluginInstalling"), title, "安装过程必须在账本上露过面。");
+        Assert.IsGreaterThan(1, progress.Count, "安装应分阶段上报进度,而不是从头到尾一个 0%。");
+        Assert.IsEmpty(activity.Activities, "安装结束后账本必须归零。");
+
+        await manager.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task InstallFromVpx_WhenRejected_StillClearsTheBackgroundLedger()
+    {
+        // 失败路径同样要收干净:装坏包比装好包常见,而"装失败之后圆环永远在转"
+        // 比没有圆环更糟 —— 它会让人以为后台还有什么没做完。
+        using var activity = new Core.Services.BackgroundActivityService();
+        PluginManager manager = CreateManager(activity: activity);
+        await manager.StartAsync();
+
+        await Assert.ThrowsExactlyAsync<VpxFormatException>(
+            () => manager.InstallFromVpxAsync(BuildRenamedZip()));
+
+        Assert.IsEmpty(activity.Activities);
 
         await manager.DisposeAsync();
     }
@@ -252,7 +306,7 @@ public class PluginInstallUninstallTests
         const string id = "acme.tab-tamper";
         const string workspace = """, "contributes": { "workspaces": [ { "id": "acme.tab-tamper.cache", "displayName": "Cache", "defaultPort": 6379 } ] }, "activationEvents": ["onWorkspace:acme.tab-tamper.cache"]""";
 
-        var firstRegistry = new VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
+        var firstRegistry = new Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
         PluginManager manager = CreateManager(repository, firstRegistry);
         await manager.StartAsync();
         await manager.InstallFromVpxAsync(BuildVpx(id, workspace), allowUntrustedPackage: true);
@@ -260,7 +314,7 @@ public class PluginInstallUninstallTests
         await manager.DisposeAsync();
 
         await File.AppendAllTextAsync(Path.Combine(_userRoot, id, "plugin.json"), " ");
-        var registry = new VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
+        var registry = new Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
         PluginManager restarted = CreateManager(repository, registry);
         await restarted.StartAsync();
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginProtocolTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginProtocolTests.cs
@@ -321,7 +321,7 @@ public sealed class PluginProtocolTests
         public Task<bool> ExistsAsync(string sessionId, string path, CancellationToken cancellationToken = default) => Task.FromResult(false);
 
         public Task<Stream> OpenReadAsync(string sessionId, string path, CancellationToken cancellationToken = default) =>
-            Task.FromResult<Stream>(Stream.Null);
+            Task.FromResult(Stream.Null);
 
         public Task UploadFileAsync(string sessionId, string localPath, string remotePath, IProgress<RemoteTransferProgress>? progress = null, long resumeOffset = 0, CancellationToken cancellationToken = default) => Task.CompletedTask;
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginTerminalProtocolTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginTerminalProtocolTests.cs
@@ -144,7 +144,7 @@ public sealed class PluginTerminalProtocolTests
     {
         // 宿主的重试/弹框逻辑认的是 Core 的异常族;漏翻的表现是"密码错了却当成网络故障"。
         var registration = new PluginProtocolRegistration("test", Descriptor(), FileSystem: null, new ThrowingTerminal());
-        await Assert.ThrowsExactlyAsync<VelaShell.Core.Protocols.PluginProtocolAuthenticationException>(
+        await Assert.ThrowsExactlyAsync<Core.Protocols.PluginProtocolAuthenticationException>(
             () => PluginProtocolTerminalConnector.OpenAsync(registration, Profile(), new("xterm", 80, 24)));
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using VelaShell.Infrastructure.Plugins;
 using VelaShell.Infrastructure.Plugins.Capabilities;
 using VelaShell.PluginSdk;
@@ -43,7 +43,7 @@ public class StreamingRoutingTests
             RemoteFs = remoteFs,
             RemoteExec = new FakeRemoteExec(),
             RemoteTunnel = new FakeRemoteTunnel(),
-            TerminalView = new VelaShell.PluginSdk.Testing.FakeTerminalViewApi(),
+            TerminalView = new FakeTerminalViewApi(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
             Ui = new FakeUi(),
@@ -56,7 +56,7 @@ public class StreamingRoutingTests
             Shutdown = CancellationToken.None
         };
         var hostConnection = new RpcConnection(serverPipe);
-        var router = new VelaShell.Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
         hostConnection.SetRequestHandler(router.HandleRequestAsync);
         hostConnection.SetNotificationHandler(router.HandleNotification);
         hostConnection.Start();

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
@@ -52,7 +52,7 @@ public class TimeSeriesRoutingTests
             RemoteFs = new FakeRemoteFs(),
             RemoteExec = new FakeRemoteExec(),
             RemoteTunnel = new FakeRemoteTunnel(),
-            TerminalView = new VelaShell.PluginSdk.Testing.FakeTerminalViewApi(),
+            TerminalView = new FakeTerminalViewApi(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
             Ui = new FakeUi(),
@@ -65,7 +65,7 @@ public class TimeSeriesRoutingTests
             Shutdown = CancellationToken.None
         };
         var hostConnection = new RpcConnection(serverPipe);
-        var router = new VelaShell.Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
         hostConnection.SetRequestHandler(router.HandleRequestAsync);
         hostConnection.SetNotificationHandler(router.HandleNotification);
         hostConnection.Start();

--- a/tests/VelaShell.Infrastructure.Tests/Sync/GistSyncServiceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Sync/GistSyncServiceTests.cs
@@ -58,4 +58,45 @@ public sealed class GistSyncServiceTests
         Assert.IsTrue(profileWasSavedWhenNotified, "通知必须发生在连接配置写入仓储之后。");
         await sessions.Received(1).SaveSessionAsync(profile);
     }
+
+    [TestMethod]
+    [TestCategory("BackgroundActivity")]
+    public async Task SyncEntryPoints_ReportToTheBackgroundLedger_AndAlwaysClearIt()
+    {
+        // 云同步一向静默(启动拉取、保存后防抖推送,失败都不打扰用户)。接进账本之后
+        // "现在有没有在同步"至少有个去处 —— 但静默的另一面是它出错也不吭声,
+        // 所以**每一条出口都必须把活动收干净**,包括配置无效直接返回的那条快速失败路径。
+        ISettingsService settings = Substitute.For<ISettingsService>();
+        ISessionRepository sessions = Substitute.For<ISessionRepository>();
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        IQuickCommandRepository snippets = Substitute.For<IQuickCommandRepository>();
+        ISecretProtector secrets = Substitute.For<ISecretProtector>();
+        sessions.GetAllSessionsAsync().Returns([]);
+        using var activity = new Core.Services.BackgroundActivityService();
+        var seen = new List<string>();
+        activity.Changed += () =>
+        {
+            lock (seen)
+            {
+                foreach (Core.Services.BackgroundActivitySnapshot snapshot in activity.Activities)
+                {
+                    if (snapshot.Detail is { } detail && !seen.Contains(detail))
+                    {
+                        seen.Add(detail);
+                    }
+                }
+            }
+        };
+        var service = new GistSyncService(settings, sessions, store, snippets, secrets, activity);
+
+        // 未配置 Gist:四条出口都走 Validate 的快速失败,正好用来验"开了必收"。
+        Assert.IsFalse((await service.SyncNowAsync()).Success);
+        Assert.IsFalse((await service.PushAsync()).Success);
+        Assert.IsFalse((await service.PullAsync()).Success);
+        Assert.IsFalse((await service.RestoreRevisionAsync("rev-1")).Success);
+
+        Assert.IsEmpty(activity.Activities, "同步的每一条出口都必须把活动收干净。");
+        // 副标题用设置页同名按钮的文案,四条各不相同 —— 用户能分清是在推还是在拉。
+        Assert.HasCount(4, seen, $"四条出口应各自可辨:{string.Join(" / ", seen)}");
+    }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatHistoryStoreTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatHistoryStoreTests.cs
@@ -142,11 +142,11 @@ public sealed class ChatHistoryStoreTests
     }
 
     /// <summary>没有数据库的宿主上的时序能力(与 PluginManager 的退化实现同语义)。</summary>
-    private sealed class UnavailableTimeSeries : VelaShell.PluginSdk.TimeSeries.ITimeSeriesApi
+    private sealed class UnavailableTimeSeries : PluginSdk.TimeSeries.ITimeSeriesApi
     {
-        public Task<VelaShell.PluginSdk.TimeSeries.ITimeSeries> OpenAsync(
-            VelaShell.PluginSdk.TimeSeries.TimeSeriesDefinition definition, CancellationToken cancellationToken = default)
-            => Task.FromException<VelaShell.PluginSdk.TimeSeries.ITimeSeries>(
+        public Task<PluginSdk.TimeSeries.ITimeSeries> OpenAsync(
+            PluginSdk.TimeSeries.TimeSeriesDefinition definition, CancellationToken cancellationToken = default)
+            => Task.FromException<PluginSdk.TimeSeries.ITimeSeries>(
                 new InvalidOperationException("Time series capability is unavailable in this host."));
 
         public Task<IReadOnlyList<string>> ListAsync(CancellationToken cancellationToken = default)

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
@@ -221,7 +221,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hosts", "127.0.0.1 localhost"u8.ToArray());
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", "web-01"u8.ToArray());
             context.FakeRemoteFs.AddDirectory(session.SessionId, "/etc/nginx");
@@ -309,7 +309,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hosts", "127.0.0.1"u8.ToArray());
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", "web-01"u8.ToArray());
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/passwd", "root:x:0:0"u8.ToArray());
@@ -357,7 +357,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/etc/hostname", "web-01"u8.ToArray());
 
             (Window window, ChatPanelView panel) = await ShowAsync(context);
@@ -403,7 +403,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/root/abc.txt", "x"u8.ToArray());
 
             (Window window, ChatPanelView panel) = await ShowAsync(context);
@@ -446,7 +446,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/root/.bashrc", "x"u8.ToArray());
 
             (Window window, ChatPanelView panel) = await ShowAsync(context);
@@ -488,7 +488,7 @@ public sealed partial class ChatPanelViewUiTests
         OnUi(async () =>
         {
             using var context = new TestPluginContext();
-            VelaShell.PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
+            PluginSdk.Sessions.SessionInfo session = context.FakeSessions.AddConnected();
             context.FakeRemoteFs.AddFile(session.SessionId, "/root/.bashrc", "export PATH=/usr/bin"u8.ToArray());
             // 没有供应商时 SendAsync 会直接引导到设置页、不发消息,所以先配一个(不会真去连它:
             // 本用例只看用户气泡长什么样,后面那半轮请求失败与否都不影响断言)。
@@ -1188,7 +1188,7 @@ public sealed partial class ChatPanelViewUiTests
                 // 全局设置搬走了:这页不再有系统提示词/压缩/后续提问,入口是窗口标题栏上的一枚 ⚙
                 Assert.IsEmpty(settings.GetVisualDescendants().OfType<TextBox>().Where(t => t.Name == "SystemPromptBox"));
                 Assert.IsEmpty(settings.GetVisualDescendants().OfType<CheckBox>().Where(c => c.Name == "SuggestFollowUpsCheck"));
-                VelaShell.PluginSdk.Ui.PanelTitleAction gear = context.FakeUi.LastPanel.Options.TitleActions.Single();
+                PluginSdk.Ui.PanelTitleAction gear = context.FakeUi.LastPanel.Options.TitleActions.Single();
                 Assert.IsFalse(string.IsNullOrWhiteSpace(gear.IconPathData));
                 int before = context.FakeUi.Panels.Count;
                 gear.OnClick();
@@ -1285,7 +1285,7 @@ public sealed partial class ChatPanelViewUiTests
             => group.GetVisualDescendants().OfType<StackPanel>().First(s => s.Classes.Contains("toolRows"));
 
         static void Press(Border toggle)
-            => toggle.RaiseEvent(new PointerPressedEventArgs(toggle, new Avalonia.Input.Pointer(0, PointerType.Mouse, true),
+            => toggle.RaiseEvent(new PointerPressedEventArgs(toggle, new Pointer(0, PointerType.Mouse, true),
                 toggle, new Point(1, 1), 0, new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed), KeyModifiers.None));
     }
 

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using NSubstitute;
+using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Behaviors;
 using VelaShell.Core.Data;
@@ -46,11 +46,11 @@ public sealed class ConnectionProfileViewModelTests
     }
 
     /// <summary>没有协议级凭据的终端协议(Telnet)替身:只用来把描述符送进视图模型。</summary>
-    private sealed class NoCredentialTerminal : VelaShell.PluginSdk.Protocols.IProtocolTerminal
+    private sealed class NoCredentialTerminal : PluginSdk.Protocols.IProtocolTerminal
     {
-        public Task<VelaShell.PluginSdk.Protocols.IProtocolTerminalSession> ConnectAsync(
-            VelaShell.PluginSdk.Protocols.ProtocolConnectRequest request,
-            VelaShell.PluginSdk.Protocols.ProtocolTerminalOptions options,
+        public Task<PluginSdk.Protocols.IProtocolTerminalSession> ConnectAsync(
+            PluginSdk.Protocols.ProtocolConnectRequest request,
+            PluginSdk.Protocols.ProtocolTerminalOptions options,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 
@@ -59,7 +59,7 @@ public sealed class ConnectionProfileViewModelTests
     {
         // Telnet 的登录发生在带内(对端打印 login:)。摆着两个填了也发不出去的框会误导用户,
         // 而"用户名不能为空"这条更会把保存/连接按钮永久灰死 —— 无凭据协议必须两条都免掉。
-        var registry = new VelaShell.Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
+        var registry = new Infrastructure.Plugins.Protocols.PluginProtocolRegistry();
         using IDisposable handle = registry.Register("test.telnet", new()
         {
             Id = "test.telnet",


### PR DESCRIPTION
实现插件安装和云同步过程在状态栏右下角圆环上分阶段展示进度，确保任务完成或失败后进度归零，提升后台任务反馈准确性。云同步四个入口均支持进度展示，副标题与设置页一致，所有出口均清理活动账本。新增多项单元测试覆盖插件安装/失败及云同步各出口的进度上报与清理。构建系统改进，插件镜像目标支持 MSBuild FileWrites，增量清理与 dotnet clean，自动剪除残留及空目录。大量类型引用简化为统一 using，接口参数类型调整，多语言资源新增相关本地化字符串，部分测试和实现同步适配接口变更，修正命名和注释。