### PR TITLE
修复终端控件 DECCOLM 行为及网格同步问题

### DIFF
--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -561,6 +561,16 @@ public sealed class TerminalEmulator : IVtActions
     /// <summary>在一块输入被应用后触发,以便 UI 重绘。</summary>
     public event Action? Updated;
 
+    /// <summary>
+    /// 主机流里的转义序列改变了网格几何(目前只有获准的 DECCOLM 一条路径)。参数:(columns, rows)。
+    /// 事件来自 feed 线程,消费者需自行编组到 UI 线程。
+    /// <para>
+    /// 宿主<b>必须</b>订阅:模拟器网格一旦不经布局就改动,渲染与命中测试立刻跟着缩,而控件缓存的
+    /// 网格尺寸与远端 PTY 的 winsize 毫不知情 —— 这正是 issue #253 那类「悄悄分家」故障的形状。
+    /// </para>
+    /// </summary>
+    public event Action<int, int>? HostGeometryChanged;
+
     /// <summary>切换所仿真的终端类型,并相应更新 VT52 解析。</summary>
     public void SetTerminalType(TerminalType type)
     {
@@ -768,6 +778,9 @@ public sealed class TerminalEmulator : IVtActions
                 case 25:
                     Modes.CursorVisible = set;
                     break; // DECTCEM
+                case 40:
+                    Modes.AllowColumnMode = set;
+                    break; // 允许 80↔132 切换(xterm c132):DECCOLM 的总闸
                 case 1000:
                     Modes.Mouse = set ? MouseTracking.Normal : MouseTracking.None;
                     break;
@@ -1064,11 +1077,24 @@ public sealed class TerminalEmulator : IVtActions
 
     private void ColumnMode(bool set)
     {
-        // DECCOLM:切换 132/80 列,并清空屏幕。
+        // DECCOLM(?3):切换 132/80 列并清屏。整条动作都受 DECSET ?40 把关(xterm 的 c132 资源),
+        // 默认关闭 = 完全空操作 —— 不改列数、不清屏、不动光标。
+        //
+        // 这不是偷懒:xterm 系 terminfo 的 is2 初始化串里就带 "ESC[?3l",screen / tmux / tput init /
+        // reset 每次启动都会照发一遍。无条件执行会把网格压成 80 列、顺手清掉整屏,而控件布局与
+        // 远端 PTY 都还以为是原来的宽度,于是「选区/命中测试只剩 80 列宽」,要切一次标签触发
+        // 重新布局才恢复(issue #253)。xterm、Windows Terminal、VTE 一律默认忽略 DECCOLM。
+        if (!Modes.AllowColumnMode)
+        {
+            return;
+        }
         int cols = set ? 132 : 80;
         Screen.EraseInDisplay(2, Blank());
         Screen.SetCursor(0, 0);
         Resize(cols, Screen.Rows);
+        // 主机流刚刚改掉了网格几何:必须让宿主知道,否则控件的布局认知与远端 PTY 的 winsize
+        // 会和模拟器分家(见 VelaTerminalControl.OnHostGeometryChanged)。
+        HostGeometryChanged?.Invoke(Screen.Columns, Screen.Rows);
     }
 
     private void SwitchAlternate(bool enable, bool saveCursor = false)

--- a/src/VelaShell.Terminal/Emulation/TerminalModes.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalModes.cs
@@ -7,6 +7,21 @@ namespace VelaShell.Terminal.Emulation;
 public sealed class TerminalModes
 {
     // DEC 私有模式
+    /// <summary>
+    /// 允许 80↔132 列切换(DECSET ?40,即 xterm 的 <c>c132</c> 资源),<b>默认关闭</b>。
+    /// 关闭时 DECCOLM(?3)整条是空操作 —— 不改列数、不清屏、不动光标,与 xterm、
+    /// Windows Terminal(<c>EnableDECCOLMSupport</c> 默认 false)、VTE 一致。
+    /// <para>
+    /// 必须默认关闭:xterm 系 terminfo 的初始化串 <c>is2=ESC[!p ESC[?3;4l ESC[4l ESC&gt;</c> 里带着
+    /// <c>ESC[?3l</c>,于是 <c>screen</c>、<c>tmux</c>、<c>tput init</c>、<c>reset</c> 每次启动都会发它。
+    /// 若无条件照做,网格会被悄悄压成 80 列,而控件布局与远端 PTY 都还以为是原宽度 ——
+    /// 表现为「打开 screen 后可选中的区域变小」,切一次标签(触发重新布局)才恢复(issue #253)。
+    /// </para>
+    /// <para>
+    /// 与 xterm 一致:本开关是「资源」语义,DECSTR / RIS <b>不</b>复位它,故不出现在 <see cref="Reset" /> 中。
+    /// </para>
+    /// </summary>
+    public bool AllowColumnMode; // DECSET ?40(xterm c132)
     /// <summary>光标键应用模式(DECCKM ?1):方向键发送应用序列而非普通序列。</summary>
     public bool ApplicationCursorKeys; // DECCKM  ?1
     /// <summary>小键盘应用模式(DECKPAM / DECKPNM):小键盘发送应用序列。</summary>

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -95,6 +95,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private (int Col, int Row) _lastMouseReportCell = (-1, -1);
     private int _lastScrollbackCount; // 上一次输出更新时的回滚大小
 
+    // 宿主认定的当前网格尺寸:布局下发、公开 Resize、或宿主主动接纳的主机端几何改动都会更新它。
+    // 0 = 尚未下发过任何网格(控件还没拿到真实布局)。模拟器几何一旦与它对不上,就说明有人
+    // 绕过宿主改了网格,ApplyOutputUpdate 的自愈闸会把网格拉回当前布局(见 issue #253)。
+    private int _appliedColumns;
+    private int _appliedRows;
+
     // 向应用上报鼠标(htop/btop/vim/tmux):记录上报按下后保持的按钮,以及
     // 最近上报的单元格,使得拖拽/移动仅在单元格真正变化时才发送。
     private TerminalMouseButton? _mouseButtonDown;
@@ -136,6 +142,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Emulator.Response += bytes => UserInput?.Invoke(bytes); // 协议自动应答:发往 PTY 但不算用户键入(不进 TypedInput)。
         Emulator.Bell += OnBell;
         Emulator.ClipboardWriteRequested += OnRemoteClipboardWrite;
+        Emulator.HostGeometryChanged += OnHostGeometryChanged;
 
         // 终端配色跟随应用主题(暗=Dracula,亮=Solarized Light);切换主题时重灌调色板并重绘。
         ActualThemeVariantChanged += (_, _) => ApplyThemePalette();
@@ -478,6 +485,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     public void Resize(int cols, int rows)
     {
         Emulator.Resize(cols, rows);
+        _appliedColumns = Emulator.Columns; // 宿主自己下发的网格,自愈闸不该把它当成"分家"。
+        _appliedRows = Emulator.Rows;
         _scrollOffset = 0;
         _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
         ClearFolds(); // reflow 会重建行对象,折叠引用失效。
@@ -632,6 +641,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Emulator.Updated -= OnEmulatorUpdated;
         Emulator.Bell -= OnBell;
         Emulator.ClipboardWriteRequested -= OnRemoteClipboardWrite;
+        Emulator.HostGeometryChanged -= OnHostGeometryChanged;
         _cursorBlinkTimer?.Stop();
         _cursorBlinkTimer = null;
     }
@@ -838,6 +848,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     private void ApplyOutputUpdate()
     {
+        ReconcileGridWithLayout();
         // 仅在已处于底部时才跟随输出;否则保持用户的历史
         // 视图固定不动,以免后台输出把其拽回下方(修复 #15)—— 除非
         // 设置 → 终端 → 有输出时自动滚动已开启,此时会把视图拉回实时底部。
@@ -1325,6 +1336,33 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     private void RelayoutFromBounds() => ApplyLayoutSize(Bounds.Size);
 
+    /// <summary>
+    /// 自愈闸:模拟器网格若与宿主最后下发的尺寸对不上,说明有东西绕过布局改了几何。
+    /// 此时按当前布局重新下发一次网格,顺带把新尺寸通知 PTY。
+    /// <para>
+    /// 为什么需要:<see cref="ApplyLayoutSize" /> 只在 arrange 时跑,而 arrange 只在布局失效时发生。
+    /// 网格被悄悄改小后控件尺寸并没变,于是没有任何 arrange 会来纠正 —— 用户看到的就是
+    /// 「打开 screen 后可选中的区域变小,切一次标签才恢复」(issue #253:切标签重挂控件才触发了 arrange)。
+    /// 这里每次输出更新做两次整型比较,代价可忽略,却让这一类「悄悄分家」自己收敛。
+    /// </para>
+    /// <para>
+    /// <c>_appliedColumns == 0</c> 表示还没拿到真实布局(单测里的裸控件即如此),此时不介入,
+    /// 免得在退化尺寸上空转。
+    /// </para>
+    /// </summary>
+    private void ReconcileGridWithLayout()
+    {
+        if (_appliedColumns <= 0)
+        {
+            return;
+        }
+        if (Emulator.Columns == _appliedColumns && Emulator.Rows == _appliedRows)
+        {
+            return;
+        }
+        RelayoutFromBounds();
+    }
+
     private void ApplyLayoutSize(Size size)
     {
         if (CellWidthForTest <= 0 || CellHeightForTest <= 0)
@@ -1347,6 +1385,10 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         if (cols == Emulator.Columns && rows == Emulator.Rows)
         {
+            // 已经是这个网格了,但仍要记账:自愈闸靠 _applied* 判断"模拟器是否被绕过宿主改过",
+            // 首帧若不记账,它会把每次输出都当成分家、反复空跑重排。
+            _appliedColumns = cols;
+            _appliedRows = rows;
             return;
         }
 
@@ -1355,10 +1397,49 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         // 落后许多次 reflow,导致其相对光标移动与擦除落在错误的行上,逐步破坏缓冲内容。
         // 传输层按顺序串行化发送,将突发合并为最新尺寸。
         Emulator.Resize(cols, rows);
+        _appliedColumns = cols;
+        _appliedRows = rows;
         _scrollOffset = Math.Clamp(_scrollOffset, 0, Emulator.Screen.ScrollbackCount);
         _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
         ClearFolds(); // reflow 会重建行对象,折叠引用失效。
         // reflow 会移动绝对行;陈旧的选区会标记(并复制)错误的文本。
+        ClearSelection();
+        InvalidateVisual();
+        ScrollChanged?.Invoke();
+        PtySizeChanged?.Invoke(cols, rows);
+    }
+
+    /// <summary>
+    /// 主机流(转义序列)改变了模拟器网格。事件来自 feed 线程,先编组回 UI 线程再接纳。
+    /// </summary>
+    private void OnHostGeometryChanged(int cols, int rows)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            AdoptHostGeometry(cols, rows);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() => AdoptHostGeometry(cols, rows));
+        }
+    }
+
+    /// <summary>
+    /// 接纳一次主机端发起的网格改动:把宿主的记账、滚动/折叠/选区状态与新几何对齐,并把新尺寸
+    /// 转告 PTY。关键在最后一步 —— 远端若不知道宽度变了,它的换行与光标数学会继续按旧宽度算,
+    /// 缓冲区会被一点点写花。
+    /// </summary>
+    private void AdoptHostGeometry(int cols, int rows)
+    {
+        if (cols == _appliedColumns && rows == _appliedRows)
+        {
+            return;
+        }
+        _appliedColumns = cols;
+        _appliedRows = rows;
+        _scrollOffset = Math.Clamp(_scrollOffset, 0, Emulator.Screen.ScrollbackCount);
+        _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
+        ClearFolds();
         ClearSelection();
         InvalidateVisual();
         ScrollChanged?.Invoke();
@@ -1529,6 +1610,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// 而"方块网格"只在分数缩放下出现,故只能由测试注入(见 TerminalSeamSnapUiTests)。
     /// </summary>
     internal double RenderScalingOverrideForTest { get; set; }
+
+    /// <summary>
+    /// 测试钩子(唯一一个会写状态的):绕过宿主直接改模拟器网格,<b>不</b>更新 <c>_applied*</c> 记账 ——
+    /// 也就是造出「有东西改了几何却没通知任何人」的分家状态,用来验证 <see cref="ReconcileGridWithLayout" />
+    /// 的自愈闸(issue #253)。生产代码一律走 <see cref="Resize" /> 或 <see cref="AdoptHostGeometry" />。
+    /// </summary>
+    internal void DesyncGridForTest(int cols, int rows) => Emulator.Resize(cols, rows);
 
     /// <summary>
     /// 按当前设备像素栅格算出某个单元格的背景矩形(坐标系与正文绘制一致:已减去内边距与侧栏平移)。

--- a/tests/VelaShell.Terminal.Tests/Emulation/ColumnModeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/ColumnModeTests.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests.Emulation;
+
+/// <summary>
+/// DECCOLM (<c>CSI ? 3 h/l</c>) gating — issue #253.
+/// <para>
+/// The xterm-family terminfo init string (<c>is2=\E[!p\E[?3;4l\E[4l\E&gt;</c>) carries <c>\E[?3l</c>,
+/// so <c>screen</c>, <c>tmux</c>, <c>tput init</c> and <c>reset</c> all emit it on startup. Honouring it
+/// unconditionally squeezed the grid to 80 columns and wiped the screen while the control's layout and
+/// the remote PTY still believed the old width — the user saw "the selectable region shrank after
+/// opening screen", and only switching tabs (which forces an arrange pass) put it back.
+/// </para>
+/// <para>
+/// Mainstream behaviour, which these tests pin: DECCOLM is a complete no-op unless the application first
+/// opts in with DECSET <c>?40</c> (xterm's <c>c132</c> resource; Windows Terminal's
+/// <c>EnableDECCOLMSupport</c>, default false; VTE never resizes at all). When it *is* allowed, the
+/// geometry change must be announced so the host can keep the PTY in sync.
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("Emulator")]
+public class ColumnModeTests
+{
+    /// <summary>The literal init string an xterm-256color terminfo hands to screen/tmux/tput init.</summary>
+    private const string XtermInitString = "\x1b[!p\x1b[?3;4l\x1b[4l\x1b>";
+
+    private static TerminalEmulator New(int cols = 140, int rows = 40) => new(cols, rows);
+
+    private static void Feed(TerminalEmulator e, string s) => e.Feed(Encoding.UTF8.GetBytes(s));
+
+    [TestMethod]
+    public void XtermInitString_LeavesGridAndContentAlone()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "pi@NanoPi-R2S:~$ screen -R test");
+        Feed(e, XtermInitString);
+
+        // The whole point of #253: neither the width nor the visible screen may move.
+        Assert.AreEqual(140, e.Columns);
+        Assert.AreEqual(40, e.Rows);
+        Assert.AreEqual("pi@NanoPi-R2S:~$ screen -R test", e.Screen.ActiveLine(0).GetText().TrimEnd());
+        Assert.AreEqual(140, e.Screen.ActiveLine(0).Columns);
+    }
+
+    [TestMethod]
+    public void Deccolm_IsIgnoredByDefault()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "keep me");
+
+        Feed(e, "\x1b[?3h"); // 132 columns
+        Assert.AreEqual(140, e.Columns);
+        Feed(e, "\x1b[?3l"); // 80 columns
+        Assert.AreEqual(140, e.Columns);
+
+        // Ignored means *fully* ignored: no erase, no cursor home.
+        Assert.AreEqual("keep me", e.Screen.ActiveLine(0).GetText().TrimEnd());
+        Assert.AreEqual(7, e.CursorX);
+    }
+
+    [TestMethod]
+    public void Deccolm_DoesNotFireHostGeometryChanged_WhenIgnored()
+    {
+        TerminalEmulator e = New();
+        int fired = 0;
+        e.HostGeometryChanged += (_, _) => fired++;
+
+        Feed(e, XtermInitString);
+        Feed(e, "\x1b[?3h");
+
+        Assert.AreEqual(0, fired);
+    }
+
+    [TestMethod]
+    public void Deccolm_ResizesAndAnnounces_OnceAllowedByDecset40()
+    {
+        TerminalEmulator e = New();
+        (int Cols, int Rows)? announced = null;
+        e.HostGeometryChanged += (c, r) => announced = (c, r);
+
+        Feed(e, "\x1b[?40h"); // xterm c132: allow 80 <-> 132
+        Feed(e, "\x1b[?3h");
+
+        Assert.AreEqual(132, e.Columns);
+        Assert.AreEqual(40, e.Rows);
+        Assert.AreEqual((132, 40), announced);
+
+        Feed(e, "\x1b[?3l");
+        Assert.AreEqual(80, e.Columns);
+        Assert.AreEqual((80, 40), announced);
+    }
+
+    [TestMethod]
+    public void Deccolm_ClearsScreenAndHomesCursor_OnceAllowed()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[?40h");
+        Feed(e, "wipe me");
+        Feed(e, "\x1b[?3l");
+
+        Assert.AreEqual("", e.Screen.ActiveLine(0).GetText().TrimEnd());
+        Assert.AreEqual(0, e.CursorX);
+        Assert.AreEqual(0, e.CursorY);
+    }
+
+    [TestMethod]
+    public void Decset40_Reset_TurnsColumnModeBackOff()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[?40h");
+        Feed(e, "\x1b[?40l");
+        Feed(e, "\x1b[?3h");
+
+        Assert.AreEqual(140, e.Columns);
+    }
+
+    [TestMethod]
+    public void Decset40_SurvivesSoftAndFullReset_LikeXterm()
+    {
+        // xterm models c132 as a resource: neither DECSTR (CSI ! p) nor RIS (ESC c) clears it.
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[?40h");
+        Feed(e, "\x1b[!p");
+        Feed(e, "\x1bc");
+
+        Assert.IsTrue(e.Modes.AllowColumnMode);
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 宿主网格不得被主机流悄悄改小(issue #253:执行 <c>screen -R test</c> 后可选中的区域缩成 80 列,
+/// 切一次标签才恢复)。这里用 headless 真控件把两层保护端到端锁住:
+/// <list type="number">
+///   <item>xterm 系 terminfo 的初始化串(<c>screen</c>/<c>tmux</c>/<c>tput init</c> 都会发)喂进去后,
+///   列数、行宽与拖拽可选中的范围一格不变;</item>
+///   <item>万一网格仍被绕过布局改掉,下一次输出更新的自愈闸会把它拉回当前布局,并把新尺寸补发给 PTY。</item>
+/// </list>
+/// 断言落在「拖出来的文本」上而不是内部字段:用户抱怨的正是选不到,行宽夹取(TerminalSelectionMath.RowSpan)
+/// 才是症状的直接成因。
+/// </summary>
+[TestClass]
+[TestCategory("TerminalGrid")]
+public sealed class HostGridReconcileUiTests
+{
+    /// <summary>xterm-256color 的 <c>is2</c>:里面的 <c>ESC[?3l</c> 就是 #253 的扳机。</summary>
+    private const string XtermInitString = "\x1b[!p\x1b[?3;4l\x1b[4l\x1b>";
+
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext _) =>
+        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    [TestMethod]
+    public void XtermInitString_DoesNotShrinkTheSelectableWidth()
+    {
+        OnUi(() =>
+        {
+            // 控件够宽,布局给出的列数必然远超 DECCOLM 的 80 —— 否则这条测试证明不了什么。
+            (VelaTerminalControl control, Window window) = NewTerminal(1400, 400);
+            int cols = control.Columns;
+            Assert.IsGreaterThan(80, cols, "测试前提:布局列数必须多于 80,才谈得上被压缩。");
+
+            string row = new('x', cols);
+            control.Feed(Encoding.ASCII.GetBytes(row));
+            control.Feed(Encoding.ASCII.GetBytes(XtermInitString));
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            Assert.AreEqual(cols, control.Columns, "初始化串不得改变网格列数。");
+            Assert.AreEqual(row, DragRow0(control, window), "整行必须仍然可选中,而不是只剩前 80 列。");
+        });
+    }
+
+    [TestMethod]
+    public void GridChangedBehindTheHost_SnapsBackOnNextOutput()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = NewTerminal(1400, 400);
+            int cols = control.Columns;
+            int rows = control.Rows;
+
+            (int Cols, int Rows)? pty = null;
+            control.PtySizeChanged += (c, r) => pty = (c, r);
+
+            // 模拟"有东西改了几何却没通知任何人"——#253 里的 DECCOLM 当初就是这样。
+            control.DesyncGridForTest(80, rows);
+            Assert.AreEqual(80, control.Columns);
+
+            // 下一批输出到来时,自愈闸按当前布局把网格拉回去,并补发 PTY 尺寸。
+            control.Feed(Encoding.ASCII.GetBytes("hello"));
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            Assert.AreEqual(cols, control.Columns, "网格应自愈回布局尺寸。");
+            Assert.AreEqual(rows, control.Rows);
+            Assert.AreEqual((cols, rows), pty, "远端 PTY 必须收到纠正后的尺寸,否则它的换行数学继续按错宽度算。");
+        });
+    }
+
+    private static (VelaTerminalControl Control, Window Window) NewTerminal(int width, int height)
+    {
+        var control = new VelaTerminalControl
+        {
+            CopyOnSelect = false, // headless 下不去碰剪贴板
+        };
+        var window = new Window
+        {
+            Width = width,
+            Height = height,
+            Content = control,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame(); // 填充屏幕行映射与单元格度量
+        return (control, window);
+    }
+
+    /// <summary>拖过第 0 行的整行宽度,返回选中的文本。</summary>
+    private static string DragRow0(VelaTerminalControl control, Window window)
+    {
+        window.MouseDown(CellPoint(control, 0, 0), MouseButton.Left);
+        window.MouseMove(CellPoint(control, 0, control.Columns));
+        window.MouseUp(CellPoint(control, 0, control.Columns), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        return control.GetSelectedText();
+    }
+
+    /// <summary>屏幕行/列的左上角坐标(略微内缩,避免落到相邻单元格)。</summary>
+    private static Point CellPoint(VelaTerminalControl control, int row, int col) =>
+        new(
+            control.GutterForTest.TotalWidth + (col * control.CellWidthForTest) + 1,
+            (row * control.CellHeightForTest) + 1
+        );
+
+    private static void OnUi(Action body) =>
+        _session
+            .Dispatch(
+                () =>
+                {
+                    body();
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None
+            )
+            .GetAwaiter()
+            .GetResult();
+}


### PR DESCRIPTION
修复 xterm 系 terminfo 初始化串导致网格被压缩为 80 列、可选区域变窄的问题（issue #253）。新增 AllowColumnMode（DECSET ?40/xterm c132）开关，默认关闭，保持与主流终端一致。DECCOLM 生效时通过 HostGeometryChanged 事件通知宿主，确保控件与 PTY 尺寸同步。VelaTerminalControl 增加网格尺寸记账与自愈逻辑，防止网格分家。新增测试钩子和单元/UI 测试，覆盖 gating、事件、恢复等场景。补充注释说明默认关闭原因及历史背景。