### PR TITLE
模型配置页 UI 优化与结构重构

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
@@ -14,6 +14,10 @@
   <StreamGeometry x:Key="AiIcon.sparkles">M9.94 14.32a1 1 0 0 0-.66-.66l-4.24-1.32a.5.5 0 0 1 0-.96l4.24-1.32a1 1 0 0 0 .66-.66l1.32-4.24a.5.5 0 0 1 .96 0l1.32 4.24a1 1 0 0 0 .66.66l4.24 1.32a.5.5 0 0 1 0 .96l-4.24 1.32a1 1 0 0 0-.66.66l-1.32 4.24a.5.5 0 0 1-.96 0Z M20 3v4 M22 5h-4 M4 17v2 M5 18H3</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.scissors">M20 4L8.12 15.88 M14.47 14.48L20 20 M8.12 8.12L12 12 M9.5 6.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z M9.5 17.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.chevron-up">M18 15l-6-6-6 6</StreamGeometry>
+  <!-- 模型配置页面包屑右侧那枚测试结果徽章的两个态(lucide circle-check / circle-x) -->
+  <StreamGeometry x:Key="AiIcon.circle-check">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M9 12l2 2 4-4</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.circle-x">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M15 9l-6 6 M9 9l6 6</StreamGeometry>
+
   <!-- 设置页左栏的两层层级:供应商 = 云,模型 = 方块 -->
   <StreamGeometry x:Key="AiIcon.cloud">M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.box">M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z M3.3 7l8.7 5 8.7-5 M12 22V12</StreamGeometry>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
@@ -42,7 +42,7 @@ public partial class ChatPanelView
         // 全局设置(系统提示词/压缩/后续提问)不占这页版面:标题栏上、最小化键左侧一枚 ⚙,
         // 与主窗体标题栏那排工具按钮同一套版式,点开是另一个小窗口。
         _ = OpenAsync(
-            _loc["ModelSettings"], 940, 760,
+            _loc["ModelSettings"], 900, 740,
             [new PanelTitleAction(SettingsIconPath, _loc["GlobalSettings"], OpenGlobalSettingsDialog)],
             () => _settingsView = new SettingsView(_context, _store, _settings, _loc, OnProvidersChanged),
             panel => _settingsPanel = panel,

--- a/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
@@ -5,14 +5,17 @@
        以前这些规则写在插件自己的对话框外壳里,窗体换成宿主的自绘卡片之后没了着落 ——
        与其在每个视图里各抄一遍,不如收在这儿,谁用谁 StyleInclude。 -->
 
-  <!-- 弱化文字一律 Tertiary 而不是 DESIGN.md 默认的 Muted:
-       这些"淡字"全是要读的信息(字段说明、状态、工具说明),
-       Muted(#545B76)压在面板底色上只有 ~2.5:1,用户实测反馈看不清。别改回去。 -->
+  <!-- 字段标签换 Secondary(设计图 E/F/G:标签 11 / normal / text-secondary)。
+       它标的是紧挨着那个输入框里该填什么,和"补充说明"不是一档信息;
+       压到 Tertiary 会跟下面的 hint 糊成同一层。 -->
   <Style Selector="TextBlock.label">
     <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
-    <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
-    <Setter Property="Margin" Value="0,8,0,3" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    <Setter Property="Margin" Value="0,8,0,4" />
   </Style>
+  <!-- 弱化文字一律 Tertiary 而不是设计图上的 Muted:
+       这些"淡字"全是要读的信息(字段说明、状态、工具说明),
+       Muted(#545B76)压在面板底色上只有 ~2.5:1,用户实测反馈看不清。别改回去。 -->
   <Style Selector="TextBlock.dim">
     <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
@@ -32,23 +35,28 @@
 
   <!-- 分节标题 / 分隔线 / 左侧导航:照抄宿主设置页(src/VelaShell/Views/SettingsView.axaml)的
        那套,插件窗口用的是同一批 Vela* 令牌,视觉上就该是同一个程序里的东西。 -->
+  <!-- 节标题压成 11/SemiBold/Tertiary(设计图 E/F/G 三张一致):
+       它是"这块卡片叫什么"的索引,不是内容本身。13/Primary 那版比卡片里的字段标签还重,
+       一页扫下来先看见的是四个标题,而不是要填的东西。 -->
   <Style Selector="TextBlock.section-title">
-    <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
-    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize13}" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
     <Setter Property="FontWeight" Value="SemiBold" />
   </Style>
   <Style Selector="Border.sep">
     <Setter Property="Height" Value="1" />
     <Setter Property="Background" Value="{DynamicResource VelaBorderPrimary}" />
   </Style>
+  <!-- 26 高、左右各 8 的行(设计图 E):两层树要在 230 宽的栏里放下七八行还留出底部三个入口,
+       32 高那版滚动条一上来就出现了。 -->
   <Style Selector="ListBox.nav">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Padding" Value="8" />
+    <Setter Property="Padding" Value="8,0" />
   </Style>
   <Style Selector="ListBox.nav ListBoxItem">
-    <Setter Property="MinHeight" Value="32" />
-    <Setter Property="Padding" Value="10,0" />
+    <Setter Property="MinHeight" Value="26" />
+    <Setter Property="Padding" Value="8,0" />
     <Setter Property="CornerRadius" Value="4" />
     <Setter Property="Margin" Value="0,1" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -57,15 +65,21 @@
   <Style Selector="ListBox.nav ListBoxItem:pointerover /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
   </Style>
+  <!-- 选中态用 AccentDim 而不是 BgActive:同一行的文字与图标都转强调色了,
+       灰底配紫字是两套语言;半透明强调底才是这套令牌里"当前项"的写法。 -->
   <Style Selector="ListBox.nav ListBoxItem:selected /template/ ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+    <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
   </Style>
+  <!-- 三档文字:模型行 Secondary、供应商行 Primary(层级靠字重 + 亮度,不靠展开箭头)、
+       选中行 Accent。顺序即优先级 —— 后写的覆盖前面的,选中态必须留在最后。 -->
   <Style Selector="ListBox.nav ListBoxItem TextBlock">
     <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
   </Style>
+  <Style Selector="ListBox.nav ListBoxItem TextBlock.provider">
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+  </Style>
   <Style Selector="ListBox.nav ListBoxItem:selected TextBlock">
     <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
-    <Setter Property="FontWeight" Value="Medium" />
   </Style>
 
   <!-- 一块内容(「配置工具」里每个来源一组 / MCP 那边右侧的表单卡片) -->

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -184,6 +184,10 @@ public sealed class Loc(string locale)
         ["Protocol"] = ["Protocol", "协议", "協議", "プロトコル", "프로토콜"],
         ["BaseUrl"] = ["Base URL", "基地址", "基底位址", "ベース URL", "베이스 URL"],
         ["Model"] = ["Model", "模型", "模型", "モデル", "모델"],
+        // 模型表单里的这两个字段与供应商那边的"名称"同框,只写"名称/模型"分不清哪个是给人看的、
+        // 哪个是要原样发给服务端的(设计图 E)。
+        ["DisplayName"] = ["Display name", "显示名称", "顯示名稱", "表示名", "표시 이름"],
+        ["ModelId"] = ["Model ID", "模型 ID", "模型 ID", "モデル ID", "모델 ID"],
         ["MaxTokens"] = ["Max output tokens", "最大输出 tokens", "最大輸出 tokens", "最大出力トークン", "최대 출력 토큰"],
         ["MaxInputTokens"] = ["Context window (max input tokens)", "上下文窗口(最大输入 tokens)", "上下文視窗(最大輸入 tokens)", "コンテキスト長(最大入力トークン)", "컨텍스트 창(최대 입력 토큰)"],
         ["MaxInputTokensHint"] = ["Only used for the usage ratio under the input box; 0 = unknown.", "只用于输入框下方的用量占比;填 0 表示未知。", "只用於輸入框下方的用量占比;填 0 表示未知。", "入力欄下の使用率表示にのみ使用します(0 = 不明)。", "입력창 아래 사용률 표시에만 쓰입니다(0 = 알 수 없음)."],

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml
@@ -15,12 +15,17 @@
 
   <UserControl.Styles>
     <StyleInclude Source="avares://VelaShell.Plugin.Ai/Ui/DialogStyles.axaml" />
+    <!-- 卡片里的字段:标签只跟自己的框留 4px,不带上边距 —— 行与行之间的距离由卡片的 Spacing 管。
+         共用样式里 label 的 0,8,0,4 是给单列长表单准备的,放进这页的两列/三列网格会把每一格顶出一截。 -->
+    <Style Selector="StackPanel.field > TextBlock.label">
+      <Setter Property="Margin" Value="0,0,0,4" />
+    </Style>
   </UserControl.Styles>
 
   <!-- 版式对齐宿主设置页:左边一条 bg-sidebar 导航(贴着窗口边,跟着卡片左下圆角),
        右边留足内边距的可滚动内容区,内容按"节"分块。
        左栏是"供应商 › 模型"两层:供应商一行、其下模型缩进一档;右侧表单随选中的是哪一层切换。 -->
-  <Grid ColumnDefinitions="220,*">
+  <Grid ColumnDefinitions="230,*">
     <!-- 左:供应商/模型树 + 新增 -->
     <Border Grid.Column="0"
             Background="{DynamicResource VelaBgSidebar}"
@@ -29,41 +34,48 @@
             CornerRadius="0,0,0,7">
       <!-- 内圆角 7 = 外框 8 − 1px 描边:照抄 8 会让方角背景盖掉外框那段弧线,看起来像断线 -->
       <DockPanel>
-        <Border DockPanel.Dock="Top" Height="40" Padding="14,0"
-                BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,0,0,1">
-          <TextBlock x:Name="ProvidersHeader" Classes="section-title" VerticalAlignment="Center" />
+        <!-- 栏头不再压一道分隔线(设计图 E):左栏本身已经比表单区亮一档,再加一条横线就是两重界。 -->
+        <Border DockPanel.Dock="Top" Height="36" Padding="14,0">
+          <TextBlock x:Name="ProvidersHeader" VerticalAlignment="Center"
+                     FontSize="{DynamicResource VelaFontSize11}" FontWeight="SemiBold"
+                     Foreground="{DynamicResource VelaTextSecondary}" />
         </Border>
         <StackPanel DockPanel.Dock="Bottom" Spacing="6" Margin="10,8,10,10">
           <!-- 新增模型挂在当前选中的供应商(或选中模型所属的供应商)下面 -->
           <Button x:Name="AddModelButton" Theme="{DynamicResource VelaOutlineButtonTheme}"
-                  HorizontalAlignment="Stretch" Height="28">
+                  HorizontalAlignment="Stretch" Height="26">
             <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
               <Viewbox Width="11" Height="11" VerticalAlignment="Center">
                 <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
                       Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
                       StrokeLineCap="Round" StrokeJoin="Round" />
               </Viewbox>
-              <TextBlock x:Name="AddModelText" VerticalAlignment="Center" />
+              <TextBlock x:Name="AddModelText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize11}" />
             </StackPanel>
           </Button>
-          <Border Classes="sep" Margin="0,4" />
-          <ComboBox x:Name="PresetCombo" HorizontalAlignment="Stretch" />
+          <Border Classes="sep" />
+          <ComboBox x:Name="PresetCombo" HorizontalAlignment="Stretch" Height="26" MinHeight="26"
+                    FontSize="{DynamicResource VelaFontSize11}" />
           <Button x:Name="AddButton" Theme="{DynamicResource VelaOutlineButtonTheme}"
-                  HorizontalAlignment="Stretch" Height="28">
+                  HorizontalAlignment="Stretch" Height="26">
             <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
               <Viewbox Width="11" Height="11" VerticalAlignment="Center">
                 <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
                       Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
                       StrokeLineCap="Round" StrokeJoin="Round" />
               </Viewbox>
-              <TextBlock x:Name="AddText" VerticalAlignment="Center" />
+              <TextBlock x:Name="AddText" VerticalAlignment="Center"
+                         FontSize="{DynamicResource VelaFontSize11}" />
             </StackPanel>
           </Button>
         </StackPanel>
         <ListBox x:Name="ProvidersList" Classes="nav">
           <ListBox.ItemTemplate>
             <DataTemplate x:DataType="ui:ProviderNavItem">
-              <!-- 供应商行加粗、模型行缩进一档:一眼分清层级,不靠展开箭头。
+              <!-- 供应商行加粗、亮一档,模型行缩进一档:一眼分清层级,不靠展开箭头。
+                   文字的三档颜色写在 DialogStyles 的 nav 样式里(.provider / :selected),
+                   图标要比同一行的文字再暗一档,那一档只能逐项算 —— 见 ApplyTints。
                    行尾那颗点是本次窗口内测出来的连通性(灰=未测 / 绿=通过 / 红=失败)——
                    哪个接入能用,不该靠一个个点开测。 -->
               <Grid ColumnDefinitions="Auto,*,Auto" Margin="{Binding Indent}">
@@ -71,7 +83,8 @@
                   <Path Width="24" Height="24" Data="{Binding Icon}" Stroke="{Binding Tint}"
                         StrokeThickness="2" StrokeLineCap="Round" StrokeJoin="Round" />
                 </Viewbox>
-                <TextBlock Grid.Column="1" Text="{Binding Text}" VerticalAlignment="Center"
+                <TextBlock Grid.Column="1" Classes.provider="{Binding IsProvider}"
+                           Text="{Binding Text}" VerticalAlignment="Center"
                            FontWeight="{Binding Weight}" TextTrimming="CharacterEllipsis" />
                 <Ellipse Grid.Column="2" Width="6" Height="6" Margin="8,0,0,0"
                          VerticalAlignment="Center" Fill="{Binding Dot}"
@@ -83,276 +96,316 @@
       </DockPanel>
     </Border>
 
-    <!-- 右:编辑表单。滚动条留白放在内容 Margin 上(勿用 ScrollViewer.Padding),
+    <!-- 右:编辑表单。底色压到 VelaBgTerminal(设计图 E):宿主的插件窗体本体是 VelaBgSurface,
+         而每一节卡片也是 VelaBgSurface —— 不垫这一层的话卡片只剩一圈 1px 描边,分不出块来。
+         滚动条留白放在内容 Margin 上(勿用 ScrollViewer.Padding),
          避免悬停展开的覆盖式滚动条压住输入框右缘。
          左右都是 24:滚动条是<b>浮在</b>内容上的(不占布局),所以左右留白就等于这里写的数,
          右边不需要为它另外扣一块。它会飘在这 24 的空档里,压不到卡片。 -->
-    <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Disabled">
-      <StackPanel Margin="24,20,24,20" Spacing="8">
+    <Border Grid.Column="1" Background="{DynamicResource VelaBgTerminal}" CornerRadius="0,0,7,0">
+      <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="24,18" Spacing="14">
 
-        <!-- 面包屑:正在编辑的是谁。左栏是两层树,模型行只写模型名 ——
-             滚到表单中段时"这是哪家的模型"就没了着落,所以在表单顶上钉一行。
-             右边那枚徽章是本次窗口内的测试结果(没测过就不显示,不假装知道)。 -->
-        <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,4">
-          <TextBlock x:Name="BreadcrumbText" VerticalAlignment="Center"
-                     FontSize="{DynamicResource VelaFontSize14}" FontWeight="SemiBold"
-                     Foreground="{DynamicResource VelaTextPrimary}" TextTrimming="CharacterEllipsis" />
-          <Border x:Name="TestBadge" Grid.Column="1" IsVisible="False" CornerRadius="3"
-                  BorderThickness="1" Padding="7,1" Margin="10,0,0,0" VerticalAlignment="Center">
-            <TextBlock x:Name="TestBadgeText" FontSize="{DynamicResource VelaFontSize10}" />
-          </Border>
-        </Grid>
+          <!-- 面包屑:正在编辑的是谁。左栏是两层树,模型行只写模型名 ——
+               滚到表单中段时"这是哪家的模型"就没了着落,所以在表单顶上钉一行。
+               右边那枚徽章是本次窗口内的测试结果(没测过就不显示,不假装知道)。 -->
+          <Grid ColumnDefinitions="Auto,Auto,*">
+            <TextBlock x:Name="BreadcrumbText" VerticalAlignment="Center"
+                       FontSize="{DynamicResource VelaFontSize13}" FontWeight="SemiBold"
+                       Foreground="{DynamicResource VelaTextPrimary}" TextTrimming="CharacterEllipsis" />
+            <!-- 只有淡底、没有描边(设计图 E):它紧挨着面包屑,描一圈边会让这枚小标签看起来像个可点的按钮 -->
+            <Border x:Name="TestBadge" Grid.Column="1" IsVisible="False" CornerRadius="3"
+                    Padding="7,2" Margin="8,0,0,0" VerticalAlignment="Center">
+              <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                <Viewbox Width="10" Height="10" VerticalAlignment="Center">
+                  <Path x:Name="TestBadgeIcon" Width="24" Height="24" StrokeThickness="2"
+                        StrokeLineCap="Round" StrokeJoin="Round" />
+                </Viewbox>
+                <TextBlock x:Name="TestBadgeText" VerticalAlignment="Center"
+                           FontSize="{DynamicResource VelaFontSize10}" />
+              </StackPanel>
+            </Border>
+          </Grid>
 
-        <!-- ═══ 供应商编辑器:选中左栏供应商行时显示 ═══ -->
-        <StackPanel x:Name="ProviderEditor" Spacing="8">
-          <TextBlock x:Name="SectionProviderTitle" Classes="section-title" />
-          <Border Classes="section">
-            <StackPanel>
-              <!-- 名称 | 基地址 并排:两个都是一行短文本,上下叠着白白拉长这一页(设计图 E) -->
-              <Grid ColumnDefinitions="*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="ProviderNameLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="ProviderNameBox" />
+          <!-- ═══ 供应商编辑器:选中左栏供应商行时显示 ═══ -->
+          <StackPanel x:Name="ProviderEditor" Spacing="8">
+            <TextBlock x:Name="SectionProviderTitle" Classes="section-title" />
+            <Border Classes="section">
+              <StackPanel Spacing="10">
+                <!-- 名称 | 基地址 并排:两个都是一行短文本,上下叠着白白拉长这一页(设计图 E) -->
+                <Grid ColumnDefinitions="*,12,*">
+                  <StackPanel Classes="field">
+                    <TextBlock x:Name="ProviderNameLabel" Classes="label" />
+                    <TextBox x:Name="ProviderNameBox" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="2" Classes="field">
+                    <TextBlock x:Name="ProviderBaseUrlLabel" Classes="label" />
+                    <TextBox x:Name="ProviderBaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                  </StackPanel>
+                </Grid>
+                <StackPanel Classes="field">
+                  <TextBlock x:Name="ProviderProtocolLabel" Classes="label" />
+                  <ComboBox x:Name="ProviderProtocolCombo" HorizontalAlignment="Stretch" />
+                  <TextBlock x:Name="ProviderProtocolHintText" Classes="hint" />
                 </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="ProviderBaseUrlLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="ProviderBaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                <!-- 填 Key 的这一刻正是用户最想知道"它会被存到哪儿"的时刻,徽章就贴在标签边上 -->
+                <StackPanel Classes="field">
+                  <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,0,0,4">
+                    <TextBlock x:Name="ProviderApiKeyLabel" Classes="label" Margin="0"
+                               VerticalAlignment="Center" />
+                    <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="6,1"
+                            VerticalAlignment="Center">
+                      <StackPanel Orientation="Horizontal" Spacing="4">
+                        <Viewbox Width="9" Height="9" VerticalAlignment="Center">
+                          <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
+                                Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                                StrokeLineCap="Round" StrokeJoin="Round" />
+                        </Viewbox>
+                        <TextBlock x:Name="ProviderKeyBadgeText" VerticalAlignment="Center"
+                                   FontSize="{DynamicResource VelaFontSize10}"
+                                   Foreground="{DynamicResource VelaAccent}" />
+                      </StackPanel>
+                    </Border>
+                  </StackPanel>
+                  <Grid ColumnDefinitions="*,6,Auto">
+                    <TextBox x:Name="ProviderApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                    <ToggleButton x:Name="ProviderRevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
+                                  Width="30" Height="28" Padding="0" CornerRadius="4" VerticalAlignment="Center">
+                      <Viewbox Width="12" Height="12">
+                        <Path Width="24" Height="24" Data="{DynamicResource Icon.eye}"
+                              Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                              StrokeLineCap="Round" StrokeJoin="Round" />
+                      </Viewbox>
+                    </ToggleButton>
+                  </Grid>
+                  <TextBlock x:Name="ProviderApiKeyHintText" Classes="hint" />
                 </StackPanel>
-              </Grid>
-              <TextBlock x:Name="ProviderProtocolLabel" Classes="label" />
-              <ComboBox x:Name="ProviderProtocolCombo" HorizontalAlignment="Stretch" />
-              <TextBlock x:Name="ProviderProtocolHintText" Classes="hint" />
-              <!-- 填 Key 的这一刻正是用户最想知道"它会被存到哪儿"的时刻,徽章就贴在标签边上 -->
-              <StackPanel Orientation="Horizontal">
-                <TextBlock x:Name="ProviderApiKeyLabel" Classes="label" VerticalAlignment="Bottom" />
-                <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="5,1"
-                        Margin="7,0,0,3" VerticalAlignment="Bottom">
-                  <StackPanel Orientation="Horizontal" Spacing="4">
-                    <Viewbox Width="9" Height="9" VerticalAlignment="Center">
-                      <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
+              </StackPanel>
+            </Border>
+          </StackPanel>
+
+          <!-- ═══ 模型编辑器:选中左栏模型行时显示 ═══ -->
+          <!-- 三节之间的 14 由外层 Spacing 给,节内"标题 → 卡片"是 8(设计图 E) -->
+          <StackPanel x:Name="ModelEditor" Spacing="14">
+            <!-- 一、接入:叫什么、模型 id、走什么协议、拿什么鉴权(默认全继承供应商) -->
+            <StackPanel Spacing="8">
+              <TextBlock x:Name="SectionEndpointTitle" Classes="section-title" />
+              <Border Classes="section">
+                <StackPanel Spacing="10">
+                  <!-- 设计图 E 的两列网格:显示名称 | 模型 id,协议 | 覆盖基地址。
+                       这四个都是一行的短值,一列纵着堆会把这一节拉成一条长带子。 -->
+                  <Grid ColumnDefinitions="*,12,*">
+                    <StackPanel Classes="field">
+                      <TextBlock x:Name="NameLabel" Classes="label" />
+                      <TextBox x:Name="NameBox" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Classes="field">
+                      <TextBlock x:Name="ModelLabel" Classes="label" />
+                      <TextBox x:Name="ModelBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                    </StackPanel>
+                  </Grid>
+                  <StackPanel>
+                    <Grid ColumnDefinitions="*,12,*">
+                      <StackPanel Classes="field">
+                        <TextBlock x:Name="ProtocolLabel" Classes="label" />
+                        <!-- 第 0 项 = 继承供应商默认;其后与 ChatProtocol 枚举一一对应 -->
+                        <ComboBox x:Name="ProtocolCombo" HorizontalAlignment="Stretch" />
+                      </StackPanel>
+                      <StackPanel Grid.Column="2" Classes="field">
+                        <TextBlock x:Name="BaseUrlLabel" Classes="label" />
+                        <TextBox x:Name="BaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                      </StackPanel>
+                    </Grid>
+                    <TextBlock x:Name="BaseUrlHintText" Classes="hint" />
+                  </StackPanel>
+
+                  <!-- 密钥块:勾选框自己就是这一行的标签,加密徽章贴在它右边(设计图 E)。
+                       不勾 = 沿用供应商的 Key,下面的输入框整块收起来。 -->
+                  <StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="7">
+                      <CheckBox x:Name="OwnKeyCheck" Theme="{StaticResource AiCheckBoxTheme}"
+                                FontSize="{DynamicResource VelaFontSize12}"
+                                Foreground="{DynamicResource VelaTextPrimary}" />
+                      <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="6,1"
+                              VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                          <Viewbox Width="9" Height="9" VerticalAlignment="Center">
+                            <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
+                                  Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
+                                  StrokeLineCap="Round" StrokeJoin="Round" />
+                          </Viewbox>
+                          <TextBlock x:Name="ModelKeyBadgeText" VerticalAlignment="Center"
+                                     FontSize="{DynamicResource VelaFontSize10}"
+                                     Foreground="{DynamicResource VelaAccent}" />
+                        </StackPanel>
+                      </Border>
+                    </StackPanel>
+                    <TextBlock x:Name="OwnKeyHintText" Classes="hint" />
+                    <StackPanel x:Name="OwnKeyPanel" Margin="0,8,0,0">
+                      <Grid ColumnDefinitions="*,6,Auto">
+                        <TextBox x:Name="ApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                        <ToggleButton x:Name="RevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
+                                      Width="30" Height="28" Padding="0" CornerRadius="4" VerticalAlignment="Center">
+                          <Viewbox Width="12" Height="12">
+                            <Path Width="24" Height="24" Data="{DynamicResource Icon.eye}"
+                                  Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                                  StrokeLineCap="Round" StrokeJoin="Round" />
+                          </Viewbox>
+                        </ToggleButton>
+                      </Grid>
+                      <TextBlock x:Name="ApiKeyHintText" Classes="hint" />
+                    </StackPanel>
+                  </StackPanel>
+                </StackPanel>
+              </Border>
+            </StackPanel>
+
+            <!-- 二、模型能力:上下限与思考 -->
+            <StackPanel Spacing="8">
+              <TextBlock x:Name="SectionCapacityTitle" Classes="section-title" />
+              <Border Classes="section">
+                <StackPanel Spacing="10">
+                  <!-- 三列(设计图 E):输出上限随请求下发;输入上限(上下文窗口)只喂给
+                       输入框下方的用量占比;思考档位跟它们是同一类"这个模型能到哪儿"的设置。 -->
+                  <StackPanel>
+                    <Grid ColumnDefinitions="*,12,*,12,*">
+                      <StackPanel Classes="field">
+                        <TextBlock x:Name="MaxTokensLabel" Classes="label" />
+                        <TextBox x:Name="MaxTokensBox" />
+                      </StackPanel>
+                      <StackPanel Grid.Column="2" Classes="field">
+                        <TextBlock x:Name="MaxInputTokensLabel" Classes="label" />
+                        <TextBox x:Name="MaxInputTokensBox" />
+                      </StackPanel>
+                      <StackPanel Grid.Column="4" Classes="field">
+                        <TextBlock x:Name="ReasoningLabel" Classes="label" />
+                        <ComboBox x:Name="ReasoningCombo" HorizontalAlignment="Stretch" />
+                      </StackPanel>
+                    </Grid>
+                    <TextBlock x:Name="MaxInputTokensHintText" Classes="hint" />
+                    <TextBlock x:Name="ReasoningHintText" Classes="hint" />
+                  </StackPanel>
+                  <!-- 提示词缓存:只有 Anthropic 协议吃这个标记,解出的协议不是它时整块隐藏 -->
+                  <StackPanel x:Name="PromptCachePanel">
+                    <CheckBox x:Name="PromptCacheCheck" Theme="{StaticResource AiCheckBoxTheme}"
+                              FontSize="{DynamicResource VelaFontSize12}"
+                              Foreground="{DynamicResource VelaTextPrimary}" />
+                    <TextBlock x:Name="PromptCacheHintText" Classes="hint" />
+                  </StackPanel>
+                </StackPanel>
+              </Border>
+            </StackPanel>
+
+            <!-- 三、采样、计费与本模型专用提示词 -->
+            <StackPanel Spacing="8">
+              <TextBlock x:Name="SectionSamplingTitle" Classes="section-title" />
+              <Border Classes="section">
+                <StackPanel Spacing="10">
+                  <!-- 采样参数:留空 = 不发这个参数,用服务端默认 -->
+                  <Grid ColumnDefinitions="*,12,*,12,*">
+                    <StackPanel Classes="field">
+                      <TextBlock x:Name="TemperatureLabel" Classes="label" />
+                      <TextBox x:Name="TemperatureBox" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Classes="field">
+                      <TextBlock x:Name="TopPLabel" Classes="label" />
+                      <TextBox x:Name="TopPBox" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="4" Classes="field">
+                      <TextBlock x:Name="StopLabel" Classes="label" />
+                      <TextBox x:Name="StopBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                    </StackPanel>
+                  </Grid>
+
+                  <!-- 单价(用户自填,用于用量提示里的花费估算);留 0 就不估。
+                       与上面那排之间不再压分隔线:设计图 E 里这两排同属一张卡,10px 的行距已经断得开。 -->
+                  <StackPanel>
+                    <Grid ColumnDefinitions="*,12,*,12,*">
+                      <StackPanel Classes="field">
+                        <TextBlock x:Name="PriceInLabel" Classes="label" />
+                        <TextBox x:Name="PriceInBox" />
+                      </StackPanel>
+                      <StackPanel Grid.Column="2" Classes="field">
+                        <TextBlock x:Name="PriceOutLabel" Classes="label" />
+                        <TextBox x:Name="PriceOutBox" />
+                      </StackPanel>
+                      <StackPanel Grid.Column="4" Classes="field">
+                        <TextBlock x:Name="PriceCachedLabel" Classes="label" />
+                        <TextBox x:Name="PriceCachedBox" />
+                      </StackPanel>
+                    </Grid>
+                    <!-- 两句说明落在网格末尾(设计图 E):它们讲的是"这一整块怎么用",
+                         夹在两排输入框中间会把网格切断。 -->
+                    <TextBlock x:Name="SamplingHintText" Classes="hint" />
+                    <TextBlock x:Name="PriceHintText" Classes="hint" />
+                  </StackPanel>
+
+                  <StackPanel Classes="field">
+                    <TextBlock x:Name="ProviderPromptLabel" Classes="label" />
+                    <TextBox x:Name="ProviderPromptBox" AcceptsReturn="True" MinHeight="60" TextWrapping="Wrap" />
+                  </StackPanel>
+                </StackPanel>
+              </Border>
+            </StackPanel>
+          </StackPanel>
+
+          <!-- 全局设置(系统提示词 / 上下文压缩 / 后续提问)不在这页了:从窗口标题栏的 ⚙ 进 GlobalSettingsView,
+               省得跟着长表单一起滚才找得到。 -->
+
+          <!-- MCP 服务器搬去「配置工具」窗口了:配好服务器紧接着就要挑它的工具,
+               那份勾选列表就在那边;隔着两个窗口来回切很别扭。 -->
+
+          <!-- 操作行落在表单最末、靠右,上方一道分隔线跟配置项断开。
+               不钉死在窗口底部:一条常驻横栏会一直占着高度,而这页大多数时候在读、在填,
+               真要按保存时滚到底就是了。
+               测试 / 删除作用于左栏当前选中的那一层(供应商 or 模型)。 -->
+          <Border BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,1,0,0"
+                  Padding="0,12,0,0">
+            <!-- 侧栏宽度不在这儿(也不在任何一节里):它跟着用户拖分割条走,拖完就记住,
+                 下次打开还是那个宽度。让人来填一个百分比,不如直接把他拖出来的结果记下来。 -->
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock x:Name="StatusText" Classes="dim" TextWrapping="Wrap"
+                         Margin="0,0,12,0" VerticalAlignment="Center" />
+              <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                <Button x:Name="SaveButton" Theme="{DynamicResource VelaAccentPillButtonTheme}" Height="26" Padding="12,0">
+                  <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                    <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                      <Path Width="24" Height="24" Data="{DynamicResource Icon.save}"
                             Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
                             StrokeLineCap="Round" StrokeJoin="Round" />
                     </Viewbox>
-                    <TextBlock x:Name="ProviderKeyBadgeText" VerticalAlignment="Center"
-                               FontSize="{DynamicResource VelaFontSize10}"
-                               Foreground="{DynamicResource VelaAccent}" />
+                    <TextBlock x:Name="SaveText" VerticalAlignment="Center"
+                               FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
                   </StackPanel>
-                </Border>
-              </StackPanel>
-              <Grid ColumnDefinitions="*,6,Auto">
-                <TextBox x:Name="ProviderApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
-                <ToggleButton x:Name="ProviderRevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
-                              Width="30" Height="30" Padding="0" VerticalAlignment="Center">
-                  <Viewbox Width="13" Height="13">
-                    <Path Width="24" Height="24" Data="{DynamicResource Icon.eye}"
-                          Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
-                          StrokeLineCap="Round" StrokeJoin="Round" />
-                  </Viewbox>
-                </ToggleButton>
-              </Grid>
-              <TextBlock x:Name="ProviderApiKeyHintText" Classes="hint" />
-            </StackPanel>
-          </Border>
-        </StackPanel>
-
-        <!-- ═══ 模型编辑器:选中左栏模型行时显示 ═══ -->
-        <StackPanel x:Name="ModelEditor" Spacing="8">
-          <!-- 一、接入:叫什么、模型 id、走什么协议、拿什么鉴权(默认全继承供应商) -->
-          <TextBlock x:Name="SectionEndpointTitle" Classes="section-title" />
-          <Border Classes="section">
-            <StackPanel>
-              <!-- 设计图 E 的两列网格:显示名称 | 模型 id,协议 | 覆盖基地址。
-                   这四个都是一行的短值,一列纵着堆会把这一节拉成一条长带子。 -->
-              <Grid ColumnDefinitions="*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="NameLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="NameBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="ModelLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="ModelBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
-                </StackPanel>
-              </Grid>
-              <Grid ColumnDefinitions="*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="ProtocolLabel" Classes="label" />
-                  <!-- 第 0 项 = 继承供应商默认;其后与 ChatProtocol 枚举一一对应 -->
-                  <ComboBox x:Name="ProtocolCombo" HorizontalAlignment="Stretch" />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="BaseUrlLabel" Classes="label" />
-                  <TextBox x:Name="BaseUrlBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
-                </StackPanel>
-              </Grid>
-              <TextBlock x:Name="BaseUrlHintText" Classes="hint" />
-
-              <CheckBox x:Name="OwnKeyCheck" Theme="{StaticResource AiCheckBoxTheme}"
-                        FontSize="{DynamicResource VelaFontSize12}" Margin="0,12,0,0" />
-              <TextBlock x:Name="OwnKeyHintText" Classes="hint" />
-              <StackPanel x:Name="OwnKeyPanel">
-                <StackPanel Orientation="Horizontal">
-                  <TextBlock x:Name="ApiKeyLabel" Classes="label" VerticalAlignment="Bottom" />
-                  <Border Background="{DynamicResource VelaAccentDim}" CornerRadius="3" Padding="5,1"
-                          Margin="7,0,0,3" VerticalAlignment="Bottom">
-                    <StackPanel Orientation="Horizontal" Spacing="4">
-                      <Viewbox Width="9" Height="9" VerticalAlignment="Center">
-                        <Path Width="24" Height="24" Data="{StaticResource AiIcon.lock}"
-                              Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
-                              StrokeLineCap="Round" StrokeJoin="Round" />
-                      </Viewbox>
-                      <TextBlock x:Name="ModelKeyBadgeText" VerticalAlignment="Center"
-                                 FontSize="{DynamicResource VelaFontSize10}"
-                                 Foreground="{DynamicResource VelaAccent}" />
-                    </StackPanel>
-                  </Border>
-                </StackPanel>
-                <Grid ColumnDefinitions="*,6,Auto">
-                  <TextBox x:Name="ApiKeyBox" PasswordChar="●" FontFamily="{DynamicResource VelaUiMonoFont}" />
-                  <ToggleButton x:Name="RevealKeyToggle" Grid.Column="2" Theme="{StaticResource AiChipToggleTheme}"
-                                Width="30" Height="30" Padding="0" VerticalAlignment="Center">
-                    <Viewbox Width="13" Height="13">
-                      <Path Width="24" Height="24" Data="{DynamicResource Icon.eye}"
-                            Stroke="{Binding $parent[ToggleButton].Foreground}" StrokeThickness="2"
+                </Button>
+                <Button x:Name="TestButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0">
+                  <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                    <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                      <Path Width="24" Height="24" Data="{DynamicResource Icon.play}"
+                            Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
                             StrokeLineCap="Round" StrokeJoin="Round" />
                     </Viewbox>
-                  </ToggleButton>
-                </Grid>
-                <TextBlock x:Name="ApiKeyHintText" Classes="hint" />
+                    <TextBlock x:Name="TestText" VerticalAlignment="Center"
+                               FontSize="{DynamicResource VelaFontSize11}" />
+                  </StackPanel>
+                </Button>
+                <Button x:Name="DeleteButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0"
+                        Foreground="{DynamicResource VelaError}" BorderBrush="{DynamicResource VelaError}">
+                  <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                    <Viewbox Width="11" Height="11" VerticalAlignment="Center">
+                      <Path Width="24" Height="24" Data="{DynamicResource Icon.trash-2}"
+                            Stroke="{DynamicResource VelaError}" StrokeThickness="2"
+                            StrokeLineCap="Round" StrokeJoin="Round" />
+                    </Viewbox>
+                    <TextBlock x:Name="DeleteText" VerticalAlignment="Center"
+                               FontSize="{DynamicResource VelaFontSize11}" />
+                  </StackPanel>
+                </Button>
               </StackPanel>
-            </StackPanel>
-          </Border>
-
-          <!-- 二、模型能力:上下限与思考 -->
-          <TextBlock x:Name="SectionCapacityTitle" Classes="section-title" Margin="0,14,0,0" />
-          <Border Classes="section">
-            <StackPanel>
-              <!-- 三列(设计图 E):输出上限随请求下发;输入上限(上下文窗口)只喂给
-                   输入框下方的用量占比;思考档位跟它们是同一类"这个模型能到哪儿"的设置。 -->
-              <Grid ColumnDefinitions="*,12,*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="MaxTokensLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="MaxTokensBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="MaxInputTokensLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="MaxInputTokensBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="4">
-                  <TextBlock x:Name="ReasoningLabel" Classes="label" Margin="0,0,0,3" />
-                  <ComboBox x:Name="ReasoningCombo" HorizontalAlignment="Stretch" />
-                </StackPanel>
-              </Grid>
-              <TextBlock x:Name="MaxInputTokensHintText" Classes="hint" />
-              <TextBlock x:Name="ReasoningHintText" Classes="hint" />
-              <!-- 提示词缓存:只有 Anthropic 协议吃这个标记,解出的协议不是它时整块隐藏 -->
-              <StackPanel x:Name="PromptCachePanel">
-                <CheckBox x:Name="PromptCacheCheck" Theme="{StaticResource AiCheckBoxTheme}"
-                          FontSize="{DynamicResource VelaFontSize12}" Margin="0,12,0,0" />
-                <TextBlock x:Name="PromptCacheHintText" Classes="hint" />
-              </StackPanel>
-            </StackPanel>
-          </Border>
-
-          <!-- 三、采样、计费与本模型专用提示词 -->
-          <TextBlock x:Name="SectionSamplingTitle" Classes="section-title" Margin="0,14,0,0" />
-          <Border Classes="section">
-            <StackPanel>
-              <!-- 采样参数:留空 = 不发这个参数,用服务端默认 -->
-              <Grid ColumnDefinitions="*,12,*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="TemperatureLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="TemperatureBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="TopPLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="TopPBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="4">
-                  <TextBlock x:Name="StopLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="StopBox" FontFamily="{DynamicResource VelaUiMonoFont}" />
-                </StackPanel>
-              </Grid>
-              <TextBlock x:Name="SamplingHintText" Classes="hint" />
-
-              <Border Classes="sep" Margin="0,14" />
-
-              <!-- 单价(用户自填,用于用量提示里的花费估算);留 0 就不估 -->
-              <Grid ColumnDefinitions="*,12,*,12,*">
-                <StackPanel>
-                  <TextBlock x:Name="PriceInLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="PriceInBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="2">
-                  <TextBlock x:Name="PriceOutLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="PriceOutBox" />
-                </StackPanel>
-                <StackPanel Grid.Column="4">
-                  <TextBlock x:Name="PriceCachedLabel" Classes="label" Margin="0,0,0,3" />
-                  <TextBox x:Name="PriceCachedBox" />
-                </StackPanel>
-              </Grid>
-              <TextBlock x:Name="PriceHintText" Classes="hint" />
-
-              <TextBlock x:Name="ProviderPromptLabel" Classes="label" />
-              <TextBox x:Name="ProviderPromptBox" AcceptsReturn="True" MinHeight="60" TextWrapping="Wrap" />
-            </StackPanel>
+            </Grid>
           </Border>
         </StackPanel>
-
-        <!-- 全局设置(系统提示词 / 上下文压缩 / 后续提问)不在这页了:从窗口标题栏的 ⚙ 进 GlobalSettingsView,
-             省得跟着长表单一起滚才找得到。 -->
-
-        <!-- MCP 服务器搬去「配置工具」窗口了:配好服务器紧接着就要挑它的工具,
-             那份勾选列表就在那边;隔着两个窗口来回切很别扭。 -->
-
-        <!-- 操作行落在表单最末、靠右,上方一道分隔线跟配置项断开。
-             不钉死在窗口底部:一条常驻横栏会一直占着高度,而这页大多数时候在读、在填,
-             真要按保存时滚到底就是了。
-             测试 / 删除作用于左栏当前选中的那一层(供应商 or 模型)。 -->
-        <Border BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,1,0,0"
-                Padding="0,14,0,0" Margin="0,4,0,0">
-          <!-- 侧栏宽度不在这儿(也不在任何一节里):它跟着用户拖分割条走,拖完就记住,
-               下次打开还是那个宽度。让人来填一个百分比,不如直接把他拖出来的结果记下来。 -->
-          <Grid ColumnDefinitions="*,Auto">
-            <TextBlock x:Name="StatusText" Classes="dim" TextWrapping="Wrap"
-                       Margin="0,0,12,0" VerticalAlignment="Center" />
-            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-              <Button x:Name="SaveButton" Theme="{DynamicResource VelaAccentPillButtonTheme}" Height="26" Padding="12,0">
-                <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
-                  <Viewbox Width="11" Height="11" VerticalAlignment="Center">
-                    <Path Width="24" Height="24" Data="{DynamicResource Icon.save}"
-                          Stroke="{DynamicResource VelaAccent}" StrokeThickness="2"
-                          StrokeLineCap="Round" StrokeJoin="Round" />
-                  </Viewbox>
-                  <TextBlock x:Name="SaveText" VerticalAlignment="Center"
-                             FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
-                </StackPanel>
-              </Button>
-              <Button x:Name="TestButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0">
-                <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
-                  <Viewbox Width="11" Height="11" VerticalAlignment="Center">
-                    <Path Width="24" Height="24" Data="{DynamicResource Icon.play}"
-                          Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
-                          StrokeLineCap="Round" StrokeJoin="Round" />
-                  </Viewbox>
-                  <TextBlock x:Name="TestText" VerticalAlignment="Center" />
-                </StackPanel>
-              </Button>
-              <Button x:Name="DeleteButton" Theme="{DynamicResource VelaOutlineButtonTheme}" Height="26" Padding="12,0"
-                      Foreground="{DynamicResource VelaError}" BorderBrush="{DynamicResource VelaError}">
-                <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
-                  <Viewbox Width="11" Height="11" VerticalAlignment="Center">
-                    <Path Width="24" Height="24" Data="{DynamicResource Icon.trash-2}"
-                          Stroke="{DynamicResource VelaError}" StrokeThickness="2"
-                          StrokeLineCap="Round" StrokeJoin="Round" />
-                  </Viewbox>
-                  <TextBlock x:Name="DeleteText" VerticalAlignment="Center" />
-                </StackPanel>
-              </Button>
-            </StackPanel>
-          </Grid>
-        </Border>
-      </StackPanel>
-    </ScrollViewer>
+      </ScrollViewer>
+    </Border>
   </Grid>
 </UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Microsoft.Extensions.AI;
 using VelaShell.Plugin.Ai.Configuration;
@@ -18,7 +19,9 @@ public sealed class ProviderNavItem(
     AiProvider provider, AiModelConfig? model, string text, Thickness indent, FontWeight weight)
     : System.ComponentModel.INotifyPropertyChanged
 {
+    private Geometry? _icon;
     private IBrush? _dot;
+    private IBrush? _tint;
     private string _dotTip = "";
 
     /// <summary>这一行所属的供应商(模型行也指向它的父供应商)。</summary>
@@ -36,11 +39,26 @@ public sealed class ProviderNavItem(
     /// <summary>字重:供应商行加粗。</summary>
     public FontWeight Weight { get; } = weight;
 
-    /// <summary>层级图标:供应商 = 云,模型 = 方块(几何在 <c>ReloadList</c> 里解析)。</summary>
-    public Geometry? Icon { get; set; }
+    /// <summary>
+    /// 层级图标:供应商 = 云,模型 = 方块。几何在 <c>RefreshNavVisuals</c> 里解析 ——
+    /// 视图挂进可视树之后还要再解析一次,所以跟 <see cref="Dot" /> 一样走通知。
+    /// </summary>
+    public Geometry? Icon
+    {
+        get => _icon;
+        set => Set(ref _icon, value, nameof(Icon));
+    }
 
-    /// <summary>图标描边色。与 <see cref="Dot" /> 一样,画笔在建项时解析好。</summary>
-    public IBrush? Tint { get; set; }
+    /// <summary>
+    /// 图标描边色:比同一行的文字再暗一档,选中时和文字一起转强调色。
+    /// 文字的三档在样式里(<c>DialogStyles.axaml</c> 的 nav 选择器),图标这一档只能逐项算,
+    /// 所以跟 <see cref="Dot" /> 一样走通知 —— 换选中项时就地改色,不重建列表。
+    /// </summary>
+    public IBrush? Tint
+    {
+        get => _tint;
+        set => Set(ref _tint, value, nameof(Tint));
+    }
 
     /// <summary>是不是供应商行。</summary>
     public bool IsProvider => Model is null;
@@ -59,7 +77,7 @@ public sealed class ProviderNavItem(
         set => Set(ref _dotTip, value, nameof(DotTip));
     }
 
-    /// <summary>状态点变色时通知绑定(<see cref="Dot" /> / <see cref="DotTip" />)。</summary>
+    /// <summary>图标/状态点变化时通知绑定(<see cref="Icon" /> / <see cref="Dot" /> / <see cref="DotTip" /> / <see cref="Tint" />)。</summary>
     public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
 
     private void Set<T>(ref T field, T value, string name)
@@ -100,7 +118,12 @@ public partial class SettingsView : UserControl
     /// <b>不落盘</b>:它说的是"刚才那一次连通",隔天再打开时那句话已经不成立了 ——
     /// 与其显示一个可能过期的绿点,不如老实退回灰点。
     /// </summary>
-    private readonly Dictionary<string, bool> _testResults = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, (bool Ok, DateTime At)> _testResults = new(StringComparer.Ordinal);
+
+    /// <summary>左栏图标的三档描边色(见 <see cref="ApplyTints" />),装载后解析一次。</summary>
+    private IBrush? _providerTint;
+    private IBrush? _modelTint;
+    private IBrush? _selectedTint;
 
     /// <summary>两击确认删供应商:记着第一击是冲着谁的,换了选择就作废。</summary>
     private string? _pendingDeleteProviderId;
@@ -123,6 +146,7 @@ public partial class SettingsView : UserControl
         ProvidersList.SelectionChanged += (_, _) =>
         {
             _pendingDeleteProviderId = null;
+            ApplyTints();
             _ = LoadEditorAsync();
         };
         ProviderProtocolCombo.SelectionChanged += (_, _) => UpdateProtocolOnlyFields();
@@ -160,11 +184,11 @@ public partial class SettingsView : UserControl
         ProviderApiKeyHintText.Text = _loc["ProviderKeyHint"];
         ProviderKeyBadgeText.Text = _loc["KeyEncrypted"];
         ModelKeyBadgeText.Text = _loc["KeyEncrypted"];
-        NameLabel.Text = _loc["Name"];
+        NameLabel.Text = _loc["DisplayName"];
         ProtocolLabel.Text = _loc["Protocol"];
         BaseUrlLabel.Text = _loc["BaseUrlOverride"];
         BaseUrlHintText.Text = _loc["BaseUrlOverrideHint"];
-        ModelLabel.Text = _loc["Model"];
+        ModelLabel.Text = _loc["ModelId"];
         OwnKeyCheck.Content = _loc["OwnApiKey"];
         OwnKeyHintText.Text = _loc["OwnApiKeyHint"];
         MaxTokensLabel.Text = _loc["MaxTokens"];
@@ -190,7 +214,6 @@ public partial class SettingsView : UserControl
         int protocol = ProtocolCombo.SelectedIndex;
         ProtocolCombo.ItemsSource = ProtocolChoices(SelectedProvider);
         ProtocolCombo.SelectedIndex = protocol;
-        ApiKeyLabel.Text = _loc["ApiKey"];
         ApiKeyHintText.Text = _loc["ApiKeyHint"];
         SaveText.Text = _loc["Save"];
         TestText.Text = _loc["Test"];
@@ -223,7 +246,7 @@ public partial class SettingsView : UserControl
     /// <summary>把某一行的状态点刷成它当前该有的颜色(没测过 = 灰)。</summary>
     private void ApplyDot(ProviderNavItem item)
     {
-        bool? result = _testResults.TryGetValue(NavKey(item), out bool ok) ? ok : null;
+        bool? result = _testResults.TryGetValue(NavKey(item), out (bool Ok, DateTime At) r) ? r.Ok : null;
         (string brushKey, string tipKey) = result switch
         {
             true => ("VelaStatusConnected", "DotPassed"),
@@ -234,22 +257,74 @@ public partial class SettingsView : UserControl
         item.DotTip = _loc[tipKey];
     }
 
+    /// <summary>
+    /// 挂进可视树之后把左栏的图标与状态点重解析一次。
+    /// <b>构造期解析不到宿主令牌</b>:那时 <c>TryFindResource</c> 只走得到本控件自己的
+    /// <c>Resources</c>,往上没有父级、也够不着 <c>Application.Resources</c>,
+    /// 于是 Vela* 全落空 —— 图标描边与状态点都是 null 画刷,整列层级标记和连通性点直接不显示。
+    /// </summary>
+    protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToLogicalTree(e);
+        _providerTint = null;
+        _modelTint = null;
+        _selectedTint = null;
+        RefreshNavVisuals();
+        UpdateTestBadge();
+    }
+
+    /// <summary>左栏每一行的层级图标、连通性点与图标描边色,一起重算。</summary>
+    private void RefreshNavVisuals()
+    {
+        Geometry? cloud = Token<Geometry>("AiIcon.cloud");
+        Geometry? box = Token<Geometry>("AiIcon.box");
+        _providerTint ??= Token<IBrush>("VelaTextSecondary");
+        _modelTint ??= Token<IBrush>("VelaTextMuted");
+        _selectedTint ??= Token<IBrush>("VelaAccent");
+        foreach (ProviderNavItem item in _nav)
+        {
+            item.Icon = item.IsProvider ? cloud : box;
+            ApplyDot(item);
+        }
+        ApplyTints();
+    }
+
+    /// <summary>本视图里解析一个宿主令牌(缺席时回落 null,属性保持默认外观)。</summary>
+    private T? Token<T>(string key) where T : class
+        => this.TryFindResource(key, ActualThemeVariant, out object? value) ? value as T : null;
+
+    /// <summary>
+    /// 左栏图标的描边色:选中行跟着文字一起转强调色,其余比同一行的文字再暗一档
+    /// (供应商行文字 Primary / 图标 Secondary,模型行文字 Secondary / 图标 Muted)。
+    /// 图标是这一行的层级标记,压过文字就成了噪点。
+    /// </summary>
+    private void ApplyTints()
+    {
+        ProviderNavItem? selected = SelectedItem;
+        foreach (ProviderNavItem item in _nav)
+        {
+            item.Tint = ReferenceEquals(item, selected)
+                ? _selectedTint
+                : item.IsProvider ? _providerTint : _modelTint;
+        }
+    }
+
     /// <summary>表单顶上那枚测试结果徽章。没测过就整枚隐掉,不假装知道。</summary>
     private void UpdateTestBadge()
     {
-        if (SelectedItem is not { } item || !_testResults.TryGetValue(NavKey(item), out bool ok))
+        if (SelectedItem is not { } item || !_testResults.TryGetValue(NavKey(item), out (bool Ok, DateTime At) r))
         {
             TestBadge.IsVisible = false;
             return;
         }
         TestBadge.IsVisible = true;
-        TestBadgeText.Text = _loc[ok ? "DotPassed" : "DotFailed"];
-        IBrush? tone = this.TryFindResource(ok ? "VelaStatusConnected" : "VelaError", ActualThemeVariant, out object? brush)
-            ? brush as IBrush
-            : null;
+        // 带上时刻:"通过"是有保质期的一句话,不写清是几点测的,隔半小时看还以为是刚测过
+        TestBadgeText.Text = $"{_loc[r.Ok ? "DotPassed" : "DotFailed"]} · {r.At:HH:mm}";
+        IBrush? tone = Token<IBrush>(r.Ok ? "VelaStatusConnected" : "VelaError");
         TestBadgeText.Foreground = tone;
-        TestBadge.BorderBrush = tone;
-        // 同色淡底(设计图 E):只有描边的话,这枚徽章在面包屑那一行里太轻,扫不到
+        TestBadgeIcon.Data = Token<Geometry>(r.Ok ? "AiIcon.circle-check" : "AiIcon.circle-x");
+        TestBadgeIcon.Stroke = tone;
+        // 同色淡底、不描边(设计图 E):描一圈边会让这枚小标签看起来像个可点的按钮
         TestBadge.Background = tone is ISolidColorBrush solid
             ? new SolidColorBrush(solid.Color, 0.14)
             : null;
@@ -279,19 +354,11 @@ public partial class SettingsView : UserControl
                     new Thickness(14, 0, 0, 0), FontWeight.Normal));
             }
         }
-        // 层级图标与状态点一起在这儿解析:这时视图已经装载过,宿主令牌查得到
-        Geometry? cloud = this.TryFindResource("AiIcon.cloud", ActualThemeVariant, out object? c) ? c as Geometry : null;
-        Geometry? box = this.TryFindResource("AiIcon.box", ActualThemeVariant, out object? b) ? b as Geometry : null;
-        IBrush? providerTint = this.TryFindResource("VelaTextSecondary", ActualThemeVariant, out object? p) ? p as IBrush : null;
-        IBrush? modelTint = this.TryFindResource("VelaTextMuted", ActualThemeVariant, out object? m) ? m as IBrush : null;
-        foreach (ProviderNavItem item in _nav)
-        {
-            item.Icon = item.IsProvider ? cloud : box;
-            item.Tint = item.IsProvider ? providerTint : modelTint;
-            ApplyDot(item);
-        }
         ProvidersList.ItemsSource = _nav;
         ProvidersList.SelectedIndex = selectIndex >= 0 ? selectIndex : Math.Min(0, _nav.Count - 1);
+        // 图标/状态点排在选中项定下来之后:选中那一行的图标要转强调色,得先知道是哪一行。
+        // (SelectedIndex 没变时 SelectionChanged 不会再触发,所以这里必须自己补一次。)
+        RefreshNavVisuals();
         if (ProvidersList.SelectedIndex < 0)
         {
             _ = LoadEditorAsync();
@@ -620,12 +687,12 @@ public partial class SettingsView : UserControl
                 "Reply with exactly: OK", new ChatOptions { MaxOutputTokens = 64 }));
             string text = response.Text.Trim();
             StatusText.Text = _loc.F("TestOk", text.Length > 80 ? text[..80] + "…" : text);
-            _testResults[NavKey(item)] = true;
+            _testResults[NavKey(item)] = (true, DateTime.Now);
         }
         catch (Exception ex)
         {
             StatusText.Text = _loc.F("TestFail", ex.Message);
-            _testResults[NavKey(item)] = false;
+            _testResults[NavKey(item)] = (false, DateTime.Now);
         }
         finally
         {


### PR DESCRIPTION
- 优化左侧导航栏图标、描边色、选中态，统一视觉分档，资源解析逻辑集中处理
- ProviderNavItem 支持图标/描边色动态变色
- 重构面包屑测试结果徽章，状态图标与颜色一致，未测试时隐藏
- 表单区视觉调整，标签、hint、section-title 等样式细化，布局更紧凑
- 编辑表单多字段并排、分组，输入区布局优化，提示语位置调整
- 操作按钮区样式统一，间距、字号、颜色协调
- 多语言文本补充，区分“显示名称”“模型ID”
- 资源查找与切换逻辑集中，减少重复，提升可维护性