### PR TITLE
重构快捷键分组与折叠交互，增强搜索体验

### DIFF
--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -24,27 +24,6 @@ public sealed record SettingsSection(string Name, string Icon);
 /// <summary>关于页的开源依赖条目(项目主页 + 许可证页面可点击跳转)。</summary>
 public sealed record DependencyInfo(string Name, string License, string Url, string LicenseUrl);
 
-/// <summary>快捷键参考页的分组与条目(纯展示;产品决定不提供自定义键位)。</summary>
-public sealed record ShortcutGroup(string Title, ShortcutItem[] Items);
-
-/// <summary>快捷键参考页的单条记录:一个功能名及其组合键序列。</summary>
-/// <param name="Label">功能说明文本(本地化后的动作名)。</param>
-/// <param name="Keys">组成该快捷键的按键序列(如 ["Ctrl", "N"];鼠标手势里也可以是「双击」「滚轮」这类本地化手势名)。</param>
-/// <param name="Note">生效条件备注(如「仅在会话已断开时」);无条件生效时为 <see langword="null" />。</param>
-public sealed record ShortcutItem(string Label, string[] Keys, string? Note = null)
-{
-    /// <summary>是否有生效条件备注(模板据此决定要不要占一行备注位)。</summary>
-    public bool HasNote => !string.IsNullOrEmpty(Note);
-
-    /// <summary>
-    /// 搜索匹配用的合并文本:动作名 + 键位 + 备注,一次过滤全覆盖。
-    /// 键位同时收录空格与加号两种拼法 —— 用户照着键帽敲的是 "Ctrl Shift F",
-    /// 照着文档敲的是 "Ctrl+Shift+F",两种都得能搜到。
-    /// </summary>
-    public string SearchText { get; } =
-        $"{Label} {string.Join(' ', Keys)} {string.Join('+', Keys)} {Note}";
-}
-
 /// <summary>设置窗口的视图模型:承载全部偏好项的绑定、分组页导航、外观即时预览与加载/保存流程。</summary>
 public class SettingsViewModel : ReactiveObject
 {
@@ -111,7 +90,18 @@ public class SettingsViewModel : ReactiveObject
         {
             int selectedSection = SelectedSectionIndex;
             Sections = BuildSections();
+            // 分组标题要跟着换语言,只能整表重建;折叠态挂在分组对象上,按稳定 id 搬到新表,
+            // 否则切一次语言就把用户收起来的分组全打开了。
+            Dictionary<string, bool> expansion = ShortcutGroups.ToDictionary(
+                group => group.Id,
+                group => group.IsExpanded,
+                StringComparer.Ordinal
+            );
             ShortcutGroups = ShortcutCatalog.Build();
+            foreach (ShortcutGroup group in ShortcutGroups)
+            {
+                group.IsExpanded = expansion.GetValueOrDefault(group.Id, true);
+            }
             this.RaisePropertyChanged(nameof(Sections));
             this.RaisePropertyChanged(nameof(ShortcutGroups));
             this.RaisePropertyChanged(nameof(ShortcutMacNote));
@@ -830,12 +820,14 @@ public class SettingsViewModel : ReactiveObject
 
     /// <summary>
     /// 按 <see cref="ShortcutFilter" /> 过滤后的分组;整组条目都被滤掉时该组不出现。
-    /// 未搜索过时直接是全量表本身(不另建一份,也就不会与 <see cref="ShortcutGroups" /> 走散)。
+    /// 元素与 <see cref="ShortcutGroups" /> 是同一批分组对象(折叠态挂在对象上,
+    /// 因此过滤前后不会丢),被滤掉的条目由各分组的 <see cref="ShortcutGroup.FilteredItems" /> 表达。
+    /// 首次访问时尚未搜索过,直接就是全量表。
     /// </summary>
     public ShortcutGroup[] FilteredShortcutGroups
     {
         get => field ??= ShortcutGroups;
-        private set => field = value;
+        private set;
     }
 
     /// <summary>过滤后是否还有条目(为 false 时页面显示「没有匹配的快捷键」)。</summary>
@@ -843,29 +835,70 @@ public class SettingsViewModel : ReactiveObject
 
     /// <summary>页脚计数文案:未过滤时是总数,过滤后是命中数。</summary>
     public string ShortcutCountText =>
-        Strings.Format("Sc_Count", ShortcutCatalog.Flatten(FilteredShortcutGroups).Count());
+        Strings.Format("Sc_Count", FilteredShortcutGroups.Sum(group => group.FilteredItems.Count));
 
     /// <summary>macOS 上终端内改用 Command 的说明(全局键位仍是 Ctrl,见 KeyboardShortcutService)。</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:将成员标记为 static", Justification = "<挂起>")]
     public string ShortcutMacNote => Strings.Get("Sc_MacNote");
 
-    /// <summary>重算过滤结果与其派生文案;换语言与改搜索词都经这里。</summary>
+    /// <summary>搜索期间被临时强制展开的分组,其原折叠态暂存于此,搜索清空后原样还回去。</summary>
+    private readonly Dictionary<string, bool> _shortcutExpansionBeforeSearch = [with(StringComparer.Ordinal)];
+
+    private bool _shortcutSearchActive;
+
+    /// <summary>
+    /// 重算过滤结果与其派生文案;换语言与改搜索词都经这里。
+    /// 折叠态的处理与快捷命令面板一致:搜索命中的分组临时强制展开(否则搜到了却看不见),
+    /// 搜索清空时把用户原来的折叠态还回去 —— 搜一次不该把人手动收起来的分组全打开。
+    /// </summary>
     private void RefreshShortcutView()
     {
-        string filter = ShortcutFilter.Trim();
-        FilteredShortcutGroups = filter.Length == 0
-            ? ShortcutGroups
-            : [.. ShortcutGroups
-                .Select(group => group with
+        string query = ShortcutFilter.Trim();
+        bool active = query.Length > 0;
+        if (active && !_shortcutSearchActive)
+        {
+            _shortcutExpansionBeforeSearch.Clear();
+            foreach (ShortcutGroup group in ShortcutGroups)
+            {
+                _shortcutExpansionBeforeSearch[group.Id] = group.IsExpanded;
+            }
+        }
+        else if (!active && _shortcutSearchActive)
+        {
+            foreach (ShortcutGroup group in ShortcutGroups)
+            {
+                group.IsExpanded = _shortcutExpansionBeforeSearch.GetValueOrDefault(group.Id, true);
+            }
+            _shortcutExpansionBeforeSearch.Clear();
+        }
+        _shortcutSearchActive = active;
+
+        List<ShortcutGroup> visible = [];
+        foreach (ShortcutGroup group in ShortcutGroups)
+        {
+            group.FilteredItems.Clear();
+            foreach (ShortcutItem item in group.Items)
+            {
+                if (!active || item.SearchText.Contains(query, StringComparison.CurrentCultureIgnoreCase))
                 {
-                    Items = [.. group.Items.Where(item =>
-                        item.SearchText.Contains(filter, StringComparison.CurrentCultureIgnoreCase))],
-                })
-                .Where(group => group.Items.Length > 0)];
+                    group.FilteredItems.Add(item);
+                }
+            }
+            if (group.FilteredItems.Count == 0)
+            {
+                continue;
+            }
+            if (active)
+            {
+                group.IsExpanded = true;
+            }
+            visible.Add(group);
+        }
+        FilteredShortcutGroups = [.. visible];
         this.RaisePropertyChanged(nameof(FilteredShortcutGroups));
         this.RaisePropertyChanged(nameof(HasShortcutMatches));
         this.RaisePropertyChanged(nameof(ShortcutCountText));
     }
-
 
     // ———— 下拉的索引映射(POCO 字符串 ↔ ComboBox SelectedIndex) ————
 

--- a/src/VelaShell/ViewModels/ShortcutCatalog.cs
+++ b/src/VelaShell/ViewModels/ShortcutCatalog.cs
@@ -1,6 +1,55 @@
+using System.Collections.ObjectModel;
+using ReactiveUI;
 using VelaShell.Core.Resources;
 
 namespace VelaShell.ViewModels;
+
+/// <summary>
+/// 快捷键参考页的一个分组(纯展示;产品决定不提供自定义键位)。
+/// 折叠态与快捷命令面板同语言:分组头是 ToggleButton,状态挂在这里。
+/// </summary>
+/// <param name="id">跨语言稳定的分组标识(取分组标题的资源键)—— 换语言会整表重建,靠它把折叠态搬过去。</param>
+/// <param name="title">已本地化的分组标题。</param>
+/// <param name="items">分组下的全部条目(不随搜索变化)。</param>
+public sealed class ShortcutGroup(string id, string title, ShortcutItem[] items) : ReactiveObject
+{
+    /// <summary>跨语言稳定的分组标识。</summary>
+    public string Id { get; } = id;
+
+    /// <summary>已本地化的分组标题。</summary>
+    public string Title { get; } = title;
+
+    /// <summary>分组下的全部条目。</summary>
+    public ShortcutItem[] Items { get; } = items;
+
+    /// <summary>应用搜索后的可见条目;未搜索时即全量。</summary>
+    public ObservableCollection<ShortcutItem> FilteredItems { get; } = [.. items];
+
+    /// <summary>分组是否展开。默认展开 —— 参考页的首要用途是通读,折叠是用户主动收纳。</summary>
+    public bool IsExpanded
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = true;
+}
+
+/// <summary>快捷键参考页的单条记录:一个功能名及其组合键序列。</summary>
+/// <param name="Label">功能说明文本(本地化后的动作名)。</param>
+/// <param name="Keys">组成该快捷键的按键序列(如 ["Ctrl", "N"];鼠标手势里也可以是「双击」「滚轮」这类本地化手势名)。</param>
+/// <param name="Note">生效条件备注(如「仅在会话已断开时」);无条件生效时为 <see langword="null" />。</param>
+public sealed record ShortcutItem(string Label, string[] Keys, string? Note = null)
+{
+    /// <summary>是否有生效条件备注(模板据此决定要不要占一行备注位)。</summary>
+    public bool HasNote => !string.IsNullOrEmpty(Note);
+
+    /// <summary>
+    /// 搜索匹配用的合并文本:动作名 + 键位 + 备注,一次过滤全覆盖。
+    /// 键位同时收录空格与加号两种拼法 —— 用户照着键帽敲的是 "Ctrl Shift F",
+    /// 照着文档敲的是 "Ctrl+Shift+F",两种都得能搜到。
+    /// </summary>
+    public string SearchText { get; } =
+        $"{Label} {string.Join(' ', Keys)} {string.Join('+', Keys)} {Note}";
+}
 
 /// <summary>
 /// 应用内全部快捷键的<b>唯一事实来源</b>:设置 → 快捷键页与 <c>docs/快捷键参考.md</c> 都以本表为准。
@@ -32,8 +81,7 @@ public static class ShortcutCatalog
     /// <summary>按当前界面语言构建完整分组表(语言切换后需重新调用)。</summary>
     public static ShortcutGroup[] Build() =>
         [
-            new(
-                T("Sc_GroupGlobal"),
+            Group("Sc_GroupGlobal",
                 [
                     Item("Cmd_NewSshConnection", [Ctrl, "N"]),
                     Item("Sc_NewTabAlias", [Ctrl, "T"]),
@@ -43,8 +91,7 @@ public static class ShortcutCatalog
                     Item("Sc_PaletteAlt", [Ctrl, "P"]),
                 ]
             ),
-            new(
-                T("Sc_GroupTabsAndPanels"),
+            Group("Sc_GroupTabsAndPanels",
                 [
                     Item("CloseTab", [Ctrl, "W"]),
                     Item("Sc_NextTab", [Ctrl, "Tab"]),
@@ -54,8 +101,7 @@ public static class ShortcutCatalog
                     Item("Cmd_ToggleLineGutter", [Ctrl, Shift, "L"]),
                 ]
             ),
-            new(
-                T("SetVm_SectionTerminal"),
+            Group("SetVm_SectionTerminal",
                 [
                     Item("Copy", [Ctrl, Shift, "C"]),
                     Item("Cmd_Paste", [Ctrl, Shift, "V"]),
@@ -77,8 +123,7 @@ public static class ShortcutCatalog
                     Item("Sc_CloseDisconnectedTab", ["Esc"], "Sc_NoteDisconnected"),
                 ]
             ),
-            new(
-                T("Sc_GroupCompletion"),
+            Group("Sc_GroupCompletion",
                 [
                     Item("Sc_CompletionPopup", [Alt, "Enter"]),
                     Item("Sc_SuggestNext", ["Down"], "Sc_NoteSuggestOpen"),
@@ -90,8 +135,7 @@ public static class ShortcutCatalog
                     Item("Sc_GhostAccept", ["End"]),
                 ]
             ),
-            new(
-                T("Sc_GroupMouse"),
+            Group("Sc_GroupMouse",
                 [
                     Item("Sc_OpenLink", [Ctrl, K("Sc_KeyLeftClick")]),
                     Item("Sc_SelectWord", [K("Sc_KeyDoubleClick")], "Sc_NoteRequiresSetting"),
@@ -108,8 +152,7 @@ public static class ShortcutCatalog
                     Item("Sc_ToggleFold", [K("Sc_KeyGutter"), K("Sc_KeyLeftClick")]),
                 ]
             ),
-            new(
-                T("Cmd_CommandPalette"),
+            Group("Cmd_CommandPalette",
                 [
                     Item("Sc_PaletteNext", ["Down"]),
                     Item("Sc_PalettePrev", ["Up"]),
@@ -117,8 +160,7 @@ public static class ShortcutCatalog
                     Item("Sc_PaletteClose", ["Esc"]),
                 ]
             ),
-            new(
-                T("Cmd_SftpFileManager"),
+            Group("Cmd_SftpFileManager",
                 [
                     Item("Sc_EditPath", [Ctrl, "L"]),
                     Item("Sc_CommitPath", ["Enter"]),
@@ -126,23 +168,20 @@ public static class ShortcutCatalog
                     Item("Sc_OpenEntry", [K("Sc_KeyDoubleClick")]),
                 ]
             ),
-            new(
-                T("Sc_GroupFileOperations"),
+            Group("Sc_GroupFileOperations",
                 [
                     Item("Sc_SaveInEditor", [Ctrl, "S"]),
                     Item("Sc_CloseEditor", ["Esc"], "Sc_NoteEditorOnly"),
                 ]
             ),
-            new(
-                T("Cmd_ProcessManager"),
+            Group("Cmd_ProcessManager",
                 [
                     Item("Sc_RefreshProcesses", ["F5"]),
                     Item("Sc_EndTask", ["Delete"], "Sc_NoteListFocused"),
                     Item("Sc_CloseWindow", ["Esc"]),
                 ]
             ),
-            new(
-                T("Sc_GroupDialogs"),
+            Group("Sc_GroupDialogs",
                 [
                     Item("Sc_DialogCancel", ["Esc"], "Sc_NoteAllDialogs"),
                     Item("Sc_DialogConfirm", ["Enter"]),
@@ -152,8 +191,7 @@ public static class ShortcutCatalog
                     Item("Sc_PasswordCopyBlocked", [Ctrl, "C"], "Sc_NotePasswordBlocked"),
                 ]
             ),
-            new(
-                T("Sc_GroupAi"),
+            Group("Sc_GroupAi",
                 [
                     Item("Sc_AiSend", ["Enter"]),
                     Item("Sc_AiNewline", [Shift, "Enter"]),
@@ -174,6 +212,9 @@ public static class ShortcutCatalog
 
     /// <summary>全部条目的扁平序列(计数与搜索用)。</summary>
     public static IEnumerable<ShortcutItem> Flatten(ShortcutGroup[] groups) => groups.SelectMany(group => group.Items);
+
+    /// <summary>分组标题的资源键同时充当分组 id —— 换语言重建后靠它把折叠态搬过去。</summary>
+    private static ShortcutGroup Group(string titleKey, ShortcutItem[] items) => new(titleKey, T(titleKey), items);
 
     private static ShortcutItem Item(string labelKey, string[] keys, string? noteKey = null) =>
         new(T(labelKey), keys, noteKey is null ? null : T(noteKey));

--- a/src/VelaShell/Views/Settings/ShortcutsPage.axaml
+++ b/src/VelaShell/Views/Settings/ShortcutsPage.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:VelaShell.ViewModels"
+             xmlns:pc="using:VelaShell.Controls.Controls"
              xmlns:loc="using:VelaShell.Localization"
              x:Class="VelaShell.Views.Settings.ShortcutsPage"
              x:DataType="vm:SettingsViewModel">
@@ -8,13 +9,42 @@
   <!-- 快捷键参考页(只读):条目全部来自 ShortcutCatalog,与 docs/快捷键参考.md 同源。
        新增绑定只需改目录,本页与文档一起跟着变;这里不放任何写死的键位。 -->
 
+  <UserControl.Styles>
+    <!-- 分组头:与代码片段页、侧栏快捷命令面板同款——压掉 Fluent ToggleButton 的强调色
+         选中态,展开状态只由箭头表达;底色沿用设置页表头的 VelaBgSidebar。 -->
+    <Style Selector="ToggleButton.group-header">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="12,8" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="ToggleButton.group-header /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgSidebar}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="ToggleButton.group-header:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgActive}" />
+    </Style>
+  </UserControl.Styles>
+
   <StackPanel Spacing="14">
     <StackPanel Spacing="2">
       <TextBlock Classes="page-title" Text="{loc:Localize SetShortcuts_Title}" />
       <TextBlock Classes="page-subtitle" Text="{loc:Localize SetShortcuts_Subtitle}" />
     </StackPanel>
 
-    <!-- 搜索:动作名、键位与生效条件一起匹配(ShortcutItem.SearchText)。 -->
+    <!-- 搜索:动作名、键位与生效条件一起匹配(ShortcutItem.SearchText)。
+         命中的分组会被临时展开,搜索清空后还原用户原本的折叠态。 -->
     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
       <TextBox Text="{Binding ShortcutFilter}"
                PlaceholderText="{loc:Localize Sc_FilterPlaceholder}" />
@@ -29,22 +59,51 @@
     <ItemsControl ItemsSource="{Binding FilteredShortcutGroups}">
       <ItemsControl.ItemsPanel>
         <ItemsPanelTemplate>
-          <StackPanel Spacing="14" />
+          <StackPanel Spacing="8" />
         </ItemsPanelTemplate>
       </ItemsControl.ItemsPanel>
       <ItemsControl.ItemTemplate>
         <DataTemplate x:DataType="vm:ShortcutGroup">
-          <StackPanel Spacing="8">
-            <TextBlock Classes="section-title" Text="{Binding Title}" />
-            <Border Classes="table">
-              <ItemsControl ItemsSource="{Binding Items}">
+          <Border Classes="table">
+            <StackPanel>
+              <ToggleButton Classes="group-header"
+                            IsChecked="{Binding IsExpanded, Mode=TwoWay}">
+                <Grid ColumnDefinitions="Auto,8,*,Auto">
+                  <Panel Width="11" Height="11" VerticalAlignment="Center">
+                    <pc:LucideIcon Width="11" Height="11"
+                                   Data="{StaticResource Icon.chevron-right}"
+                                   Foreground="{DynamicResource VelaTextTertiary}"
+                                   IsVisible="{Binding !IsExpanded}" />
+                    <pc:LucideIcon Width="11" Height="11"
+                                   Data="{StaticResource Icon.chevron-down}"
+                                   Foreground="{DynamicResource VelaTextTertiary}"
+                                   IsVisible="{Binding IsExpanded}" />
+                  </Panel>
+                  <TextBlock Grid.Column="2" Text="{Binding Title}"
+                             Foreground="{DynamicResource VelaTextSecondary}"
+                             FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold"
+                             VerticalAlignment="Center"
+                             TextTrimming="CharacterEllipsis" />
+                  <!-- 计数徽标:折叠后仍能一眼看出这组里有几条,不必展开确认。 -->
+                  <Border Grid.Column="3" Padding="6,1" CornerRadius="8"
+                          Background="{DynamicResource VelaBgInput}"
+                          VerticalAlignment="Center">
+                    <TextBlock Text="{Binding FilteredItems.Count}"
+                               Foreground="{DynamicResource VelaTextMuted}"
+                               FontSize="{DynamicResource VelaFontSize10}" />
+                  </Border>
+                </Grid>
+              </ToggleButton>
+
+              <ItemsControl ItemsSource="{Binding FilteredItems}"
+                            IsVisible="{Binding IsExpanded}">
                 <ItemsControl.ItemTemplate>
                   <DataTemplate x:DataType="vm:ShortcutItem">
-                    <!-- 行高改为自适应:带生效条件的条目要在动作名下面多排一行备注,
-                         写死 36px 会把备注裁掉。 -->
+                    <!-- 行高自适应:带生效条件的条目要在动作名下面多排一行备注,
+                         写死 36px 会把备注裁掉。分隔线画在上边框,免得最后一行与分组框重线。 -->
                     <Border MinHeight="36" Padding="12,7"
                             BorderBrush="{DynamicResource VelaBorderPrimary}"
-                            BorderThickness="0,0,0,1">
+                            BorderThickness="0,1,0,0">
                       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                         <StackPanel VerticalAlignment="Center" Spacing="2">
                           <TextBlock Text="{Binding Label}"
@@ -78,8 +137,8 @@
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>
-            </Border>
-          </StackPanel>
+            </StackPanel>
+          </Border>
         </DataTemplate>
       </ItemsControl.ItemTemplate>
     </ItemsControl>

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -446,12 +446,12 @@ public class SettingsViewModelTests
     public void ShortcutFilter_KeepsOnlyMatchingRows()
     {
         SettingsViewModel vm = CreateVm();
-        int total = vm.FilteredShortcutGroups.Sum(group => group.Items.Length);
+        int total = vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count);
 
         vm.ShortcutFilter = "F5";
 
         Assert.HasCount(1, vm.FilteredShortcutGroups, "F5 只在进程管理器一组里出现");
-        Assert.HasCount(1, vm.FilteredShortcutGroups[0].Items);
+        Assert.HasCount(1, vm.FilteredShortcutGroups[0].FilteredItems);
         Assert.IsTrue(vm.HasShortcutMatches);
         Assert.IsGreaterThan(1, total, "全量表不该只有一条,否则下面的收窄断言没意义");
     }
@@ -464,10 +464,10 @@ public class SettingsViewModelTests
         SettingsViewModel vm = CreateVm();
 
         vm.ShortcutFilter = "Ctrl+Shift+L";
-        int withPlus = vm.FilteredShortcutGroups.Sum(group => group.Items.Length);
+        int withPlus = vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count);
 
         vm.ShortcutFilter = "Ctrl Shift L";
-        int withSpaces = vm.FilteredShortcutGroups.Sum(group => group.Items.Length);
+        int withSpaces = vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count);
 
         Assert.AreEqual(1, withPlus, "加号写法搜不到 Ctrl+Shift+L");
         Assert.AreEqual(1, withSpaces, "空格写法搜不到 Ctrl Shift L");
@@ -486,16 +486,65 @@ public class SettingsViewModelTests
         Assert.IsFalse(vm.HasShortcutMatches);
     }
 
-    /// <summary>清空搜索词回到全量表本身(不是重建的另一份副本)。</summary>
+    /// <summary>清空搜索词(只剩空白也算清空)回到全量表。</summary>
     [TestMethod]
     [TestCategory("Settings")]
     public void ShortcutFilter_Cleared_RestoresFullCatalog()
     {
         SettingsViewModel vm = CreateVm();
+        int total = vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count);
         vm.ShortcutFilter = "F5";
 
         vm.ShortcutFilter = "   ";
 
-        Assert.AreSame(vm.ShortcutGroups, vm.FilteredShortcutGroups, "只有空白的搜索词等于没搜");
+        Assert.AreEqual(vm.ShortcutGroups.Length, vm.FilteredShortcutGroups.Length, "只有空白的搜索词等于没搜");
+        Assert.AreEqual(total, vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count));
+    }
+
+    // ———— 快捷键参考页的分组折叠 ————
+
+    /// <summary>分组默认展开:参考页的首要用途是通读,折叠是用户主动收纳。</summary>
+    [TestMethod]
+    [TestCategory("Settings")]
+    public void ShortcutGroups_DefaultToExpanded()
+    {
+        SettingsViewModel vm = CreateVm();
+
+        Assert.IsTrue(vm.ShortcutGroups.All(group => group.IsExpanded));
+    }
+
+    /// <summary>
+    /// 搜索命中的分组必须临时展开 —— 搜到了却因为分组是收起的而看不见,等于没搜。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Settings")]
+    public void ShortcutFilter_ForcesMatchingGroupOpen()
+    {
+        SettingsViewModel vm = CreateVm();
+        foreach (ShortcutGroup group in vm.ShortcutGroups)
+        {
+            group.IsExpanded = false;
+        }
+
+        vm.ShortcutFilter = "F5";
+
+        Assert.IsTrue(vm.FilteredShortcutGroups[0].IsExpanded, "命中的分组应被临时展开");
+    }
+
+    /// <summary>
+    /// 搜索清空后要把用户原本的折叠态还回去:搜一次不该把人手动收起来的分组全打开。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Settings")]
+    public void ShortcutFilter_Cleared_RestoresCollapsedState()
+    {
+        SettingsViewModel vm = CreateVm();
+        ShortcutGroup first = vm.ShortcutGroups[0];
+        first.IsExpanded = false;
+
+        vm.ShortcutFilter = "Ctrl";
+        vm.ShortcutFilter = string.Empty;
+
+        Assert.IsFalse(first.IsExpanded, "搜索结束后应还原为用户收起的状态");
     }
 }


### PR DESCRIPTION
重构 ShortcutGroup/Item 结构，支持分组折叠与过滤，折叠态可迁移。优化搜索与分组展开联动，搜索时临时展开命中分组，结束后还原。UI 增加分组 ToggleButton、计数徽标，统一样式。完善多语言支持与分组折叠迁移。补充分组折叠与过滤相关单元测试。整体提升可用性与可维护性。