### PR TITLE
发布配置支持按 RID 启用 ReadyToRun 预编译

### DIFF
--- a/docs-en/plugins/STATUS.md
+++ b/docs-en/plugins/STATUS.md
@@ -290,3 +290,55 @@ each one always cleared).
   protocol. The cost is 30–50% larger R2R'd assemblies (noticeable under self-contained). **The
   benefit must be measured**, so it gets its own round: change the configuration, measure cold start
   on all three platforms, then decide whether the size is worth it.
+
+## 2026-08-23 (3): ReadyToRun enabled (with measurements)
+
+One line added to the Release property group in `src/VelaShell/VelaShell.csproj`:
+
+```xml
+<PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
+```
+
+**Only when a RID is supplied**: R2R compiles against a specific target runtime, and a publish
+without a RID fails outright with NETSDK1095. The release pipeline passes `-r` on all three
+platforms (each on a matching-OS runner — cross-architecture is fine, cross-OS is not), while a
+local RID-less publish quietly falls back to an ordinary one. Plugin projects are unaffected: their
+`ProjectReference` has listed `PublishReadyToRun` under `UndefineProperties` all along.
+
+`PublishReadyToRunComposite` stays off: composite mode starts faster but fuses the whole
+self-contained runtime into one enormous image, and neither the size nor the build-time increase is
+what this round wanted to pay.
+
+### Measured (win-x64, self-contained)
+
+| | Baseline | R2R on | Change |
+|---|---|---|---|
+| Publish directory total | 277 MB | 318 MB | **+41 MB (+15%)** |
+| `VelaShell.dll` | 4.2 MB | 9.3 MB | ×2.2 |
+| `VelaShell.PluginHost.dll` | 61 KB | 184 KB | ×3.0 |
+| PluginHost bootstrap + Avalonia init (median) | 387 ms | **355 ms** | −32 ms (−8%) |
+
+The package grows only 15% rather than the 2–3× seen on individual assemblies because most of those
+277 MB are the self-contained runtime, and **the framework assemblies in the runtime pack are
+already R2R**. Only this repository's own assemblies and third-party libraries such as Avalonia grow.
+
+The startup row needs its method stated: PluginHost is given a pipe name that does not exist, so it
+runs bootstrap → `AppBuilder.SetupWithoutStarting()` → 10-second connect timeout → exit, and the
+fixed 10 seconds is subtracted. Beyond the faster median, **the tail variance collapses**
+(baseline 373–1348 ms, R2R 348–385 ms).
+
+> A wrong turn worth recording so nobody repeats it: the first attempt measured "run PluginHost with
+> no environment variables at all", and R2R came out 52 ms *slower*. On that path `Require()` throws
+> immediately, so **no JIT ever happens** — the measurement captured R2R's file-size cost and none of
+> its benefit. Measuring R2R requires the path under test to actually execute a meaningful amount of
+> code.
+
+### Not yet verified
+
+The main application's own cold start is **not measured**: it is a GUI app with no "exit without
+opening a window" entry point, so measuring it means actually raising the window. The main app should
+benefit considerably more than PluginHost (ReactiveUI, AvaloniaEdit, SonnetDB and the entire shell
+live on that side), but that is inference, not data. By the same token, "the R2R output runs
+correctly" currently rests only on the PluginHost side of the evidence (it did start, initialize
+Avalonia and wait for the timeout). **Before shipping, launch the main app once on each of the three
+platforms** to confirm R2R + Avalonia + the plugin ALC hold together.

--- a/docs/plugins/STATUS.md
+++ b/docs/plugins/STATUS.md
@@ -242,3 +242,49 @@ MSBuild 自己的增量清理机制免费提供。另加一道扫尾:`Incrementa
   且能顺带吃掉一部分隔离宿主的冷启动、不用动 IPC 协议。代价是 R2R'd 程序集大 30~50%
   (self-contained 下包体增长可观)。**收益必须实测**,单独开一轮:改配置 → 三平台各测冷启动
   → 拿数据决定包体值不值。
+
+## 2026-08-23(三):ReadyToRun 开启(附实测)
+
+`src/VelaShell/VelaShell.csproj` 的 Release 属性组加一句:
+
+```xml
+<PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
+```
+
+**只在给了 RID 时打开**:R2R 必须按目标运行时编译,没有 RID 的 publish 会直接报 NETSDK1095。
+发布流水线三个平台都传 `-r`(且各自跑在对应 OS 的 runner 上 —— 跨架构可以,跨 OS 不行),
+本机不带 RID 的 publish 则安静地退回普通发布。插件工程不受影响:它们的 ProjectReference
+早就在 `UndefineProperties` 里摘掉了 `PublishReadyToRun`。
+
+不开 `PublishReadyToRunComposite`:复合模式启动更快,但把整个自包含运行时熔成一个巨大镜像,
+包体与构建时间的涨幅都不是这一轮想付的。
+
+### 实测(win-x64,自包含)
+
+| | 基线 | 开 R2R | 变化 |
+|---|---|---|---|
+| 发布目录总大小 | 277 MB | 318 MB | **+41 MB(+15%)** |
+| `VelaShell.dll` | 4.2 MB | 9.3 MB | ×2.2 |
+| `VelaShell.PluginHost.dll` | 61 KB | 184 KB | ×3.0 |
+| PluginHost 启动 + Avalonia 初始化(中位) | 387 ms | **355 ms** | −32 ms(−8%) |
+
+包体只涨 15% 而不是单个程序集的 2~3 倍,是因为 277 MB 里绝大部分是自包含运行时,
+而运行时包里的框架程序集**本来就是 R2R 的** —— 涨的只有本仓库自己的程序集与
+Avalonia 这类第三方库。
+
+启动那一栏的测法要说清楚:给 PluginHost 喂一个不存在的管道名,让它走完
+"运行时引导 → `AppBuilder.SetupWithoutStarting()` → 10 秒连接超时 → 退出",
+总耗时扣掉那个固定的 10 秒。除了中位数变快,**尾部抖动收敛得更明显**
+(基线 373–1348 ms,开启后 348–385 ms)。
+
+> 走过一次弯路,记下来免得再踩:第一次测的是"不给任何环境变量直接跑 PluginHost",
+> 结果 R2R 反而慢 52 ms。原因是那条路径上 `Require()` 立刻抛异常退出,**根本没走到 JIT** ——
+> 只吃到了 R2R 把文件撑大的代价,吃不到收益。测 R2R 必须让被测路径真的执行到有量的代码。
+
+### 尚未验证
+
+主程序自身的冷启动**没有实测**:它是 GUI 应用,没有"不开窗就退出"的启动路径,
+量它必须真的把窗口拉起来。按理说主程序受益应当明显大于 PluginHost
+(ReactiveUI、AvaloniaEdit、SonnetDB、整个 Shell 的代码量都在它这边),但这是推断不是数据。
+同理,R2R 产物"能正常跑"目前只有 PluginHost 那一侧的旁证(它确实起来了、初始化了 Avalonia、
+等到超时才退)。**发版前需要在三平台各拉起一次主程序**,确认 R2R + Avalonia + 插件 ALC 组合无恙。

--- a/src/VelaShell/VelaShell.csproj
+++ b/src/VelaShell/VelaShell.csproj
@@ -31,6 +31,22 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <SelfContained>true</SelfContained>
     <PublishTrimmed>false</PublishTrimmed>
+    <!--
+      ReadyToRun:把托管程序集预编译成本机代码随包分发,用户机器上不必再从零 JIT。
+      受益的是**每一次冷启动**,而且这里有两个可执行体都吃到:主程序,以及隔离插件的宿主
+      VelaShell.PluginHost(它是 ProjectReference,同一次 publish 一并 R2R)——
+      后者的冷启动此前实测约 1 秒,大头正是运行时 + Avalonia 初始化。
+
+      代价是包体:R2R 的程序集里 IL 与本机代码并存,自包含发布下增长可观。这是已知取舍。
+
+      只在给了 RID 时打开:R2R 必须按目标运行时编译,没有 RID 的 publish 会直接报
+      NETSDK1095。发布流水线三个平台都传 -r(且各自跑在对应 OS 的 runner 上 ——
+      跨架构可以,跨 OS 不行),本机不带 RID 的 publish 则安静地退回普通发布。
+
+      不开 PublishReadyToRunComposite:复合模式启动更快,但把整个自包含运行时熔成一个
+      巨大镜像,包体与构建时间的涨幅都不是这一轮想付的。
+    -->
+    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
在 Release 发布配置中新增 PublishReadyToRun，仅在指定 RuntimeIdentifier 时启用 R2R 预编译，提升主程序和插件宿主冷启动速度。STATUS.md 详细记录配置方法、三平台流水线适用方式、包体积与启动性能数据，并说明未启用 PublishReadyToRunComposite 的原因。中文说明同步更新，强调收益、代价、测量方法及注意事项。