### PR TITLE
修复分数缩放下终端控件背景缝隙问题

### DIFF
--- a/src/VelaShell.Terminal/Rendering/DevicePixelGrid.cs
+++ b/src/VelaShell.Terminal/Rendering/DevicePixelGrid.cs
@@ -1,0 +1,63 @@
+using Avalonia;
+
+namespace VelaShell.Terminal.Rendering;
+
+/// <summary>
+/// 设备像素栅格:把绘制坐标(DIP)吸附到整数设备像素边界。
+/// <para>
+/// 终端的格子尺寸取整到<b>整数 DIP</b>(见 <c>VelaTerminalControl.RecomputeMetrics</c>),
+/// 而这只在 <c>RenderScaling</c> 为整数时才等于整数设备像素。125% / 150% 这类分数缩放下,
+/// 相邻单元格的背景矩形共享的那条边落在设备像素中间,Skia 对两个矩形各自做抗锯齿,
+/// 两次半覆盖叠加起来凑不回 100%(覆盖率 = 1 − f(1−f),最坏 0.75),于是每条格线上
+/// 都留下一道比底色浅一档的缝 —— 表现为整屏的"方块网格"(issue #245)。
+/// </para>
+/// <para>
+/// 修法是绘制前把矩形四边各自吸附到最近的设备像素:相邻矩形的公共边吸附到<b>同一个</b>
+/// 整数上,于是严丝合缝、既无缝隙也无重叠,抗锯齿在这些边上退化为无操作。
+/// 代价是格子的背景带宽度会在 ±1 设备像素间浮动(21.25 的行距必然如此),
+/// 但字形位置不吸附,字距保持均匀。
+/// </para>
+/// </summary>
+/// <param name="originX">当前绘制原点相对渲染根的 X 偏移(DIP)。含控件在窗口中的位置与内边距/侧栏平移。</param>
+/// <param name="originY">当前绘制原点相对渲染根的 Y 偏移(DIP)。</param>
+/// <param name="scale">渲染缩放(<c>IRenderRoot.RenderScaling</c>);非正/非有限值回退为 1。</param>
+public readonly struct DevicePixelGrid(double originX, double originY, double scale)
+{
+    /// <summary>整数缩放(含 1.0)下吸附是无操作,可整体跳过。</summary>
+    private static bool IsWhole(double v) => Math.Abs(v - Math.Round(v)) < 1e-9;
+
+    /// <summary>渲染缩放;非正/非有限值回退为 1。</summary>
+    public double Scale { get; } = scale > 0 && double.IsFinite(scale) ? scale : 1;
+
+    /// <summary>绘制原点相对渲染根的 X 偏移(DIP)。</summary>
+    public double OriginX { get; } = double.IsFinite(originX) ? originX : 0;
+
+    /// <summary>绘制原点相对渲染根的 Y 偏移(DIP)。</summary>
+    public double OriginY { get; } = double.IsFinite(originY) ? originY : 0;
+
+    /// <summary>本栅格下坐标是否天然对齐(缩放与原点都落在整数设备像素上),对齐时可跳过吸附。</summary>
+    public bool IsAligned =>
+        IsWhole(Scale) && IsWhole(OriginX * Scale) && IsWhole(OriginY * Scale);
+
+    /// <summary>把绘制坐标 <paramref name="x" /> 吸附到最近的设备像素边界(返回值仍是绘制坐标)。</summary>
+    public double SnapX(double x) => Snap(x, OriginX);
+
+    /// <summary>把绘制坐标 <paramref name="y" /> 吸附到最近的设备像素边界(返回值仍是绘制坐标)。</summary>
+    public double SnapY(double y) => Snap(y, OriginY);
+
+    /// <summary>
+    /// 把矩形的四条边分别吸附到设备像素边界。四边独立吸附(而非"吸附左上角再保持宽高")
+    /// 是无缝拼接的关键:相邻矩形的公共边输入相同,输出必然相同。
+    /// </summary>
+    public Rect Snap(Rect rect)
+    {
+        double left = SnapX(rect.X);
+        double top = SnapY(rect.Y);
+        return new(left, top, SnapX(rect.Right) - left, SnapY(rect.Bottom) - top);
+    }
+
+    // 中点一律远离零取整:同一条公共边的输入相同,取整结果自然相同(拼接只要求"一致",
+    // 不要求某个方向);相比银行家舍入,行高 21.25 这类节律下的带宽变化也更可预测。
+    private double Snap(double value, double origin) =>
+        (Math.Round((origin + value) * Scale, MidpointRounding.AwayFromZero) / Scale) - origin;
+}

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -1367,6 +1367,31 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     // ---- Rendering ----------------------------------------------------------
 
+    // 本帧的设备像素栅格。整数 DIP 的格子尺寸在 125%/150% 这类分数缩放下不落在整数设备像素上,
+    // 相邻格子的背景各自抗锯齿、叠加后凑不回满覆盖,于是每条格线上留下一道浅缝(issue #245)。
+    private DevicePixelGrid _pixels = new(0, 0, 1);
+
+    /// <summary>
+    /// 刷新本帧的设备像素栅格。原点取「控件在渲染根中的位置 + 正文平移(内边距 + 侧栏)」:
+    /// 吸附必须以渲染根的像素格为准,控件本身若停在半个像素上,只按控件内坐标取整照样错位。
+    /// </summary>
+    private void RefreshPixelGrid()
+    {
+        var top = TopLevel.GetTopLevel(this);
+        double scale = RenderScalingOverrideForTest > 0 ? RenderScalingOverrideForTest : top?.RenderScaling ?? 1;
+        Point offset = top is null ? default : this.TranslatePoint(default, top) ?? default;
+        _pixels = new(offset.X + ContentPadding + GutterWidth(), offset.Y + ContentPadding, scale);
+    }
+
+    /// <summary>
+    /// 单元格背景矩形(正文坐标系),四边已吸附到设备像素 —— 相邻格子因此严丝合缝。
+    /// 字形位置<b>不</b>吸附:那会让字距忽宽忽窄,而背景带宽度浮动 ±1 设备像素肉眼不可见。
+    /// </summary>
+    private Rect CellRect(int col, int width, double y) =>
+        _pixels.Snap(
+            new(col * CellWidthForTest, y, CellWidthForTest * width, CellHeightForTest)
+        );
+
     /// <summary>
     /// 视觉 BEL:整个终端上的一次短暂半透明闪烁(§终端 → 视觉闪烁)
     /// </summary>
@@ -1375,6 +1400,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     {
         TerminalScreen screen = Emulator.Screen;
         TerminalPalette palette = Emulator.Palette;
+        RefreshPixelGrid();
         context.FillRectangle(DefaultBackgroundBrush(palette.DefaultBackground), new(Bounds.Size));
         int rows = screen.Rows;
         int cols = screen.Columns;
@@ -1497,6 +1523,22 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     internal double CellWidthForTest { get; private set; } = 8;
     internal double CellHeightForTest { get; private set; } = 16;
     internal GutterLayout GutterForTest => Gutter;
+
+    /// <summary>
+    /// 测试用的 <c>RenderScaling</c> 覆盖(&gt;0 生效)。headless 平台的窗口恒为 1.0 缩放,
+    /// 而"方块网格"只在分数缩放下出现,故只能由测试注入(见 TerminalSeamSnapUiTests)。
+    /// </summary>
+    internal double RenderScalingOverrideForTest { get; set; }
+
+    /// <summary>
+    /// 按当前设备像素栅格算出某个单元格的背景矩形(坐标系与正文绘制一致:已减去内边距与侧栏平移)。
+    /// 与 <see cref="RenderLine" /> 走同一个 <see cref="CellRect" />,测试因此锁住的是真实绘制路径。
+    /// </summary>
+    internal Rect CellRectForTest(int col, int screenRow, int width = 1)
+    {
+        RefreshPixelGrid();
+        return CellRect(col, width, screenRow * CellHeightForTest);
+    }
 
     /// <summary>
     /// 该行是否显示侧栏(行号/时间戳),并计入折叠导引线的下端。
@@ -1868,15 +1910,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 fg = SemanticColor(palette, kind);
                 semanticUnderline = kind is SemanticKind.Url or SemanticKind.IpAddress;
             }
-            var cellRect = new Rect(
-                col * CellWidthForTest,
-                y,
-                CellWidthForTest * width,
-                CellHeightForTest
-            );
             if (!bg.Equals(palette.DefaultBackground))
             {
-                context.FillRectangle(BrushFor(bg), cellRect);
+                context.FillRectangle(BrushFor(bg), CellRect(col, width, y));
             }
 
             // 空白/空格/不可见单元不绘制字形;它只留出一段空隙由下一运行的
@@ -2044,7 +2080,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         double x = screen.CursorX * CellWidthForTest;
         double y = screenRow * CellHeightForTest;
-        var rect = new Rect(x, y, CellWidthForTest, CellHeightForTest);
+        // 光标块与格子背景共用吸附后的矩形,否则分数缩放下它会比背景带错开半个像素。
+        Rect rect = CellRect(screen.CursorX, 1, y);
         ImmutableSolidColorBrush cursorBrush = BrushFor(palette.CursorColor);
         if (!_hasFocus)
         {
@@ -2063,13 +2100,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             case "bar":
                 context.FillRectangle(
                     cursorBrush,
-                    new(x, y, Math.Max(1.5, CellWidthForTest * 0.15), CellHeightForTest)
+                    _pixels.Snap(rect.WithWidth(Math.Max(1.5, CellWidthForTest * 0.15)))
                 );
                 break;
             case "underline":
                 context.FillRectangle(
                     cursorBrush,
-                    new(x, y + CellHeightForTest - 2, CellWidthForTest, 2)
+                    _pixels.Snap(new(rect.X, rect.Bottom - 2, rect.Width, 2))
                 );
                 break;
             default: // block

--- a/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
+++ b/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
@@ -1,0 +1,158 @@
+using Avalonia;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 设备像素吸附(issue #245「终端能看出方块」)。
+/// <para>
+/// 成因:格子尺寸取整到整数 <b>DIP</b>,在 125% / 150% 这类分数缩放下并不落在整数设备像素上。
+/// 逐单元 <c>FillRectangle</c> 的相邻矩形共享的那条边落在像素中间,两个矩形各自抗锯齿,
+/// 叠加后的覆盖率是 1 − f(1−f)(最坏 0.75),于是每条格线上留下一道浅缝,整屏看起来是网格方块。
+/// 报告者的截图实测行距 21.25 设备像素 = 17 DIP × 1.25,列距 10 = 8 DIP × 1.25。
+/// </para>
+/// <para>本类锁住吸附本身的纯几何契约:<b>相邻矩形零缝隙零重叠,且每条边都落在整数设备像素上</b>。</para>
+/// </summary>
+[TestClass]
+[TestCategory("DevicePixelSnap")]
+public class DevicePixelGridTests
+{
+    // 截图反推出来的真实参数:8×17 DIP 的格子,5 DIP 内边距,125% 缩放。
+    private const double CellWidth = 8;
+    private const double CellHeight = 17;
+    private const double Padding = 5;
+    private const double FractionalScale = 1.25;
+
+    private static void AssertOnDevicePixel(double dip, double origin, double scale, string what)
+    {
+        double device = (origin + dip) * scale;
+        Assert.AreEqual(
+            Math.Round(device),
+            device,
+            1e-6,
+            $"{what} 落在设备像素 {device} 上,不是整数边界 —— 抗锯齿会在这里留缝。"
+        );
+    }
+
+    /// <summary>同一行内相邻格子:公共边必须重合到同一个设备像素上。</summary>
+    [TestMethod]
+    public void Snap_AdjacentColumns_ShareExactlyOneDevicePixelEdge()
+    {
+        var grid = new DevicePixelGrid(Padding, Padding, FractionalScale);
+        double previousRight = double.NaN;
+        for (int col = 0; col < 64; col++)
+        {
+            Rect snapped = grid.Snap(new(col * CellWidth, 0, CellWidth, CellHeight));
+            if (!double.IsNaN(previousRight))
+            {
+                Assert.AreEqual(
+                    previousRight,
+                    snapped.X,
+                    1e-9,
+                    $"第 {col} 列的左边与前一列的右边必须严丝合缝(有缝隙或重叠都会显出竖线)。"
+                );
+            }
+            AssertOnDevicePixel(snapped.X, Padding, FractionalScale, $"第 {col} 列左边");
+            AssertOnDevicePixel(snapped.Right, Padding, FractionalScale, $"第 {col} 列右边");
+            Assert.IsGreaterThan(0, snapped.Width, $"第 {col} 列被吸附成了零宽,背景会整格消失。");
+            previousRight = snapped.Right;
+        }
+    }
+
+    /// <summary>
+    /// 相邻行:issue 截图里的横向条纹就出在这儿 —— 21.25 的行距每 4 行才对齐一次,
+    /// 其余 3 条边界都在像素中间。吸附后每行的带宽只在 21/22 设备像素之间浮动,但绝不留缝。
+    /// </summary>
+    [TestMethod]
+    public void Snap_AdjacentRows_TileWithoutSeam_AndKeepHeightWithinOneDevicePixel()
+    {
+        var grid = new DevicePixelGrid(Padding, Padding, FractionalScale);
+        double previousBottom = double.NaN;
+        var deviceHeights = new HashSet<long>();
+        for (int row = 0; row < 40; row++)
+        {
+            Rect snapped = grid.Snap(new(0, row * CellHeight, CellWidth, CellHeight));
+            if (!double.IsNaN(previousBottom))
+            {
+                Assert.AreEqual(
+                    previousBottom,
+                    snapped.Y,
+                    1e-9,
+                    $"第 {row} 行的上边与前一行的下边必须严丝合缝(有缝隙就是横向条纹)。"
+                );
+            }
+            AssertOnDevicePixel(snapped.Y, Padding, FractionalScale, $"第 {row} 行上边");
+            AssertOnDevicePixel(snapped.Bottom, Padding, FractionalScale, $"第 {row} 行下边");
+            deviceHeights.Add((long)Math.Round(snapped.Height * FractionalScale));
+            previousBottom = snapped.Bottom;
+        }
+
+        // 21.25 的行距只能落在 21 或 22 设备像素上;出现第三种值说明吸附把行距算飘了。
+        CollectionAssert.AreEquivalent(
+            new long[] { 21, 22 },
+            deviceHeights.OrderBy(h => h).ToArray(),
+            "行高应只在 21/22 设备像素之间浮动。"
+        );
+    }
+
+    /// <summary>
+    /// 反证:不吸附时同样的矩形边确实落在像素中间 —— 说明上面两条测试锁的是真问题,
+    /// 而不是一个本来就成立的恒等式。
+    /// </summary>
+    [TestMethod]
+    public void WithoutSnapping_RowEdges_FallBetweenDevicePixels()
+    {
+        int offGrid = 0;
+        for (int row = 0; row < 8; row++)
+        {
+            double device = (Padding + (row * CellHeight)) * FractionalScale;
+            if (Math.Abs(device - Math.Round(device)) > 1e-6)
+            {
+                offGrid++;
+            }
+        }
+        Assert.IsGreaterThan(0, offGrid, "125% 缩放下未吸附的行边界本应大多不在整数设备像素上。");
+    }
+
+    /// <summary>整数缩放(100% / 200%)且原点也在整数上时,吸附必须是恒等变换 —— 现有观感零改动。</summary>
+    [TestMethod]
+    [DataRow(1.0)]
+    [DataRow(2.0)]
+    public void Snap_IntegerScale_IsIdentity(double scale)
+    {
+        var grid = new DevicePixelGrid(Padding, Padding, scale);
+        Assert.IsTrue(grid.IsAligned, $"{scale}× 且整数原点下应判定为天然对齐。");
+        for (int col = 0; col < 16; col++)
+        {
+            var raw = new Rect(col * CellWidth, 3 * CellHeight, CellWidth, CellHeight);
+            Rect snapped = grid.Snap(raw);
+            Assert.AreEqual(raw.X, snapped.X, 1e-9);
+            Assert.AreEqual(raw.Y, snapped.Y, 1e-9);
+            Assert.AreEqual(raw.Width, snapped.Width, 1e-9);
+            Assert.AreEqual(raw.Height, snapped.Height, 1e-9);
+        }
+    }
+
+    /// <summary>分数缩放、或原点本身停在半个像素上,都不算对齐。</summary>
+    [TestMethod]
+    public void IsAligned_DetectsFractionalScaleAndFractionalOrigin()
+    {
+        Assert.IsFalse(new DevicePixelGrid(Padding, Padding, 1.25).IsAligned, "1.25× 不对齐。");
+        Assert.IsFalse(new DevicePixelGrid(0.5, 0, 1.0).IsAligned, "100% 下 0.5 DIP 的原点不对齐。");
+        Assert.IsTrue(new DevicePixelGrid(0.5, 0, 2.0).IsAligned, "200% 下 0.5 DIP 正好是一个设备像素。");
+    }
+
+    /// <summary>非法缩放(0/负数/NaN)回退为 1,不能让绘制坐标变成 NaN。</summary>
+    [TestMethod]
+    [DataRow(0.0)]
+    [DataRow(-2.0)]
+    [DataRow(double.NaN)]
+    public void Snap_InvalidScale_FallsBackToOne(double scale)
+    {
+        var grid = new DevicePixelGrid(Padding, Padding, scale);
+        Assert.AreEqual(1.0, grid.Scale, 1e-9);
+        Rect snapped = grid.Snap(new(CellWidth, CellHeight, CellWidth, CellHeight));
+        Assert.AreEqual(CellWidth, snapped.Width, 1e-9);
+        Assert.AreEqual(CellHeight, snapped.Height, 1e-9);
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
@@ -1,0 +1,160 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// issue #245「终端能看出方块」的端到端回归:用 headless 真控件跑一遍真实渲染,
+/// 再从真实绘制路径(<c>CellRect</c>)取出单元格背景矩形,验证 125% 缩放下相邻格子
+/// 严丝合缝、每条边都落在整数设备像素上。
+/// <para>
+/// headless 窗口的 <c>RenderScaling</c> 恒为 1.0,而这个 bug 只在分数缩放下出现,
+/// 故用 <c>RenderScalingOverrideForTest</c> 注入 1.25(截图实测值:行距 21.25 设备像素 = 17 DIP × 1.25)。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("DevicePixelSnap")]
+public class TerminalSeamSnapUiTests
+{
+    private const double FractionalScale = 1.25;
+    private const double Padding = 5;
+
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>控件 + 窗口 + 一次真实渲染;返回已就绪的控件。</summary>
+    private static VelaTerminalControl RenderedControl(double scale)
+    {
+        var control = new VelaTerminalControl { ContentPadding = Padding, RenderScalingOverrideForTest = scale };
+        // 带背景色的输出(反显)才会走到逐单元 FillRectangle —— 也就是出缝的那条路径。
+        control.Feed(
+            Encoding.UTF8.GetBytes(
+                "\u001b[7mPID USER  PRI NI VIRT\u001b[0m\r\nrow2\r\nrow3\r\nrow4"
+            )
+        );
+        var window = new Window { Width = 640, Height = 400, Content = control };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame(); // 真跑一遍 Render(),顺带确认吸附路径不抛异常
+        return control;
+    }
+
+    private static void AssertOnDevicePixel(double dip, double origin, double scale, string what)
+    {
+        double device = (origin + dip) * scale;
+        Assert.AreEqual(Math.Round(device), device, 1e-6, $"{what} 落在设备像素 {device},不是整数边界。");
+    }
+
+    [TestMethod]
+    public void FractionalScaling_AdjacentCellBackgrounds_LeaveNoSeam()
+    {
+        OnUi(() =>
+        {
+            VelaTerminalControl control = RenderedControl(FractionalScale);
+            double originX = Padding + control.GutterForTest.TotalWidth;
+            double originY = Padding;
+            Assert.IsGreaterThan(0, control.CellWidthForTest);
+            Assert.IsGreaterThan(0, control.CellHeightForTest);
+
+            // 横向:同一行内逐列推进,公共边必须重合。
+            double previousRight = double.NaN;
+            for (int col = 0; col < Math.Min(40, control.Columns); col++)
+            {
+                Rect cell = control.CellRectForTest(col, 0);
+                if (!double.IsNaN(previousRight))
+                {
+                    Assert.AreEqual(previousRight, cell.X, 1e-9, $"第 {col} 列与前一列之间出现缝隙/重叠。");
+                }
+                AssertOnDevicePixel(cell.X, originX, FractionalScale, $"第 {col} 列左边");
+                AssertOnDevicePixel(cell.Right, originX, FractionalScale, $"第 {col} 列右边");
+                Assert.IsGreaterThan(0, cell.Width, $"第 {col} 列被吸附成零宽。");
+                previousRight = cell.Right;
+            }
+
+            // 纵向:逐行推进,公共边同样必须重合(截图里的横向条纹就出在这儿)。
+            double previousBottom = double.NaN;
+            for (int row = 0; row < Math.Min(20, control.Rows); row++)
+            {
+                Rect cell = control.CellRectForTest(0, row);
+                if (!double.IsNaN(previousBottom))
+                {
+                    Assert.AreEqual(previousBottom, cell.Y, 1e-9, $"第 {row} 行与前一行之间出现缝隙/重叠。");
+                }
+                AssertOnDevicePixel(cell.Y, originY, FractionalScale, $"第 {row} 行上边");
+                AssertOnDevicePixel(cell.Bottom, originY, FractionalScale, $"第 {row} 行下边");
+                Assert.IsGreaterThan(0, cell.Height, $"第 {row} 行被吸附成零高。");
+                previousBottom = cell.Bottom;
+            }
+        });
+    }
+
+    /// <summary>宽字符(CJK)占两格,吸附后仍必须正好接上后一格,不能因取整少半个像素。</summary>
+    [TestMethod]
+    public void FractionalScaling_WideCell_StillTilesWithItsNeighbour()
+    {
+        OnUi(() =>
+        {
+            VelaTerminalControl control = RenderedControl(FractionalScale);
+            Rect wide = control.CellRectForTest(0, 0, 2);
+            Rect next = control.CellRectForTest(2, 0);
+            Assert.AreEqual(wide.Right, next.X, 1e-9, "双宽格子的右边必须与第 3 列的左边重合。");
+            Assert.AreEqual(
+                control.CellRectForTest(0, 0).X,
+                wide.X,
+                1e-9,
+                "双宽格子的左边应与单宽时一致。"
+            );
+        });
+    }
+
+    /// <summary>吸附确实起了作用:1.25 缩放下至少有一条边被挪动过(否则上面的断言可能是空转)。</summary>
+    [TestMethod]
+    public void FractionalScaling_ActuallyMovesSomeEdges()
+    {
+        OnUi(() =>
+        {
+            VelaTerminalControl control = RenderedControl(FractionalScale);
+            bool moved = false;
+            for (int col = 0; col < Math.Min(16, control.Columns) && !moved; col++)
+            {
+                Rect snapped = control.CellRectForTest(col, 0);
+                moved = Math.Abs(snapped.X - (col * control.CellWidthForTest)) > 1e-9;
+            }
+            Assert.IsTrue(moved, "125% 缩放下应当有格子边界被吸附挪动,否则这组回归测试是空转的。");
+        });
+    }
+
+    /// <summary>100% 缩放(维护者本地的 Ubuntu/Debian 环境)必须零改动 —— 吸附不能动到既有观感。</summary>
+    [TestMethod]
+    public void IntegerScaling_LeavesCellRectsUntouched()
+    {
+        OnUi(() =>
+        {
+            VelaTerminalControl control = RenderedControl(1.0);
+            for (int col = 0; col < Math.Min(16, control.Columns); col++)
+            {
+                Rect cell = control.CellRectForTest(col, 2);
+                Assert.AreEqual(col * control.CellWidthForTest, cell.X, 1e-9, "100% 下横坐标不应被挪动。");
+                Assert.AreEqual(2 * control.CellHeightForTest, cell.Y, 1e-9, "100% 下纵坐标不应被挪动。");
+                Assert.AreEqual(control.CellWidthForTest, cell.Width, 1e-9, "100% 下格宽不应变化。");
+                Assert.AreEqual(control.CellHeightForTest, cell.Height, 1e-9, "100% 下格高不应变化。");
+            }
+        });
+    }
+}


### PR DESCRIPTION
引入 DevicePixelGrid，将绘制坐标吸附到设备像素边界，消除抗锯齿导致的单元格缝隙。VelaTerminalControl 集成像素栅格，统一吸附后绘制单元格背景和光标。新增 RenderScalingOverrideForTest 及 CellRectForTest，提升测试覆盖。补充 DevicePixelGridTests 和 TerminalSeamSnapUiTests，确保吸附算法和 UI 渲染在分数缩放下无缝且无副作用。整体提升高 DPI/分数缩放下渲染质量。