### PR TITLE
修复自绘标题栏拖动导致的光标异常

### DIFF
--- a/src/VelaShell.PluginHost/PluginHostShellWindow.cs
+++ b/src/VelaShell.PluginHost/PluginHostShellWindow.cs
@@ -1,9 +1,11 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
+using Avalonia.Threading;
 using VelaShell.PluginSdk.Ui;
 
 namespace VelaShell.PluginHost;
@@ -14,7 +16,7 @@ namespace VelaShell.PluginHost;
 /// 纯代码构建(PluginHost 不依赖 VelaShell.Controls);配色用宿主下发的 <c>Vela*</c> 令牌;
 /// caption 图标用几何 Path(lucide minus/square/x)。
 /// </summary>
-internal sealed class PluginHostShellWindow : Window
+internal sealed partial class PluginHostShellWindow : Window
 {
     private const double InnerRadius = 7;
 
@@ -279,7 +281,78 @@ internal sealed class PluginHostShellWindow : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        BeginWindowMoveDrag(e);
+    }
+
+    /// <summary>
+    /// 拖动窗口:Windows 上自己走一遍移动模态循环,避开 Avalonia 留下的 (0,0) 幽灵指针。
+    /// </summary>
+    /// <remarks>
+    /// Avalonia 的 Win32 <c>BeginMoveDrag</c> 在系统移动模态循环结束后,会给自己补一条
+    /// <c>WM_LBUTTONUP(wParam: 0, lParam: 0)</c> —— 真正那次弹起被模态循环吃掉了,不补
+    /// 指针状态会停在"按下"。但 <c>lParam = 0</c> 被解码成客户区 (0,0),pointer-over 因此
+    /// 落到窗口左上角,压在那里的正是 NorthWest 缩放抓取区(TopLeftCorner 光标),光标于是
+    /// 闪一下对角双箭头(主仓 issue #264)。这里照抄那两步,只把补发弹起的坐标换成光标真实位置。
+    ///
+    /// 与主程序 <c>VelaShell.Views.WindowMoveDrag</c> 同源;本工程按依赖纪律不引用任何
+    /// VelaShell.* 主程序工程,故复制一份,改动请两边同步。
+    /// </remarks>
+    /// <param name="e">触发拖动的指针按下事件。</param>
+    private void BeginWindowMoveDrag(PointerPressedEventArgs e)
+    {
+        const uint WM_SYSCOMMAND = 0x0112,
+            WM_LBUTTONUP = 0x0202;
+        const int SC_MOUSEMOVE = 0xF012; // SC_MOVE + HTCAPTION:鼠标发起的标题栏移动
+        if (!OperatingSystem.IsWindows() || !e.Pointer.IsPrimary || TryGetPlatformHandle() is not { } handle)
+        {
+            BeginMoveDrag(e);
+            return;
+        }
+        IntPtr hWnd = handle.Handle;
+        e.Pointer.Capture(null);
+        // 与 Avalonia 同样后置到派发队列:在输入处理栈里直接进模态循环会把这次派发一起卡住。
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _ = SendMessage(hWnd, WM_SYSCOMMAND, (IntPtr)SC_MOUSEMOVE, IntPtr.Zero); // 阻塞至松键
+                if (IsWindow(hWnd))
+                {
+                    _ = SendMessage(hWnd, WM_LBUTTONUP, IntPtr.Zero, CursorLParam(hWnd));
+                }
+            },
+            DispatcherPriority.Send
+        );
+    }
+
+    /// <summary>把光标当前位置打包成鼠标消息的 lParam(客户区物理坐标,低 16 位 x / 高 16 位 y)。</summary>
+    private static IntPtr CursorLParam(IntPtr hWnd)
+    {
+        if (!GetCursorPos(out POINT cursor) || !ScreenToClient(hWnd, ref cursor))
+        {
+            return IntPtr.Zero; // 取不到就退回 Avalonia 原本的行为,不会更差
+        }
+        return unchecked((IntPtr)(((cursor.Y & 0xFFFF) << 16) | (cursor.X & 0xFFFF)));
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsWindow(IntPtr hWnd);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetCursorPos(out POINT point);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ScreenToClient(IntPtr hWnd, ref POINT point);
+
+    [LibraryImport("user32.dll", EntryPoint = "SendMessageW")]
+    private static partial IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X, Y;
     }
 
     private void BeginResize(WindowEdge edge, PointerPressedEventArgs e)

--- a/src/VelaShell.PluginHost/VelaShell.PluginHost.csproj
+++ b/src/VelaShell.PluginHost/VelaShell.PluginHost.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>VelaShell 隔离插件宿主进程:经命名管道 RPC 连接主程序,在可收集 ALC 中装载并运行单个插件。</Description>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- 只依赖 SDK 契约,严禁引用任何 VelaShell.* 主程序工程(设计稿 02 §2 依赖纪律)。 -->
   </PropertyGroup>
 

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
@@ -55,7 +55,7 @@ public partial class AuthenticationDialogView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionDiagnosticsView.axaml.cs
@@ -32,7 +32,7 @@ public partial class ConnectionDiagnosticsView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -273,7 +273,7 @@ public partial class ConnectionProfileView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/HostKeyPromptView.axaml.cs
+++ b/src/VelaShell/Views/HostKeyPromptView.axaml.cs
@@ -59,7 +59,7 @@ public partial class HostKeyPromptView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 }

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml.cs
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml.cs
@@ -150,7 +150,7 @@ public partial class LocalPathPickerDialog : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 }

--- a/src/VelaShell/Views/MessageDialog.axaml.cs
+++ b/src/VelaShell/Views/MessageDialog.axaml.cs
@@ -212,7 +212,7 @@ public partial class MessageDialog : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 }

--- a/src/VelaShell/Views/PluginManagerWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginManagerWindow.axaml.cs
@@ -47,7 +47,7 @@ public partial class PluginManagerWindow : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        this.BeginWindowMoveDrag(e);
     }
 
     /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>

--- a/src/VelaShell/Views/PluginPanelWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginPanelWindow.axaml.cs
@@ -69,7 +69,7 @@ public partial class PluginPanelWindow : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        this.BeginWindowMoveDrag(e);
     }
 
     /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>

--- a/src/VelaShell/Views/PluginPermissionDialog.axaml.cs
+++ b/src/VelaShell/Views/PluginPermissionDialog.axaml.cs
@@ -48,7 +48,7 @@ public partial class PluginPermissionDialog : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/ProcessManagerView.axaml.cs
+++ b/src/VelaShell/Views/ProcessManagerView.axaml.cs
@@ -78,7 +78,7 @@ public partial class ProcessManagerView : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        this.BeginWindowMoveDrag(e);
     }
 
     /// <summary>

--- a/src/VelaShell/Views/RecordingPlayerView.axaml.cs
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml.cs
@@ -53,7 +53,7 @@ public partial class RecordingPlayerView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
@@ -245,7 +245,7 @@ public partial class RemoteFileEditorView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
+++ b/src/VelaShell/Views/ResourceMonitorWindow.axaml.cs
@@ -58,7 +58,7 @@ public partial class ResourceMonitorWindow : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        this.BeginWindowMoveDrag(e);
     }
 
     /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>

--- a/src/VelaShell/Views/SessionImportView.axaml.cs
+++ b/src/VelaShell/Views/SessionImportView.axaml.cs
@@ -61,7 +61,7 @@ public partial class SessionImportView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/SettingsView.axaml.cs
+++ b/src/VelaShell/Views/SettingsView.axaml.cs
@@ -84,7 +84,7 @@ public partial class SettingsView : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 

--- a/src/VelaShell/Views/TitleBarView.axaml.cs
+++ b/src/VelaShell/Views/TitleBarView.axaml.cs
@@ -139,7 +139,7 @@ public partial class TitleBarView : UserControl
             _pressPoint = e.GetPosition(this);
             return;
         }
-        window.BeginMoveDrag(e);
+        window.BeginWindowMoveDrag(e);
     }
 
     private void Bar_PointerMoved(object? sender, PointerEventArgs e)
@@ -166,7 +166,7 @@ public partial class TitleBarView : UserControl
             int offsetX = (int)(window.Bounds.Width * ratioX * scaling);
             int offsetY = (int)(_pressPoint.Y * scaling);
             window.Position = new PixelPoint(screenPoint.X - offsetX, screenPoint.Y - offsetY);
-            window.BeginMoveDrag(pressed);
+            window.BeginWindowMoveDrag(pressed);
         }, DispatcherPriority.Render);
     }
 

--- a/src/VelaShell/Views/TraceRouteWindow.axaml.cs
+++ b/src/VelaShell/Views/TraceRouteWindow.axaml.cs
@@ -85,7 +85,7 @@ public partial class TraceRouteWindow : Window
             e.Handled = true;
             return;
         }
-        BeginMoveDrag(e);
+        this.BeginWindowMoveDrag(e);
     }
 
     /// <summary>缩放抓取区。只认左键:系统 sizing 模态循环只在左键弹起时退出(#116)。</summary>

--- a/src/VelaShell/Views/TunnelHelpDialog.axaml.cs
+++ b/src/VelaShell/Views/TunnelHelpDialog.axaml.cs
@@ -33,7 +33,7 @@ public partial class TunnelHelpDialog : Window
     {
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            BeginMoveDrag(e);
+            this.BeginWindowMoveDrag(e);
         }
     }
 }

--- a/src/VelaShell/Views/WindowMoveDrag.cs
+++ b/src/VelaShell/Views/WindowMoveDrag.cs
@@ -1,0 +1,101 @@
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+
+namespace VelaShell.Views;
+
+/// <summary>
+/// 自绘标题栏"按住拖动窗口"的统一入口:Windows 上自己走一遍移动模态循环,以免踩到
+/// Avalonia 的 <see cref="Window.BeginMoveDrag" /> 留下的 (0,0) 幽灵指针(#264)。
+/// </summary>
+/// <remarks>
+/// 【问题】Avalonia 12 的 Win32 <c>BeginMoveDrag</c> 是:<c>SendMessage(WM_SYSCOMMAND, SC_MOUSEMOVE)</c>
+/// 进系统移动模态循环(该调用阻塞到松键为止),循环结束后再 <c>SendMessage(WM_LBUTTONUP, 0, 0)</c>
+/// 给自己补一条弹起 —— 真正那次弹起被模态循环吃掉了,不补 Avalonia 的指针状态会停在"按下"。
+/// 但补发的 <c>lParam = 0</c> 被照常解码成客户区 (0,0),于是 pointer-over 落到窗口左上角:
+/// 自绘窗体那里压着 NorthWest 缩放抓取区(Cursor=TopLeftCorner),光标便闪一下对角双箭头,
+/// 直到下一次真实鼠标移动才恢复(#264 截图);没有抓取区的对话框则在左上角留一块悬停高亮。
+///
+/// 【修法】照抄 Avalonia 那两步,只把补发弹起的坐标换成光标真实所在的客户区位置。
+/// 语义不变(Avalonia 该收的弹起照收),只是位置从"窗口左上角"变成"鼠标当前位置"。
+///
+/// 【为什么不挂 WndProc 钩子改那条消息】试过,会打死窗口:<c>Win32Properties.AddWndProcHookCallback</c>
+/// 是往同一个委托上 <c>+=</c>,而 <c>WindowImpl.WndProcMessageHandler</c> 取的是【最后一个回调】的
+/// 返回值。再挂一个钩子就会把 <see cref="Win32WindowChrome" /> 给 WM_NCHITTEST 返回的
+/// HTCLIENT/HTMAXBUTTON 覆盖成 0(HTNOWHERE),整窗对鼠标失聪 —— 拖不动、按钮也点不了。
+/// 一个窗口只能有一个真正决定返回值的钩子,已经被窗口装饰占了。
+/// </remarks>
+internal static partial class WindowMoveDrag
+{
+    private const uint WM_SYSCOMMAND = 0x0112,
+        WM_LBUTTONUP = 0x0202;
+
+    /// <summary>SC_MOVE(0xF010) + 2:低位是命中码 HTCAPTION,即"鼠标发起的标题栏移动"。</summary>
+    private const int SC_MOUSEMOVE = 0xF012;
+
+    /// <summary>
+    /// 开始拖动窗口。自绘标题栏一律走这里,不要直接调 <see cref="Window.BeginMoveDrag" />
+    /// (原因见类型注释;<c>WindowMoveDragUsageTests</c> 会把这条约定钉死)。
+    /// </summary>
+    /// <param name="window">被拖动的窗口。</param>
+    /// <param name="e">触发拖动的指针按下事件。</param>
+    public static void BeginWindowMoveDrag(this Window window, PointerPressedEventArgs e)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        ArgumentNullException.ThrowIfNull(e);
+        if (!OperatingSystem.IsWindows()
+            || !e.Pointer.IsPrimary
+            || window.TryGetPlatformHandle() is not { } handle)
+        {
+            window.BeginMoveDrag(e); // 非 Windows(或拿不到窗口句柄)照走平台实现
+            return;
+        }
+        IntPtr hWnd = handle.Handle;
+        e.Pointer.Capture(null);
+        // 与 Avalonia 同样后置到派发队列:在输入处理栈里直接进模态循环会把这次派发一起卡住。
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _ = SendMessage(hWnd, WM_SYSCOMMAND, SC_MOUSEMOVE, IntPtr.Zero); // 阻塞至松键
+                if (IsWindow(hWnd))
+                {
+                    _ = SendMessage(hWnd, WM_LBUTTONUP, IntPtr.Zero, CursorLParam(hWnd));
+                }
+            },
+            DispatcherPriority.Send
+        );
+    }
+
+    /// <summary>把光标当前位置打包成鼠标消息的 lParam(客户区物理坐标,低 16 位 x / 高 16 位 y)。</summary>
+    /// <remarks>取不到就退回 0 —— 与 Avalonia 原本的行为一致,不会更差。</remarks>
+    private static IntPtr CursorLParam(IntPtr hWnd)
+    {
+        if (!GetCursorPos(out POINT cursor) || !ScreenToClient(hWnd, ref cursor))
+        {
+            return IntPtr.Zero;
+        }
+        return unchecked((IntPtr)(((cursor.Y & 0xFFFF) << 16) | (cursor.X & 0xFFFF)));
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetCursorPos(out POINT point);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ScreenToClient(IntPtr hWnd, ref POINT point);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsWindow(IntPtr hWnd);
+
+    [LibraryImport("user32.dll", EntryPoint = "SendMessageW")]
+    private static partial IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X, Y;
+    }
+}

--- a/tests/VelaShell.Tests/Views/WindowMoveDragUsageTests.cs
+++ b/tests/VelaShell.Tests/Views/WindowMoveDragUsageTests.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 自绘标题栏起拖必须走 <c>BeginWindowMoveDrag</c> 的约定检查(静态扫描 .cs,不实例化窗口)。
+/// </summary>
+/// <remarks>
+/// Avalonia 12 的 Win32 <c>BeginMoveDrag</c> 在系统移动模态循环结束后,会给窗口补一条
+/// <c>WM_LBUTTONUP(wParam: 0, lParam: 0)</c>。那个 <c>lParam = 0</c> 被 Avalonia 解码成
+/// 客户区 (0,0) 的指针弹起,于是 pointer-over 落到窗口左上角 —— 自绘窗体的左上角正压着
+/// NorthWest 缩放抓取区(TopLeftCorner 光标),光标便闪一下对角双箭头(#264);没有抓取区的
+/// 对话框则会在左上角留下一块悬停高亮。
+///
+/// 修法在 <c>VelaShell.Views.WindowMoveDrag</c>:装 WndProc 钩子把那条消息的坐标换成光标真实
+/// 位置。但它只在【经 BeginWindowMoveDrag 起拖】时才装得上,任何一处直接调
+/// <c>BeginMoveDrag</c> 的窗体就重新长回这个毛病,故在此把约定钉死。
+///
+/// PluginHost 是独立进程、按依赖纪律不引用主程序工程,自带一份同源实现,不在本扫描范围内。
+/// </remarks>
+[TestClass]
+[TestCategory("WindowChrome")]
+public sealed partial class WindowMoveDragUsageTests
+{
+    /// <summary>允许出现裸 <c>BeginMoveDrag</c> 的文件:修复本身就在这里。</summary>
+    private const string FixFile = "WindowMoveDrag.cs";
+
+    [TestMethod]
+    public void SelfDrawnTitleBars_AlwaysDragThroughTheFixedEntryPoint()
+    {
+        var offenders = new List<string>();
+        foreach (string file in MainAppSourceFiles())
+        {
+            if (Path.GetFileName(file).Equals(FixFile, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            string[] lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                // 只揪真实调用(BeginMoveDrag( 前面不是 BeginWindow…),注释与文档里的提名不算。
+                string line = lines[i];
+                if (!BareBeginMoveDragRegex.IsMatch(line) || IsCommentLine(line))
+                {
+                    continue;
+                }
+                offenders.Add($"{Path.GetFileName(file)}:{i + 1} → {line.Trim()}");
+            }
+        }
+        Assert.IsEmpty(offenders,
+            "自绘标题栏起拖一律走 window.BeginWindowMoveDrag(e):直接调 BeginMoveDrag 会漏掉"
+            + " Avalonia 合成的 (0,0) 幽灵弹起纠正,点标题栏时光标闪成缩放样式(#264):\n"
+            + string.Join("\n", offenders));
+    }
+
+    private static bool IsCommentLine(string line)
+    {
+        string trimmed = line.TrimStart();
+        return trimmed.StartsWith("//", StringComparison.Ordinal) || trimmed.StartsWith("///", StringComparison.Ordinal);
+    }
+
+    /// <summary>主程序 src 下所有 .cs(跳过 obj/bin 与独立进程 PluginHost)。</summary>
+    private static IEnumerable<string> MainAppSourceFiles()
+    {
+        string root = SourceRoot();
+        char sep = Path.DirectorySeparatorChar;
+        return Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains($"{sep}obj{sep}", StringComparison.Ordinal)
+                && !file.Contains($"{sep}bin{sep}", StringComparison.Ordinal)
+                && !file.Contains($"{sep}VelaShell.PluginHost{sep}", StringComparison.Ordinal));
+    }
+
+    /// <summary>从测试输出目录向上找到仓库里的 src 目录。</summary>
+    private static string SourceRoot()
+    {
+        for (string? dir = AppContext.BaseDirectory; dir is not null; dir = Directory.GetParent(dir)?.FullName)
+        {
+            string candidate = Path.Combine(dir, "src");
+            if (File.Exists(Path.Combine(dir, "VelaShell.slnx")) && Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        throw new InvalidOperationException("未能从测试输出目录向上定位到仓库的 src 目录(找不到同级的 VelaShell.slnx)。");
+    }
+
+    [GeneratedRegex(@"(?<!BeginWindow)(?<!\w)BeginMoveDrag\s*\(")]
+    private static partial Regex BareBeginMoveDragRegex { get; }
+}

--- a/tests/VelaShell.Tests/Views/WndProcHookOwnershipTests.cs
+++ b/tests/VelaShell.Tests/Views/WndProcHookOwnershipTests.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 一个窗口只能有一个 WndProc 钩子的约定检查(静态扫描 .cs,不实例化窗口)。
+/// </summary>
+/// <remarks>
+/// <c>Win32Properties.AddWndProcHookCallback</c> 名字像"添加",实际是往同一个委托上 <c>+=</c>,
+/// 而 <c>WindowImpl.WndProcMessageHandler</c> 只取【最后一个回调】的返回值:
+/// <code>
+/// if (WndProcHookCallback is { } callback) ret = callback(hWnd, msg, wParam, lParam, ref handled);
+/// if (handled) return ret;
+/// </code>
+/// 于是第二个钩子哪怕什么都不干、老老实实 <c>return IntPtr.Zero</c>,也会把前一个钩子给
+/// WM_NCHITTEST 返回的 HTCLIENT/HTMAXBUTTON 覆盖成 0(HTNOWHERE)—— 整窗对鼠标失聪:
+/// 标题栏拖不动、最小化/关闭按钮点不了(2026-08-24 修 #264 时真踩过一次)。
+///
+/// 所以返回值的所有权归 <see cref="VelaShell.Views.Win32WindowChrome" /> 一家:要挂新的消息处理,
+/// 加到它的 <c>WndProc</c> 里去,不要再调一次 AddWndProcHookCallback。
+/// </remarks>
+[TestClass]
+[TestCategory("WindowChrome")]
+public sealed partial class WndProcHookOwnershipTests
+{
+    /// <summary>唯一允许注册 WndProc 钩子的文件。</summary>
+    private const string OwnerFile = "Win32WindowChrome.cs";
+
+    [TestMethod]
+    public void OnlyTheWindowChromeRegistersAWndProcHook()
+    {
+        var offenders = new List<string>();
+        foreach (string file in SourceFiles())
+        {
+            if (Path.GetFileName(file).Equals(OwnerFile, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            string[] lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                // 只揪真实调用;注释/文档里提名(比如解释为什么不能挂)不算。
+                if (!HookRegistrationRegex.IsMatch(line) || line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                offenders.Add($"{Path.GetFileName(file)}:{i + 1} → {line.Trim()}");
+            }
+        }
+        Assert.IsEmpty(offenders,
+            $"WndProc 钩子的返回值所有权归 {OwnerFile} 一家:AddWndProcHookCallback 是 += 多播,"
+            + "而 Avalonia 只取最后一个回调的返回值,第二个钩子会把 WM_NCHITTEST 的 HTCLIENT 覆盖成 "
+            + "HTNOWHERE,整窗对鼠标失聪(拖不动、按钮点不了)。新的消息处理请并入 Win32WindowChrome.WndProc:\n"
+            + string.Join("\n", offenders));
+    }
+
+    /// <summary>src 下所有 .cs(跳过 obj/bin)。</summary>
+    private static IEnumerable<string> SourceFiles()
+    {
+        string root = SourceRoot();
+        char sep = Path.DirectorySeparatorChar;
+        return Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains($"{sep}obj{sep}", StringComparison.Ordinal)
+                && !file.Contains($"{sep}bin{sep}", StringComparison.Ordinal));
+    }
+
+    /// <summary>从测试输出目录向上找到仓库里的 src 目录。</summary>
+    private static string SourceRoot()
+    {
+        for (string? dir = AppContext.BaseDirectory; dir is not null; dir = Directory.GetParent(dir)?.FullName)
+        {
+            string candidate = Path.Combine(dir, "src");
+            if (File.Exists(Path.Combine(dir, "VelaShell.slnx")) && Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        throw new InvalidOperationException("未能从测试输出目录向上定位到仓库的 src 目录(找不到同级的 VelaShell.slnx)。");
+    }
+
+    [GeneratedRegex(@"AddWndProcHookCallback\s*\(")]
+    private static partial Regex HookRegistrationRegex { get; }
+}


### PR DESCRIPTION
本次修复 Avalonia 12 在 Windows 下自绘标题栏拖动窗口时，因 BeginMoveDrag 遗留 (0,0) 幽灵指针导致的光标样式异常。新增 WindowMoveDrag.cs，统一提供 BeginWindowMoveDrag 扩展方法，通过 Win32 API 修正拖动行为并补发 WM_LBUTTONUP，避免光标异常。主程序及各窗口均替换为新方法，PluginHostShellWindow 独立实现同源逻辑。新增静态测试用例，确保所有自绘拖动均走修正入口，并限制 WndProc 钩子注册，防止鼠标事件失效。提升了自绘窗口拖动体验并防止回归。