### PR TITLE
重构AI聊天面板UI/UX与配置对话框

### DIFF
--- a/VelaShell.Plugin.Ai.pen
+++ b/VelaShell.Plugin.Ai.pen
@@ -1,0 +1,18 @@
+{
+  "version": "2.17",
+  "children": [
+    {
+      "type": "frame",
+      "id": "bi8Au",
+      "x": 0,
+      "y": 0,
+      "name": "Frame",
+      "clip": true,
+      "width": 800,
+      "height": 600,
+      "fill": "#FFFFFF",
+      "layout": "none"
+    }
+  ],
+  "fileToken": "a283a7f2-d35a-4a1d-a1da-553278ae1f02"
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
@@ -5,6 +5,19 @@
        与设置窗口标题栏上的"全局设置"齿轮撞了含义)。几何内联,不依赖宿主 Icon.* 资源。 -->
   <StreamGeometry x:Key="AiIcon.brain">M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4 M17.599 6.5a3 3 0 0 0 .399-1.375 M6.003 5.125A3 3 0 0 0 6.401 6.5 M3.477 10.896a4 4 0 0 1 .585-.396 M19.938 10.5a4 4 0 0 1 .585.396 M6 18a4 4 0 0 1-1.967-.516 M19.967 17.484A4 4 0 0 1 18 18</StreamGeometry>
 
+  <!-- 以下几何在宿主 Icon.* 里没有(lucide 原样内联,与 AiIcon.brain 同一个理由:
+       隔离进程只下发 Vela* 令牌,不能假定宿主的 Icon.* 一定在)。全部按描边渲染,勿填充。 -->
+  <StreamGeometry x:Key="AiIcon.shield-alert">M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1 1 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1Z M12 8v4 M12 16h.01</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.shield-check">M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1 1 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1Z M9 12l2 2 4-4</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.shield-off">M19.7 14a6.9 6.9 0 0 0 .3-2V5a1 1 0 0 0-1-1c-2 0-4.5-1.2-6.24-2.72a1 1 0 0 0-1.52 0C9.6 2.71 8.4 3.5 7 4.1 M4 4v8c0 5 3.5 7.5 7.67 8.94a1 1 0 0 0 .67 0c1.2-.42 2.36-.99 3.4-1.76 M2 2l20 20</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.lock">M19 11H5a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2Z M7 11V7a5 5 0 0 1 10 0v4</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.sparkles">M9.94 14.32a1 1 0 0 0-.66-.66l-4.24-1.32a.5.5 0 0 1 0-.96l4.24-1.32a1 1 0 0 0 .66-.66l1.32-4.24a.5.5 0 0 1 .96 0l1.32 4.24a1 1 0 0 0 .66.66l4.24 1.32a.5.5 0 0 1 0 .96l-4.24 1.32a1 1 0 0 0-.66.66l-1.32 4.24a.5.5 0 0 1-.96 0Z M20 3v4 M22 5h-4 M4 17v2 M5 18H3</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.scissors">M20 4L8.12 15.88 M14.47 14.48L20 20 M8.12 8.12L12 12 M9.5 6.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z M9.5 17.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.chevron-up">M18 15l-6-6-6 6</StreamGeometry>
+  <!-- 设置页左栏的两层层级:供应商 = 云,模型 = 方块 -->
+  <StreamGeometry x:Key="AiIcon.cloud">M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.box">M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z M3.3 7l8.7 5 8.7-5 M12 22V12</StreamGeometry>
+
   <!-- 芯片式开关(Agent / 设置等):对齐宿主 VelaOutlineButtonTheme 的描边语言,
        选中态换 VelaAccentDim 半透明底 + 强调色描边(与宿主"强调药丸"同一配方)。
        之所以自带 ControlTheme 而不是依赖宿主资源:隔离进程宿主只下发 Vela* 令牌,

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Compaction.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Compaction.cs
@@ -86,7 +86,8 @@ public partial class ChatPanelView
     /// </summary>
     private void ShowCompactionMarker(int foldedMessages)
     {
-        var collapsible = new Collapsible(this, _loc.F("Compacted", foldedMessages));
+        var collapsible = new Collapsible(this, _loc.F("Compacted", foldedMessages),
+            iconKey: "AiIcon.scissors", iconBrushKey: "VelaAccent");
         collapsible.SetBody(_contextSummary);
         var host = new Border { Classes = { "compactionMarker" }, Child = collapsible.Root };
         MessagesPanel.Children.Add(host);

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
@@ -28,6 +28,9 @@ public partial class ChatPanelView
     private IPluginPanel? _toolsPanel;
     private IPluginPanel? _mcpPanel;
 
+    /// <summary>MCP 表单视图本体。窗口已经开着时要把选中项挪到用户刚点的那台上,得有个把手。</summary>
+    private McpServersView? _mcpView;
+
     /// <summary>打开设置窗口(已开着就带到前面,不重复开)。</summary>
     private void OpenSettingsDialog()
     {
@@ -82,14 +85,15 @@ public partial class ChatPanelView
             return;
         }
         ToolPickerView? picker = null;
-        // 标题栏的 ⚙ 通向 MCP 服务器配置。它是一整套左列表右表单,
-        // 压在勾选列表上面会把这一页挤得没法看,所以自己占一个窗口;
-        // 入口放标题栏而不是内容区右上角,和模型配置窗口的全局设置一个位置。
+        // 左栏是 MCP 服务器概览、右栏是它们带来的工具:配完一台紧接着就能在同一屏勾选,
+        // 不用在两个窗口之间来回切(设计图 G)。
+        // 但服务器<b>表单</b>仍旧独占一个窗口 —— 它自己就是"左列表右表单",
+        // 塞不进 270 宽的左栏;点概览行或「新增服务器」把它开出来。
         // (picker 在工厂里才造出来,回调只在用户点的时候跑,那时它早就有了。)
         _ = OpenAsync(
-            _loc["ConfigureTools"], 720, 680,
-            [new PanelTitleAction(SettingsIconPath, _loc["McpServers"], () => OpenMcpDialog(picker!))],
-            () => picker = new ToolPickerView(_context, _settings, _loc, PersistSettingsAsync),
+            _loc["ConfigureTools"], 940, 680, [],
+            () => picker = new ToolPickerView(_context, _settings, _loc, PersistSettingsAsync,
+                serverId => OpenMcpDialog(picker!, serverId)),
             panel => _toolsPanel = panel,
             () =>
             {
@@ -100,10 +104,16 @@ public partial class ChatPanelView
     }
 
     /// <summary>打开 MCP 服务器配置窗口;改完当场重建工具勾选列表。</summary>
-    private void OpenMcpDialog(ToolPickerView picker)
+    /// <param name="picker">改完服务器要回头刷新的那份勾选列表。</param>
+    /// <param name="serverId">
+    /// 要选中的服务器;null 表示直接进入"新增一台"。
+    /// 窗口已经开着时不重开,只把选中项挪过去 —— 用户点的是左栏某一行,期待的是"看到它"。
+    /// </param>
+    private void OpenMcpDialog(ToolPickerView picker, string? serverId = null)
     {
         if (Activate(_mcpPanel))
         {
+            ApplySelection(_mcpView);
             return;
         }
         _ = OpenAsync(
@@ -112,10 +122,32 @@ public partial class ChatPanelView
             {
                 var servers = new McpServersView(_context, _settings, _loc, PersistSettingsAsync);
                 servers.ServersChanged += picker.Rebuild;
+                _mcpView = servers;
+                ApplySelection(servers);
                 return servers;
             },
             panel => _mcpPanel = panel,
-            () => _mcpPanel = null);
+            () =>
+            {
+                _mcpPanel = null;
+                _mcpView = null;
+            });
+
+        void ApplySelection(McpServersView? view)
+        {
+            if (view is null)
+            {
+                return;
+            }
+            if (serverId is { Length: > 0 })
+            {
+                view.Select(serverId);
+            }
+            else
+            {
+                view.BeginAdd();
+            }
+        }
     }
 
     /// <summary>已经开着就带到前面并返回 true —— 什么都不做会像是按钮坏了。</summary>
@@ -157,16 +189,7 @@ public partial class ChatPanelView
                 TitleActions = titleActions
             }, () => view);
             onOpened(panel);
-            // Esc 关窗,与宿主其它窗口一致。挂在内容上而不是让宿主对所有插件面板统一处理:
-            // 聊天面板也能以窗口形态打开,那里 Esc 必须留给输入框(正打着字被关掉窗口很糟)。
-            view.AddHandler(InputElement.KeyDownEvent, (_, e) =>
-            {
-                if (e.Key == Key.Escape)
-                {
-                    e.Handled = true;
-                    _ = panel.CloseAsync();
-                }
-            }, RoutingStrategies.Bubble);
+            HookEscape(view, panel);
             // Closed 是宿主在线程池上回调的(见 PluginPanel.NotifyClosed),清账要回 UI 线程。
             // 注意用类型名限定:Avalonia 的 AvaloniaObject 上也有个实例属性叫 Dispatcher。
             panel.Closed += () => Avalonia.Threading.Dispatcher.UIThread.Post(onClosed);
@@ -176,6 +199,62 @@ public partial class ChatPanelView
             _context.Log.Error($"Opening the '{title}' window failed.", ex);
             onClosed();
         }
+    }
+
+    /// <summary>
+    /// 让 Esc 关掉这个窗口,效果与点标题栏的 ✕ 一致。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>处理器必须挂在窗口(TopLevel)上,不能挂在内容控件上。</b>冒泡是从<b>焦点所在的元素</b>
+    /// 往上走的:窗口刚开出来时焦点还在窗体自己身上(自绘标题栏那一侧),按键压根不经过
+    /// 插件内容这条链路 —— 挂在内容上的处理器于是一次都不触发。这正是之前"按 Esc 没反应"的原因。
+    /// </para>
+    /// <para>
+    /// 用<b>冒泡</b>而不是隧道,且不收已处理的事件:这样 Esc 会先归还给需要它的控件 ——
+    /// 下拉展开时先收起下拉、弹层开着时先关弹层,都轮不到关窗。隧道会把这些统统抢掉。
+    /// </para>
+    /// <para>
+    /// 也不把这件事推给宿主对所有插件面板统一处理:聊天面板本身也能以窗口形态打开
+    /// (<c>AI:打开聊天(窗口)</c>),那里的 Esc 必须留给输入框 —— 正打着字被关掉窗口很糟。
+    /// 只有经这个工厂开出来的二级窗口才挂。
+    /// </para>
+    /// </remarks>
+    private static void HookEscape(Control view, IPluginPanel panel)
+    {
+        void OnKeyDown(object? _, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape || e.Handled)
+            {
+                return;
+            }
+            e.Handled = true;
+            _ = panel.CloseAsync();
+        }
+
+        void Attach()
+        {
+            if (TopLevel.GetTopLevel(view) is not { } top)
+            {
+                return;
+            }
+            top.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Bubble);
+            view.DetachedFromVisualTree += (_, _) =>
+                top.RemoveHandler(InputElement.KeyDownEvent, OnKeyDown);
+        }
+
+        // ShowPanelAsync 返回时内容可能已经装进窗口了(那就直接挂),也可能还没(等装上再挂)
+        if (TopLevel.GetTopLevel(view) is not null)
+        {
+            Attach();
+            return;
+        }
+        void OnAttached(object? _, Avalonia.VisualTreeAttachmentEventArgs __)
+        {
+            view.AttachedToVisualTree -= OnAttached;
+            Attach();
+        }
+        view.AttachedToVisualTree += OnAttached;
     }
 
     /// <summary>面板关闭时把这几个窗口一并带走,别留在屏幕上。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
@@ -140,7 +140,8 @@ public partial class ChatPanelView
         ResetCompaction();
 
         ClearSuggestions();
-        ShowStarterSuggestions();
+        // 删到一条不剩就退回空状态(起手示例在那儿,不再是输入框上方的药丸)
+        UpdateEmptyState();
         UpdateUsageText();
         return true;
     }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
@@ -47,6 +47,8 @@ public partial class ChatPanelView
         {
             ChatScroll.IsVisible = view == PanelView.Chat;
             HistoryHost.IsVisible = view == PanelView.History;
+            // 空状态与聊天流叠在同一个 Panel 里,切到历史时得跟着一起让位
+            EmptyStateHost.IsVisible = _showEmptyState && view == PanelView.Chat;
             HistoryToggle.IsChecked = view == PanelView.History;
         }
         finally
@@ -78,10 +80,13 @@ public partial class ChatPanelView
             Text = session.Title.Length > 0 ? session.Title : _loc["Untitled"]
         };
         text.Children.Add(titleText);
+        // 日期已经由组标题说了,行里只留必要的那部分:今天/昨天给时刻,更早的补上月日
+        DateTimeOffset stamp = session.UpdatedAt.ToLocalTime();
+        bool nearby = stamp.Date == DateTime.Today || stamp.Date == DateTime.Today.AddDays(-1);
         text.Children.Add(new TextBlock
         {
             Classes = { "dim" },
-            Text = $"{session.UpdatedAt.ToLocalTime():yyyy-MM-dd HH:mm} · {_loc.F("MessageCount", session.MessageCount)}"
+            Text = $"{stamp.ToString(nearby ? "HH:mm" : "MM-dd HH:mm")} · {_loc.F("MessageCount", session.MessageCount)}"
         });
         grid.Children.Add(text);
 
@@ -140,7 +145,7 @@ public partial class ChatPanelView
         if (!_clearHistoryArmed)
         {
             _clearHistoryArmed = true;
-            ClearHistoryButton.Content = _loc["ConfirmClear"];
+            ClearHistoryText.Text = _loc["ConfirmClear"];
             if (FindBrush("VelaError") is { } warn)
             {
                 ClearHistoryButton.Foreground = warn;
@@ -159,7 +164,7 @@ public partial class ChatPanelView
     private void ResetClearHistoryButton()
     {
         _clearHistoryArmed = false;
-        ClearHistoryButton.Content = _loc["ClearHistory"];
+        ClearHistoryText.Text = _loc["ClearHistory"];
         ClearHistoryButton.ClearValue(ForegroundProperty);
         ClearHistoryButton.ClearValue(Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty);
     }
@@ -221,6 +226,8 @@ public partial class ChatPanelView
             await RestoreSummaryAsync();
             StatusText.Text = _loc.F("HistoryLoaded", entries.Count);
             SetActiveView(PanelView.Chat);
+            // 载进来的会话把消息流填上了,空状态得退场(一个模型都没配时也照样能翻旧会话)
+            UpdateEmptyState();
             RequestAutoScroll(force: true);
         }
         catch (Exception ex)

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.HistoryTools.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.HistoryTools.cs
@@ -26,10 +26,31 @@ public partial class ChatPanelView
                 ? _loc.F("HistoryFiltered", shown.Count, _historySessions.Count)
                 : _loc.F("HistoryCount", _historySessions.Count);
         ClearHistoryButton.IsVisible = _historySessions.Count > 0;
+        // 按日期分组(今天 / 昨天 / 更早)。列表是按更新时间倒序取回来的,所以顺着走一遍
+        // 就能在跨天处插一条组标题 —— 一整列平铺时,"昨天那条"只能一行行读时间戳去找。
+        string? currentGroup = null;
         foreach (ChatSessionSummary session in shown)
         {
+            string group = HistoryGroupLabel(session.UpdatedAt.ToLocalTime());
+            if (!string.Equals(group, currentGroup, StringComparison.Ordinal))
+            {
+                currentGroup = group;
+                HistoryList.Children.Add(new TextBlock { Classes = { "histGroup" }, Text = group });
+            }
             HistoryList.Children.Add(BuildHistoryRow(session));
         }
+    }
+
+    /// <summary>这条会话该归到哪一组。按<b>本地日历日</b>比,不是按"距今 24 小时"。</summary>
+    private string HistoryGroupLabel(DateTimeOffset stamp)
+    {
+        DateTime today = DateTime.Today;
+        DateTime day = stamp.Date;
+        return day == today
+            ? _loc["HistToday"]
+            : day == today.AddDays(-1)
+                ? _loc["HistYesterday"]
+                : _loc["HistEarlier"];
     }
 
     /// <summary>把某个会话改名:标题就地变成输入框,回车确认、失焦或 Esc 取消。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Suggestions.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Suggestions.cs
@@ -23,16 +23,6 @@ public partial class ChatPanelView
 
     private CancellationTokenSource? _suggestCts;
 
-    /// <summary>空会话的起手提示(本地文案,不请求模型)。</summary>
-    private void ShowStarterSuggestions()
-    {
-        if (_history.Count > 0)
-        {
-            return;
-        }
-        RenderSuggestions([_loc["Starter1"], _loc["Starter2"], _loc["Starter3"]]);
-    }
-
     private void ClearSuggestions()
     {
         _suggestCts?.Cancel();
@@ -182,12 +172,14 @@ public partial class ChatPanelView
         _suggestCts = null;
     }
 
-    /// <summary>语言切换时,若当前显示的是起手提示就换成新语言的。</summary>
+    /// <summary>
+    /// 语言切换时把空状态整块重建(标题 / 说明 / 三条起手示例都是文案)。
+    /// 起手示例已经从输入框上方的药丸挪进空状态了 —— 药丸只留给对话开始<b>之后</b>
+    /// 由模型给的后续提问,那些是上一轮的产物,换语言不该也不能就地翻译。
+    /// </summary>
     private void RefreshStarterSuggestions()
     {
-        if (_history.Count == 0 && SuggestionBar.IsVisible)
-        {
-            ShowStarterSuggestions();
-        }
+        _emptyStateNeedsProvider = null; // 作废缓存,强制按新语言重建
+        UpdateEmptyState();
     }
 }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -463,6 +463,200 @@
     <Style Selector="Grid#TopBar Button">
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
+
+    <!-- ===== 模式 / 审批两枚下拉的芯片化 =====
+         模式决定"这条消息怎么发",审批决定"会不会替你按下确定" —— 两者都得能被余光读到,
+         所以从灰底下拉变成带色描边的芯片。模式恒为强调色;审批的三档颜色由 SyncModeUi 按挡位写,
+         这里只把模板里的底/描边接到控件自身的属性上(否则悬停态会被 Fluent 的主题色盖回去)。 -->
+    <Style Selector="ComboBox#ModeCombo, ComboBox#ModeCombo:pointerover">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <!-- 部件名是实测出来的(Fluent 12 的 ComboBox 模板里有两层底:Border#Background 是常态那层,
+         Border#HighlightBackground 是悬停/聚焦时盖上来的那层)。两层都要接管,
+         否则鼠标一移上去,芯片的强调色底就被 Fluent 的高亮层糊掉了。 -->
+    <Style Selector="ComboBox#ModeCombo /template/ Border#Background,
+                     ComboBox#ModeCombo:pointerover /template/ Border#Background,
+                     ComboBox#ModeCombo:focus /template/ Border#Background">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="ComboBox#ModeCombo /template/ Border#HighlightBackground,
+                     ComboBox#ModeCombo:pointerover /template/ Border#HighlightBackground,
+                     ComboBox#ModeCombo:focus /template/ Border#HighlightBackground">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="ComboBox#ModeCombo /template/ PathIcon#DropDownGlyph">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <!-- 选中项那块内容是模板里的 ContentControl#ContentPresenter,它的前景不跟随控件的
+         Foreground(实测:只设控件 Foreground,芯片里的字仍是默认的浅灰) -->
+    <Style Selector="ComboBox#ModeCombo /template/ ContentControl#ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <Style Selector="ComboBox#ApprovalCombo /template/ Border#Background,
+                     ComboBox#ApprovalCombo:pointerover /template/ Border#Background,
+                     ComboBox#ApprovalCombo:focus /template/ Border#Background,
+                     ComboBox#ApprovalCombo /template/ Border#HighlightBackground,
+                     ComboBox#ApprovalCombo:pointerover /template/ Border#HighlightBackground,
+                     ComboBox#ApprovalCombo:focus /template/ Border#HighlightBackground">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{Binding $parent[ComboBox].BorderBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="ComboBox#ApprovalCombo /template/ PathIcon#DropDownGlyph">
+      <Setter Property="Foreground" Value="{Binding $parent[ComboBox].Foreground}" />
+    </Style>
+
+    <!-- ===== 阻塞类卡片:审批与失败 =====
+         两者都是"这一轮停在这儿了",与工具日志不是一个分量:左边一道 3px 语义色竖条,
+         整张卡从工具卡的灰描边里拎出来。 -->
+    <Style Selector="Border.approvalCard, Border.errorCard, Border.approvedCard, Border.deniedCard">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderThickness" Value="3,0,0,0" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="10,8" />
+      <Setter Property="Margin" Value="0,6,0,0" />
+    </Style>
+    <Style Selector="Border.approvalCard">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaWarning}" />
+    </Style>
+    <Style Selector="Border.errorCard, Border.deniedCard">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaError}" />
+    </Style>
+    <!-- 已批准:左边条转绿并整卡压暗一档 —— 一屏堆着好几张时,过掉的那些该退到背景里去 -->
+    <Style Selector="Border.approvedCard">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaStatusConnected}" />
+    </Style>
+    <Style Selector="Border.approvedCard, Border.deniedCard">
+      <Setter Property="Opacity" Value="0.72" />
+    </Style>
+    <!-- 卡里的命令原文 / 报错正文:等宽,压在输入底色上与说明文字区分开 -->
+    <Style Selector="Border.cardCode">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Padding" Value="8,6" />
+    </Style>
+
+    <!-- 回复头部的阶段芯片(正在思考 / 调用工具 / 正在生成 / 等待你确认)。
+         等待审批那一档换成实心 warn:此刻界面是停着的,得比"在动"更响。 -->
+    <Style Selector="Border.phaseChip">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Padding" Value="5,1" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Border.phaseChip TextBlock">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="Border.phaseChip.waiting">
+      <Setter Property="Background" Value="{DynamicResource VelaWarning}" />
+    </Style>
+    <Style Selector="Border.phaseChip.waiting TextBlock">
+      <Setter Property="Foreground" Value="{DynamicResource VelaBgPage}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <!-- 审批卡右上角的风险标签:只说"会做什么"(写远端文件 / 执行命令),不做价值判断 -->
+    <Style Selector="Border.riskBadge">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaWarning}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Padding" Value="5,0" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Border.riskBadge TextBlock">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaWarning}" />
+    </Style>
+
+    <!-- 带前置图标的搜索框:外层 Border 承担边框与焦点态(同 Border.inputWrap 的配方),
+         里头的 TextBox 去壳,免得出现"框里还有一个框"。 -->
+    <Style Selector="Border.searchWrap">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="MinHeight" Value="26" />
+    </Style>
+    <Style Selector="Border.searchWrap:pointerover">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+    </Style>
+    <Style Selector="Border.searchWrap:focus-within">
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="Border.searchWrap TextBox">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="MinHeight" Value="24" />
+      <Setter Property="Padding" Value="0,0,8,0" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Border.searchWrap TextBox /template/ Border">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <!-- 历史列表的日期分组标题(今天 / 昨天 / 更早) -->
+    <Style Selector="TextBlock.histGroup">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize10}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
+      <Setter Property="Margin" Value="2,6,0,0" />
+    </Style>
+
+    <!-- 空状态(一个模型都没配):标题 + 说明 + 三条可点的示例问句 -->
+    <Style Selector="TextBlock.emptyTitle">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize15}" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="TextBlock.emptyBody">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+      <Setter Property="TextAlignment" Value="Center" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+      <Setter Property="LineSpacing" Value="4" />
+    </Style>
+    <Style Selector="Border.exampleRow">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="9,6" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Border.exampleRow:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="Border.exampleRow TextBlock">
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    </Style>
+
+    <!-- 压缩分隔条:里头那枚 Collapsible 默认长得像工具卡,在这儿要的是"一道线",
+         所以把它的底与描边抹平,只留分隔条自己那根强调色下划线与强调色标题。 -->
+    <Style Selector="Border.compactionMarker Border.toolCard">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="0,0,0,4" />
+      <Setter Property="Margin" Value="0" />
+    </Style>
+    <Style Selector="Border.compactionMarker TextBlock.dim">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+
+    <!-- 重试中的状态行:瞬时故障有别于普通提示,给 warn 色 -->
+    <Style Selector="TextBlock#StatusText.retrying">
+      <Setter Property="Foreground" Value="{DynamicResource VelaWarning}" />
+    </Style>
   </UserControl.Styles>
 
   <DockPanel Margin="10">
@@ -470,9 +664,18 @@
          模型选择与 Agent 开关不在这里 —— 它们跟着输入框走(见下方 InputToolbar),
          与 GitHub Copilot 一致:决定"这条消息怎么发"的东西,应当挨着输入框。 -->
     <Grid x:Name="TopBar" DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
-      <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-        <ComboBox x:Name="SessionCombo" MinWidth="110" MaxWidth="240" />
-      </StackPanel>
+      <!-- 会话选择器铺满剩下的宽度(右侧四枚图标钮是定宽的):主机名越长越该给它地方,
+           而不是让它先被截断。选中项前面那颗点是连接状态,由 ItemTemplate 画。 -->
+      <ComboBox x:Name="SessionCombo" HorizontalAlignment="Stretch" MinWidth="110">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="ui:SessionNavItem">
+            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+              <Ellipse Width="6" Height="6" Fill="{Binding Dot}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Text}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+            </StackPanel>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
       <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
         <ToggleButton x:Name="HistoryToggle" Theme="{StaticResource AiChipToggleTheme}" Width="30" Padding="0">
           <Viewbox Width="13" Height="13">
@@ -481,15 +684,14 @@
                   StrokeLineCap="Round" StrokeJoin="Round" />
           </Viewbox>
         </ToggleButton>
-        <Button x:Name="NewChatButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="8,0">
-          <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
-            <Viewbox Width="11" Height="11" VerticalAlignment="Center">
-              <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
-                    Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
-                    StrokeLineCap="Round" StrokeJoin="Round" />
-            </Viewbox>
-            <TextBlock x:Name="NewChatText" VerticalAlignment="Center" />
-          </StackPanel>
+        <!-- 四枚动作统一 26×30 图标钮:原来「新会话」带文字,面板一窄就把会话名挤没了;
+             文案走 ToolTip(见 ApplyLoc)。 -->
+        <Button x:Name="NewChatButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Width="30" Padding="0">
+          <Viewbox Width="13" Height="13">
+            <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
+                  Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
+                  StrokeLineCap="Round" StrokeJoin="Round" />
+          </Viewbox>
         </Button>
         <!-- 配置工具:勾选哪些内置/MCP 工具暴露给模型(独立窗口) -->
         <Button x:Name="ToolsButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Width="30" Padding="0">
@@ -512,12 +714,37 @@
 
     <!-- 最下沿的一条细行(同 Copilot 输入框下方那排):左边是 Agent 的审批模式,
          右边是 token 用量。放在容器外而不是工具条里,是为了不跟模型下拉抢那点宽度。 -->
-    <Grid x:Name="InputStatusBar" DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto" Margin="2,5,2,0">
-      <!-- 审批方式:默认审批 / 只读放行 / 绕过审批(只在有工具的模式下才有意义) -->
-      <ComboBox x:Name="ApprovalCombo" IsVisible="False" MinWidth="96" />
+    <Grid x:Name="InputStatusBar" DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto,Auto" Margin="2,5,2,0">
+      <!-- 审批方式:默认审批 / 只读放行 / 绕过审批(只在有工具的模式下才有意义)。
+           三档的语义色由 SyncModeUi 就地写(问=中性 / 只读自动=warn / 全部自动=error) ——
+           这是个安全开关,当前挡位该在余光里就能读出来。 -->
+      <ComboBox x:Name="ApprovalCombo" IsVisible="False" MinWidth="96">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="ui:ApprovalNavItem">
+            <!-- 盾牌形状本身就分得开三档(打勾 / 感叹号 / 划掉),不必只靠颜色 ——
+                 用户把强调色调成偏红时,"全部自动"的 error 色会和强调色撞在一起。
+                 颜色写在数据项上而不是控件上:下拉里每一行也就各自带色,选中哪档一目了然。 -->
+            <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+              <Viewbox Width="10" Height="10" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{Binding Icon}" Stroke="{Binding Tone}"
+                      StrokeThickness="2" StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock Text="{Binding Text}" Foreground="{Binding Tone}" VerticalAlignment="Center" />
+            </StackPanel>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
       <!-- 命中缓存时这段会长一截(多一个"缓存 80%"),留够宽度;再长由 TextTrimming 收,
            完整明细本来就在悬停提示里。 -->
-      <TextBlock x:Name="UsageText" Grid.Column="1" Classes="meta" MaxWidth="320" Margin="8,0,0,0" />
+      <TextBlock x:Name="UsageText" Grid.Column="1" Classes="meta" MaxWidth="300" Margin="8,0,0,0" />
+      <!-- 上下文占用条:占比是要被瞥见的东西,不该只活在悬停提示里。
+           知道窗口大小才画得出来(MaxInputTokens=0 就整条隐掉,见 UpdateUsageText)。 -->
+      <Border x:Name="UsageMeterTrack" Grid.Column="2" Width="56" Height="4" CornerRadius="2"
+              Margin="8,0,0,0" IsVisible="False" VerticalAlignment="Center"
+              Background="{DynamicResource VelaBorderSecondary}">
+        <Border x:Name="UsageMeterFill" Width="0" CornerRadius="2"
+                HorizontalAlignment="Left" Background="{DynamicResource VelaAccent}" />
+      </Border>
     </Grid>
 
     <!-- 输入容器 = 编辑区 + 其下的工具条(模型选择 / Agent / 发送),状态行悬于其上。
@@ -573,22 +800,32 @@
           <!-- 对话模式:纯对话 / 计划 / Agent(对齐 Copilot 的模式选择) -->
           <ComboBox x:Name="ModeCombo" Grid.Column="2" Margin="6,0,0,0" MinWidth="88" />
           <StackPanel Grid.Column="3" Orientation="Horizontal" Margin="8,0,0,0" VerticalAlignment="Center">
+            <!-- 主操作带文字(设计图):这一枚是整个面板唯一的"提交",纯图标要靠猜。
+                 模型那列是 * ,面板收窄时先挤模型名,挤不到这里。 -->
             <Button x:Name="SendButton" Theme="{DynamicResource VelaAccentPillButtonTheme}"
-                    Height="24" Width="34" Padding="0">
-              <Viewbox Width="12" Height="12">
-                <Path Width="24" Height="24" Data="{DynamicResource Icon.send}"
-                      Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
-                      StrokeLineCap="Round" StrokeJoin="Round" />
-              </Viewbox>
+                    Height="24" Padding="10,0">
+              <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                  <Path Width="24" Height="24" Data="{DynamicResource Icon.send}"
+                        Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                        StrokeLineCap="Round" StrokeJoin="Round" />
+                </Viewbox>
+                <TextBlock x:Name="SendText" VerticalAlignment="Center"
+                           FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+              </StackPanel>
             </Button>
             <Button x:Name="StopButton" Theme="{DynamicResource VelaOutlineButtonTheme}"
-                    Height="24" Width="34" Padding="0" IsVisible="False"
+                    Height="24" Padding="10,0" IsVisible="False"
                     Foreground="{DynamicResource VelaError}" BorderBrush="{DynamicResource VelaError}">
-              <Viewbox Width="11" Height="11">
-                <Path Width="24" Height="24" Data="{DynamicResource Icon.square}"
-                      Stroke="{DynamicResource VelaError}" StrokeThickness="2"
-                      StrokeLineCap="Round" StrokeJoin="Round" />
-              </Viewbox>
+              <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                <Viewbox Width="10" Height="10" VerticalAlignment="Center">
+                  <Path Width="24" Height="24" Data="{DynamicResource Icon.square}"
+                        Stroke="{DynamicResource VelaError}" StrokeThickness="2"
+                        StrokeLineCap="Round" StrokeJoin="Round" />
+                </Viewbox>
+                <TextBlock x:Name="StopText" VerticalAlignment="Center"
+                           FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
+              </StackPanel>
             </Button>
           </StackPanel>
         </Grid>
@@ -615,15 +852,41 @@
         <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,6">
           <TextBlock x:Name="HistoryHeader" Classes="dim" VerticalAlignment="Center" />
           <Button x:Name="ClearHistoryButton" Grid.Column="1" Theme="{DynamicResource VelaOutlineButtonTheme}"
-                  Height="24" Padding="10,0" FontSize="{DynamicResource VelaFontSize11}" />
+                  Height="22" Padding="8,0">
+            <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+              <Viewbox Width="10" Height="10" VerticalAlignment="Center">
+                <Path Width="24" Height="24" Data="{DynamicResource Icon.trash-2}"
+                      Stroke="{Binding $parent[Button].Foreground}" StrokeThickness="2"
+                      StrokeLineCap="Round" StrokeJoin="Round" />
+              </Viewbox>
+              <TextBlock x:Name="ClearHistoryText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize10}" />
+            </StackPanel>
+          </Button>
         </Grid>
-        <!-- 按标题搜索(本地筛已取回的摘要,不重复查库) -->
-        <TextBox x:Name="HistorySearchBox" DockPanel.Dock="Top" Margin="0,0,0,6"
-                 MinHeight="26" FontSize="{DynamicResource VelaFontSize12}" />
+        <!-- 按标题搜索(本地筛已取回的摘要,不重复查库)。
+             放大镜在框内起手位置(设计图):这一栏里还有会话行的输入态,
+             不给个图标的话"这是搜索框"要靠占位文字才看得出来。 -->
+        <Border x:Name="HistorySearchWrap" Classes="searchWrap" DockPanel.Dock="Top" Margin="0,0,0,6">
+          <Grid ColumnDefinitions="Auto,*">
+            <Viewbox Width="12" Height="12" Margin="8,0,6,0" VerticalAlignment="Center">
+              <Path Width="24" Height="24" Data="{DynamicResource Icon.search}"
+                    Stroke="{DynamicResource VelaTextMuted}" StrokeThickness="2"
+                    StrokeLineCap="Round" StrokeJoin="Round" />
+            </Viewbox>
+            <TextBox x:Name="HistorySearchBox" Grid.Column="1"
+                     FontSize="{DynamicResource VelaFontSize12}" />
+          </Grid>
+        </Border>
         <ScrollViewer HorizontalScrollBarVisibility="Disabled">
           <StackPanel x:Name="HistoryList" Spacing="4" />
         </ScrollViewer>
       </DockPanel>
+      <!-- 空状态(一个模型都没配):内容由 BuildEmptyState 灌进来。
+           与聊天流叠在同一个 Panel 里、而不是塞进 MessagesPanel —— 只有这样它才能真的垂直居中,
+           StackPanel 里的东西永远是顶着上沿排的。 -->
+      <StackPanel x:Name="EmptyStateHost" IsVisible="False" Spacing="10" MaxWidth="340"
+                  VerticalAlignment="Center" HorizontalAlignment="Center" Margin="24,0" />
     </Panel>
   </DockPanel>
 </UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -19,6 +20,21 @@ using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Sessions;
 
 namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>顶栏会话下拉的一项:主机标签 + 连接状态点(<c>SessionCombo</c> 的 ItemTemplate 用)。</summary>
+/// <param name="Text">显示文字(<c>用户@主机</c>)。</param>
+/// <param name="Dot">状态点的颜色。画笔在构造项时就解析好,免得为它写一个 bool→Brush 的转换器。</param>
+public sealed record SessionNavItem(string Text, IBrush Dot);
+
+/// <summary>
+/// 审批方式下拉的一项(<c>ApprovalCombo</c> 的 ItemTemplate 用)。
+/// 形状与颜色都挂在数据项上:用户把强调色调成偏红时,"全部自动"的 error 色会和强调色撞在一起,
+/// 光靠颜色分不出挡位 —— 盾牌的三种形状(打勾 / 感叹号 / 划掉)才是那个分得开的信号。
+/// </summary>
+/// <param name="Text">挡位文案。</param>
+/// <param name="Icon">盾牌几何。</param>
+/// <param name="Tone">这一档的语义色(中性 / warn / error)。</param>
+public sealed record ApprovalNavItem(string Text, Geometry? Icon, IBrush? Tone);
 
 /// <summary>
 /// AI 聊天面板:回复以 Markdown 渲染(流式期间节流重渲染,收尾整段定稿),
@@ -37,6 +53,12 @@ public partial class ChatPanelView : UserControl
     private readonly ChatHistoryStore _historyStore;
 
     private AiSettings _settings = new();
+    /// <summary>正在流的那条回复。审批卡与失败卡要挂进它里面(而不是气泡外面),所以得有个把手。</summary>
+    private AssistantBubble? _activeBubble;
+    /// <summary>当前该不该显示空状态(还要再与"中部正显示聊天流"取与,见 <see cref="SetActiveView" />)。</summary>
+    private bool _showEmptyState;
+    /// <summary>已摆出来的是哪一版空状态(true = 引导去配模型那版);null = 还没摆。</summary>
+    private bool? _emptyStateNeedsProvider;
     private SettingsView? _settingsView;
     private GlobalSettingsView? _globalSettingsView;
     private List<ResolvedModel> _providers = [];
@@ -131,6 +153,8 @@ public partial class ChatPanelView : UserControl
                 return;
             }
             _settings.Approval = (ApprovalMode)ApprovalCombo.SelectedIndex;
+            SyncModeUi();        // 挡位换了,芯片的语义色跟着换
+            ApplyApprovalMode(); // 并且当场对这一轮生效(含放行已经挂出来的卡)
             _ = PersistSettingsAsync();
         };
         ProviderCombo.SelectionChanged += (_, _) =>
@@ -195,16 +219,13 @@ public partial class ChatPanelView : UserControl
             SyncModeUi();
             ReloadProviderCombo();
             await RefreshSessionsAsync();
-            if (_providers.Count == 0)
-            {
-                // 只提示,不自动弹窗:面板可能是随宿主启动一起开的,
-                // 冷不丁弹一个设置窗口在用户脸上不合适 —— 点 ⚙ 是他自己的决定。
-                StatusText.Text = _loc["NoProvider"];
-            }
             // 历史能力可选:时序不可用的宿主上按钮直接禁用,聊天照常
             await _historyStore.InitAsync();
             HistoryToggle.IsEnabled = _historyStore.IsAvailable;
-            ShowStarterSuggestions();
+            // 空会话的居中空状态(图标 + 标题 + 说明 + 三条起手示例)。
+            // 不自动弹配置窗:面板可能是随宿主启动一起开的,冷不丁弹一个窗在用户脸上不合适 ——
+            // 点「添加模型接入」是他自己的决定。
+            UpdateEmptyState();
             if (_historyStore.IsAvailable)
             {
                 // ↑↓ 历史不挡首屏:面板先能用,这份在后台补齐(用户不可能在几十毫秒内就按 ↑)
@@ -223,20 +244,22 @@ public partial class ChatPanelView : UserControl
         // 下拉项跟着语言换,选中项按索引留住(枚举值 = 索引,见 ChatMode / ApprovalMode)
         int mode = ModeCombo.SelectedIndex, approval = ApprovalCombo.SelectedIndex;
         ModeCombo.ItemsSource = (string[])[_loc["ModeChat"], _loc["ModePlan"], _loc["ModeAgent"]];
-        ApprovalCombo.ItemsSource = (string[])[_loc["ApprovalAsk"], _loc["ApprovalReadOnly"], _loc["ApprovalBypass"]];
+        ReloadApprovalItems();
         ModeCombo.SelectedIndex = mode;
         ApprovalCombo.SelectedIndex = approval;
         SyncModeUi();
-        NewChatText.Text = _loc["NewChat"];
-        ToolTip.SetTip(NewChatButton, _loc["NewChatTip"]);
+        // 「新会话」也是纯图标钮了(顶栏四枚统一 26×30),文案只剩提示这一处
+        ToolTip.SetTip(NewChatButton, $"{_loc["NewChat"]} — {_loc["NewChatTip"]}");
+        ToolTip.SetTip(UsageMeterTrack, _loc["MeterTip"]);
         ToolTip.SetTip(SettingsButton, _loc["ModelSettings"]);
         ToolTip.SetTip(ToolsButton, _loc["ConfigureTools"]);
         ToolTip.SetTip(HistoryToggle, _loc["History"]);
-        ClearHistoryButton.Content = _loc["ClearHistory"];
+        ClearHistoryText.Text = _loc["ClearHistory"];
         HistoryHeader.Text = _loc["HistoryHeader"];
         HistorySearchBox.PlaceholderText = _loc["SearchHistory"];
         InputPlaceholder.Text = _loc["InputPlaceholder"];
-        // 发送/停止是图标按钮(工具条宽度紧张,文字标签让给模型名):文案走提示
+        SendText.Text = _loc["Send"];
+        StopText.Text = _loc["Stop"];
         ToolTip.SetTip(SendButton, _loc["Send"]);
         ToolTip.SetTip(StopButton, _loc["Stop"]);
         ToolTip.SetTip(ProviderCombo, _loc["Model"]);
@@ -244,6 +267,43 @@ public partial class ChatPanelView : UserControl
         // 代码块头部按钮的提示藏在 LiveMarkdown 的 ControlTemplate 里,只能经 DynamicResource 灌进去
         Resources["AiCopyTip"] = _loc["Copy"];
         Resources["AiWrapTip"] = _loc["ToggleWrap"];
+    }
+
+    /// <summary>
+    /// 审批下拉的三档数据项(盾牌形状 + 语义色都挂在数据项上)。
+    /// </summary>
+    /// <remarks>
+    /// <b>装载到可视树之后必须再建一次。</b>颜色取自宿主令牌(<c>Vela*</c>),而构造期这个控件
+    /// 还没有 TopLevel,<c>TryFindResource</c> 一律返回 null —— 那样建出来的项前景是 null,
+    /// 文字和盾牌<b>全是隐形的</b>,表象就是"下拉框里空空如也、展开也是三行空白"(实测)。
+    /// 兜底画笔同样不能省:headless 测试宿主与隔离进程首帧都可能一个 Vela 令牌都没有。
+    /// </remarks>
+    private void ReloadApprovalItems()
+    {
+        int keep = ApprovalCombo.SelectedIndex;
+        ApprovalCombo.ItemsSource = (ApprovalNavItem[])
+        [
+            new(_loc["ApprovalAsk"], FindIcon("AiIcon.shield-check"),
+                FindBrush("VelaTextSecondary") ?? Brushes.Gainsboro),
+            new(_loc["ApprovalReadOnly"], FindIcon("AiIcon.shield-alert"),
+                FindBrush("VelaWarning") ?? Brushes.Orange),
+            new(_loc["ApprovalBypass"], FindIcon("AiIcon.shield-off"),
+                FindBrush("VelaError") ?? Brushes.IndianRed)
+        ];
+        ApprovalCombo.SelectedIndex = keep;
+    }
+
+    /// <inheritdoc />
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        // 到这一刻才查得到宿主资源,构造期(以及 InitAsync 续体里)建的东西要重来一遍。
+        // 空状态尤其明显:三条示例的图标取自宿主的 Icon.*,建早了就是三个空 Path ——
+        // 位置占着、图形没有(品牌脑图标反而在,因为它在插件自己的资源字典里)。
+        ReloadApprovalItems();
+        SyncModeUi();
+        _emptyStateNeedsProvider = null;
+        UpdateEmptyState();
     }
 
     // ---------- Markdown 渲染(LiveMarkdown.Avalonia) ----------
@@ -309,14 +369,14 @@ public partial class ChatPanelView : UserControl
 
         void Skin(string key, string velaKey)
         {
-            if (this.TryFindResource(velaKey, out object? value) && value is IBrush brush)
+            if (this.TryFindResource(velaKey, ActualThemeVariant, out object? value) && value is IBrush brush)
             {
                 Resources[key] = brush;
             }
         }
 
         Color? SkinColor(string velaKey)
-            => this.TryFindResource(velaKey, out object? value) && value is ISolidColorBrush brush
+            => this.TryFindResource(velaKey, ActualThemeVariant, out object? value) && value is ISolidColorBrush brush
                 ? brush.Color
                 : null;
     }
@@ -361,7 +421,118 @@ public partial class ChatPanelView : UserControl
         {
             StatusText.Text = "";
         }
+        UpdateEmptyState();
         _ = PersistSettingsAsync();
+    }
+
+    /// <summary>
+    /// 空状态:一个模型都没配的时候,中部给出"下一步该干什么",而不是状态行里一句
+    /// 「尚未配置模型」。第一次打开面板的人要的是一个按钮和几个例子,不是一句陈述。
+    /// </summary>
+    private void UpdateEmptyState()
+    {
+        // 这段对话一个字都还没有 —— 无论模型配没配,中部都不该是一整块空白
+        _showEmptyState = _history.Count == 0 && MessagesPanel.Children.Count == 0;
+        EmptyStateHost.IsVisible = _showEmptyState && ChatScroll.IsVisible;
+        if (!_showEmptyState)
+        {
+            EmptyStateHost.Children.Clear();
+            _emptyStateNeedsProvider = null;
+            return;
+        }
+        bool noProvider = _providers.Count == 0;
+        if (_emptyStateNeedsProvider == noProvider)
+        {
+            return; // 已经是对的那一版了,别每次刷新都重建一遍
+        }
+        _emptyStateNeedsProvider = noProvider;
+        EmptyStateHost.Children.Clear();
+        BuildEmptyState(noProvider);
+        // 起手示例现在长在空状态里,输入框上方那排药丸留给<b>对话开始之后</b>的后续提问。
+        // 两处同时摆着同样的三条,只是重复。
+        ClearSuggestions();
+    }
+
+    /// <summary>
+    /// 摆空状态:图标 + 标题 + 说明 + 三条示例。两版只差"要不要引导去配模型" ——
+    /// 没配的多一枚「添加模型接入」,而且点示例是<b>填进输入框</b>(这会儿还没有模型能答);
+    /// 配好的点一下直接发出去。
+    /// </summary>
+    private void BuildEmptyState(bool noProvider)
+    {
+        EmptyStateHost.Children.Add(new Decorator
+        {
+            Child = MakeIcon("AiIcon.brain", "VelaTextMuted", 34),
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center
+        });
+        EmptyStateHost.Children.Add(new TextBlock
+        {
+            Classes = { "emptyTitle" },
+            Text = _loc[noProvider ? "EmptyTitle" : "ReadyTitle"]
+        });
+        EmptyStateHost.Children.Add(new TextBlock
+        {
+            Classes = { "emptyBody" },
+            Text = _loc[noProvider ? "EmptyBody" : "ReadyBody"]
+        });
+        if (noProvider)
+        {
+            var cta = new Button
+            {
+                Content = _loc["EmptyAction"],
+                Height = 28,
+                Padding = new Thickness(14, 0),
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center
+            };
+            ApplyThemeResource(cta, "VelaAccentPillButtonTheme");
+            cta.Click += (_, _) => OpenSettingsDialog();
+            EmptyStateHost.Children.Add(cta);
+        }
+
+        EmptyStateHost.Children.Add(new TextBlock
+        {
+            Classes = { "dim" },
+            Text = _loc[noProvider ? "EmptyExamples" : "ReadyExamples"],
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            Margin = new Thickness(0, 8, 0, 0)
+        });
+        foreach ((string icon, string text) in (ReadOnlySpan<(string, string)>)
+                 [("Icon.terminal", _loc["Starter1"]),
+                  ("Icon.hard-drive", _loc["Starter2"]),
+                  ("Icon.network", _loc["Starter3"])])
+        {
+            var grid = new Grid { ColumnDefinitions = [with("Auto,*")] };
+            grid.Children.Add(new Decorator
+            {
+                Child = MakeIcon(icon, "VelaTextTertiary", 12),
+                Margin = new Thickness(0, 0, 7, 0),
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            });
+            var label = new TextBlock
+            {
+                Text = text,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+            Grid.SetColumn(label, 1);
+            grid.Children.Add(label);
+            var row = new Border { Classes = { "exampleRow" }, Child = grid };
+            row.PointerPressed += (_, e) =>
+            {
+                e.Handled = true;
+                if (noProvider)
+                {
+                    // 还没有模型能答,直接发只会撞回一句"尚未配置" —— 填进输入框放着,
+                    // 配完接着按回车就行。
+                    InputBox.Text = text;
+                    InputBox.TextArea.Focus();
+                    InputBox.CaretOffset = InputBox.Document.TextLength;
+                    return;
+                }
+                _ = SendAsync(text);
+            };
+            EmptyStateHost.Children.Add(row);
+        }
     }
 
     private void ReloadProviderCombo()
@@ -391,6 +562,7 @@ public partial class ChatPanelView : UserControl
         if (_totalInputTokens == 0 && _totalOutputTokens == 0)
         {
             UsageText.Text = "";
+            UsageMeterTrack.IsVisible = false;
             ToolTip.SetTip(UsageText, _loc["UsageIdle"]);
             return;
         }
@@ -402,10 +574,13 @@ public partial class ChatPanelView : UserControl
             int percent = (int)Math.Min(100, Math.Round(_lastInputTokens * 100.0 / window));
             label.Append($"{Compact(_lastInputTokens)}/{Compact(window)} · {percent}%");
             detail.AppendLine(_loc.F("UsageContextLine", $"{_lastInputTokens:N0}", $"{window:N0}", percent));
+            SetUsageMeter(percent);
         }
         else
         {
             label.Append($"↑{Compact(_totalInputTokens)} ↓{Compact(_totalOutputTokens)}");
+            // 不知道窗口多大就画不出占比,整条隐掉(留一根空槽反而像"用量为零")
+            UsageMeterTrack.IsVisible = false;
         }
 
         // 命中率 = 缓存读取 / 输入。两家口径实测已被适配器抹平:OpenAI 的 prompt_tokens 本就含
@@ -445,6 +620,29 @@ public partial class ChatPanelView : UserControl
                 window > 0 ? $"{window:N0}" : "—"));
         }
         ToolTip.SetTip(UsageText, detail.ToString().TrimEnd());
+    }
+
+    /// <summary>
+    /// 上下文占用条:把"上一轮吃掉了窗口的百分之几"画成一根 56px 的槽。
+    /// 数字仍在文字与悬停提示里,这根条只负责让占比进入余光 —— 逼近上限时颜色先变,
+    /// 用户不必先去读数才知道该开新会话了。
+    /// </summary>
+    /// <param name="percent">0–100。低于 1% 也给 2px,免得"有用量"看上去像"没用量"。</param>
+    private void SetUsageMeter(int percent)
+    {
+        double track = UsageMeterTrack.Width;
+        UsageMeterTrack.IsVisible = true;
+        UsageMeterFill.Width = percent <= 0 ? 0 : Math.Max(2, Math.Round(track * Math.Min(100, percent) / 100.0));
+        string key = percent switch
+        {
+            >= 95 => "VelaError",
+            >= 80 => "VelaWarning",
+            _ => "VelaAccent"
+        };
+        if (FindBrush(key) is { } brush)
+        {
+            UsageMeterFill.Background = brush;
+        }
     }
 
     /// <summary>
@@ -489,9 +687,13 @@ public partial class ChatPanelView : UserControl
             IReadOnlyList<SessionInfo> all = await _context.Sessions.ListAsync();
             string? previous = SelectedSessionId;
             _sessions = [.. all.Where(s => s.State == SessionState.Connected)];
+            // 顶栏的会话行前面带一颗状态点。列表里只有"已连接"的会话,所以点恒为绿;
+            // 一台都没有时那条占位项给灰点 —— 空着不画反而会让整行的对齐跳一下。
+            IBrush online = FindBrush("VelaStatusConnected") ?? Brushes.LimeGreen;
+            IBrush offline = FindBrush("VelaTextMuted") ?? Brushes.Gray;
             SessionCombo.ItemsSource = _sessions.Count == 0
-                ? [_loc["NoSession"]]
-                : _sessions.Select(s => $"{s.Username}@{s.Host}").ToList();
+                ? (IReadOnlyList<SessionNavItem>)[new SessionNavItem(_loc["NoSession"], offline)]
+                : [.. _sessions.Select(s => new SessionNavItem($"{s.Username}@{s.Host}", online))];
             int keep = _sessions.FindIndex(s => s.SessionId == previous);
             SessionCombo.SelectedIndex = keep >= 0 ? keep : 0;
         }
@@ -643,6 +845,7 @@ public partial class ChatPanelView : UserControl
         SetActiveView(PanelView.Chat);
 
         AddUserBubble(text + AttachmentTrace());
+        UpdateEmptyState(); // 消息流有东西了,居中的空状态得让位
         RequestAutoScroll(force: true);
 
         _cts = new CancellationTokenSource();
@@ -666,6 +869,7 @@ public partial class ChatPanelView : UserControl
             await PersistAsync("user", text + AttachmentTrace());
             ClearAttachments();
             bubble = new AssistantBubble(this);
+            _activeBubble = bubble;
             MessagesPanel.Children.Add(bubble.Root);
             TrimMessageWindow(); // 常驻条数封顶,别让可视树越聊越长
             RequestAutoScroll(force: true);
@@ -686,10 +890,9 @@ public partial class ChatPanelView : UserControl
             // 纯对话模式不给任何工具;计划模式只给只读工具(见 AgentToolbox.CreateTools)
             if (mode != ChatMode.Chat)
             {
-                _toolbox.Approval = _settings.Approval;
+                ApplyApprovalMode(); // 挡位推给工具箱与 MCP(中途再改也会经这条路重推)
                 _toolbox.DisabledTools = new HashSet<string>(
                     SplitLines(_settings.DisabledBuiltinTools) ?? [], StringComparer.OrdinalIgnoreCase);
-                _mcp.Approval = _settings.Approval;
                 IList<AITool> tools = _toolbox.CreateTools(mode);
                 // 计划模式下不接 MCP:那些工具的副作用由第三方服务器说了算,插件无从判断,
                 // 而"计划"的承诺是这一步不动任何东西。
@@ -788,10 +991,13 @@ public partial class ChatPanelView : UserControl
                                            && !token.IsCancellationRequested && IsTransient(ex))
                 {
                     _context.Log.Warn($"Stream failed before any content (attempt {attempt + 1}): {ex.Message}");
+                    // 重试是瞬时故障,给 warn 色区别于普通提示;成功后连色带字一起撤掉
+                    StatusText.Classes.Add("retrying");
                     StatusText.Text = _loc.F("Retrying", attempt + 1);
                     await Task.Delay(TimeSpan.FromMilliseconds(400 * (attempt + 1)), token);
                 }
             }
+            StatusText.Classes.Remove("retrying");
             StatusText.Text = "";
             DrainUpdates(); // 兜底清空残留批(此处已回到 UI 线程)
 
@@ -831,13 +1037,17 @@ public partial class ChatPanelView : UserControl
             // 真正说清哪儿不对的那段在 ResponseBody 里(见 ApiErrorText)。
             string detail = ApiErrorText.Describe(ex);
             _context.Log.Error($"AI request failed. — {detail}", ex);
-            bubble?.AppendText($"\n\n**[{_loc["Error"]}]** {detail}");
+            // 失败不再当成一段 Markdown 追加进正文:它不是模型说的话,混排会让人分不清
+            // 哪句是回答、哪句是故障。改成一张 error 卡挂在这条回复里(见 AddErrorCard)。
+            AddErrorCard(bubble, detail);
             await SettleUnfinishedTurnAsync(bubble);
         }
         finally
         {
             _cts?.Dispose();
             _cts = null;
+            _activeBubble = null;
+            StatusText.Classes.Remove("retrying");
             SetBusy(false);
             // 一轮到此为止(成功/取消/出错都算):收起思考区,补上"耗时 · 步数"与"时间 · 模型"
             bubble?.FinishStreaming(
@@ -906,6 +1116,19 @@ public partial class ChatPanelView : UserControl
             ApprovalMode.ReadOnlyAuto => "ApprovalReadOnlyTip",
             _ => "ApprovalAskTip"
         }]);
+        // 审批是安全开关:当前挡位的风险高低要能被余光读到,而不是靠去读那四个字。
+        // 每次询问 = 中性(什么都不会替你按),只读自动 = warn,全部自动 = error。
+        string tone = _settings.Approval switch
+        {
+            ApprovalMode.Bypass => "VelaError",
+            ApprovalMode.ReadOnlyAuto => "VelaWarning",
+            _ => "VelaTextSecondary"
+        };
+        if (FindBrush(tone) is { } brush)
+        {
+            ApprovalCombo.Foreground = brush;
+            ApprovalCombo.BorderBrush = brush;
+        }
     }
 
     /// <summary>用量归零(换会话时用:计数是"这一段对话"的,不是进程级的)。</summary>
@@ -1111,6 +1334,7 @@ public partial class ChatPanelView : UserControl
         ResetEditing();
         ResetCompaction();
         _alwaysApproved.Clear(); // 放行记忆只在同一段对话里有效
+        _pendingApprovals.Clear(); // 连同卡片一起被清出可视树了,名册不能留着
         ResetUsage();
         _conversationId = ChatHistoryStore.NewConversationId();
         _conversationStartedAt = DateTimeOffset.UtcNow;
@@ -1118,8 +1342,8 @@ public partial class ChatPanelView : UserControl
         _inputHistoryIndex = -1;
         StatusText.Text = "";
         ClearSuggestions();
-        ShowStarterSuggestions();
         SetActiveView(PanelView.Chat);
+        UpdateEmptyState();
         InputBox.TextArea.Focus();
     }
 
@@ -1130,6 +1354,20 @@ public partial class ChatPanelView : UserControl
     /// 不写进配置:一次排查里放行 <c>ls</c>,不代表下次打开还想默认放行。
     /// </summary>
     private readonly HashSet<string> _alwaysApproved = [with(StringComparer.Ordinal)];
+
+    /// <summary>一张还悬着的审批卡:它请求的是什么,以及怎么替用户按下去。</summary>
+    /// <param name="Request">这次请求。</param>
+    /// <param name="Resolve">落定回调,参数同 <c>Finish(approved, remember)</c>。</param>
+    private sealed record PendingApproval(ApprovalRequest Request, Action<bool, bool> Resolve);
+
+    /// <summary>
+    /// 悬而未决的审批卡。<b>会同时有好几张</b>:模型一帧里发起多个工具调用时,
+    /// 每个都各自 <c>await</c> 一次审批,卡片是一起挂出来的。
+    /// 有了这份名册,"总是允许"和"把挡位切成全部自动"才能把<b>同批已经挂出来的</b>
+    /// 那几张一并放行 —— 否则用户点完之后还得对着剩下的卡再点一遍,
+    /// 看上去就像"设置根本没生效"。
+    /// </summary>
+    private readonly List<PendingApproval> _pendingApprovals = [];
 
     private async Task<bool> RequestApprovalAsync(ApprovalRequest request)
     {
@@ -1142,11 +1380,156 @@ public partial class ChatPanelView : UserControl
         return await tcs.Task.ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// 把还悬着的审批卡按条件批量放行(挡位改成自动、或用户点了"总是允许"时)。
+    /// 先拷一份再遍历:<c>Resolve</c> 会把自己从名册里摘掉。
+    /// </summary>
+    private void ReleasePendingApprovals(Func<ApprovalRequest, bool> match)
+    {
+        foreach (PendingApproval pending in _pendingApprovals.ToArray())
+        {
+            if (match(pending.Request))
+            {
+                pending.Resolve(true, false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 审批挡位变了:<b>当场</b>推给工具箱与 MCP,并把已经挂出来、按新挡位本就不该问的卡放掉。
+    /// </summary>
+    /// <remarks>
+    /// 以前这两个赋值只在 <c>SendAsync</c> 起手做一次,于是"跑到一半把挡位改成全部自动"
+    /// 对这一轮完全无效 —— 工具箱手里还攥着旧值,照旧一条条问(用户实测反馈)。
+    /// </remarks>
+    private void ApplyApprovalMode()
+    {
+        _toolbox.Approval = _settings.Approval;
+        _mcp.Approval = _settings.Approval;
+        switch (_settings.Approval)
+        {
+            case ApprovalMode.Bypass:
+                ReleasePendingApprovals(_ => true);
+                break;
+            case ApprovalMode.ReadOnlyAuto:
+                // 与 AgentToolbox.ApproveAsync 同一把尺子:只放"确定无副作用"的命令
+                ReleasePendingApprovals(r => r.Kind == "run_command" && ReadOnlyCommand.IsSafe(r.Detail));
+                break;
+        }
+    }
+
+    /// <summary>
+    /// 审批卡上那枚风险标签的文案:只说这次调用<b>会做什么</b>(写远端文件 / 执行命令 / 写入终端),
+    /// 不替用户判断危不危险 —— 同一条命令在不同机器上的分量完全不同,那是他的判断。
+    /// 认不出的工具就把工具名原样摆出来,总好过瞎归类。
+    /// </summary>
+    private string RiskLabel(string kind)
+    {
+        if (kind.StartsWith("mcp", StringComparison.OrdinalIgnoreCase))
+        {
+            return _loc["RiskMcp"];
+        }
+        if (kind.Contains("write", StringComparison.OrdinalIgnoreCase))
+        {
+            return _loc["RiskWrite"];
+        }
+        if (kind.Contains("send", StringComparison.OrdinalIgnoreCase)
+            || kind.Contains("input", StringComparison.OrdinalIgnoreCase)
+            || kind.Contains("terminal", StringComparison.OrdinalIgnoreCase))
+        {
+            return _loc["RiskInput"];
+        }
+        return kind.Contains("command", StringComparison.OrdinalIgnoreCase)
+               || kind.Contains("exec", StringComparison.OrdinalIgnoreCase)
+            ? _loc["RiskExec"]
+            : kind;
+    }
+
+    /// <summary>
+    /// 记忆键去掉工具名前缀,只留人认得出的那半截:<c>run_command:du</c> → <c>du</c>。
+    /// 按钮上要写的是"总是允许什么",写全键反而更绕。
+    /// </summary>
+    private static string RepeatKeyLabel(string repeatKey)
+    {
+        int colon = repeatKey.IndexOf(':');
+        return colon >= 0 && colon + 1 < repeatKey.Length ? repeatKey[(colon + 1)..] : repeatKey;
+    }
+
+    /// <summary>卡片的头行:语义色图标 + 标题占满中间 + 右端一枚小标签(可省)。</summary>
+    private Grid BuildCardHeader(string iconKey, string toneKey, string title, string? badge)
+    {
+        var head = new Grid { ColumnDefinitions = [with("Auto,*,Auto")] };
+        head.Children.Add(new Decorator
+        {
+            Child = MakeIcon(iconKey, toneKey, 12),
+            Margin = new Thickness(0, 0, 6, 0),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+        });
+        var titleText = new TextBlock
+        {
+            Classes = { "meta" },
+            Text = title,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = FindBrush(toneKey)
+        };
+        Grid.SetColumn(titleText, 1);
+        head.Children.Add(titleText);
+        if (badge is { Length: > 0 })
+        {
+            var chip = new Border
+            {
+                Classes = { "riskBadge" },
+                Child = new TextBlock { Text = badge },
+                BorderBrush = FindBrush(toneKey)
+            };
+            Grid.SetColumn(chip, 2);
+            head.Children.Add(chip);
+        }
+        return head;
+    }
+
+    /// <summary>
+    /// 一轮里出的错(请求失败、服务端拒绝)。挂成一张 error 卡而不是接在正文后面:
+    /// 它不是模型说的话,混排会让人分不清哪句是回答、哪句是故障。
+    /// 没有气泡可挂(还没开口就炸了)时退回状态行,至少别把消息吞掉。
+    /// </summary>
+    private void AddErrorCard(AssistantBubble? bubble, string detail)
+    {
+        if (bubble is null)
+        {
+            StatusText.Text = $"{_loc["Error"]}: {detail}";
+            return;
+        }
+        var stack = new StackPanel { Spacing = 6 };
+        stack.Children.Add(BuildCardHeader("Icon.triangle-alert", "VelaError", _loc["Error"], null));
+        stack.Children.Add(new Border
+        {
+            Classes = { "cardCode" },
+            Child = new SelectableTextBlock { Classes = { "mono" }, Text = Truncate(detail, 1200) }
+        });
+        stack.Children.Add(new TextBlock { Classes = { "dim" }, Text = _loc["ErrorKept"], TextWrapping = TextWrapping.Wrap });
+        bubble.AddCard(new Border { Classes = { "errorCard" }, Child = stack });
+        RequestAutoScroll(force: true);
+    }
+
     private void AddApprovalCard(ApprovalRequest request, TaskCompletionSource<bool> tcs)
     {
+        // 就地抓住"这张卡属于哪条回复":整轮结束后 _activeBubble 会被清掉,
+        // 而卡上的按钮此刻可能还活着(用户按了停止、审批却没落定),那时仍要能把芯片撤回去。
+        AssistantBubble? host = _activeBubble;
         var stack = new StackPanel { Spacing = 6 };
-        stack.Children.Add(new TextBlock { Classes = { "dim" }, Text = _loc["ApprovalTitle"] });
-        stack.Children.Add(new SelectableTextBlock { Classes = { "mono" }, Text = Truncate(request.Summary, 600) });
+        // 头行的盾牌与标题在落定时要换成绿/红,所以两者都留个把手
+        Grid header = BuildCardHeader("AiIcon.shield-alert", "VelaWarning",
+            _loc["ApprovalTitle"], RiskLabel(request.Kind));
+        var headerIcon = (Decorator)header.Children[0];
+        var headerTitle = (TextBlock)header.Children[1];
+        stack.Children.Add(header);
+        // 命令原文压在输入底色上:它是要被逐字读的东西,不该和说明文字一个背景
+        stack.Children.Add(new Border
+        {
+            Classes = { "cardCode" },
+            Child = new SelectableTextBlock { Classes = { "mono" }, Text = Truncate(request.Summary, 600) }
+        });
         // 主/次操作对齐宿主按钮方案:批准 = 强调药丸,拒绝 = 描边换危险色
         var approveButton = new Button { Content = _loc["Approve"], Height = 24, Padding = new Thickness(12, 0) };
         var denyButton = new Button { Content = _loc["Deny"], Height = 24, Padding = new Thickness(12, 0) };
@@ -1164,38 +1547,87 @@ public partial class ChatPanelView : UserControl
         Button? alwaysButton = null;
         if (request.RepeatKey is { } repeatKey)
         {
-            alwaysButton = new Button { Content = _loc["ApproveAlways"], Height = 24, Padding = new Thickness(12, 0) };
+            // 按钮上写清"总是允许的到底是什么"。原来只写「本次会话总是允许」,
+            // 读起来像"这一整段对话里什么都别再问了",实际只对同名命令生效
+            // (键是 run_command:du 这种)—— 用户点完 du 又被 journalctl 拦住,
+            // 以为是功能坏了。把键摆到脸上,歧义就没了。
+            alwaysButton = new Button
+            {
+                Content = _loc.F("ApproveAlwaysKey", RepeatKeyLabel(repeatKey)),
+                Height = 24,
+                Padding = new Thickness(12, 0)
+            };
             ApplyThemeResource(alwaysButton, "VelaOutlineButtonTheme");
             ToolTip.SetTip(alwaysButton, _loc.F("ApproveAlwaysTip", repeatKey));
             buttons.Children.Add(alwaysButton);
         }
         buttons.Children.Add(denyButton);
         stack.Children.Add(buttons);
-        var card = new Border { Classes = { "toolCard" }, Child = stack };
+        // 这一轮此刻是停着的 —— 说出来,免得用户以为是卡住了(落定后这句就撤掉)
+        var paused = new TextBlock
+        {
+            Classes = { "dim" },
+            Text = _loc["ApprovalPaused"],
+            TextWrapping = TextWrapping.Wrap
+        };
+        stack.Children.Add(paused);
+        var card = new Border { Classes = { "approvalCard" }, Child = stack };
+        // 名册项要引用 Finish、Finish 又要引用名册项,先留个空位再回填
+        PendingApproval? pending = null;
 
         void Finish(bool approved, bool remember)
         {
-            approveButton.IsEnabled = false;
-            denyButton.IsEnabled = false;
-            alwaysButton?.IsEnabled = false;
+            // 先摘名册再干别的:下面放行同键的其它卡时会重入这里
+            if (pending is null || !_pendingApprovals.Remove(pending))
+            {
+                return; // 已经落定过了(比如刚被批量放行)
+            }
+            buttons.IsVisible = false;
+            host?.SetWaitingForApproval(false);
             if (remember && request.RepeatKey is { } key)
             {
                 _alwaysApproved.Add(key);
             }
-            stack.Children.Add(new TextBlock
-            {
-                Classes = { "dim" },
-                Text = approved
-                    ? (remember ? _loc["ApproveAlways"] : _loc["Approve"]) + " ✓"
-                    : _loc["Deny"] + " ✕"
-            });
+
+            // 落定之后整张卡换成结果态:左边条、盾牌、标题一起转绿(批准)或转红(拒绝)。
+            // 只在末尾补一行小字是不够的 —— 一屏堆着五六张卡时,得能一眼扫出哪些已经过了。
+            string toneKey = approved ? "VelaStatusConnected" : "VelaError";
+            IBrush? tone = FindBrush(toneKey);
+            card.Classes.Remove("approvalCard");
+            card.Classes.Add(approved ? "approvedCard" : "deniedCard");
+            headerIcon.Child = MakeIcon(approved ? "AiIcon.shield-check" : "AiIcon.shield-off", toneKey, 12);
+            headerTitle.Foreground = tone;
+            headerTitle.Text = approved
+                ? (remember ? _loc.F("ApproveAlwaysKey", RepeatKeyLabel(request.RepeatKey ?? "")) : _loc["Approve"])
+                : _loc["Deny"];
+            paused.IsVisible = false;
             tcs.TrySetResult(approved);
+
+            // 同一帧里模型常常一次发好几个同名命令,卡是一起挂出来的。
+            // 点了"总是允许"却还要对着剩下那几张再点一遍,看上去就像设置没生效。
+            if (remember && request.RepeatKey is { } sameKey)
+            {
+                ReleasePendingApprovals(other => other.RepeatKey == sameKey);
+            }
         }
+
+        pending = new PendingApproval(request, Finish);
+        _pendingApprovals.Add(pending);
 
         approveButton.Click += (_, _) => Finish(true, remember: false);
         denyButton.Click += (_, _) => Finish(false, remember: false);
         alwaysButton?.Click += (_, _) => Finish(true, remember: true);
-        MessagesPanel.Children.Add(card);
+        // 挂进正在流的那条回复里(而不是气泡外面):后续正文还会继续往气泡里长,
+        // 卡片摆在外头就会排到正文<b>前面</b>去,前后颠倒。
+        if (host is not null)
+        {
+            host.AddCard(card);
+            host.SetWaitingForApproval(true);
+        }
+        else
+        {
+            MessagesPanel.Children.Add(card);
+        }
         // 审批卡阻塞整轮对话,必须让用户看见
         RequestAutoScroll(force: true);
     }
@@ -1284,31 +1716,53 @@ public partial class ChatPanelView : UserControl
     /// <summary>套用宿主 ControlTheme(进程内可查;隔离进程缺失时保持默认外观)。</summary>
     private void ApplyThemeResource(Avalonia.Controls.Primitives.TemplatedControl control, string themeKey)
     {
-        if (this.TryFindResource(themeKey, out object? value) && value is ControlTheme theme)
+        if (this.TryFindResource(themeKey, ActualThemeVariant, out object? value) && value is ControlTheme theme)
         {
             control.Theme = theme;
         }
     }
 
+    /// <summary>
+    /// 按当前主题变体查资源。<b>必须带 <see cref="StyledElement.ActualThemeVariant" /></b>:
+    /// 宿主把大半令牌(<c>VelaAccent</c> / <c>VelaStatusConnected</c> / <c>VelaText*</c> …)放在
+    /// <c>ResourceDictionary.ThemeDictionaries</c> 的 Dark/Light 块里,不带变体的那个重载查不到,
+    /// 一律返回 null —— 于是 <c>MakeIcon</c> 退回灰色、<c>Foreground = null</c> 的文字直接隐形。
+    /// XAML 里的 <c>{DynamicResource}</c> 自己是主题感知的,所以毛病只出在代码后置这一侧:
+    /// 表象就是"工具卡完成了图标还是灰的""审批卡的标题看不见"。
+    /// </summary>
     private Geometry? FindIcon(string key)
-        => this.TryFindResource(key, out object? value) && value is Geometry geometry ? geometry : null;
+        => this.TryFindResource(key, ActualThemeVariant, out object? value) && value is Geometry geometry
+            ? geometry
+            : null;
 
+    /// <inheritdoc cref="FindIcon" />
     private IBrush? FindBrush(string key)
-        => this.TryFindResource(key, out object? value) && value is IBrush brush ? brush : null;
+        => this.TryFindResource(key, ActualThemeVariant, out object? value) && value is IBrush brush
+            ? brush
+            : null;
 
-    /// <summary>lucide 描边图标(24 视图框经 Viewbox 等比缩放)。</summary>
+    /// <summary>
+    /// lucide 描边图标(24 视图框经 Viewbox 等比缩放)。
+    /// </summary>
+    /// <remarks>
+    /// 几何与描边都用 <see cref="DynamicResourceExtension" /> <b>绑</b>,不要一次性取值:
+    /// ① 宿主的 <c>Icon.*</c> 与 <c>Vela*</c> 令牌要面板装载之后才查得到,建早了(构造期、
+    /// <c>InitAsync</c> 的续体里)取到的是 null,结果是"位置占着、图形不见了";
+    /// ② 一次性取值扛不住主题切换 —— 绑上去才会跟着 Dark/Light 变。
+    /// 同一条经验在 <see cref="ToolPickerView" /> 里也写着,这里是它的统一版本。
+    /// </remarks>
     private Viewbox MakeIcon(string geometryKey, string brushKey, double size)
     {
         var path = new Avalonia.Controls.Shapes.Path
         {
             Width = 24,
             Height = 24,
-            Data = FindIcon(geometryKey),
-            Stroke = FindBrush(brushKey) ?? Brushes.Gray,
             StrokeThickness = 2,
             StrokeLineCap = PenLineCap.Round,
             StrokeJoin = PenLineJoin.Round
         };
+        path[!Avalonia.Controls.Shapes.Path.DataProperty] = new DynamicResourceExtension(geometryKey);
+        path[!Avalonia.Controls.Shapes.Shape.StrokeProperty] = new DynamicResourceExtension(brushKey);
         return new Viewbox { Width = size, Height = size, Child = path };
     }
 
@@ -1322,6 +1776,8 @@ public partial class ChatPanelView : UserControl
         private readonly ChatPanelView _owner;
         private readonly StackPanel _stack;
         private readonly TextBlock _header;
+        private readonly TextBlock _phaseText;
+        private readonly Border _phaseChip;
         private readonly Dictionary<string, ToolCard> _toolCards = [];
         private readonly StringBuilder _thinkingText = new();
         // 复制整段回复用的原文:正文按到达顺序原样攒着(Markdown 源码,不是渲染后的可视树)
@@ -1329,6 +1785,7 @@ public partial class ChatPanelView : UserControl
         private MarkdownSegment? _currentSegment;
         private Collapsible? _thinking;
         private bool _thinkingRenderScheduled;
+        private string _phaseKey = "";
         private long _thinkingStartedAt;
         private TimeSpan? _thinkingElapsed;
         private int _steps;
@@ -1353,7 +1810,7 @@ public partial class ChatPanelView : UserControl
             {
                 _thinkingText.Append(meta.Thinking);
                 _thinking = new Collapsible(_owner, _owner._loc.F("ThinkingDone",
-                    FormatDuration(TimeSpan.FromMilliseconds(meta.ThinkingMs))));
+                    FormatDuration(TimeSpan.FromMilliseconds(meta.ThinkingMs))), trailingIconKey: "AiIcon.sparkles");
                 _stack.Children.Insert(1, _thinking.Root);
                 _thinking.SetBody(meta.Thinking);
                 // 时长已经是存下来的,别让后面的 AppendText 再去按"现在"算一遍
@@ -1371,9 +1828,63 @@ public partial class ChatPanelView : UserControl
         {
             _owner = owner;
             _stack = new StackPanel { Spacing = 4 };
-            _header = new TextBlock { Classes = { "roleHeader" }, Text = owner._loc["AssistantRole"] };
-            _stack.Children.Add(_header);
+            _header = new TextBlock
+            {
+                Classes = { "roleHeader" },
+                Text = owner._loc["AssistantRole"],
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+            // 阶段芯片:输入框那圈流光只说明"在动",这几个字说明"在干什么"。
+            // 与角色行同处一行,读完"助手 · 3 步"顺势就读到了当前阶段。
+            _phaseText = new TextBlock();
+            _phaseChip = new Border
+            {
+                Classes = { "phaseChip" },
+                Child = _phaseText,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            var headerRow = new StackPanel
+            {
+                Orientation = Avalonia.Layout.Orientation.Horizontal,
+                Spacing = 6
+            };
+            headerRow.Children.Add(_header);
+            headerRow.Children.Add(_phaseChip);
+            _stack.Children.Add(headerRow);
             Root = new Border { Classes = { "msg" }, Child = _stack };
+            // 第一个 token 到达之前,模型确实在"想这道题",即便它不吐 reasoning
+            SetPhase("PhaseThinking");
+        }
+
+        /// <summary>
+        /// 换阶段芯片的文案。<paramref name="waiting" /> 会把芯片换成实心 warn ——
+        /// 那一档意味着界面此刻是<b>停着的</b>,分量得比"在动"更重。
+        /// </summary>
+        private void SetPhase(string key, bool waiting = false)
+        {
+            // AppendText 是逐块调的,同一档反复写会白白触发排版
+            if (_phaseKey == key)
+            {
+                return;
+            }
+            _phaseKey = key;
+            _phaseText.Text = _owner._loc[key];
+            _phaseChip.Classes.Set("waiting", waiting);
+            _phaseChip.IsVisible = true;
+        }
+
+        /// <summary>审批卡出现/落定时切换"等待你确认"这一档(由 <see cref="AddApprovalCard" /> 调)。</summary>
+        public void SetWaitingForApproval(bool waiting) => SetPhase(waiting ? "PhaseWaiting" : "PhaseTool", waiting);
+
+        /// <summary>
+        /// 把一张卡(审批 / 失败)挂进这条回复里。
+        /// 以前审批卡是直接扔进 <c>MessagesPanel</c> 的 —— 那样它排在整个气泡<b>下面</b>,
+        /// 而后续正文还在气泡里继续往下长,读起来前后颠倒。
+        /// </summary>
+        public void AddCard(Control card)
+        {
+            _stack.Children.Add(card);
+            _currentSegment = null; // 卡之后的新文本另起一个 Markdown 段
         }
 
         public void AppendText(string text)
@@ -1386,6 +1897,7 @@ public partial class ChatPanelView : UserControl
             // 思考往往刚吐完正文就跟上,立刻折叠等于让人根本没机会读(用户反馈的
             // "思考和正文一起冒出来"就是这么来的)。留到整轮结束再收。
             MarkThinkingDone();
+            SetPhase("PhaseWriting");
             _replyText.Append(text);
             // 工具卡片之后的新一轮文本另起 Markdown 段
             if (_currentSegment is null || !ReferenceEquals(_stack.Children[^1], _currentSegment.Host))
@@ -1403,12 +1915,13 @@ public partial class ChatPanelView : UserControl
                 return;
             }
             _thinkingText.Append(text);
+            SetPhase("PhaseThinking");
             if (_thinking is null)
             {
                 // 默认收起(用户决策):标题一行就够说明"在想",要看内容自己点开。
                 // 展开过就一路留着,标题从"正在思考…"变成"已思考 N 秒",正文照样往里灌。
                 _thinkingStartedAt = Environment.TickCount64;
-                _thinking = new Collapsible(_owner, _owner._loc["ThinkingActive"]);
+                _thinking = new Collapsible(_owner, _owner._loc["ThinkingActive"], trailingIconKey: "AiIcon.sparkles");
                 _stack.Children.Insert(1, _thinking.Root);
             }
             // 逐 token 全量刷文本是 O(n²) 的字符串与排版开销,所以节流;但别压太狠 ——
@@ -1431,6 +1944,7 @@ public partial class ChatPanelView : UserControl
                 return;
             }
             MarkThinkingDone();
+            SetPhase("PhaseTool");
             _steps++;
             var card = new ToolCard(_owner, name, argumentsJson);
             _toolCards[callId] = card;
@@ -1461,17 +1975,15 @@ public partial class ChatPanelView : UserControl
             // Markdown 段不需要收口:LiveMarkdown 自己会把最后一次追加渲染完
             _thinking?.SetBody(_thinkingText.ToString());
             MarkThinkingDone();
+            _phaseChip.IsVisible = false; // 一轮到此为止,阶段芯片退场(历史回放也走这里)
             // 默认本来就是收起的;这里不再强制折叠 —— 用户中途点开了就让它开着,
             // 别在他正读的时候把内容抽走。
 
+            // 头部只留"这条回复是谁、走了几步、是不是被停掉的";时刻 / 模型 / 耗时归底部元信息条
             var head = new StringBuilder(_owner._loc["AssistantRole"]);
             if (_steps > 0)
             {
                 head.Append(" · ").Append(_owner._loc.F("Steps", _steps));
-            }
-            if (elapsed is { } span)
-            {
-                head.Append(" · ").Append(FormatDuration(span));
             }
             if (cancelled)
             {
@@ -1479,9 +1991,9 @@ public partial class ChatPanelView : UserControl
             }
             _header.Text = head.ToString();
 
-            if (at is not null || modelLabel is not null)
+            if (at is not null || modelLabel is not null || elapsed is not null)
             {
-                _stack.Children.Add(BuildFooter(modelLabel, at));
+                _stack.Children.Add(BuildFooter(modelLabel, at, elapsed));
             }
         }
 
@@ -1499,12 +2011,20 @@ public partial class ChatPanelView : UserControl
             _thinking.SetTitle(_owner._loc.F("ThinkingDone", FormatDuration(_thinkingElapsed.Value)));
         }
 
-        /// <summary>底部元信息条:左边"复制整段回复",右边"时间 · 模型"(不显示积分/评价)。</summary>
-        private Border BuildFooter(string? modelLabel, DateTimeOffset? at)
+        /// <summary>
+        /// 底部元信息条:<b>左边"时刻 · 模型 · 耗时",右边两枚动作</b>(复制整段 / 重新生成)。
+        /// 要读的信息排在起手位置,次要动作靠右让位 —— 与设计图一致。
+        /// </summary>
+        private Border BuildFooter(string? modelLabel, DateTimeOffset? at, TimeSpan? elapsed)
         {
-            var grid = new Grid { ColumnDefinitions = [with("Auto,*,Auto")] };
+            var grid = new Grid { ColumnDefinitions = [with("*,Auto")] };
 
-            var buttons = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 2 };
+            var buttons = new StackPanel
+            {
+                Orientation = Avalonia.Layout.Orientation.Horizontal,
+                Spacing = 2,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
             var copyIcon = new Decorator { Child = _owner.MakeIcon("Icon.copy", "VelaTextMuted", 12) };
             var copy = new Button { Content = copyIcon };
             _owner.ApplyThemeResource(copy, "AiGhostIconButtonTheme");
@@ -1515,10 +2035,11 @@ public partial class ChatPanelView : UserControl
             // 与其悄悄连坐,不如让用户走"编辑上一条"这条明确的路。
             buttons.Children.Add(_owner.IconAction("Icon.refresh-cw", _owner._loc["Regenerate"],
                 () => _ = _owner.RegenerateIfLastAsync(Root)));
+            Grid.SetColumn(buttons, 1);
             grid.Children.Add(buttons);
 
             var meta = new TextBlock { Classes = { "meta" } };
-            var parts = new List<string>(2);
+            var parts = new List<string>(3);
             if (at is { } stamp)
             {
                 parts.Add(stamp.ToString("HH:mm"));
@@ -1527,9 +2048,12 @@ public partial class ChatPanelView : UserControl
             {
                 parts.Add(modelLabel);
             }
+            if (elapsed is { } span)
+            {
+                parts.Add(FormatDuration(span));
+            }
             meta.Text = string.Join(" · ", parts);
             ToolTip.SetTip(meta, meta.Text);
-            Grid.SetColumn(meta, 2);
             grid.Children.Add(meta);
 
             return new Border { Classes = { "replyFooter" }, Child = grid };
@@ -1606,11 +2130,19 @@ public partial class ChatPanelView : UserControl
         /// <param name="owner">宿主面板(取图标与令牌)。</param>
         /// <param name="title">头部文案。</param>
         /// <param name="expanded">初始是否展开。</param>
-        public Collapsible(ChatPanelView owner, string title, bool expanded = false)
+        /// <param name="iconKey">
+        /// 折叠箭头后面那枚小图标(压缩分隔条 = 剪刀)。
+        /// 省略就只有箭头 —— 那一列是 Auto,不给东西就是 0 宽,不占位。
+        /// </param>
+        /// <param name="iconBrushKey">图标颜色令牌;省略走弱化色。</param>
+        /// <param name="trailingIconKey">贴在行尾的图标(思考 = 星火,见设计图)。</param>
+        public Collapsible(ChatPanelView owner, string title, bool expanded = false,
+            string? iconKey = null, string? iconBrushKey = null, string? trailingIconKey = null)
         {
             var header = new Grid
             {
-                ColumnDefinitions = [with("Auto,Auto,*")],
+                // 箭头 | 前置图标 | 标题 | 行尾图标 —— 两个图标位都是 Auto,不给就 0 宽
+                ColumnDefinitions = [with("Auto,Auto,*,Auto")],
                 Background = Brushes.Transparent,
                 Cursor = new Cursor(StandardCursorType.Hand)
             };
@@ -1618,17 +2150,41 @@ public partial class ChatPanelView : UserControl
             {
                 Width = 24,
                 Height = 24,
-                Data = owner.FindIcon("Icon.chevron-right"),
-                Stroke = owner.FindBrush("VelaTextMuted") ?? Brushes.Gray,
                 StrokeThickness = 2,
                 StrokeLineCap = PenLineCap.Round,
                 StrokeJoin = PenLineJoin.Round
             };
+            // 同 MakeIcon:绑而不是取一次,否则建早了没图形、换主题也不跟着变
+            _chevron[!Avalonia.Controls.Shapes.Path.DataProperty] =
+                new DynamicResourceExtension("Icon.chevron-right");
+            _chevron[!Avalonia.Controls.Shapes.Shape.StrokeProperty] =
+                new DynamicResourceExtension("VelaTextMuted");
             var chevronBox = new Viewbox { Width = 10, Height = 10, Child = _chevron, Margin = new Thickness(0, 0, 5, 0), VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
             header.Children.Add(chevronBox);
+            if (iconKey is { Length: > 0 })
+            {
+                var iconBox = new Decorator
+                {
+                    Child = owner.MakeIcon(iconKey, iconBrushKey ?? "VelaTextMuted", 11),
+                    Margin = new Thickness(0, 0, 5, 0),
+                    VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+                };
+                Grid.SetColumn(iconBox, 1);
+                header.Children.Add(iconBox);
+            }
             _title = new TextBlock { Classes = { "dim" }, Text = title, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
-            Grid.SetColumn(_title, 1);
+            Grid.SetColumn(_title, 2);
             header.Children.Add(_title);
+            if (trailingIconKey is { Length: > 0 })
+            {
+                var trailing = new Decorator
+                {
+                    Child = owner.MakeIcon(trailingIconKey, "VelaTextMuted", 11),
+                    VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+                };
+                Grid.SetColumn(trailing, 3);
+                header.Children.Add(trailing);
+            }
 
             _body = new SelectableTextBlock { Classes = { "mono" } };
             _details = new ScrollViewer
@@ -1748,12 +2304,15 @@ public partial class ChatPanelView : UserControl
             {
                 Width = 24,
                 Height = 24,
-                Data = owner.FindIcon("Icon.chevron-right"),
-                Stroke = owner.FindBrush("VelaTextMuted") ?? Brushes.Gray,
                 StrokeThickness = 2,
                 StrokeLineCap = PenLineCap.Round,
                 StrokeJoin = PenLineJoin.Round
             };
+            // 同 MakeIcon:绑而不是取一次,否则建早了没图形、换主题也不跟着变
+            _chevron[!Avalonia.Controls.Shapes.Path.DataProperty] =
+                new DynamicResourceExtension("Icon.chevron-right");
+            _chevron[!Avalonia.Controls.Shapes.Shape.StrokeProperty] =
+                new DynamicResourceExtension("VelaTextMuted");
             var chevronBox = new Viewbox { Width = 10, Height = 10, Child = _chevron, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
             Grid.SetColumn(chevronBox, 3);
             header.Children.Add(chevronBox);

--- a/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
@@ -82,17 +82,19 @@
     <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
     <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="6" />
-    <Setter Property="Padding" Value="16,12,16,16" />
+    <Setter Property="CornerRadius" Value="5" />
+    <Setter Property="Padding" Value="14" />
   </Style>
 
+  <!-- 28 高(设计图):表单排成两列 / 三列之后,30 高的框把每一节都撑得比该有的高一截 -->
   <Style Selector="TextBox">
     <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
-    <Setter Property="MinHeight" Value="30" />
+    <Setter Property="MinHeight" Value="28" />
   </Style>
   <Style Selector="ComboBox">
     <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
-    <Setter Property="MinHeight" Value="30" />
+    <Setter Property="MinHeight" Value="28" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
   <Style Selector="ListBox">
     <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -45,7 +45,9 @@ public sealed class Loc(string locale)
     private static readonly Dictionary<string, string[]> Table = new()
     {
         ["Title"] = ["AI Assistant", "AI 助手", "AI 助手", "AI アシスタント", "AI 어시스턴트"],
-        ["NoProvider"] = ["No provider configured — open Settings (⚙) to add one.", "尚未配置模型接入 —— 点右上角 ⚙ 添加。", "尚未設定模型接入 —— 點右上角 ⚙ 新增。", "プロバイダー未設定 — 右上の ⚙ から追加してください。", "프로바이더가 없습니다 — 오른쪽 위 ⚙에서 추가하세요."],
+        // 只在"用户按了发送、却一个模型都没配"时出现,紧接着就会把配置窗口开出来 ——
+        // 所以这句是在交代"接下来发生了什么",不再指路去点哪个按钮(空状态那边有按钮)。
+        ["NoProvider"] = ["No model configured — opening the model settings.", "尚未配置模型 —— 已为你打开模型配置。", "尚未設定模型 —— 已為你開啟模型設定。", "モデル未設定 — モデル設定を開きました。", "모델이 없습니다 — 모델 설정을 열었습니다."],
         ["Agent"] = ["Agent", "Agent", "Agent", "Agent", "Agent"],
         ["AgentTip"] = ["Agent mode: the model may call tools (read terminal, run commands…).", "Agent 模式:模型可调用工具(读终端、执行命令等)。", "Agent 模式:模型可呼叫工具(讀終端、執行命令等)。", "Agent モード:モデルがツールを呼び出せます(端末読取・コマンド実行など)。", "Agent 모드: 모델이 도구를 호출할 수 있습니다(터미널 읽기, 명령 실행 등)."],
         // 对话模式(顺序 = ChatMode 的枚举值)
@@ -140,6 +142,9 @@ public sealed class Loc(string locale)
         ["ApprovalTitle"] = ["The agent wants to run:", "Agent 请求执行:", "Agent 請求執行:", "エージェントが実行を要求:", "에이전트가 실행을 요청:"],
         ["Approve"] = ["Approve", "批准", "批准", "承認", "승인"],
         ["ApproveAlways"] = ["Always in this chat", "本次会话总是允许", "本次會話總是允許", "この会話では常に許可", "이 대화에서는 항상 허용"],
+        // 按钮上必须写清"总是允许的到底是什么":记忆键是按命令名分的(run_command:du),
+        // 只写「本次会话总是允许」会被读成"这段对话里什么都别再问了" —— 用户实测就是这么理解的。
+        ["ApproveAlwaysKey"] = ["Always allow “{0}”", "总是允许「{0}」", "總是允許「{0}」", "「{0}」を常に許可", "「{0}」 항상 허용"],
         ["ApproveAlwaysTip"] = ["Stop asking for “{0}” until this chat ends (not saved to settings).", "本次会话内不再询问「{0}」(不写入设置,换会话即失效)。", "本次會話內不再詢問「{0}」(不寫入設定,換會話即失效)。", "この会話が終わるまで「{0}」は確認しません(設定には保存されません)。", "이 대화가 끝날 때까지 「{0}」은(는) 묻지 않습니다(설정에 저장되지 않음)."],
         ["Retrying"] = ["Connection failed, retrying ({0})…", "连接失败,正在重试({0})…", "連線失敗,正在重試({0})…", "接続に失敗、再試行中({0})…", "연결 실패, 재시도 중({0})…"],
         ["Deny"] = ["Deny", "拒绝", "拒絕", "拒否", "거부"],
@@ -217,10 +222,14 @@ public sealed class Loc(string locale)
         ["McpServers"] = ["MCP servers", "MCP 服务器", "MCP 伺服器", "MCP サーバー", "MCP 서버"],
         ["McpHint"] = ["Model Context Protocol servers add extra tools to Agent mode. Tools that may modify state ask for approval before running.", "MCP(Model Context Protocol)服务器为 Agent 模式提供额外工具;可能修改状态的工具执行前会请求审批。", "MCP(Model Context Protocol)伺服器為 Agent 模式提供額外工具;可能修改狀態的工具執行前會請求審批。", "MCP(Model Context Protocol)サーバーは Agent モードにツールを追加します。状態を変更しうるツールは実行前に承認を求めます。", "MCP(Model Context Protocol) 서버는 Agent 모드에 도구를 추가합니다. 상태를 변경할 수 있는 도구는 실행 전 승인을 요청합니다."],
         ["McpEnabled"] = ["Enabled", "启用", "啟用", "有効", "사용"],
+        // 「配置工具」左栏的一句话:说清左右两边是什么关系
+        ["McpPaneHint"] = ["Once a server is set up, its tools show up on the right for you to check.", "配好服务器后,它带来的工具直接在右侧勾选。", "設定好伺服器後,它帶來的工具直接在右側勾選。", "サーバーを設定すると、そのツールが右側に並んで選べます。", "서버를 설정하면 그 도구가 오른쪽에 나와 선택할 수 있습니다."],
+        ["McpAdd"] = ["New server", "新增服务器", "新增伺服器", "サーバーを追加", "서버 추가"],
         ["ToolsChecked"] = ["{0}/{1} checked", "已勾 {0}/{1}", "已勾 {0}/{1}", "{0}/{1} 選択", "{0}/{1} 선택"],
         // 设置页的分节标题(版式对齐宿主设置页:节标题 + 一张描边卡片)
-        ["SecEndpoint"] = ["Model", "模型", "模型", "モデル", "모델"],
-        ["SecCapacity"] = ["Model capacity", "模型能力", "模型能力", "モデルの上限", "모델 용량"],
+        // 这一节装的是名称 / 模型 id / 协议 / Key / 基地址 —— 叫「模型」太窄了,它整体是"怎么接上去"
+        ["SecEndpoint"] = ["Endpoint", "接入端点", "接入端點", "接続エンドポイント", "접속 엔드포인트"],
+        ["SecCapacity"] = ["Capacity & thinking", "容量与思考", "容量與思考", "上限と思考", "용량과 사고"],
         ["SecSampling"] = ["Sampling, pricing & prompt", "采样、计费与提示词", "採樣、計費與提示詞", "サンプリング・料金・プロンプト", "샘플링·요금·프롬프트"],
         ["SecGlobal"] = ["Global", "全局", "全域", "全体設定", "전역"],
         // 回复正文里的链接(远端路径 = 下载下来)
@@ -255,6 +264,39 @@ public sealed class Loc(string locale)
         ["NoConnectedSession"] = ["No connected session.", "没有已连接的会话。", "沒有已連接的會話。", "接続中のセッションがありません。", "연결된 세션이 없습니다."],
         ["CmdChat"] = ["AI: Open Chat (Tab)", "AI:打开聊天(标签页)", "AI:開啟聊天(標籤頁)", "AI:チャットを開く(タブ)", "AI: 채팅 열기(탭)"],
         ["CmdChatWindow"] = ["AI: Open Chat (Window)", "AI:打开聊天(窗口)", "AI:開啟聊天(視窗)", "AI:チャットを開く(ウィンドウ)", "AI: 채팅 열기(창)"],
-        ["CmdExplain"] = ["AI: Explain Terminal Output", "AI:解释终端输出", "AI:解釋終端輸出", "AI:ターミナル出力を説明", "AI: 터미널 출력 설명"]
+        ["CmdExplain"] = ["AI: Explain Terminal Output", "AI:解释终端输出", "AI:解釋終端輸出", "AI:ターミナル出力を説明", "AI: 터미널 출력 설명"],
+        // 回复头部的阶段芯片:辉光只说明"在动",这几个字说明"在干什么"
+        ["PhaseThinking"] = ["thinking", "正在思考", "正在思考", "思考中", "생각 중"],
+        ["PhaseTool"] = ["running tools", "调用工具", "呼叫工具", "ツール実行中", "도구 실행 중"],
+        ["PhaseWriting"] = ["writing", "正在生成", "正在生成", "生成中", "생성 중"],
+        ["PhaseWaiting"] = ["waiting for you", "等待你确认", "等待你確認", "確認待ち", "확인 대기"],
+        // 审批卡上的风险标签(按工具名归类,只说"会做什么",不做价值判断)
+        ["RiskWrite"] = ["writes a remote file", "写远端文件", "寫遠端檔案", "リモートファイルに書き込み", "원격 파일 쓰기"],
+        ["RiskExec"] = ["runs a command", "执行命令", "執行命令", "コマンド実行", "명령 실행"],
+        ["RiskInput"] = ["types into the terminal", "写入终端", "寫入終端", "端末へ入力", "터미널 입력"],
+        ["RiskMcp"] = ["external MCP tool", "外部 MCP 工具", "外部 MCP 工具", "外部 MCP ツール", "외부 MCP 도구"],
+        ["ApprovalPaused"] = ["This turn stays paused until you decide.", "在你做出选择之前,这一轮是暂停的。", "在你做出選擇之前,這一輪是暫停的。", "選択するまでこのターンは停止しています。", "선택하기 전까지 이번 턴은 멈춰 있습니다."],
+        // 失败卡:错误不该混在正文里当一段 Markdown
+        ["ErrorKept"] = ["Whatever this turn already produced is kept.", "本轮已产生的内容保留。", "本輪已產生的內容保留。", "このターンで既に生成された内容は保持されます。", "이번 턴에서 이미 생성된 내용은 유지됩니다."],
+        // 空状态(一个模型都没配):给下一步动作,而不是一句陈述
+        ["EmptyTitle"] = ["No model available yet", "还没有可用的模型", "還沒有可用的模型", "利用できるモデルがありません", "사용할 수 있는 모델이 없습니다"],
+        ["EmptyBody"] = ["Add a provider and a model, and you can ask this server anything right here.", "添加一个供应商和模型之后,就能直接对着当前这台服务器提问。", "新增一個供應商和模型之後,就能直接對著目前這台伺服器提問。", "プロバイダーとモデルを追加すれば、このサーバーについてそのまま質問できます。", "프로바이더와 모델을 추가하면 이 서버에 대해 바로 물어볼 수 있습니다."],
+        ["EmptyAction"] = ["Add a model", "添加模型接入", "新增模型接入", "モデルを追加", "모델 추가"],
+        ["EmptyExamples"] = ["Once it's set up, you can ask", "配好之后可以这样问", "設定好之後可以這樣問", "設定後はこんなふうに聞けます", "설정한 뒤에는 이렇게 물어볼 수 있습니다"],
+        // 配好了、但这段对话还一个字都没有:中部别留一整块空白,说清它能替你看什么
+        ["ReadyExamples"] = ["Try one of these", "可以这样问", "可以這樣問", "こんなふうに聞けます", "이렇게 물어볼 수 있습니다"],
+        ["ReadyTitle"] = ["Ask this server anything", "问这台服务器点什么", "問這台伺服器點什麼", "このサーバーについて聞いてみましょう", "이 서버에 대해 물어보세요"],
+        ["ReadyBody"] = ["The model can read this session's terminal output, and files on the server when you ask it to.", "模型能读到这个会话的终端输出,你让它看时也能读服务器上的文件。", "模型能讀到這個工作階段的終端輸出,你讓它看時也能讀伺服器上的檔案。", "モデルはこのセッションの端末出力を読めます。指示すればサーバー上のファイルも読みます。", "모델은 이 세션의 터미널 출력을 읽을 수 있고, 요청하면 서버의 파일도 읽습니다."],
+        // 历史会话按日期分组
+        ["HistToday"] = ["Today", "今天", "今天", "今日", "오늘"],
+        ["HistYesterday"] = ["Yesterday", "昨天", "昨天", "昨日", "어제"],
+        ["HistEarlier"] = ["Earlier", "更早", "更早", "それ以前", "이전"],
+        // 设置页:密钥去向徽章 + 左栏的连通性状态点(本次窗口内测出来的)
+        ["KeyEncrypted"] = ["encrypted by the host", "由宿主加密存储", "由宿主加密儲存", "ホストが暗号化して保存", "호스트가 암호화 저장"],
+        ["DotUntested"] = ["Not tested in this window", "本次窗口内未测试", "本次視窗內未測試", "このウィンドウでは未テスト", "이 창에서 테스트하지 않음"],
+        ["DotPassed"] = ["Test passed", "测试通过", "測試通過", "テスト成功", "테스트 통과"],
+        ["DotFailed"] = ["Test failed", "测试失败", "測試失敗", "テスト失敗", "테스트 실패"],
+        // 上下文占用条的悬停说明(条只给量感,数字仍在用量提示里)
+        ["MeterTip"] = ["Share of the context window taken by the last turn.", "上一轮占掉了多大比例的上下文窗口。", "上一輪佔掉了多大比例的上下文視窗。", "直近のターンがコンテキスト長のどれだけを占めたか。", "직전 턴이 컨텍스트 창을 얼마나 차지했는지."]
     };
 }

--- a/plugins/VelaShell.Plugin.Ai/Ui/McpServersView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/McpServersView.axaml.cs
@@ -85,6 +85,23 @@ public partial class McpServersView : UserControl
             ? _settings.McpServers[McpList.SelectedIndex]
             : null;
 
+    /// <summary>
+    /// 选中某台服务器。「配置工具」左栏点某一行时会带着 id 进来 ——
+    /// 那边只摆一份概览,真要改还是回到这张表单。
+    /// </summary>
+    /// <param name="serverId">服务器 id;找不到就保持当前选中不动。</param>
+    public void Select(string serverId)
+    {
+        int index = _settings.McpServers.FindIndex(s => s.Id == serverId);
+        if (index >= 0)
+        {
+            McpList.SelectedIndex = index;
+        }
+    }
+
+    /// <summary>直接进入"新增一台"的状态(「配置工具」左栏的「新增服务器」走这里)。</summary>
+    public void BeginAdd() => OnAddClick(null, new RoutedEventArgs());
+
     private void ReloadList(int selectIndex)
     {
         McpList.ItemsSource = _settings.McpServers.Select(ToListItem).ToList();

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
@@ -63,9 +63,20 @@
         <ListBox x:Name="ProvidersList" Classes="nav">
           <ListBox.ItemTemplate>
             <DataTemplate x:DataType="ui:ProviderNavItem">
-              <!-- 供应商行加粗、模型行缩进一档:一眼分清层级,不靠展开箭头 -->
-              <TextBlock Text="{Binding Text}" Margin="{Binding Indent}"
-                         FontWeight="{Binding Weight}" TextTrimming="CharacterEllipsis" />
+              <!-- 供应商行加粗、模型行缩进一档:一眼分清层级,不靠展开箭头。
+                   行尾那颗点是本次窗口内测出来的连通性(灰=未测 / 绿=通过 / 红=失败)——
+                   哪个接入能用,不该靠一个个点开测。 -->
+              <Grid ColumnDefinitions="Auto,*,Auto" Margin="{Binding Indent}">
+                <Viewbox Width="12" Height="12" Margin="0,0,7,0" VerticalAlignment="Center">
+                  <Path Width="24" Height="24" Data="{Binding Icon}" Stroke="{Binding Tint}"
+                        StrokeThickness="2" StrokeLineCap="Round" StrokeJoin="Round" />
+                </Viewbox>
+                <TextBlock Grid.Column="1" Text="{Binding Text}" VerticalAlignment="Center"
+                           FontWeight="{Binding Weight}" TextTrimming="CharacterEllipsis" />
+                <Ellipse Grid.Column="2" Width="6" Height="6" Margin="8,0,0,0"
+                         VerticalAlignment="Center" Fill="{Binding Dot}"
+                         ToolTip.Tip="{Binding DotTip}" />
+              </Grid>
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
@@ -79,19 +90,55 @@
     <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Disabled">
       <StackPanel Margin="24,20,24,20" Spacing="8">
 
+        <!-- 面包屑:正在编辑的是谁。左栏是两层树,模型行只写模型名 ——
+             滚到表单中段时"这是哪家的模型"就没了着落,所以在表单顶上钉一行。
+             右边那枚徽章是本次窗口内的测试结果(没测过就不显示,不假装知道)。 -->
+        <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+          <TextBlock x:Name="BreadcrumbText" VerticalAlignment="Center"
+                     FontSize="{DynamicResource VelaFontSize14}" FontWeight="SemiBold"
+                     Foreground="{DynamicResource VelaTextPrimary}" TextTrimming="CharacterEllipsis" />
+          <Border x:Name="TestBadge" Grid.Column="1" IsVisible="False" CornerRadius="3"
+                  BorderThickness="1" Padding="7,1" Margin="10,0,0,0" VerticalAlignment="Center">
+            <TextBlock x:Name="TestBadgeText" FontSize="{DynamicResource VelaFontSize10}" />
+          </Border>
+        </Grid>
+
         <!-- ═══ 供应商编辑器:选中左栏供应商行时显示 ═══ -->
         <StackPanel x:Name="ProviderEditor" Spacing="8">
           <TextBlock x:Name="SectionProviderTitle" Classes="section-title" />
           <Border Classes="section">
             <StackPanel>
-              <TextBlock x:Name="ProviderNameLabel" Classes="label" Margin="0,0,0,3" />
-              <TextBox x:Name="ProviderNameBox" />
-              <TextBlock x:Name="ProviderBaseUrlLabel" Classes="label" />
-              <TextBox x:Name="ProviderBaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+              <!-- 名称 | 基地址 并排:两个都是一行短文本,上下叠着白白拉长这一页(设计图 E) -->
+              <Grid ColumnDefinitions="*,12,*">
+                <StackPanel>
+                  <TextBlock x:Name="ProviderNameLabel" Classes="label" Margin="0,0,0,3" />
+                  <TextBox x:Name="ProviderNameBox" />
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                  <TextBlock x:Name="ProviderBaseUrlLabel" Classes="label" Margin="0,0,0,3" />
+                  <TextBox x:Name="ProviderBaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                </StackPanel>
+              </Grid>
               <TextBlock x:Name="ProviderProtocolLabel" Classes="label" />
               <ComboBox x:Name="ProviderProtocolCombo" HorizontalAlignment="Stretch" />
               <TextBlock x:Name="ProviderProtocolHintText" Classes="hint" />
-              <TextBlock x:Name="ProviderApiKeyLabel" Classes="label" />
+              <!-- 填 Key 的这一刻正是用户最想知道"它会被存到哪儿"的时刻,徽章就贴在标签边上 -->
+              <StackPanel Orientation="Horizontal">
+                <TextBlock x:Name="ProviderApiKeyLabel" Classes="label" VerticalAlignment="Bottom" />
+                <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="5,1"
+                        Margin="7,0,0,3" VerticalAlignment="Bottom">
+                  <StackPanel Orientation="Horizontal" Spacing="4">
+                    <Viewbox Width="9" Height="9" VerticalAlignment="Center">
+                      <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
+                            Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                            StrokeLineCap="Round" StrokeJoin="Round" />
+                    </Viewbox>
+                    <TextBlock x:Name="ProviderKeyBadgeText" VerticalAlignment="Center"
+                               FontSize="{DynamicResource VelaFontSize10}"
+                               Foreground="{DynamicResource VelaAccent}" />
+                  </StackPanel>
+                </Border>
+              </StackPanel>
               <Grid ColumnDefinitions="*,6,Auto">
                 <TextBox x:Name="ProviderApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
                 <ToggleButton x:Name="ProviderRevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
@@ -114,19 +161,51 @@
           <TextBlock x:Name="SectionEndpointTitle" Classes="section-title" />
           <Border Classes="section">
             <StackPanel>
-              <TextBlock x:Name="NameLabel" Classes="label" Margin="0,0,0,3" />
-              <TextBox x:Name="NameBox" />
-              <TextBlock x:Name="ModelLabel" Classes="label" />
-              <TextBox x:Name="ModelBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
-              <TextBlock x:Name="ProtocolLabel" Classes="label" />
-              <!-- 第 0 项 = 继承供应商默认;其后与 ChatProtocol 枚举一一对应 -->
-              <ComboBox x:Name="ProtocolCombo" HorizontalAlignment="Stretch" />
+              <!-- 设计图 E 的两列网格:显示名称 | 模型 id,协议 | 覆盖基地址。
+                   这四个都是一行的短值,一列纵着堆会把这一节拉成一条长带子。 -->
+              <Grid ColumnDefinitions="*,12,*">
+                <StackPanel>
+                  <TextBlock x:Name="NameLabel" Classes="label" Margin="0,0,0,3" />
+                  <TextBox x:Name="NameBox" />
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                  <TextBlock x:Name="ModelLabel" Classes="label" Margin="0,0,0,3" />
+                  <TextBox x:Name="ModelBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                </StackPanel>
+              </Grid>
+              <Grid ColumnDefinitions="*,12,*">
+                <StackPanel>
+                  <TextBlock x:Name="ProtocolLabel" Classes="label" />
+                  <!-- 第 0 项 = 继承供应商默认;其后与 ChatProtocol 枚举一一对应 -->
+                  <ComboBox x:Name="ProtocolCombo" HorizontalAlignment="Stretch" />
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                  <TextBlock x:Name="BaseUrlLabel" Classes="label" />
+                  <TextBox x:Name="BaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                </StackPanel>
+              </Grid>
+              <TextBlock x:Name="BaseUrlHintText" Classes="hint" />
 
               <CheckBox x:Name="OwnKeyCheck" Theme="{StaticResource AiCheckBoxTheme}"
                         FontSize="{DynamicResource VelaFontSize12}" Margin="0,12,0,0" />
               <TextBlock x:Name="OwnKeyHintText" Classes="hint" />
               <StackPanel x:Name="OwnKeyPanel">
-                <TextBlock x:Name="ApiKeyLabel" Classes="label" />
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock x:Name="ApiKeyLabel" Classes="label" VerticalAlignment="Bottom" />
+                  <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="5,1"
+                          Margin="7,0,0,3" VerticalAlignment="Bottom">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                      <Viewbox Width="9" Height="9" VerticalAlignment="Center">
+                        <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
+                              Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                              StrokeLineCap="Round" StrokeJoin="Round" />
+                      </Viewbox>
+                      <TextBlock x:Name="ModelKeyBadgeText" VerticalAlignment="Center"
+                                 FontSize="{DynamicResource VelaFontSize10}"
+                                 Foreground="{DynamicResource VelaAccent}" />
+                    </StackPanel>
+                  </Border>
+                </StackPanel>
                 <Grid ColumnDefinitions="*,6,Auto">
                   <TextBox x:Name="ApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
                   <ToggleButton x:Name="RevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
@@ -140,10 +219,6 @@
                 </Grid>
                 <TextBlock x:Name="ApiKeyHintText" Classes="hint" />
               </StackPanel>
-
-              <TextBlock x:Name="BaseUrlLabel" Classes="label" />
-              <TextBox x:Name="BaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
-              <TextBlock x:Name="BaseUrlHintText" Classes="hint" />
             </StackPanel>
           </Border>
 
@@ -151,8 +226,9 @@
           <TextBlock x:Name="SectionCapacityTitle" Classes="section-title" Margin="0,14,0,0" />
           <Border Classes="section">
             <StackPanel>
-              <!-- 输出上限随请求下发;输入上限(上下文窗口)只喂给输入框下方的用量占比 -->
-              <Grid ColumnDefinitions="*,12,*">
+              <!-- 三列(设计图 E):输出上限随请求下发;输入上限(上下文窗口)只喂给
+                   输入框下方的用量占比;思考档位跟它们是同一类"这个模型能到哪儿"的设置。 -->
+              <Grid ColumnDefinitions="*,12,*,12,*">
                 <StackPanel>
                   <TextBlock x:Name="MaxTokensLabel" Classes="label" Margin="0,0,0,3" />
                   <TextBox x:Name="MaxTokensBox" />
@@ -161,10 +237,12 @@
                   <TextBlock x:Name="MaxInputTokensLabel" Classes="label" Margin="0,0,0,3" />
                   <TextBox x:Name="MaxInputTokensBox" />
                 </StackPanel>
+                <StackPanel Grid.Column="4">
+                  <TextBlock x:Name="ReasoningLabel" Classes="label" Margin="0,0,0,3" />
+                  <ComboBox x:Name="ReasoningCombo" HorizontalAlignment="Stretch" />
+                </StackPanel>
               </Grid>
               <TextBlock x:Name="MaxInputTokensHintText" Classes="hint" />
-              <TextBlock x:Name="ReasoningLabel" Classes="label" />
-              <ComboBox x:Name="ReasoningCombo" HorizontalAlignment="Stretch" />
               <TextBlock x:Name="ReasoningHintText" Classes="hint" />
               <!-- 提示词缓存:只有 Anthropic 协议吃这个标记,解出的协议不是它时整块隐藏 -->
               <StackPanel x:Name="PromptCachePanel">

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
@@ -9,10 +9,68 @@ using VelaShell.PluginSdk;
 namespace VelaShell.Plugin.Ai.Ui;
 
 /// <summary>左栏一行:供应商行(<see cref="Model" /> 为 null)或其下的模型行。</summary>
-public sealed record ProviderNavItem(AiProvider Provider, AiModelConfig? Model, string Text, Thickness Indent, FontWeight Weight)
+/// <remarks>
+/// 是<b>类</b>不是 record:行尾那颗连通性状态点要在"测试"跑完的那一刻就地变色。
+/// record 是不可变的,只能靠重建整个列表来刷新 —— 而重建会重置选中项、
+/// 进而触发 <c>LoadEditorAsync</c> 把用户表单里还没保存的改动冲掉。
+/// </remarks>
+public sealed class ProviderNavItem(
+    AiProvider provider, AiModelConfig? model, string text, Thickness indent, FontWeight weight)
+    : System.ComponentModel.INotifyPropertyChanged
 {
+    private IBrush? _dot;
+    private string _dotTip = "";
+
+    /// <summary>这一行所属的供应商(模型行也指向它的父供应商)。</summary>
+    public AiProvider Provider { get; } = provider;
+
+    /// <summary>模型行指向的模型;供应商行为 null。</summary>
+    public AiModelConfig? Model { get; } = model;
+
+    /// <summary>行上显示的名字。</summary>
+    public string Text { get; } = text;
+
+    /// <summary>左缩进:模型行比供应商行进一档。</summary>
+    public Thickness Indent { get; } = indent;
+
+    /// <summary>字重:供应商行加粗。</summary>
+    public FontWeight Weight { get; } = weight;
+
+    /// <summary>层级图标:供应商 = 云,模型 = 方块(几何在 <c>ReloadList</c> 里解析)。</summary>
+    public Geometry? Icon { get; set; }
+
+    /// <summary>图标描边色。与 <see cref="Dot" /> 一样,画笔在建项时解析好。</summary>
+    public IBrush? Tint { get; set; }
+
     /// <summary>是不是供应商行。</summary>
     public bool IsProvider => Model is null;
+
+    /// <summary>状态点的颜色:灰 = 本次窗口内没测过,绿 = 通过,红 = 失败。</summary>
+    public IBrush? Dot
+    {
+        get => _dot;
+        set => Set(ref _dot, value, nameof(Dot));
+    }
+
+    /// <summary>状态点的悬停说明。</summary>
+    public string DotTip
+    {
+        get => _dotTip;
+        set => Set(ref _dotTip, value, nameof(DotTip));
+    }
+
+    /// <summary>状态点变色时通知绑定(<see cref="Dot" /> / <see cref="DotTip" />)。</summary>
+    public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, string name)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+        field = value;
+        PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(name));
+    }
 }
 
 /// <summary>
@@ -36,6 +94,13 @@ public partial class SettingsView : UserControl
     private readonly Action _onProvidersChanged;
     private List<ProviderNavItem> _nav = [];
     private bool _loadingEditor;
+
+    /// <summary>
+    /// 本次窗口内"测试"跑出来的结果(键 = 模型 id,供应商行用供应商 id)。
+    /// <b>不落盘</b>:它说的是"刚才那一次连通",隔天再打开时那句话已经不成立了 ——
+    /// 与其显示一个可能过期的绿点,不如老实退回灰点。
+    /// </summary>
+    private readonly Dictionary<string, bool> _testResults = new(StringComparer.Ordinal);
 
     /// <summary>两击确认删供应商:记着第一击是冲着谁的,换了选择就作废。</summary>
     private string? _pendingDeleteProviderId;
@@ -93,6 +158,8 @@ public partial class SettingsView : UserControl
         ProviderProtocolHintText.Text = _loc["DefaultProtocolHint"];
         ProviderApiKeyLabel.Text = _loc["ApiKey"];
         ProviderApiKeyHintText.Text = _loc["ProviderKeyHint"];
+        ProviderKeyBadgeText.Text = _loc["KeyEncrypted"];
+        ModelKeyBadgeText.Text = _loc["KeyEncrypted"];
         NameLabel.Text = _loc["Name"];
         ProtocolLabel.Text = _loc["Protocol"];
         BaseUrlLabel.Text = _loc["BaseUrlOverride"];
@@ -150,6 +217,44 @@ public partial class SettingsView : UserControl
         return [_loc.F("InheritProtocol", inherited), .. ProtocolLabels];
     }
 
+    /// <summary>状态点/徽章的记忆键:模型行按模型 id,供应商行按供应商 id。</summary>
+    private static string NavKey(ProviderNavItem item) => item.Model?.Id ?? item.Provider.Id;
+
+    /// <summary>把某一行的状态点刷成它当前该有的颜色(没测过 = 灰)。</summary>
+    private void ApplyDot(ProviderNavItem item)
+    {
+        bool? result = _testResults.TryGetValue(NavKey(item), out bool ok) ? ok : null;
+        (string brushKey, string tipKey) = result switch
+        {
+            true => ("VelaStatusConnected", "DotPassed"),
+            false => ("VelaError", "DotFailed"),
+            _ => ("VelaTextMuted", "DotUntested")
+        };
+        item.Dot = this.TryFindResource(brushKey, ActualThemeVariant, out object? brush) ? brush as IBrush : null;
+        item.DotTip = _loc[tipKey];
+    }
+
+    /// <summary>表单顶上那枚测试结果徽章。没测过就整枚隐掉,不假装知道。</summary>
+    private void UpdateTestBadge()
+    {
+        if (SelectedItem is not { } item || !_testResults.TryGetValue(NavKey(item), out bool ok))
+        {
+            TestBadge.IsVisible = false;
+            return;
+        }
+        TestBadge.IsVisible = true;
+        TestBadgeText.Text = _loc[ok ? "DotPassed" : "DotFailed"];
+        IBrush? tone = this.TryFindResource(ok ? "VelaStatusConnected" : "VelaError", ActualThemeVariant, out object? brush)
+            ? brush as IBrush
+            : null;
+        TestBadgeText.Foreground = tone;
+        TestBadge.BorderBrush = tone;
+        // 同色淡底(设计图 E):只有描边的话,这枚徽章在面包屑那一行里太轻,扫不到
+        TestBadge.Background = tone is ISolidColorBrush solid
+            ? new SolidColorBrush(solid.Color, 0.14)
+            : null;
+    }
+
     private void ReloadList(string? selectId)
     {
         _nav = [];
@@ -174,6 +279,17 @@ public partial class SettingsView : UserControl
                     new Thickness(14, 0, 0, 0), FontWeight.Normal));
             }
         }
+        // 层级图标与状态点一起在这儿解析:这时视图已经装载过,宿主令牌查得到
+        Geometry? cloud = this.TryFindResource("AiIcon.cloud", ActualThemeVariant, out object? c) ? c as Geometry : null;
+        Geometry? box = this.TryFindResource("AiIcon.box", ActualThemeVariant, out object? b) ? b as Geometry : null;
+        IBrush? providerTint = this.TryFindResource("VelaTextSecondary", ActualThemeVariant, out object? p) ? p as IBrush : null;
+        IBrush? modelTint = this.TryFindResource("VelaTextMuted", ActualThemeVariant, out object? m) ? m as IBrush : null;
+        foreach (ProviderNavItem item in _nav)
+        {
+            item.Icon = item.IsProvider ? cloud : box;
+            item.Tint = item.IsProvider ? providerTint : modelTint;
+            ApplyDot(item);
+        }
         ProvidersList.ItemsSource = _nav;
         ProvidersList.SelectedIndex = selectIndex >= 0 ? selectIndex : Math.Min(0, _nav.Count - 1);
         if (ProvidersList.SelectedIndex < 0)
@@ -197,6 +313,15 @@ public partial class SettingsView : UserControl
             DeleteButton.IsEnabled = hasSelection;
             AddModelButton.IsEnabled = hasSelection;
             StatusText.Text = "";
+            // 面包屑:左栏的模型行只写模型名,滚到表单中段时"这是哪家的"就没了着落
+            string providerName = provider is null
+                ? ""
+                : string.IsNullOrWhiteSpace(provider.Name) ? _loc["Unnamed"] : provider.Name;
+            string modelName = model is null
+                ? ""
+                : string.IsNullOrWhiteSpace(model.DisplayName) ? _loc["Unnamed"] : model.DisplayName;
+            BreadcrumbText.Text = model is null ? providerName : $"{providerName}  ›  {modelName}";
+            UpdateTestBadge();
 
             // 供应商表单
             ProviderNameBox.Text = provider?.Name ?? "";
@@ -495,13 +620,19 @@ public partial class SettingsView : UserControl
                 "Reply with exactly: OK", new ChatOptions { MaxOutputTokens = 64 }));
             string text = response.Text.Trim();
             StatusText.Text = _loc.F("TestOk", text.Length > 80 ? text[..80] + "…" : text);
+            _testResults[NavKey(item)] = true;
         }
         catch (Exception ex)
         {
             StatusText.Text = _loc.F("TestFail", ex.Message);
+            _testResults[NavKey(item)] = false;
         }
         finally
         {
+            // 就地改这一行的点(item 是同一个实例,绑定自己会跟上),不重建列表 ——
+            // 重建会连带重置选中项并触发 LoadEditorAsync,把用户还没保存的编辑冲掉。
+            ApplyDot(item);
+            UpdateTestBadge();
             TestButton.IsEnabled = SelectedItem is not null;
         }
     }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ToolPickerView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ToolPickerView.axaml.cs
@@ -20,9 +20,11 @@ namespace VelaShell.Plugin.Ai.Ui;
 /// <see cref="AiSettings.DisabledBuiltinTools" />):服务器以后新增了工具,默认就是可用的,
 /// 而不是因为"不在已保存的白名单里"被静默屏蔽掉。
 ///
-/// <para>服务器本身怎么配在<see cref="McpServersView" />(窗口标题栏的 ⚙ 另开一个窗口,见 <c>ChatPanelView.OpenToolsDialog</c>)——
-/// 那是一整套左列表右表单,压在勾选列表上面会把这一页挤得没法看;
-/// 改完它会回调 <see cref="Rebuild" />,这边的分组当场跟着变。</para>
+/// <para>版式是"左栏服务器概览 + 右栏工具清单"(设计图 G):配完一台服务器紧接着就在同一屏勾选它的工具,
+/// 不用在两个窗口之间来回切。左栏只摆概览(状态点 + 名字 + 传输 · 工具库状态);
+/// 服务器<b>本身怎么配</b>仍在 <see cref="McpServersView" /> —— 它自己就是一整套左列表右表单,
+/// 塞不进 270 宽的左栏,所以另开一个窗口,点概览行或「新增服务器」进去。
+/// 改完它会回调 <see cref="Rebuild" />,这边的左栏与分组当场跟着变。</para>
 /// </remarks>
 public sealed class ToolPickerView : UserControl
 {
@@ -32,6 +34,15 @@ public sealed class ToolPickerView : UserControl
     private readonly Func<Task> _persist;
     private readonly StackPanel _groups = new() { Spacing = 14 };
     private readonly TextBlock _status = new() { Classes = { "dim" }, TextWrapping = TextWrapping.Wrap };
+
+    /// <summary>左栏的服务器概览行容器。</summary>
+    private readonly StackPanel _servers = new();
+
+    /// <summary>一台服务器都没有时左栏摆的那句话。</summary>
+    private readonly TextBlock _serversEmpty = new() { Classes = { "dim" }, TextWrapping = TextWrapping.Wrap, IsVisible = false };
+
+    /// <summary>点某台服务器(或「新增」,此时参数为 null)时打开那张配置表单。</summary>
+    private readonly Action<string?> _openServerEditor;
 
     /// <summary>
     /// 各组的折叠状态,键 = 组 id(内置 = 空串,MCP = 服务器 id)。只活在这个视图里,不落盘:
@@ -45,12 +56,19 @@ public sealed class ToolPickerView : UserControl
     /// <param name="settings">面板共享的设置实例;勾选直接改它。</param>
     /// <param name="loc">多语言文案。</param>
     /// <param name="persist">把设置落盘(勾一下就存一次,没有"保存"按钮)。</param>
-    public ToolPickerView(IPluginContext context, AiSettings settings, Loc loc, Func<Task> persist)
+    /// <param name="openServerEditor">
+    /// 打开某台服务器的配置表单;参数为 null 表示"新增一台"。
+    /// 左栏只摆概览,表单仍在 <see cref="McpServersView" />(它自己就是左列表右表单,塞不进 270 宽)。
+    /// </param>
+    public ToolPickerView(IPluginContext context, AiSettings settings, Loc loc, Func<Task> persist,
+        Action<string?> openServerEditor)
     {
         _context = context;
         _settings = settings;
         _loc = loc;
         _persist = persist;
+        _openServerEditor = openServerEditor;
+        _serversEmpty.Text = _loc["McpNoServers"];
         // 这套版式规则原先由插件自己的对话框外壳下发;窗体换成宿主的自绘卡片之后自己带上
         Styles.Add(new StyleInclude(new Uri("avares://VelaShell.Plugin.Ai/"))
         {
@@ -68,10 +86,9 @@ public sealed class ToolPickerView : UserControl
         // 全放根上的话它就飘在卡片边上了;拆开之后滚动区比卡片宽出 10,条子正好落在空档里。
         // 卡片左右仍旧各离窗口 20(离屏渲染量过:左 20 / 右 20)。
         const double Gutter = 10;
-        var root = new DockPanel { Margin = new Avalonia.Thickness(20, 16, 20 - Gutter, 16) };
+        var right = new DockPanel { Margin = new Avalonia.Thickness(20, 16, 20 - Gutter, 16) };
         _status.Margin = new Avalonia.Thickness(0, 10, Gutter, 0);
         DockPanel.SetDock(_status, Dock.Bottom);
-        // 顶上一句说明。MCP 服务器配置的入口在窗口标题栏(⚙,PanelOptions.TitleActions),不再占内容区
         var hint = new TextBlock
         {
             Classes = { "dim" },
@@ -80,16 +97,148 @@ public sealed class ToolPickerView : UserControl
             Margin = new Avalonia.Thickness(0, 0, Gutter, 10)
         };
         DockPanel.SetDock(hint, Dock.Top);
-        root.Children.Add(hint);
-        root.Children.Add(_status);
-        root.Children.Add(new ScrollViewer
+        right.Children.Add(hint);
+        right.Children.Add(_status);
+        right.Children.Add(new ScrollViewer
         {
             HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
             // 覆盖式滚动条会压住右缘,留白放在内容上而不是 ScrollViewer.Padding
             Content = new Border { Padding = new Avalonia.Thickness(0, 0, Gutter, 0), Child = _groups }
         });
+
+        // 左栏:MCP 服务器概览。配好一台服务器紧接着就要挑它的工具,那份勾选列表就在右边 ——
+        // 原先两者隔着两个窗口来回切。这里只摆概览(状态点 + 名字 + 传输),
+        // 真要改仍旧回到 McpServersView 那张"左列表右表单" —— 它塞不进 270 宽。
+        var left = new Grid { RowDefinitions = [with("Auto,Auto,*,Auto")], Margin = new Avalonia.Thickness(16, 16, 16, 16) };
+        left.Children.Add(new TextBlock
+        {
+            Classes = { "section-title" },
+            Text = _loc["McpServers"],
+            FontSize = 12
+        });
+        var paneHint = new TextBlock
+        {
+            Classes = { "dim" },
+            Text = _loc["McpPaneHint"],
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(0, 6, 0, 10)
+        };
+        Grid.SetRow(paneHint, 1);
+        left.Children.Add(paneHint);
+        var serverScroll = new ScrollViewer
+        {
+            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
+            Content = _servers
+        };
+        Grid.SetRow(serverScroll, 2);
+        left.Children.Add(serverScroll);
+        Button add = OutlineButton("Icon.plus", _loc["McpAdd"], () => _openServerEditor(null));
+        add.Name = "McpRailAddButton"; // 用例按名字找它(文案随语言变,不能按文字找)
+        add.Margin = new Avalonia.Thickness(0, 10, 0, 0);
+        add.HorizontalAlignment = HorizontalAlignment.Stretch;
+        Grid.SetRow(add, 3);
+        left.Children.Add(add);
+
+        var rail = new Border
+        {
+            Width = 270,
+            Child = left,
+            BorderThickness = new Avalonia.Thickness(0, 0, 1, 0)
+        };
+        rail[!BackgroundProperty] = new DynamicResourceExtension("VelaBgSidebar");
+        rail[!BorderBrushProperty] = new DynamicResourceExtension("VelaBorderPrimary");
+
+        var root = new Grid { ColumnDefinitions = [with("Auto,*")] };
+        root.Children.Add(rail);
+        Grid.SetColumn(right, 1);
+        root.Children.Add(right);
         Content = root;
         Rebuild();
+    }
+
+    /// <summary>描边小按钮(图标 + 文字),供左栏的「新增服务器」与组里的「更新工具库」共用。</summary>
+    private Button OutlineButton(string icon, string text, Action onClick)
+    {
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+        content.Children.Add(new Viewbox { Width = 11, Height = 11, Child = Glyph(icon), VerticalAlignment = VerticalAlignment.Center });
+        content.Children.Add(new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center, FontSize = 11 });
+        var button = new Button { Content = content, Height = 26, Padding = new Avalonia.Thickness(10, 0) };
+        button[!ThemeProperty] = new DynamicResourceExtension("VelaOutlineButtonTheme");
+        button.Click += (_, _) => onClick();
+        return button;
+    }
+
+    /// <summary>左栏的服务器概览行:状态点 + 名字 + "传输 · 工具库状态"。点一下回到那张表单去改。</summary>
+    private void RebuildServerRail()
+    {
+        _servers.Children.Clear();
+        foreach (McpServerConfig server in _settings.McpServers)
+        {
+            string id = server.Id;
+            var row = new Grid { ColumnDefinitions = [with("Auto,*")] };
+            // 绿点 = 启用且工具库已拉过;其余一律灰点。没探过活就别拿颜色替用户下结论。
+            bool live = server.Enabled && server.KnownTools.Count > 0;
+            var dot = new Ellipse { Width = 6, Height = 6, Margin = new Avalonia.Thickness(0, 0, 8, 0), VerticalAlignment = VerticalAlignment.Center };
+            dot[!Shape.FillProperty] = new DynamicResourceExtension(live ? "VelaStatusConnected" : "VelaTextMuted");
+            row.Children.Add(dot);
+
+            var text = new StackPanel { Spacing = 2 };
+            var name = new TextBlock
+            {
+                Text = string.IsNullOrWhiteSpace(server.Name) ? _loc["Unnamed"] : server.Name,
+                FontWeight = FontWeight.Medium,
+                FontSize = 12,
+                TextTrimming = TextTrimming.CharacterEllipsis
+            };
+            name[!ForegroundProperty] = new DynamicResourceExtension("VelaTextPrimary");
+            text.Children.Add(name);
+            text.Children.Add(new TextBlock
+            {
+                Classes = { "dim" },
+                Text = ServerDetail(server),
+                FontSize = 10,
+                TextTrimming = TextTrimming.CharacterEllipsis
+            });
+            Grid.SetColumn(text, 1);
+            row.Children.Add(text);
+
+            var card = new Border
+            {
+                Classes = { "card" },
+                Padding = new Avalonia.Thickness(9, 7),
+                Margin = new Avalonia.Thickness(0, 0, 0, 5),
+                Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand),
+                Child = row
+            };
+            card.PointerPressed += (_, e) =>
+            {
+                e.Handled = true;
+                _openServerEditor(id);
+            };
+            _servers.Children.Add(card);
+        }
+        _serversEmpty.IsVisible = _settings.McpServers.Count == 0;
+        if (_serversEmpty.IsVisible)
+        {
+            _servers.Children.Add(_serversEmpty);
+        }
+    }
+
+    /// <summary>概览行的第二行文字:传输方式 · 工具库状态 [· 已停用]。</summary>
+    private string ServerDetail(McpServerConfig server)
+    {
+        string transport = server.Transport == McpTransportType.Http ? "HTTP" : "Stdio";
+        string tools = server.KnownTools.Count > 0
+            ? _loc.F("McpToolCount", server.KnownTools.Count)
+            : _loc["McpToolsNotLoaded"];
+        string detail = $"{transport} · {tools}";
+        return server.Enabled ? detail : $"{detail} · {_loc["McpDisabledMark"]}";
     }
 
     /// <summary>
@@ -115,6 +264,7 @@ public sealed class ToolPickerView : UserControl
     /// <summary>整页重建(改完 MCP 服务器、刷新工具库之后都走这里)。</summary>
     public void Rebuild()
     {
+        RebuildServerRail();
         _groups.Children.Clear();
         _groups.Children.Add(BuildBuiltinGroup());
         foreach (McpServerConfig server in _settings.McpServers)

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
@@ -103,20 +103,31 @@ public sealed partial class ChatPanelViewUiTests
                 Assert.IsNotNull(Find<Popup>(panel, "FilePopup"));
                 Assert.IsFalse(Find<Popup>(panel, "FilePopup").IsOpen, "没输入 @ 时文件选择器不该弹出");
                 Assert.IsFalse(Find<DockPanel>(panel, "HistoryHost").IsVisible);
-                Assert.IsTrue(Find<ToggleButton>(panel, "HistoryToggle").IsEnabled,
-                    "时序能力可用时历史按钮应可点");
-                // 裸测试宿主里一个供应商都没配。设置改成独立窗口之后就不再抢版面了:
-                // 聊天流照常在,只在状态行留一句"去 ⚙ 配一个"(见 InitAsync 的 NoProvider 分支)。
-                // 面板可能是随宿主启动一起开的,冷不丁弹一个窗口在用户脸上不合适。
+                Assert.IsTrue(Find<ToggleButton>(panel, "HistoryToggle").IsEnabled, "时序能力可用时历史按钮应可点");
+                // 裸测试宿主里一个供应商都没配。这时中部摆的是空状态(图标 + 标题 + 说明 +
+                // 「添加模型接入」按钮 + 三条示例),而不是状态行里一句陈述 —— 第一次打开面板的人
+                // 需要的是下一步动作。面板仍不自动弹窗:它可能是随宿主启动一起开的。
                 Assert.IsTrue(Find<ScrollViewer>(panel, "ChatScroll").IsVisible);
-                Assert.Contains("⚙", Find<TextBlock>(panel, "StatusText").Text ?? "",
-                    "没配接入时状态行要指路(五种语言的这句文案里都有 ⚙)");
+                StackPanel empty = Find<StackPanel>(panel, "EmptyStateHost");
+                Assert.IsTrue(empty.IsVisible, "没配模型时中部要摆空状态");
+                Assert.IsNotEmpty(empty.Children.OfType<Button>().ToList(), "空状态得给一个可点的主按钮");
+                Assert.IsEmpty(Find<TextBlock>(panel, "StatusText").Text ?? "", "空状态接手之后,状态行不再重复说一遍");
+                // 审批下拉的三档:形状与颜色挂在数据项上,而这些颜色取自宿主令牌 ——
+                // 这个测试宿主一个 Vela 令牌都不给,正是"画笔解析不出来"的那种环境。
+                // 曾经把项建在构造期,那时控件还没 TopLevel,TryFindResource 全返回 null,
+                // 结果文字与盾牌一起变成隐形的,表象是"下拉框空空如也"。兜底画笔与
+                // OnLoaded 里的重建就是钉这个的。
+                List<ApprovalNavItem> approvals = [.. Find<ComboBox>(panel, "ApprovalCombo").ItemsSource!.Cast<ApprovalNavItem>()];
+                Assert.HasCount(3, approvals);
+                foreach (ApprovalNavItem item in approvals)
+                {
+                    Assert.IsNotEmpty(item.Text);
+                    Assert.IsNotNull(item.Tone, $"「{item.Text}」没有前景画笔,文字会是隐形的");
+                }
                 // 输入框是 AvaloniaEdit(要 Markdown 着色与 @ 芯片),不是 TextBox
                 Assert.IsNotNull(Find<TextEditor>(panel, "InputBox"));
-                Assert.IsNotNull(Find<TextEditor>(panel, "InputBox").SyntaxHighlighting,
-                    "输入框应挂上 Markdown 着色");
-                Assert.IsTrue(Find<TextBlock>(panel, "InputPlaceholder").IsVisible,
-                    "空输入框要显示占位提示");
+                Assert.IsNotNull(Find<TextEditor>(panel, "InputBox").SyntaxHighlighting, "输入框应挂上 Markdown 着色");
+                Assert.IsTrue(Find<TextBlock>(panel, "InputPlaceholder").IsVisible, "空输入框要显示占位提示");
             }
             finally
             {
@@ -158,9 +169,11 @@ public sealed partial class ChatPanelViewUiTests
                 Find<ToggleButton>(panel, "HistoryToggle").IsChecked = true;
                 await PumpAsync();
                 StackPanel list = Find<StackPanel>(panel, "HistoryList");
-                Assert.HasCount(1, list.Children);
+                // 列表按日期分组,所以行前面还有一条组标题(今天 / 昨天 / 更早);会话行是那些 Border
+                List<Border> rows = [.. list.Children.OfType<Border>()];
+                Assert.HasCount(1, rows);
 
-                List<Button> tools = [.. list.Children[0].GetVisualDescendants().OfType<Button>()];
+                List<Button> tools = [.. rows[0].GetVisualDescendants().OfType<Button>()];
                 Assert.HasCount(3, tools, "行尾是 重命名 / 导出 / 删除 三枚");
 
                 tools[2].RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
@@ -198,9 +211,14 @@ public sealed partial class ChatPanelViewUiTests
                 Assert.IsTrue(Find<DockPanel>(panel, "HistoryHost").IsVisible);
                 Assert.IsFalse(Find<ScrollViewer>(panel, "ChatScroll").IsVisible, "历史与聊天流是二选一");
                 StackPanel list = Find<StackPanel>(panel, "HistoryList");
-                Assert.HasCount(1, list.Children);
+                // 会话行前面先有一条日期组标题(刚写进去的会话必然落在"今天"这一组)
+                Assert.IsInstanceOfType<TextBlock>(list.Children[0]);
+                Assert.Contains("histGroup", ((TextBlock)list.Children[0]).Classes,
+                    "分组标题用 histGroup 这个类");
+                List<Border> rows = [.. list.Children.OfType<Border>()];
+                Assert.HasCount(1, rows);
                 Assert.Contains("磁盘满了怎么查?",
-                    [.. list.Children[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")]);
+                    [.. rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")]);
 
                 // 再点一次回到聊天流
                 Find<ToggleButton>(panel, "HistoryToggle").IsChecked = false;
@@ -776,10 +794,12 @@ public sealed partial class ChatPanelViewUiTests
             .SelectMany(b => b.GetVisualDescendants().OfType<MarkdownRenderer>())];
 
     /// <summary>
-    /// 空会话在输入框上方给几条起手提示(本地文案,不请求模型),点一下就发出去。
+    /// 空会话的起手提示长在<b>居中的空状态里</b>(本地文案,不请求模型),点一下就发出去。
+    /// 输入框上方那排药丸只留给对话开始<b>之后</b>由模型给的后续提问 ——
+    /// 两处同时摆着同样三条只是重复(用户实测反馈)。
     /// </summary>
     [TestMethod]
-    public void Suggestions_OfferStarterPrompts_AndClickingOneSendsIt()
+    public void EmptyState_OffersStarterPrompts_AndClickingOneSendsIt()
     {
         OnUi(async () =>
         {
@@ -803,17 +823,20 @@ public sealed partial class ChatPanelViewUiTests
             (Window window, ChatPanelView panel) = await ShowAsync(context);
             try
             {
-                WrapPanel bar = Find<WrapPanel>(panel, "SuggestionBar");
-                Assert.IsTrue(bar.IsVisible, "空会话该给点起手提示");
-                Assert.HasCount(3, bar.Children);
+                StackPanel empty = Find<StackPanel>(panel, "EmptyStateHost");
+                Assert.IsTrue(empty.IsVisible, "空会话该摆空状态");
+                Assert.IsFalse(Find<WrapPanel>(panel, "SuggestionBar").IsVisible,
+                    "起手示例在空状态里了,输入框上方不该再重复一排");
+                List<Border> examples = [.. empty.Children.OfType<Border>()];
+                Assert.HasCount(3, examples);
 
-                var chip = (Border)bar.Children[0];
+                Border chip = examples[0];
                 string prompt = chip.GetVisualDescendants().OfType<TextBlock>().First().Text!;
                 chip.RaiseEvent(new PointerPressedEventArgs(chip, new Pointer(0, PointerType.Mouse, true),
                     chip, default, 0, new PointerPointProperties(), KeyModifiers.None));
                 await PumpAsync(10);
 
-                Assert.IsFalse(bar.IsVisible, "发出去之后建议就该收起");
+                Assert.IsFalse(empty.IsVisible, "发出去之后消息流接手,空状态该退场");
                 // 气泡正文是 Markdown 渲染的,拿不到平整的 TextBlock.Text —— 直接看发给模型的是什么
                 string body = await stub.RequestBodyAsync.WaitAsync(TimeSpan.FromSeconds(10));
                 using var request = JsonDocument.Parse(body);
@@ -1054,8 +1077,21 @@ public sealed partial class ChatPanelViewUiTests
     /// 这几个配置窗口要能按 Esc 关掉,和宿主其它窗口一致。
     /// </summary>
     /// <remarks>
-    /// Esc 挂在<b>内容</b>上而不是让宿主对所有插件面板统一处理:聊天面板也能以窗口形态打开,
+    /// <para>
+    /// Esc 挂在<b>窗口(TopLevel)</b>上,不是挂在内容控件上:冒泡是从焦点所在的元素往上走的,
+    /// 而窗口刚开出来时焦点还在窗体铬色那一侧 —— 挂内容上的处理器一次都收不到,
+    /// 表象就是"按 Esc 没反应"。
+    /// </para>
+    /// <para>
+    /// 所以这个用例<b>必须把内容真的装进窗口</b>,并且分两种来源各打一次:
+    /// 从窗口自己发(焦点没进内容)和从内容里发(用户点过某个字段)。
+    /// 此前这里是直接对着一个<b>没有装进任何窗口</b>的控件打 Esc —— 那是旧实现唯一能通过的姿势,
+    /// 于是功能坏了一路而用例一直是绿的。
+    /// </para>
+    /// <para>
+    /// 也不把这件事推给宿主对所有插件面板统一处理:聊天面板也能以窗口形态打开,
     /// 那里 Esc 必须留给输入框 —— 正打着字被关掉窗口很糟。
+    /// </para>
     /// </remarks>
     [TestMethod]
     public void ConfigWindows_CloseOnEscape()
@@ -1066,33 +1102,54 @@ public sealed partial class ChatPanelViewUiTests
             (Window window, ChatPanelView panel) = await ShowAsync(context);
             try
             {
-                Click(panel, "SettingsButton");
-                await PumpAsync(5);
-                FakePanel opened = context.FakeUi.LastPanel;
-                var content = (Control)opened.CreateContent();
-
-                content.RaiseEvent(new KeyEventArgs
-                {
-                    RoutedEvent = InputElement.KeyDownEvent,
-                    Key = Key.Escape,
-                    Source = content
-                });
-                await PumpAsync(3);
-
-                Assert.IsFalse(opened.IsOpen, "Esc 要关掉设置窗口");
+                // ① 焦点还没进内容:按键从窗口自己发出
+                await OpenAndEscapeAsync(fromWindow: true);
+                // ② 用户点过内容里的某个字段:按键从内容发出,冒泡到窗口
+                await OpenAndEscapeAsync(fromWindow: false);
             }
             finally
             {
                 panel.Detach();
                 window.Close();
             }
+
+            async Task OpenAndEscapeAsync(bool fromWindow)
+            {
+                Click(panel, "SettingsButton");
+                await PumpAsync(5);
+                FakePanel opened = context.FakeUi.LastPanel;
+                var content = (Control)opened.CreateContent();
+                Window host = Host(content);
+                try
+                {
+                    await PumpAsync(3);
+                    Assert.IsTrue(opened.IsOpen);
+
+                    Control source = fromWindow ? host : content;
+                    source.RaiseEvent(new KeyEventArgs
+                    {
+                        RoutedEvent = InputElement.KeyDownEvent,
+                        Key = Key.Escape,
+                        Source = source
+                    });
+                    await PumpAsync(5);
+
+                    Assert.IsFalse(opened.IsOpen,
+                        fromWindow ? "焦点在窗体上时 Esc 也要关窗" : "焦点在内容里时 Esc 要关窗");
+                }
+                finally
+                {
+                    host.Close();
+                }
+            }
         });
     }
 
     /// <summary>
-    /// MCP 服务器配置<b>自己占一个窗口</b>,由「配置工具」右上角的 ⚙ 打开 ——
-    /// 它是一整套左列表右表单,压在勾选列表上面会把那一页挤得没法看。
-    /// 加完服务器,勾选窗口里的分组要<b>当场</b>多出一块,不用关掉重开。
+    /// 「配置工具」左栏是 MCP 服务器概览、右栏是它们带来的工具(设计图 G):
+    /// 配完一台紧接着就能在同一屏勾选。服务器<b>表单</b>仍旧自己占一个窗口 ——
+    /// 它是一整套左列表右表单,塞不进 270 宽的左栏;入口从原来的标题栏 ⚙ 挪到了左栏。
+    /// 加完服务器,右栏的分组要<b>当场</b>多出一块,不用关掉重开。
     /// </summary>
     [TestMethod]
     public void McpServers_LiveInTheirOwnWindow_AndAddingOneRebuildsTheToolGroups()
@@ -1110,25 +1167,26 @@ public sealed partial class ChatPanelViewUiTests
                 var picker = (ToolPickerView)tools.CreateContent();
                 toolsHost = Host(picker);
                 Assert.IsEmpty(picker.GetVisualDescendants().OfType<McpServersView>(),
-                    "服务器编辑不该再挤在勾选列表上面");
+                    "服务器表单不该挤在勾选列表上面");
+                Assert.IsEmpty(tools.Options.TitleActions,
+                    "入口从标题栏 ⚙ 挪到左栏了,标题栏不该再挂动作");
                 List<Border> groups = ToolGroups(picker);
                 Assert.IsNotEmpty(groups, "至少有内置工具那一组");
 
-                // 标题栏那枚 ⚙(PanelOptions.TitleActions)—— 就是它开出服务器配置窗口
-                tools.Options.TitleActions.Single().OnClick();
+                // 左栏底部的「新增服务器」—— 现在的入口
+                picker.GetVisualDescendants().OfType<Button>().Single(b => b.Name == "McpRailAddButton")
+                      .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
                 await PumpAsync(5);
 
                 FakePanel mcp = context.FakeUi.LastPanel;
-                Assert.AreNotSame(tools, mcp, "⚙ 要开出第二个窗口");
+                Assert.AreNotSame(tools, mcp, "服务器表单要开在第二个窗口里");
+                // 内容工厂跑起来的同时就进了"新增一台"的状态(见 OpenMcpDialog 的 ApplySelection)
                 var servers = (McpServersView)mcp.CreateContent();
                 mcpHost = Host(servers);
-
-                servers.GetVisualDescendants().OfType<Button>().Single(b => b.Name == "McpAddButton")
-                       .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
                 await PumpAsync(5);
 
                 Assert.HasCount(groups.Count + 1, ToolGroups(picker),
-                    "新服务器要当场在勾选窗口里出现一块自己的分组");
+                    "新服务器要当场在右栏出现一块自己的分组");
 
                 // 勾选列表都没了,单剩一个服务器配置窗口飘着没有意义
                 await tools.CloseAsync();


### PR DESCRIPTION
- 聊天面板空状态重设计：中心展示图标、标题、描述、CTA按钮和示例提示
- 顶栏操作统一为带提示的图标按钮，Session下拉带状态点
- 审批模式下拉使用语义色盾牌图标，输入区新增上下文用量条
- 历史记录按日期分组，搜索框带图标，清除按钮优化
- 审批/错误以卡片形式展示，支持风险徽章与“始终允许”
- 设置页列表显示层级图标与状态点，表单多列布局，API密钥带加密徽章
- 工具选择器左侧新增MCP服务器列表及状态，右侧动态展示工具组
- 全面支持动态主题资源，OnLoaded时重绑定资源
- 新增/重构辅助数据结构，审批逻辑集中，组件支持动态主题
- 本地化字符串大量更新，UI测试同步调整