### PR TITLE
优化下载目录默认行为，支持系统目录跟随

### DIFF
--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -78,6 +78,16 @@ public class AppSettings
             TerminalBehavior.BellMode = "visual";
             TerminalBehavior.VisualBell = false;
         }
+
+        // 旧版把下载目录的默认值硬写成 "~/Downloads",于是 Windows 上把"下载"文件夹改到
+        // 别处的用户,东西照样落在 %USERPROFILE%\Downloads(#257)。默认值已改为空串
+        // (= 跟随系统下载目录),存量配置里残留的这个字面默认值一并迁移过去 —— 它是默认值
+        // 而非用户选择;真要钉死在主目录下,填绝对路径即可。
+        string downloadDirectory = Transfer.LocalDownloadDirectory?.Trim() ?? string.Empty;
+        if (downloadDirectory is "~/Downloads" or "~\\Downloads")
+        {
+            Transfer.LocalDownloadDirectory = string.Empty;
+        }
     }
 }
 
@@ -631,12 +641,19 @@ public class TerminalBehaviorOptions : ObservableOptions
 /// <summary>设置 - 文件传输(设计 HGwa7)。</summary>
 public class TransferOptions : ObservableOptions
 {
-    /// <summary>下载文件保存到的本地默认目录。</summary>
+    /// <summary>
+    /// 下载文件保存到的本地默认目录;<b>留空 = 跟随系统"下载"文件夹</b>
+    /// (由 <see cref="UserPathResolver.ResolveOrDownloads" /> 解析)。
+    /// </summary>
+    /// <remarks>
+    /// 默认值不能写死成 <c>~/Downloads</c>:Windows 上"下载"文件夹可被用户改到别处,
+    /// 写死之后无论用户怎么改都还是往 <c>%USERPROFILE%\Downloads</c> 里放(#257)。
+    /// </remarks>
     public string LocalDownloadDirectory
     {
         get;
         set => Set(ref field, value);
-    } = "~/Downloads";
+    } = string.Empty;
 
     /// <summary>同时进行的最大传输任务数。</summary>
     public int MaxConcurrentTransfers

--- a/src/VelaShell.Core/Models/SystemFolders.cs
+++ b/src/VelaShell.Core/Models/SystemFolders.cs
@@ -1,0 +1,116 @@
+using System.Runtime.InteropServices;
+
+namespace VelaShell.Core.Models;
+
+/// <summary>
+/// 系统标准目录的平台实现(目前只有"下载")。
+/// </summary>
+/// <remarks>
+/// .NET 的 <see cref="Environment.SpecialFolder" /> 没有"下载"这一项,历史上只能拼
+/// <c>~/Downloads</c> —— 而这个目录在 Windows 上是可以被用户改到任意位置的
+/// (资源管理器 → 下载 → 属性 → 位置),改过之后 <c>%USERPROFILE%\Downloads</c> 要么不存在,
+/// 要么是个没人往里放东西的空壳(#257)。Linux 同理:XDG 用户目录允许把下载目录
+/// 指到 <c>~/下载</c> 之类的本地化名字上。因此这里按平台问系统要真实位置:
+/// <list type="bullet">
+///   <item>Windows:<c>SHGetKnownFolderPath(FOLDERID_Downloads)</c>,重定向后返回的就是新位置;</item>
+///   <item>Linux:<c>XDG_DOWNLOAD_DIR</c> 环境变量,没有则读 <c>user-dirs.dirs</c>;</item>
+///   <item>macOS:系统不支持重定向,由调用方回落到 <c>~/Downloads</c>。</item>
+/// </list>
+/// 取不到一律返回 null,由 <see cref="UserPathResolver.Downloads" /> 回落到 <c>~/Downloads</c>。
+/// </remarks>
+internal static partial class SystemFolders
+{
+    /// <summary>FOLDERID_Downloads。</summary>
+    private static readonly Guid FolderIdDownloads = new("374DE290-123F-4565-9164-39C4925E467B");
+
+    /// <summary>KF_FLAG_DONT_VERIFY:目录暂时不可达(如重定向到未连接的移动盘)时也返回路径,存在性由调用方判。</summary>
+    private const uint KfFlagDontVerify = 0x00004000;
+
+    /// <summary>系统"下载"目录;取不到返回 null。</summary>
+    /// <remarks>不做缓存:用户在运行期改了下载目录位置,下一次用到时就该生效。</remarks>
+    internal static string? Downloads()
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return WindowsDownloads();
+            }
+            return OperatingSystem.IsLinux() ? LinuxDownloads() : null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ExternalException)
+        {
+            // 问不到就当没有:下载目录不值得让调用方炸掉。
+            return null;
+        }
+    }
+
+    private static string? WindowsDownloads()
+    {
+        nint buffer = 0;
+        try
+        {
+            return SHGetKnownFolderPath(in FolderIdDownloads, KfFlagDontVerify, 0, out buffer) == 0 && buffer != 0
+                ? Marshal.PtrToStringUni(buffer)
+                : null;
+        }
+        finally
+        {
+            if (buffer != 0)
+            {
+                // 无论成败都要还:SHGetKnownFolderPath 用 CoTaskMemAlloc 分配返回串。
+                Marshal.FreeCoTaskMem(buffer);
+            }
+        }
+    }
+
+    /// <summary>
+    /// XDG 用户目录:先看环境变量(桌面会话通常不导出,但用户可以自己导),
+    /// 再读 <c>$XDG_CONFIG_HOME/user-dirs.dirs</c>(默认 <c>~/.config/user-dirs.dirs</c>)。
+    /// </summary>
+    private static string? LinuxDownloads()
+    {
+        if (Environment.GetEnvironmentVariable("XDG_DOWNLOAD_DIR") is { Length: > 0 } fromEnv)
+        {
+            return ExpandXdgValue(fromEnv);
+        }
+
+        string configHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") is { Length: > 0 } xdgConfig
+            ? xdgConfig
+            : Path.Combine(UserPathResolver.Home, ".config");
+        string file = Path.Combine(configHome, "user-dirs.dirs");
+        if (!File.Exists(file))
+        {
+            return null;
+        }
+
+        foreach (string raw in File.ReadLines(file))
+        {
+            string line = raw.Trim();
+            if (line.StartsWith('#') || !line.StartsWith("XDG_DOWNLOAD_DIR=", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            string value = line["XDG_DOWNLOAD_DIR=".Length..].Trim().Trim('"');
+            return value.Length == 0 ? null : ExpandXdgValue(value);
+        }
+        return null;
+    }
+
+    /// <summary>展开 user-dirs.dirs 里的 <c>$HOME</c> / <c>${HOME}</c> 前缀(该文件只用这一个变量)。</summary>
+    private static string ExpandXdgValue(string value)
+    {
+        ReadOnlySpan<string> prefixes = ["$HOME/", "${HOME}/"];
+        foreach (string prefix in prefixes)
+        {
+            if (value.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return Path.Combine(UserPathResolver.Home, value[prefix.Length..]);
+            }
+        }
+        return value is "$HOME" or "${HOME}" ? UserPathResolver.Home : value;
+    }
+
+    [LibraryImport("shell32.dll", EntryPoint = "SHGetKnownFolderPath")]
+    private static partial int SHGetKnownFolderPath(in Guid rfid, uint dwFlags, nint hToken, out nint ppszPath);
+}

--- a/src/VelaShell.Core/Models/UserPathResolver.cs
+++ b/src/VelaShell.Core/Models/UserPathResolver.cs
@@ -17,6 +17,19 @@ public static class UserPathResolver
     public static string Home => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
     /// <summary>
+    /// 系统"下载"目录:向系统要真实位置(Windows 的已知文件夹 / Linux 的 XDG 用户目录),
+    /// 问不到才回落到 <c>~/Downloads</c>。
+    /// </summary>
+    /// <remarks>
+    /// 不能直接拼 <c>~/Downloads</c>:Windows 上"下载"文件夹可以被改到任意位置(如 D:\Downloads),
+    /// 改过之后 <c>%USERPROFILE%\Downloads</c> 不是用户要的落点(#257)。见 <see cref="SystemFolders" />。
+    /// </remarks>
+    public static string Downloads =>
+        SystemFolders.Downloads() is { Length: > 0 } system
+            ? Normalize(system)
+            : Normalize(Path.Combine(Home, "Downloads"));
+
+    /// <summary>
     /// 把设置里的目录/路径解析成绝对路径:
     /// 空白 → <paramref name="fallback" />;<c>~</c> 开头 → 用户主目录下;
     /// 相对路径 → 用户主目录下;绝对路径 → 规范化后原样返回。
@@ -54,6 +67,12 @@ public static class UserPathResolver
     /// 同 <see cref="Resolve" />,但取值为空时回退到用户主目录。
     /// </summary>
     public static string ResolveOrHome(string? configured) => Resolve(configured, Home);
+
+    /// <summary>
+    /// 同 <see cref="Resolve" />,但取值为空时回退到系统下载目录 —— 下载目录设置留空即
+    /// "跟随系统",这是所有"下载落点"的唯一解析入口。
+    /// </summary>
+    public static string ResolveOrDownloads(string? configured) => Resolve(configured, Downloads);
 
     private static string Combine(string basePath, string relative) =>
         Normalize(Path.Combine(basePath, relative.TrimStart('/', '\\')));

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2488,7 +2488,7 @@
     <value>ローカルのダウンロードフォルダー</value>
   </data>
   <data name="SetTransfer_DownloadDirDesc" xml:space="preserve">
-    <value>ダウンロードしたファイルの既定の保存先</value>
+    <value>ダウンロードしたファイルの既定の保存先。空欄の場合はシステムの「ダウンロード」フォルダーに従います</value>
   </data>
   <data name="SetTransfer_DownloadLimit" xml:space="preserve">
     <value>ダウンロード速度制限</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2488,7 +2488,7 @@
     <value>로컬 다운로드 폴더</value>
   </data>
   <data name="SetTransfer_DownloadDirDesc" xml:space="preserve">
-    <value>다운로드한 파일의 기본 저장 위치</value>
+    <value>다운로드한 파일의 기본 저장 위치. 비워 두면 시스템 「다운로드」 폴더를 따릅니다</value>
   </data>
   <data name="SetTransfer_DownloadLimit" xml:space="preserve">
     <value>다운로드 속도 제한</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2585,7 +2585,7 @@ Paste anyway?</value>
     <value>Local download folder</value>
   </data>
   <data name="SetTransfer_DownloadDirDesc" xml:space="preserve">
-    <value>Default save location for downloaded files</value>
+    <value>Default save location for downloaded files; leave empty to follow the system Downloads folder</value>
   </data>
   <data name="SetTransfer_DownloadLimit" xml:space="preserve">
     <value>Download speed limit</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2676,7 +2676,7 @@
     <value>本地下载目录</value>
   </data>
   <data name="SetTransfer_DownloadDirDesc" xml:space="preserve">
-    <value>文件下载的默认保存位置</value>
+    <value>文件下载的默认保存位置,留空则跟随系统「下载」文件夹</value>
   </data>
   <data name="SetTransfer_DownloadLimit" xml:space="preserve">
     <value>下载速度限制</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2488,7 +2488,7 @@
     <value>本機下載目錄</value>
   </data>
   <data name="SetTransfer_DownloadDirDesc" xml:space="preserve">
-    <value>檔案下載的預設儲存位置</value>
+    <value>檔案下載的預設儲存位置,留空則跟隨系統「下載」資料夾</value>
   </data>
   <data name="SetTransfer_DownloadLimit" xml:space="preserve">
     <value>下載速度限制</value>

--- a/src/VelaShell.Core/VelaShell.Core.csproj
+++ b/src/VelaShell.Core/VelaShell.Core.csproj
@@ -5,6 +5,8 @@
          无需 en 卫星。中文卫星按脚本中性文化命名(zh-Hans/zh-Hant),使 zh-CN/zh-SG →
          zh-Hans、zh-TW/zh-HK/zh-MO → zh-Hant 沿标准回退链自动命中。 -->
     <NeutralLanguage>en</NeutralLanguage>
+    <!-- LibraryImport 源生成的封送桩是 unsafe 的(Models/SystemFolders.cs 要问 Windows 已知文件夹)。 -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/VelaShell/Services/ZModem/FolderZModemFileSink.cs
+++ b/src/VelaShell/Services/ZModem/FolderZModemFileSink.cs
@@ -36,7 +36,7 @@ internal sealed class FolderZModemFileSink(
         // 首个文件:弹目录选择框,结果缓存在本会话 sink 内。
         if (!_folderResolved)
         {
-            string suggested = ExpandHome(settings.Transfer.LocalDownloadDirectory);
+            string suggested = ExpandDownloadDirectory(settings.Transfer.LocalDownloadDirectory);
             var request = new ZModemFolderPromptRequest(suggested, metadata.FileName, metadata.Size);
             _sessionFolder = await _pickFolderAsync(request, cancellationToken).ConfigureAwait(false);
 
@@ -169,9 +169,9 @@ internal sealed class FolderZModemFileSink(
 
     /// <summary>
     /// 把配置的下载目录解析成绝对路径:<c>~</c> 与相对路径一律以用户主目录为基准,
-    /// 空值回退到用户主目录(见 <see cref="UserPathResolver" />)。
+    /// 空值回退到系统"下载"文件夹(见 <see cref="UserPathResolver" />)。
     /// </summary>
-    private static string ExpandHome(string path) => UserPathResolver.ResolveOrHome(path);
+    private static string ExpandDownloadDirectory(string path) => UserPathResolver.ResolveOrDownloads(path);
 
     /// <summary>把远端文件名归一为安全的纯文件名:剥离任何目录成分并替换非法字符。</summary>
     private static string SanitizeFileName(string remoteFileName)

--- a/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
+++ b/src/VelaShell/ViewModels/LocalFilePaneViewModel.cs
@@ -561,10 +561,10 @@ public sealed class LocalFilePaneViewModel : ReactiveObject
 
     /// <summary>
     /// 解析配置的下载目录:"~" 与相对路径一律以用户主目录为基准(见 <see cref="UserPathResolver" />),
-    /// 空值返回空串,交给调用方回退到用户主目录。
+    /// 空值跟随系统"下载"文件夹;该目录不可用时由调用方回退到用户主目录。
     /// </summary>
     private static string ExpandConfiguredPath(string configured) =>
-        UserPathResolver.Resolve(configured, string.Empty);
+        UserPathResolver.ResolveOrDownloads(configured);
 
     private static bool DirectoryIsAccessible(string path)
     {

--- a/src/VelaShell/Views/FileBrowserView.axaml.cs
+++ b/src/VelaShell/Views/FileBrowserView.axaml.cs
@@ -431,11 +431,11 @@ public partial class FileBrowserView : UserControl
         {
             return null;
         }
-        // "~" 与相对路径一律以用户主目录为基准(见 UserPathResolver);目录不存在时退回主目录,
-        // 绝不落回进程工作目录 —— 那是外部环境决定的,不是用户想要的落点(#120)。
+        // "~" 与相对路径一律以用户主目录为基准、留空则跟随系统"下载"文件夹(见 UserPathResolver);
+        // 目录不存在时退回主目录,绝不落回进程工作目录 —— 那是外部环境决定的,不是用户想要的落点(#120)。
         return await StorageDefaults.FolderAsync(
                    top,
-                   UserPathResolver.ResolveOrHome(vm.TransferOptions.LocalDownloadDirectory)
+                   UserPathResolver.ResolveOrDownloads(vm.TransferOptions.LocalDownloadDirectory)
                )
                ?? await StorageDefaults.HomeAsync(top);
     }

--- a/src/VelaShell/Views/Settings/TransferSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/TransferSettingsPage.axaml.cs
@@ -14,6 +14,8 @@ public partial class TransferSettingsPage : UserControl
     public TransferSettingsPage()
     {
         InitializeComponent();
+        // 留空 = 跟随系统"下载"文件夹;占位符直接显示它当前指向哪,免得空输入框看着像没配置好。
+        DownloadDirBox.PlaceholderText = UserPathResolver.Downloads;
     }
 
     private async void BrowseDownloadDir_Click(object? sender, RoutedEventArgs e)
@@ -26,10 +28,10 @@ public partial class TransferSettingsPage : UserControl
         {
             Title = Strings.Get("SelectDownloadFolder"),
             AllowMultiple = false,
-            // 起点用当前已配置的下载目录:改目录时从旧值出发比从头翻更顺手。
+            // 起点用当前已配置的下载目录(留空则是系统"下载"文件夹):改目录时从旧值出发比从头翻更顺手。
             SuggestedStartLocation = await StorageDefaults.FolderAsync(
                 top,
-                UserPathResolver.ResolveOrHome(DownloadDirBox.Text)
+                UserPathResolver.ResolveOrDownloads(DownloadDirBox.Text)
             ) ?? await StorageDefaults.HomeAsync(top)
         });
         if (folders.AsParallel().FirstOrDefault()?.TryGetLocalPath() is { Length: > 0 } path)

--- a/src/VelaShell/Views/StorageDefaults.cs
+++ b/src/VelaShell/Views/StorageDefaults.cs
@@ -43,9 +43,11 @@ internal static class StorageDefaults
     public static Task<IStorageFolder?> HomeAsync(TopLevel? top) =>
         FolderAsync(top, UserPathResolver.Home);
 
-    /// <summary>设置 → 文件传输里配置的下载目录;未配置或不存在时退回用户主目录。</summary>
+    /// <summary>
+    /// 设置 → 文件传输里配置的下载目录;未配置时跟随系统"下载"文件夹,两者都不可用时退回用户主目录。
+    /// </summary>
     public static async Task<IStorageFolder?> DownloadsAsync(TopLevel? top) =>
-        await FolderAsync(top, UserPathResolver.ResolveOrHome(await ConfiguredDownloadDirectoryAsync()))
+        await FolderAsync(top, UserPathResolver.ResolveOrDownloads(await ConfiguredDownloadDirectoryAsync()))
         ?? await HomeAsync(top);
 
     /// <summary>密钥目录 <c>~/.ssh</c>;不存在时退回用户主目录。</summary>

--- a/tests/VelaShell.Core.Tests/Models/AppSettingsNormalizeTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/AppSettingsNormalizeTests.cs
@@ -1,0 +1,58 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Tests.Models;
+
+/// <summary>
+/// 设置载入后的规整(<see cref="AppSettings.Normalize" />):把旧字段迁移到唯一权威字段。
+/// </summary>
+[TestClass]
+[TestCategory("DataStore")]
+public class AppSettingsNormalizeTests
+{
+    [TestMethod]
+    public void VisualBell_IsMigratedToBellMode()
+    {
+        AppSettings settings = new();
+        settings.TerminalBehavior.VisualBell = true;
+
+        settings.Normalize();
+
+        Assert.AreEqual("visual", settings.TerminalBehavior.BellMode);
+        Assert.IsFalse(settings.TerminalBehavior.VisualBell);
+    }
+
+    /// <summary>
+    /// 旧版把下载目录的默认值硬写成 "~/Downloads",Windows 上把"下载"文件夹改到别处的用户
+    /// 因此永远拿不到自己指定的位置(#257)。存量配置里的这个字面默认值要迁成空串 = 跟随系统。
+    /// </summary>
+    [TestMethod]
+    [DataRow("~/Downloads")]
+    [DataRow("~\\Downloads")]
+    [DataRow("  ~/Downloads  ")]
+    public void LegacyDefaultDownloadDirectory_IsMigratedToFollowSystem(string legacy)
+    {
+        AppSettings settings = new();
+        settings.Transfer.LocalDownloadDirectory = legacy;
+
+        settings.Normalize();
+
+        Assert.AreEqual(string.Empty, settings.Transfer.LocalDownloadDirectory);
+        Assert.AreEqual(UserPathResolver.Downloads, UserPathResolver.ResolveOrDownloads(settings.Transfer.LocalDownloadDirectory));
+    }
+
+    [TestMethod]
+    public void ExplicitDownloadDirectory_IsKept()
+    {
+        string chosen = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "vela-dl"));
+        AppSettings settings = new();
+        settings.Transfer.LocalDownloadDirectory = chosen;
+
+        settings.Normalize();
+
+        Assert.AreEqual(chosen, settings.Transfer.LocalDownloadDirectory);
+    }
+
+    [TestMethod]
+    public void DefaultDownloadDirectory_IsEmpty_MeaningFollowSystem() =>
+        Assert.AreEqual(string.Empty, new AppSettings().Transfer.LocalDownloadDirectory);
+}

--- a/tests/VelaShell.Core.Tests/Models/UserPathResolverTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/UserPathResolverTests.cs
@@ -79,4 +79,32 @@ public class UserPathResolverTests
     [TestMethod]
     public void ResolveOrHome_FallsBackToHome() =>
         Assert.AreEqual(Home, UserPathResolver.ResolveOrHome(null));
+
+    /// <summary>
+    /// 下载目录留空时跟随系统"下载"文件夹,而不是硬拼 <c>~/Downloads</c> —— 该文件夹在 Windows 上
+    /// 可被用户改到任意位置(#257)。真实位置因机器而异,这里只断言"是规范化过的绝对路径"。
+    /// </summary>
+    [TestMethod]
+    public void Downloads_IsRootedAbsolutePath()
+    {
+        string downloads = UserPathResolver.Downloads;
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(downloads));
+        Assert.IsTrue(Path.IsPathRooted(downloads), downloads);
+        Assert.AreEqual(Path.GetFullPath(downloads), downloads);
+    }
+
+    [TestMethod]
+    public void ResolveOrDownloads_EmptyValue_FallsBackToSystemDownloads()
+    {
+        Assert.AreEqual(UserPathResolver.Downloads, UserPathResolver.ResolveOrDownloads(null));
+        Assert.AreEqual(UserPathResolver.Downloads, UserPathResolver.ResolveOrDownloads("   "));
+    }
+
+    [TestMethod]
+    public void ResolveOrDownloads_ConfiguredValue_Wins() =>
+        Assert.AreEqual(
+            Path.GetFullPath(Path.Combine(Home, "somewhere")),
+            UserPathResolver.ResolveOrDownloads("~/somewhere")
+        );
 }


### PR DESCRIPTION
优化“下载目录”配置，默认值改为空以跟随系统下载文件夹。实现跨平台获取真实下载目录（Windows 调用 SHGetKnownFolderPath，Linux 读取 XDG，macOS 回退 ~/Downloads）。旧配置自动迁移，统一解析逻辑，留空时始终跟随系统目录。多语言描述同步更新，新增相关单元测试。允许 unsafe 代码以支持 P/Invoke。提升跨平台一致性和用户体验，避免目录重定向问题。