### PR TITLE
增强SSH算法协商失败诊断与用户体验

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3737,6 +3737,27 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Msg_ProxyAuthFailed" xml:space="preserve">
     <value>プロキシ認証に失敗しました。ユーザー名とパスワードを確認してください。</value>
   </data>
+  <data name="Ssh_AlgoMismatchTitle" xml:space="preserve">
+    <value>接続先 ({0}) とこのクライアントに共通のアルゴリズムがありません。</value>
+  </data>
+  <data name="Ssh_AlgoMismatchPeer" xml:space="preserve">
+    <value>  接続先の提供: {0}</value>
+  </data>
+  <data name="Ssh_AlgoMismatchOurs" xml:space="preserve">
+    <value>  本クライアントの対応: {0}</value>
+  </data>
+  <data name="Ssh_AlgoKindKex" xml:space="preserve">
+    <value>鍵交換</value>
+  </data>
+  <data name="Ssh_AlgoKindHostKey" xml:space="preserve">
+    <value>ホスト鍵</value>
+  </data>
+  <data name="Ssh_AlgoKindEncryption" xml:space="preserve">
+    <value>暗号化</value>
+  </data>
+  <data name="Ssh_AlgoKindMac" xml:space="preserve">
+    <value>完全性 (MAC)</value>
+  </data>
   <data name="Plugin_ProtocolUnavailable" xml:space="preserve">
     <value>このプロトコルを提供するプラグインが利用できません。プラグイン管理画面でインストールまたは有効化してください。</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3737,6 +3737,27 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Msg_ProxyAuthFailed" xml:space="preserve">
     <value>프록시 인증에 실패했습니다. 사용자 이름과 비밀번호를 확인하세요.</value>
   </data>
+  <data name="Ssh_AlgoMismatchTitle" xml:space="preserve">
+    <value>상대 서버({0})와 이 클라이언트 간에 공통 알고리즘이 없습니다.</value>
+  </data>
+  <data name="Ssh_AlgoMismatchPeer" xml:space="preserve">
+    <value>  서버 제공: {0}</value>
+  </data>
+  <data name="Ssh_AlgoMismatchOurs" xml:space="preserve">
+    <value>  클라이언트 지원: {0}</value>
+  </data>
+  <data name="Ssh_AlgoKindKex" xml:space="preserve">
+    <value>키 교환</value>
+  </data>
+  <data name="Ssh_AlgoKindHostKey" xml:space="preserve">
+    <value>호스트 키</value>
+  </data>
+  <data name="Ssh_AlgoKindEncryption" xml:space="preserve">
+    <value>암호화</value>
+  </data>
+  <data name="Ssh_AlgoKindMac" xml:space="preserve">
+    <value>무결성(MAC)</value>
+  </data>
   <data name="Plugin_ProtocolUnavailable" xml:space="preserve">
     <value>이 프로토콜을 제공하는 플러그인을 사용할 수 없습니다. 플러그인 관리에서 설치하거나 활성화하세요.</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3738,6 +3738,27 @@ Overwrite it?</value>
   <data name="Msg_ProxyAuthFailed" xml:space="preserve">
     <value>Proxy authentication failed; check the proxy username and password.</value>
   </data>
+  <data name="Ssh_AlgoMismatchTitle" xml:space="preserve">
+    <value>The peer ({0}) and this client have no algorithm in common.</value>
+  </data>
+  <data name="Ssh_AlgoMismatchPeer" xml:space="preserve">
+    <value>  peer offers: {0}</value>
+  </data>
+  <data name="Ssh_AlgoMismatchOurs" xml:space="preserve">
+    <value>  this client supports: {0}</value>
+  </data>
+  <data name="Ssh_AlgoKindKex" xml:space="preserve">
+    <value>Key exchange</value>
+  </data>
+  <data name="Ssh_AlgoKindHostKey" xml:space="preserve">
+    <value>Host key</value>
+  </data>
+  <data name="Ssh_AlgoKindEncryption" xml:space="preserve">
+    <value>Encryption</value>
+  </data>
+  <data name="Ssh_AlgoKindMac" xml:space="preserve">
+    <value>Integrity (MAC)</value>
+  </data>
   <data name="Plugin_ProtocolUnavailable" xml:space="preserve">
     <value>The plugin providing this protocol is unavailable. Install or enable it in the plugin manager.</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3829,6 +3829,27 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Msg_ProxyAuthFailed" xml:space="preserve">
     <value>代理认证失败,请检查代理用户名与密码。</value>
   </data>
+  <data name="Ssh_AlgoMismatchTitle" xml:space="preserve">
+    <value>对端({0})与本客户端没有共同的算法。</value>
+  </data>
+  <data name="Ssh_AlgoMismatchPeer" xml:space="preserve">
+    <value>  对端提供:{0}</value>
+  </data>
+  <data name="Ssh_AlgoMismatchOurs" xml:space="preserve">
+    <value>  本客户端支持:{0}</value>
+  </data>
+  <data name="Ssh_AlgoKindKex" xml:space="preserve">
+    <value>密钥交换</value>
+  </data>
+  <data name="Ssh_AlgoKindHostKey" xml:space="preserve">
+    <value>主机密钥</value>
+  </data>
+  <data name="Ssh_AlgoKindEncryption" xml:space="preserve">
+    <value>加密</value>
+  </data>
+  <data name="Ssh_AlgoKindMac" xml:space="preserve">
+    <value>完整性(MAC)</value>
+  </data>
   <data name="Plugin_ProtocolUnavailable" xml:space="preserve">
     <value>提供该协议的插件当前不可用。请在插件管理页安装或启用它。</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3737,6 +3737,27 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Msg_ProxyAuthFailed" xml:space="preserve">
     <value>代理驗證失敗,請檢查代理使用者名稱與密碼。</value>
   </data>
+  <data name="Ssh_AlgoMismatchTitle" xml:space="preserve">
+    <value>對端({0})與本用戶端沒有共同的演算法。</value>
+  </data>
+  <data name="Ssh_AlgoMismatchPeer" xml:space="preserve">
+    <value>  對端提供:{0}</value>
+  </data>
+  <data name="Ssh_AlgoMismatchOurs" xml:space="preserve">
+    <value>  本用戶端支援:{0}</value>
+  </data>
+  <data name="Ssh_AlgoKindKex" xml:space="preserve">
+    <value>金鑰交換</value>
+  </data>
+  <data name="Ssh_AlgoKindHostKey" xml:space="preserve">
+    <value>主機金鑰</value>
+  </data>
+  <data name="Ssh_AlgoKindEncryption" xml:space="preserve">
+    <value>加密</value>
+  </data>
+  <data name="Ssh_AlgoKindMac" xml:space="preserve">
+    <value>完整性(MAC)</value>
+  </data>
   <data name="Plugin_ProtocolUnavailable" xml:space="preserve">
     <value>提供該協定的外掛程式目前無法使用。請在外掛程式管理頁安裝或啟用它。</value>
   </data>

--- a/src/VelaShell.Infrastructure/Ssh/SshAlgorithmDiagnostics.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshAlgorithmDiagnostics.cs
@@ -1,0 +1,105 @@
+using Tmds.Ssh;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.Infrastructure.Ssh;
+
+/// <summary>
+/// 把 <c>KeyExchangeFailed</c> 翻译成用户能照着办的一段话:哪一类算法没有交集、对端提供了什么、
+/// 本客户端支持什么。
+/// <para>
+/// 底层库给的是一句 "No common encryption algorithm." —— 它没说对端提供的是什么,也没说我们
+/// 支持什么,用户拿到手里做不了任何事。补上这两个名单,才谈得上"去把服务端配置改成 X"或者
+/// "这台设备太老,本客户端连不了"。
+/// </para>
+/// <para>
+/// "本客户端支持什么"刻意从 <see cref="SshClientSettings" /> 现读而不是写死:底层库升级增删算法时,
+/// 写死的那份会悄悄变成假话 —— 而这段话恰恰是用户唯一的判断依据。
+/// </para>
+/// </summary>
+internal static class SshAlgorithmDiagnostics
+{
+    /// <summary>
+    /// 5 秒:用户已经在等一个失败的结果了,诊断不能再让他多等太久;
+    /// 而能走到协商这一步说明 TCP 是通的,正常对端一个来回远用不了这么久。
+    /// </summary>
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// 探一次对端并给出差异说明;探不到、或每一类算法其实都有交集(失败另有原因)时返回
+    /// <see langword="null" />,由调用方保持原样的错误消息。
+    /// </summary>
+    public static async Task<string?> TryDescribeAsync(SshClientSettings settings, CancellationToken cancellationToken)
+    {
+        SshPeerAlgorithms? peer = await SshAlgorithmProbe
+                                        .TryProbeAsync(settings.HostName, settings.Port, ProbeTimeout, cancellationToken)
+                                        .ConfigureAwait(false);
+        if (peer is null)
+        {
+            return null;
+        }
+
+        List<string> lines = [];
+        AddIfDisjoint(lines, Strings.Get("Ssh_AlgoKindKex"), peer.KeyExchange, settings.KeyExchangeAlgorithms);
+        AddIfDisjoint(lines, Strings.Get("Ssh_AlgoKindHostKey"), peer.HostKey, settings.ServerHostKeyAlgorithms);
+        AddDirectional(lines, Strings.Get("Ssh_AlgoKindEncryption"),
+                       peer.EncryptionServerToClient, settings.EncryptionAlgorithmsServerToClient,
+                       peer.EncryptionClientToServer, settings.EncryptionAlgorithmsClientToServer);
+        AddDirectional(lines, Strings.Get("Ssh_AlgoKindMac"),
+                       peer.MacServerToClient, settings.MacAlgorithmsServerToClient,
+                       peer.MacClientToServer, settings.MacAlgorithmsClientToServer);
+        if (lines.Count == 0)
+        {
+            return null;
+        }
+        lines.Insert(0, Strings.Format("Ssh_AlgoMismatchTitle", peer.ServerVersion));
+        return string.Join('\n', lines);
+    }
+
+    /// <summary>
+    /// 收发两个方向各有一份名单,但现实里两份几乎总是一样。一样时只报一行,免得同一件事说两遍;
+    /// 真不一样时两行都报 —— 那种服务器已经够反常,不该再被我们合并掉细节。
+    /// </summary>
+    private static void AddDirectional(
+        List<string> lines, string kind,
+        IReadOnlyList<string> peerServerToClient, IEnumerable<string> oursServerToClient,
+        IReadOnlyList<string> peerClientToServer, IEnumerable<string> oursClientToServer)
+    {
+        AddIfDisjoint(lines, kind, peerServerToClient, oursServerToClient);
+        if (!peerClientToServer.SequenceEqual(peerServerToClient, StringComparer.Ordinal))
+        {
+            AddIfDisjoint(lines, kind, peerClientToServer, oursClientToServer);
+        }
+    }
+
+    /// <summary>
+    /// 两份名单没有任何交集时记三行(类别 / 对端提供 / 本端支持);有交集(或任一份为空)
+    /// 说明这一类不是失败原因。
+    /// </summary>
+    /// <remarks>
+    /// 拆成三行而不是挤成一行:名单动辄六七个算法名,挤在一行里换行之后就成了一团,
+    /// 用户要对着找"我这边有没有对端要的那个"根本看不下去。
+    /// </remarks>
+    private static void AddIfDisjoint(List<string> lines, string kind, IReadOnlyList<string> peer, IEnumerable<string> ours)
+    {
+        string[] mine = [.. ours];
+        if (peer.Count == 0 || mine.Length == 0 || peer.Intersect(mine, StringComparer.Ordinal).Any())
+        {
+            return;
+        }
+        lines.Add(kind);
+        lines.Add(Strings.Format("Ssh_AlgoMismatchPeer", string.Join(", ", peer)));
+        lines.Add(Strings.Format("Ssh_AlgoMismatchOurs", string.Join(", ", mine.Where(IsWorthShowing))));
+    }
+
+    /// <summary>
+    /// 证书变体(<c>*-cert-v01@openssh.com</c>)不列进"本客户端支持"。
+    /// </summary>
+    /// <remarks>
+    /// 它们只在对端出示 OpenSSH **证书**时才用得上,而会走到这条诊断的对端出示的是普通主机密钥 ——
+    /// 列出来既不能指导用户改配置,还把六个可用算法淹没在十二行里(实测那台堡垒机就是这样)。
+    /// 交集判断仍用完整名单,只是显示时不摆出来:少显示不会改变判断结果,证书算法真能匹配上时
+    /// 压根不会走到这里。
+    /// </remarks>
+    private static bool IsWorthShowing(string algorithm) =>
+        !algorithm.Contains("-cert-", StringComparison.Ordinal);
+}

--- a/src/VelaShell.Infrastructure/Ssh/SshAlgorithmProbe.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshAlgorithmProbe.cs
@@ -1,0 +1,199 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text;
+
+namespace VelaShell.Infrastructure.Ssh;
+
+/// <summary>对端在 <c>SSH_MSG_KEXINIT</c> 里报出来的算法名单(原样,不做规整)。</summary>
+public sealed record SshPeerAlgorithms
+{
+    /// <summary>对端的版本串(<c>SSH-2.0-OpenSSH_9.5</c> 这种)。</summary>
+    public required string ServerVersion { get; init; }
+
+    /// <summary>密钥交换算法。</summary>
+    public required IReadOnlyList<string> KeyExchange { get; init; }
+
+    /// <summary>主机密钥算法。</summary>
+    public required IReadOnlyList<string> HostKey { get; init; }
+
+    /// <summary>加密算法(客户端 → 服务端)。</summary>
+    public required IReadOnlyList<string> EncryptionClientToServer { get; init; }
+
+    /// <summary>加密算法(服务端 → 客户端)。</summary>
+    public required IReadOnlyList<string> EncryptionServerToClient { get; init; }
+
+    /// <summary>完整性算法(客户端 → 服务端)。</summary>
+    public required IReadOnlyList<string> MacClientToServer { get; init; }
+
+    /// <summary>完整性算法(服务端 → 客户端)。</summary>
+    public required IReadOnlyList<string> MacServerToClient { get; init; }
+}
+
+/// <summary>
+/// 算法协商失败后的回探:再开一条 TCP,做一次 SSH 版本串交换,读对端的第一个
+/// <c>SSH_MSG_KEXINIT</c>,把它提供的算法名单取出来。
+/// <para>
+/// 存在的理由是 <c>KeyExchangeFailed</c> 这个错误本身什么都没说明:用户只看到"连不上",
+/// 而真正该知道的是"对端只提供 aes128-ctr,本客户端一个都不支持"。这条信息没法从失败的
+/// 连接里拿到 —— 底层库没有把对端的 KEXINIT 暴露出来 —— 所以只能再问一次。
+/// </para>
+/// <para>
+/// KEXINIT 是握手的第一个包,处在**加密之前**的明文阶段,因此读它既不需要认证,也不发送
+/// 任何凭据:本探针只发一行版本串,读一个包,然后关闭。代价是对端会多看到一条建立后立刻
+/// 断开的连接(日志里多一行),所以只在确认协商失败后跑一次,绝不放在正常连接路径上。
+/// </para>
+/// </summary>
+public static class SshAlgorithmProbe
+{
+    /// <summary>SSH_MSG_KEXINIT。</summary>
+    private const byte MsgKexInit = 20;
+
+    /// <summary>RFC 4253 §4.2:版本串含 CR LF 不超过 255 字节。</summary>
+    private const int MaxIdentificationLine = 255;
+
+    /// <summary>版本串之前允许有若干行 banner(法律声明之类);给个上限免得被无限喂数据。</summary>
+    private const int MaxIdentificationLines = 64;
+
+    /// <summary>RFC 4253 §6 要求实现至少支持 35000 字节的包;KEXINIT 远小于此。</summary>
+    private const int MaxPacketLength = 35000;
+
+    /// <summary>msg 类型 1 字节 + cookie 16 字节,后面才是第一个 name-list。</summary>
+    private const int CookieEnd = 1 + 16;
+
+    /// <summary>KEXINIT 里的 name-list 个数(kex、主机密钥、加密 ×2、MAC ×2、压缩 ×2、语言 ×2)。</summary>
+    private const int NameListCount = 10;
+
+    /// <summary>
+    /// 探一次对端算法;任何失败(连不上、超时、不是 SSH、包读不全)一律返回 <see langword="null" />,
+    /// 绝不抛 —— 调用方正走在错误路径上,诊断失败最多是少一段说明,不能再掀一次异常。
+    /// </summary>
+    public static async Task<SshPeerAlgorithms?> TryProbeAsync(
+        string host, int port, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+        try
+        {
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(host, port, cts.Token).ConfigureAwait(false);
+            await using NetworkStream stream = tcp.GetStream();
+            if (await ReadIdentificationAsync(stream, cts.Token).ConfigureAwait(false) is not { } serverVersion)
+            {
+                return null;
+            }
+            // 对端要等我们的版本串才会发 KEXINIT(OpenSSH 会先发,但不是所有实现都这样)。
+            byte[] identification = Encoding.ASCII.GetBytes("SSH-2.0-VelaShell_Probe\r\n");
+            await stream.WriteAsync(identification, cts.Token).ConfigureAwait(false);
+            return await ReadKexInitAsync(stream, serverVersion, cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or SocketException or EndOfStreamException
+                                       or OperationCanceledException or ObjectDisposedException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>读到第一行以 <c>SSH-</c> 开头的版本串;之前的 banner 行原样丢掉。</summary>
+    private static async Task<string?> ReadIdentificationAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var line = new StringBuilder(MaxIdentificationLine);
+        byte[] one = new byte[1];
+        for (int lines = 0; lines < MaxIdentificationLines;)
+        {
+            if (await stream.ReadAsync(one, cancellationToken).ConfigureAwait(false) == 0)
+            {
+                return null;
+            }
+            if (one[0] != (byte)'\n')
+            {
+                // 超长且还没换行:对面多半不是 SSH(HTTP 服务、TLS 端口),别再往内存里堆。
+                if (line.Length >= MaxIdentificationLine)
+                {
+                    return null;
+                }
+                line.Append((char)one[0]);
+                continue;
+            }
+            string text = line.ToString().TrimEnd('\r');
+            line.Clear();
+            lines++;
+            if (text.StartsWith("SSH-", StringComparison.Ordinal))
+            {
+                return text;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>读一个明文二进制包并按 KEXINIT 解析。</summary>
+    /// <remarks>
+    /// 明文阶段的包结构(RFC 4253 §6):<c>uint32 包长 | byte 填充长 | payload | 填充</c>。
+    /// 这里不做 MAC 校验 —— 密钥还没协商出来,明文阶段本来就没有 MAC。
+    /// </remarks>
+    private static async Task<SshPeerAlgorithms?> ReadKexInitAsync(
+        Stream stream, string serverVersion, CancellationToken cancellationToken)
+    {
+        byte[] header = new byte[4];
+        await stream.ReadExactlyAsync(header, cancellationToken).ConfigureAwait(false);
+        uint packetLength = BinaryPrimitives.ReadUInt32BigEndian(header);
+        if (packetLength is < 8 or > MaxPacketLength)
+        {
+            return null;
+        }
+        byte[] packet = new byte[packetLength];
+        await stream.ReadExactlyAsync(packet, cancellationToken).ConfigureAwait(false);
+
+        int payloadLength = (int)packetLength - 1 - packet[0];
+        if (payloadLength <= CookieEnd)
+        {
+            return null;
+        }
+        ReadOnlySpan<byte> payload = packet.AsSpan(1, payloadLength);
+        if (payload[0] != MsgKexInit)
+        {
+            return null;
+        }
+
+        int offset = CookieEnd;
+        string[] lists = new string[NameListCount];
+        for (int i = 0; i < NameListCount; i++)
+        {
+            if (!TryReadNameList(payload, ref offset, out lists[i]))
+            {
+                return null;
+            }
+        }
+        return new SshPeerAlgorithms
+        {
+            ServerVersion = serverVersion,
+            KeyExchange = Split(lists[0]),
+            HostKey = Split(lists[1]),
+            EncryptionClientToServer = Split(lists[2]),
+            EncryptionServerToClient = Split(lists[3]),
+            MacClientToServer = Split(lists[4]),
+            MacServerToClient = Split(lists[5])
+        };
+    }
+
+    /// <summary>读一条 <c>uint32 长度 + ASCII</c> 的 name-list;越界即判包不完整。</summary>
+    private static bool TryReadNameList(ReadOnlySpan<byte> payload, ref int offset, out string value)
+    {
+        value = string.Empty;
+        if (offset + 4 > payload.Length)
+        {
+            return false;
+        }
+        uint length = BinaryPrimitives.ReadUInt32BigEndian(payload[offset..]);
+        offset += 4;
+        if (length > (uint)(payload.Length - offset))
+        {
+            return false;
+        }
+        value = Encoding.ASCII.GetString(payload.Slice(offset, (int)length));
+        offset += (int)length;
+        return true;
+    }
+
+    private static IReadOnlyList<string> Split(string nameList) =>
+        nameList.Length == 0 ? [] : nameList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSshClientWrapper.cs
@@ -119,13 +119,45 @@ public sealed class TmdsSshClientWrapper : ISshClientWrapper
             SafeDisposeClient(client);
             // 代理拨号/握手失败时,Tmds 只看到连接被断;用中继记录的真实原因报错。
             Exception? proxyError = _relay?.Error;
+            // 算法协商失败时回探一次对端的 KEXINIT,把"对端提供什么、我们支持什么"补进消息。
+            // 必须赶在 DisposeRelay 之前:走代理时 _settings.HostName 指的正是那条环回中继。
+            string? mismatch = proxyError is null
+                ? await TryDescribeAlgorithmMismatchAsync(ex, cancellationToken).ConfigureAwait(false)
+                : null;
             DisposeRelay();
             if (proxyError is not null)
                 throw new VelaSshConnectionException(proxyError.Message, proxyError);
+            if (mismatch is not null)
+                throw new VelaSshConnectionException($"{ex.Message}\n{mismatch}", ex);
             if (TmdsSshInterop.Translate(ex, cancellationToken) is { } translated) throw translated;
             throw;
         }
         _client = client;
+    }
+
+    /// <summary>
+    /// 只在算法协商失败(<c>KeyExchangeFailed</c>)时回探对端算法名单。其余失败原因 —— 认证不过、
+    /// 超时、根本连不上 —— 本身已经说清楚了,再去开一条连接只是白白打扰对端。
+    /// </summary>
+    /// <remarks>
+    /// 诊断绝不能改变失败本身:探不到就返回 null,原来的异常照常抛出。
+    /// </remarks>
+    private async Task<string?> TryDescribeAlgorithmMismatchAsync(Exception ex, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested
+            || TmdsSshInterop.ExtractConnectFailedReason(ex.Message) is not "KeyExchangeFailed")
+        {
+            return null;
+        }
+        try
+        {
+            return await SshAlgorithmDiagnostics.TryDescribeAsync(_settings, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception probeError)
+        {
+            System.Diagnostics.Trace.WriteLine($"[VelaShell] SSH algorithm probe failed: {probeError}");
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/VelaShell.Infrastructure/Startup/XshellLaunchParser.cs
+++ b/src/VelaShell.Infrastructure/Startup/XshellLaunchParser.cs
@@ -125,6 +125,12 @@ public static class XshellLaunchParser
     /// 刻意手写而不是丢给 <see cref="Uri" />:堡垒机现发的一次性密码里出现未转义的
     /// <c>@ : / #</c> 是常态,<see cref="Uri" /> 遇到就直接判非法 URI 或把主机截错;
     /// 而这里按「最后一个 @ 才是主机分界」来切,天然容得下密码里的 @。
+    /// <para>
+    /// 同理,路径/查询/片段的起始符只在**主机那一侧**找 —— 用户名与口令里同样会出现裸的
+    /// <c># ? /</c>:某 SSO 客户端给 SSH/SFTP 资源发的用户名就是字面量 <c>#sso</c>
+    /// (<c>ssh://#sso:一次性口令@堡垒机:代理端口</c>)。若先按整串截 authority,那个 <c>#</c>
+    /// 会把主机连同端口一并吃掉,解析结果为 null —— 用户看到的就是「网页上点了登录,终端开了但没连」。
+    /// </para>
     /// </remarks>
     public static ExternalLaunchRequest? ParseUrl(string? url, ExternalLaunchOrigin origin = ExternalLaunchOrigin.UrlProtocol)
     {
@@ -142,24 +148,15 @@ public static class XshellLaunchParser
             text = text[(schemeEnd + 3)..];
         }
 
-        // 主机之后的路径/查询/片段与登录无关(<c>ssh://u@h:22/?foo=1</c> 这类调用方常见)。
-        int authorityEnd = text.AsSpan().IndexOfAny('/', '?', '#');
-        if (authorityEnd >= 0)
-        {
-            text = text[..authorityEnd];
-        }
-        if (text.Length == 0)
+        if (!TrySplitAuthority(text, out string userInfo, out string authority))
         {
             return null;
         }
 
         string username = string.Empty;
         string? password = null;
-        int at = text.LastIndexOf('@');
-        if (at >= 0)
+        if (userInfo.Length > 0)
         {
-            string userInfo = text[..at];
-            text = text[(at + 1)..];
             int colon = userInfo.IndexOf(':', StringComparison.Ordinal);
             username = Decode(colon >= 0 ? userInfo[..colon] : userInfo);
             if (colon >= 0)
@@ -169,7 +166,7 @@ public static class XshellLaunchParser
             }
         }
 
-        if (!TrySplitHostPort(text, out string host, out int port) || host.Length == 0)
+        if (!TrySplitHostPort(authority, out string host, out int port) || host.Length == 0)
         {
             return null;
         }
@@ -239,6 +236,89 @@ public static class XshellLaunchParser
             "rlogin" => (ConnectionType.SSH, false, 513),
             _ => (ConnectionType.SSH, false, 22)
         };
+
+    /// <summary>
+    /// 把 <c>[user[:password]@]host[:port][/…]</c> 切成「凭据」与「主机」两段。切不出主机时返回
+    /// <see langword="false" />。
+    /// </summary>
+    /// <remarks>
+    /// 难点全在于两侧都可能出现裸的 <c>@ # ? /</c>:凭据里有(堡垒机现发,不转义),路径里也可能有。
+    /// 因此按可信度从高到低试,取第一条能读出主机的:
+    /// <list type="number">
+    /// <item>第一个 <c>/</c> 之前若有 <c>@</c>,分界就是其中**最后**那个 —— 路径永远在 authority
+    /// 之后,所以路径里的 <c>@</c> 抢不走分界(<c>sftp://ops@h/home/ops@corp</c> 连的是 h)。</item>
+    /// <item>那一段本身就是个像样的主机 ⇒ 整条 URL 没带凭据(<c>sftp://h:22/home/ops@corp</c>)。</item>
+    /// <item>都不成,才从右往左找 <c>@</c>,取第一个「其后能读成 host[:port]」的位置。凭据里带了
+    /// <c>/</c> 的走这条(<c>sftp://ops#dev:a/b@h:22</c>)。</item>
+    /// <item>最后按 URI 本来的规矩整串截一次,收尾 <c>ssh://h:22?x=1</c> 这类没有凭据的写法。</item>
+    /// </list>
+    /// </remarks>
+    private static bool TrySplitAuthority(string text, out string userInfo, out string authority)
+    {
+        int slash = text.IndexOf('/', StringComparison.Ordinal);
+        string beforePath = slash >= 0 ? text[..slash] : text;
+        int at = beforePath.LastIndexOf('@');
+        if (at >= 0 && Accept(text, at, out userInfo, out authority))
+        {
+            return true;
+        }
+        if (LooksLikeHost(beforePath))
+        {
+            userInfo = string.Empty;
+            authority = beforePath;
+            return true;
+        }
+        for (at = text.LastIndexOf('@'); at >= 0; at = at == 0 ? -1 : text.LastIndexOf('@', at - 1))
+        {
+            if (Accept(text, at, out userInfo, out authority))
+            {
+                return true;
+            }
+        }
+        userInfo = string.Empty;
+        authority = TrimAfterAuthority(text);
+        // 一个像样的主机都认不出来(例如 scheme 后面就没了):交给调用方按解析失败处理。
+        return LooksLikeHost(authority);
+
+        static bool Accept(string text, int at, out string userInfo, out string authority)
+        {
+            userInfo = text[..at];
+            authority = TrimAfterAuthority(text[(at + 1)..]);
+            return LooksLikeHost(authority);
+        }
+    }
+
+    /// <summary>截掉主机之后的路径/查询/片段(<c>ssh://u@h:22/?folder=prod</c> 这类调用方常见)。</summary>
+    private static string TrimAfterAuthority(string value)
+    {
+        int end = value.AsSpan().IndexOfAny('/', '?', '#');
+        return end >= 0 ? value[..end] : value;
+    }
+
+    /// <summary>
+    /// 这一段读起来像不像 <c>host[:port]</c>。只做字符集判断:主机名/IPv4 只允许字母数字与
+    /// <c>. - _</c>(字母按 Unicode 认,IDN 主机名照常放行);带 <c>:</c> 的按 IPv6 收紧到
+    /// 十六进制数字 —— 否则 <c>user:pass</c> 这样的凭据片段也会被当成 IPv6 主机放行,分界就切歪了。
+    /// </summary>
+    private static bool LooksLikeHost(string value)
+    {
+        if (value.Length == 0 || !TrySplitHostPort(value, out string host, out _) || host.Length == 0)
+        {
+            return false;
+        }
+        bool ipv6 = host.Contains(':', StringComparison.Ordinal);
+        foreach (char c in host)
+        {
+            bool accepted = ipv6
+                ? char.IsAsciiHexDigit(c) || c is ':' or '.' or '%'
+                : char.IsLetterOrDigit(c) || c is '.' or '-' or '_';
+            if (!accepted)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /// <summary>切分 <c>host[:port]</c>,兼容 IPv6 的 <c>[::1]:22</c> 写法。</summary>
     private static bool TrySplitHostPort(string authority, out string host, out int port)

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -20,7 +20,11 @@ namespace VelaShell.ViewModels;
 /// </summary>
 public class TerminalTabViewModel : TabViewModel, IDisposable
 {
+    /// <summary>「已复制」回执停留的时长;与连接配置页保持一致。</summary>
+    private static readonly TimeSpan CopyFeedbackDuration = TimeSpan.FromSeconds(2);
+
     private readonly Lock _ptyResizeGate = new();
+    private IDisposable? _copyFeedbackReset;
     private bool _disposed;
     private (int Columns, int Rows)? _pendingPtySize;
     private bool _ptyResizeSending;
@@ -86,6 +90,11 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
                 SyncChannelCloseRequested?.Invoke(channel);
             }
         });
+
+        CopyErrorCommand = ReactiveCommand.CreateFromTask(
+            CopyErrorAsync,
+            this.WhenAnyValue(x => x.ConnectionError, error => !string.IsNullOrWhiteSpace(error))
+        );
     }
 
     /// <summary>创建一个标签并立即挂载实时传输(已建立连接的场景)。</summary>
@@ -447,6 +456,23 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     public bool HasConnectionError => !string.IsNullOrEmpty(ConnectionError);
 
     /// <summary>
+    /// 复制覆盖层上的失败原因到剪贴板。失败原因往往是一长串原文 —— 服务端的认证链、
+    /// 主机密钥指纹、算法协商差异的两份名单 —— 要拿去搜索、贴给同事或发给设备厂商,
+    /// 照着屏幕抄不现实。与连接配置页的「复制」是同一套做法。
+    /// </summary>
+    public ReactiveCommand<RxVoid, RxVoid> CopyErrorCommand { get; }
+
+    /// <summary>写系统剪贴板的回调;由视图注入(视图模型层拿不到 TopLevel)。</summary>
+    public Func<string, Task>? CopyToClipboard { get; set; }
+
+    /// <summary>刚复制过:按钮上短暂显示「已复制」回执。</summary>
+    public bool ErrorCopied
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>
     /// 标签页内失败/断开覆盖层(设计 yxjmg)的可见性:未连接(断开/错误)且是一个
     /// 真实会话标签(SSH 或本地)时显示。连接中/已连接不显示。
     /// </summary>
@@ -534,6 +560,9 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
             return;
         }
         _disposed = true;
+        // 「已复制」回执的定时器可能还挂着:不取消的话它会在标签消失之后才回调。
+        _copyFeedbackReset?.Dispose();
+        _copyFeedbackReset = null;
         // 立即标记为未连接:同步频道转发(WriteSyncInput)以 IsConnected 为闸门。
         // 频道内其他标签的输入可能与本标签的关闭并发,不复位 IsConnected 的话,
         // 转发会向已释放的桥写入而与释放竞争。
@@ -752,6 +781,29 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     /// 不弹全局框。置为断开态以启用“重新连接”;不触发 <see cref="Disconnected" /> 事件——
     /// 初始连接失败不应自动重连(尤其认证失败),由用户手动决定重连或关闭。
     /// </summary>
+    /// <summary>
+    /// 把失败原因原文送进剪贴板,并在按钮上留一句「已复制」的回执 —— 没有回执就分不清
+    /// 「复制成功了」和「按钮没反应」,用户只会再点两下。回执到点自动退回;连点时先取消
+    /// 上一个定时器,否则第二次点完会立刻被第一次的定时器把提示抹掉。
+    /// </summary>
+    private async Task CopyErrorAsync()
+    {
+        if (CopyToClipboard is not { } copy || ConnectionError is not { Length: > 0 })
+        {
+            return;
+        }
+        // 复制覆盖层上那一整段(标题下面显示的就是它),而不是只复制 ConnectionError:
+        // 用户要的是「屏幕上这段话」,两者不一致就会让人以为漏复制了。
+        await copy(DisconnectOverlayDetail).ConfigureAwait(true);
+        ErrorCopied = true;
+        _copyFeedbackReset?.Dispose();
+        _copyFeedbackReset = DispatcherTimer.RunOnce(() => ErrorCopied = false, CopyFeedbackDuration);
+    }
+
+    /// <summary>
+    /// 把标签切换到断开状态并记录连接失败的原因(幂等)。覆盖层显示为“连接失败 + 具体原因”,
+    /// </summary>
+    /// <param name="message"></param>
     public void MarkConnectionFailed(string message)
     {
         if (_disposed)

--- a/src/VelaShell/Views/TerminalTabView.axaml
+++ b/src/VelaShell/Views/TerminalTabView.axaml
@@ -26,6 +26,37 @@
       <Setter Property="VerticalContentAlignment" Value="Center" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
     </Style>
+
+    <!-- 失败/断开覆盖层。两种形态差别很大,所以宽度与对齐都随 .error 切换而不是写死一套:
+         「连接已断开」只有一句话,窄卡片居中最好看;「连接失败」的原因是多行技术文本
+         (算法协商会把双方名单都列出来),窄卡片里居中就成了一团没法读的东西。 -->
+    <Style Selector="Border.dc-card">
+      <Setter Property="Width" Value="340" />
+    </Style>
+    <Style Selector="Border.dc-card.error">
+      <Setter Property="Width" Value="560" />
+    </Style>
+    <!-- 原因块:出错时给一层输入框同款底色,把「这是原文」和上面的标题分开。 -->
+    <Style Selector="Border.dc-detail">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="Border.dc-detail.error">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="14,12" />
+    </Style>
+    <Style Selector="SelectableTextBlock.dc-detail">
+      <Setter Property="TextAlignment" Value="Center" />
+      <Setter Property="MaxWidth" Value="280" />
+    </Style>
+    <Style Selector="SelectableTextBlock.dc-detail.error">
+      <Setter Property="TextAlignment" Value="Left" />
+      <Setter Property="MaxWidth" Value="Infinity" />
+      <Setter Property="LineHeight" Value="18" />
+    </Style>
   </UserControl.Styles>
 
   <Grid RowDefinitions="Auto,*,Auto">
@@ -273,12 +304,12 @@
               Background="#66000000"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch">
-        <Border Background="{DynamicResource VelaBgSurface}"
+        <Border Classes="dc-card" Classes.error="{Binding HasConnectionError}"
+                Background="{DynamicResource VelaBgSurface}"
                 BorderBrush="{DynamicResource VelaBorderSecondary}"
                 BorderThickness="1"
                 CornerRadius="8"
                 Padding="32,24"
-                Width="340"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 BoxShadow="{DynamicResource VelaShadowWindow}">
@@ -299,14 +330,55 @@
                        FontSize="{DynamicResource VelaFontSize16}" FontWeight="SemiBold"
                        HorizontalAlignment="Center" />
 
-            <TextBlock Text="{Binding DisconnectOverlayDetail}"
-                       Foreground="{DynamicResource VelaTextMuted}"
-                       FontFamily="{DynamicResource VelaUiMonoFont}"
-                       FontSize="{DynamicResource VelaFontSize11}"
-                       MaxWidth="280"
-                       TextWrapping="Wrap"
-                       TextAlignment="Center"
-                       HorizontalAlignment="Center" />
+            <!-- 失败原因可能很长(算法协商差异会把双方的算法名单都列出来):套一层限高滚动区,
+                 否则卡片会被撑高到把「重新连接 / 关闭标签页」顶出屏幕。 -->
+            <Border Classes="dc-detail" Classes.error="{Binding HasConnectionError}">
+              <ScrollViewer MaxHeight="200"
+                            HorizontalScrollBarVisibility="Disabled"
+                            VerticalScrollBarVisibility="Auto">
+                <!-- SelectableTextBlock 而不是 TextBlock:失败原因要能划选、Ctrl+C 拿走。
+                     下面那颗「复制」按钮管整段,这里管只想要其中一行的情况。 -->
+                <SelectableTextBlock Classes="dc-detail" Classes.error="{Binding HasConnectionError}"
+                                     Text="{Binding DisconnectOverlayDetail}"
+                                     Foreground="{DynamicResource VelaTextMuted}"
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize11}"
+                                     TextWrapping="Wrap" />
+              </ScrollViewer>
+            </Border>
+
+            <!-- 失败原因常是一长串原文(认证链、主机密钥指纹、算法名单):给它一颗复制按钮,
+                 用户才拿得走去搜索、贴给同事或发给设备厂商 —— 照着屏幕抄不现实。
+                 与连接配置页的「复制」同款(两态叠放,同宽同位,复制完按钮不会跳一下)。 -->
+            <Button HorizontalAlignment="Center"
+                    IsVisible="{Binding HasConnectionError}"
+                    Command="{Binding CopyErrorCommand}"
+                    Background="Transparent"
+                    Foreground="{DynamicResource VelaTextSecondary}"
+                    BorderBrush="{DynamicResource VelaBorderPrimary}"
+                    BorderThickness="1"
+                    Height="24" Padding="8,0" CornerRadius="4" Cursor="Hand"
+                    FontSize="{DynamicResource VelaFontSize10}"
+                    ToolTip.Tip="{loc:Localize Profile_CopyErrorTip}"
+                    ToolTip.Placement="Top">
+              <Panel>
+                <StackPanel Orientation="Horizontal" Spacing="5" IsVisible="{Binding !ErrorCopied}">
+                  <pc:LucideIcon Width="11" Height="11"
+                                 Data="{StaticResource Icon.copy}"
+                                 Foreground="{DynamicResource VelaTextSecondary}"
+                                 VerticalAlignment="Center" />
+                  <TextBlock Text="{loc:Localize Copy}" VerticalAlignment="Center" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="5" IsVisible="{Binding ErrorCopied}">
+                  <pc:LucideIcon Width="11" Height="11"
+                                 Data="{StaticResource Icon.circle-check}"
+                                 Foreground="{DynamicResource VelaAccent}"
+                                 VerticalAlignment="Center" />
+                  <TextBlock Text="{loc:Localize Profile_ErrorCopied}" VerticalAlignment="Center"
+                             Foreground="{DynamicResource VelaAccent}" />
+                </StackPanel>
+              </Panel>
+            </Button>
 
             <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
               <Button Command="{Binding ReconnectCommand}"

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -52,6 +52,11 @@ public partial class TerminalTabView : UserControl
         {
             HookTerminalControl();
             HookSuggestions();
+            // 失败覆盖层上的「复制」:剪贴板要经 TopLevel 取,视图模型层拿不到,由视图注入。
+            if (DataContext is TerminalTabViewModel tab)
+            {
+                tab.CopyToClipboard = CopyToClipboardAsync;
+            }
         };
         ScrollBarView?.Scroll += OnScrollBarScroll;
 
@@ -892,6 +897,15 @@ public partial class TerminalTabView : UserControl
 
     // 终端控件是跨分屏重新挂载的单一共享实例,因此每个视图都把滚动条(重新)绑定到它
     // 当前承载的那个控件上。
+    /// <summary>把文本写进系统剪贴板;拿不到剪贴板(无 TopLevel)时静默跳过。</summary>
+    private async Task CopyToClipboardAsync(string text)
+    {
+        if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+        {
+            await clipboard.SetTextAsync(text);
+        }
+    }
+
     private void HookTerminalControl()
     {
         var ctrl =

--- a/tests/VelaShell.Core.Tests/Ssh/SshAlgorithmProbeTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/SshAlgorithmProbeTests.cs
@@ -1,0 +1,278 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Tmds.Ssh;
+using VelaShell.Infrastructure.Ssh;
+
+namespace VelaShell.Core.Tests.Ssh;
+
+/// <summary>
+/// 协商失败后回探对端算法名单。
+/// </summary>
+/// <remarks>
+/// 这里的期望值不是编出来的:名单取自一台真实的国产堡垒机网关(<c>SSH-2.0-9.9.9</c>)——
+/// 它只提供 <c>aes128-ctr</c> 与 <c>ssh-rsa</c>,正是 Tmds.Ssh 一个都不支持、用户只看到
+/// 一句 <c>KeyExchangeFailed</c> 的那种对端。假服务端按 RFC 4253 §6 的分组格式回放这份名单,
+/// 断言落在"解出来的算法名"和"诊断文案里到底提了哪几类",而不是解析器自己的中间状态。
+/// </remarks>
+[TestClass]
+[TestCategory("Ssh")]
+public class SshAlgorithmProbeTests
+{
+    private const string BastionVersion = "SSH-2.0-9.9.9";
+    private static readonly string[] BastionKex =
+        ["ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521"];
+    private static readonly string[] BastionHostKey = ["ssh-rsa"];
+    private static readonly string[] BastionEncryption = ["aes128-ctr"];
+    private static readonly string[] BastionMac = ["hmac-sha2-256", "hmac-sha2-512"];
+
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
+
+    [TestMethod]
+    public async Task Probe_ReadsEveryListTheServerAdvertises()
+    {
+        await using FakeSshServer server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
+
+        SshPeerAlgorithms peer = (await SshAlgorithmProbe.TryProbeAsync(
+            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationTokenSource.Token))!;
+
+        Assert.AreEqual(BastionVersion, peer.ServerVersion);
+        CollectionAssert.AreEqual(BastionKex, peer.KeyExchange.ToArray());
+        CollectionAssert.AreEqual(BastionHostKey, peer.HostKey.ToArray());
+        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionServerToClient.ToArray());
+        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionClientToServer.ToArray());
+        CollectionAssert.AreEqual(BastionMac, peer.MacServerToClient.ToArray());
+    }
+
+    [TestMethod]
+    public async Task Probe_SkipsTheBannerLinesBeforeTheVersionString()
+    {
+        // 堡垒机与政企设备普遍在版本串之前先甩一段法律声明;认死第一行就什么也探不到了。
+        await using FakeSshServer server = FakeSshServer.Start(
+            (stream, ct) => ServeBastionKexInitAsync(stream, ct, banner: "*** 授权用户专用,操作全程审计 ***"));
+
+        SshPeerAlgorithms peer = (await SshAlgorithmProbe.TryProbeAsync(
+            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationTokenSource.Token))!;
+
+        Assert.AreEqual(BastionVersion, peer.ServerVersion);
+        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionServerToClient.ToArray());
+    }
+
+    [TestMethod]
+    public async Task Probe_EndpointThatIsNotSsh_ReturnsNullInsteadOfThrowing()
+    {
+        // 端口填错(填到 HTTP 或 TLS 上)时诊断只该沉默,不能再抛一个异常盖掉真正的失败。
+        await using FakeSshServer server = FakeSshServer.Start(async (stream, ct) =>
+        {
+            await WriteLineAsync(stream, "HTTP/1.1 400 Bad Request", ct);
+            await WriteLineAsync(stream, "Content-Length: 0", ct);
+        });
+
+        Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
+                          IPAddress.Loopback.ToString(), server.Port, ProbeTimeout,
+                          TestContext.CancellationTokenSource.Token));
+    }
+
+    [TestMethod]
+    public async Task Probe_PacketCutShort_ReturnsNullInsteadOfThrowing()
+    {
+        await using FakeSshServer server = FakeSshServer.Start(async (stream, ct) =>
+        {
+            await WriteLineAsync(stream, BastionVersion, ct);
+            await ReadLineAsync(stream, ct);
+            // 声称有 1000 字节却只发了包头就断开。
+            byte[] header = new byte[4];
+            BinaryPrimitives.WriteUInt32BigEndian(header, 1000);
+            await stream.WriteAsync(header, ct);
+        });
+
+        Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
+                          IPAddress.Loopback.ToString(), server.Port, ProbeTimeout,
+                          TestContext.CancellationTokenSource.Token));
+    }
+
+    [TestMethod]
+    public async Task Probe_NothingListening_ReturnsNullInsteadOfThrowing()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+
+        Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
+                          IPAddress.Loopback.ToString(), port, ProbeTimeout,
+                          TestContext.CancellationTokenSource.Token));
+    }
+
+    [TestMethod]
+    public async Task Describe_ReportsOnlyTheAlgorithmClassesWithNoOverlap()
+    {
+        await using FakeSshServer server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
+        var settings = new SshClientSettings("probe@127.0.0.1")
+        {
+            HostName = IPAddress.Loopback.ToString(),
+            Port = server.Port
+        };
+
+        string message = (await SshAlgorithmDiagnostics.TryDescribeAsync(
+            settings, TestContext.CancellationTokenSource.Token))!;
+
+        Assert.Contains(BastionVersion, message, "对端版本要摆出来 —— 用户和厂商对线时就靠这一句。");
+        Assert.Contains("aes128-ctr", message, "对端提供的加密算法必须原样列出。");
+        Assert.Contains("ssh-rsa", message, "主机密钥同样没有交集(我们只认 rsa-sha2-*),该报。");
+        Assert.Contains("chacha20-poly1305@openssh.com", message,
+                        "只说对端提供什么没用,得同时告诉用户本客户端支持什么才知道该改成什么。");
+        // 这两类是有交集的:kex 双方都有 ecdh-sha2-nistp256,MAC 双方都有 hmac-sha2-256。
+        // 把它们也列进去,用户就会去改本来没问题的配置。
+        Assert.DoesNotContain("ecdh-", message, "密钥交换有交集,不该出现在失败原因里。");
+        Assert.DoesNotContain("hmac-", message, "MAC 有交集,不该出现在失败原因里。");
+        // 证书变体只在对端出示 OpenSSH 证书时才用得上,列出来纯粹是把六个可用算法淹掉。
+        Assert.DoesNotContain("-cert-", message, "证书变体是噪音,不该出现在「本客户端支持」里。");
+        // 双方名单各占一行:挤在一行里换行之后就成了一团,对不上"我这边有没有对端要的那个"。
+        Assert.IsGreaterThanOrEqualTo(5, message.Split('\n').Length,
+                                      "标题 + 两类各三行:名单必须分行,不能挤成一坨。");
+    }
+
+    [TestMethod]
+    public async Task Describe_PeerThatShareseverything_ReturnsNull()
+    {
+        // 协商失败另有原因(比如对端在 KEXINIT 之后才出问题)时不能硬凑一段说明:
+        // 指着一堆其实能用的算法说"没有交集"比不说更糟。
+        await using FakeSshServer server = FakeSshServer.Start((stream, ct) =>
+            ServeKexInitAsync(stream, ct, BastionVersion, BastionKex,
+                              ["rsa-sha2-256"], ["chacha20-poly1305@openssh.com"], ["hmac-sha2-256"]));
+        var settings = new SshClientSettings("probe@127.0.0.1")
+        {
+            HostName = IPAddress.Loopback.ToString(),
+            Port = server.Port
+        };
+
+        Assert.IsNull(await SshAlgorithmDiagnostics.TryDescribeAsync(
+                          settings, TestContext.CancellationTokenSource.Token));
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private static Task ServeBastionKexInitAsync(NetworkStream stream, CancellationToken ct, string? banner = null) =>
+        ServeKexInitAsync(stream, ct, BastionVersion, BastionKex, BastionHostKey, BastionEncryption, BastionMac, banner);
+
+    /// <summary>假服务端:banner(可选) → 版本串 → 等客户端的版本串 → 一个 KEXINIT。</summary>
+    /// <remarks>
+    /// 刻意在发 KEXINIT 之前先读一行:探针若不发自己的版本串,这里就永远等下去,
+    /// 测试会以超时而不是"碰巧通过"的方式失败。
+    /// </remarks>
+    private static async Task ServeKexInitAsync(
+        NetworkStream stream, CancellationToken ct, string version,
+        string[] kex, string[] hostKey, string[] encryption, string[] mac, string? banner = null)
+    {
+        if (banner is not null)
+        {
+            await WriteLineAsync(stream, banner, ct);
+        }
+        await WriteLineAsync(stream, version, ct);
+        await ReadLineAsync(stream, ct);
+        await stream.WriteAsync(BuildKexInit(kex, hostKey, encryption, mac), ct);
+    }
+
+    /// <summary>按 RFC 4253 §6 拼一个明文分组包,载荷是 §7.1 的 SSH_MSG_KEXINIT。</summary>
+    private static byte[] BuildKexInit(string[] kex, string[] hostKey, string[] encryption, string[] mac)
+    {
+        List<byte> payload = [20];
+        payload.AddRange(new byte[16]); // cookie
+        foreach (string[] list in new[] { kex, hostKey, encryption, encryption, mac, mac })
+        {
+            AddNameList(payload, string.Join(',', list));
+        }
+        AddNameList(payload, "none");   // 压缩 c2s
+        AddNameList(payload, "none");   // 压缩 s2c
+        AddNameList(payload, "");       // 语言 c2s
+        AddNameList(payload, "");       // 语言 s2c
+        payload.Add(0);                 // first_kex_packet_follows
+        payload.AddRange(new byte[4]);  // reserved
+
+        // 4(长度) + 1(填充长) + 载荷 + 填充 必须是 8 的倍数,且填充至少 4 字节。
+        int padding = (8 - ((5 + payload.Count) % 8)) % 8;
+        if (padding < 4)
+        {
+            padding += 8;
+        }
+        byte[] packet = new byte[5 + payload.Count + padding];
+        BinaryPrimitives.WriteUInt32BigEndian(packet, (uint)(1 + payload.Count + padding));
+        packet[4] = (byte)padding;
+        payload.CopyTo(packet, 5);
+        return packet;
+    }
+
+    private static void AddNameList(List<byte> payload, string nameList)
+    {
+        byte[] length = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(length, (uint)nameList.Length);
+        payload.AddRange(length);
+        payload.AddRange(Encoding.ASCII.GetBytes(nameList));
+    }
+
+    private static Task WriteLineAsync(Stream stream, string line, CancellationToken ct) =>
+        stream.WriteAsync(Encoding.ASCII.GetBytes(line + "\r\n"), ct).AsTask();
+
+    private static async Task ReadLineAsync(Stream stream, CancellationToken ct)
+    {
+        byte[] one = new byte[1];
+        while (await stream.ReadAsync(one, ct) == 1 && one[0] != (byte)'\n')
+        {
+            // 逐字节读到换行为止:版本串阶段还没有分组格式可依。
+        }
+    }
+
+    /// <summary>只接一条连接的假 SSH 服务端。</summary>
+    private sealed class FakeSshServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        private FakeSshServer(TcpListener listener, Func<NetworkStream, CancellationToken, Task> handle)
+        {
+            _listener = listener;
+            _loop = RunAsync(handle);
+        }
+
+        public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+        public static FakeSshServer Start(Func<NetworkStream, CancellationToken, Task> handle)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return new FakeSshServer(listener, handle);
+        }
+
+        private async Task RunAsync(Func<NetworkStream, CancellationToken, Task> handle)
+        {
+            try
+            {
+                using TcpClient client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                await using NetworkStream stream = client.GetStream();
+                await handle(stream, _cts.Token);
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or SocketException or IOException or ObjectDisposedException)
+            {
+                // 测试结束时监听器被关掉,或探针提前断开:都属正常收尾。
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _cts.CancelAsync();
+            _listener.Stop();
+            try
+            {
+                await _loop;
+            }
+            catch (OperationCanceledException)
+            {
+                // 同上。
+            }
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/Startup/XshellLaunchParserTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Startup/XshellLaunchParserTests.cs
@@ -79,6 +79,46 @@ public class XshellLaunchParserTests
     }
 
     [TestMethod]
+    public void Parse_SsoClientCommandLine_SurvivesHashOnlyUserName()
+    {
+        // 地面真值:某 SSO 客户端(D:\SsoTool)对 SSH/SFTP 资源固定把用户名换成字面量 "#sso"、
+        // 口令换成 sessionId,再按 Xshell 的约定拉起:
+        //     VelaShell.exe ssh://#sso:<sessionId>@<堡垒机IP>:<代理端口> -newtab CBH_<资源>
+        // 那个开头的 # 曾把整个 authority 截没,解析返回 null —— 网页点了登录,终端开了却没连。
+        ExternalLaunchRequest request = XshellLaunchParser.TryParse(
+            ["ssh://#sso:1f4b9c2e7a@10.20.30.40:9527", "-newtab", "CBH_10.1.2.3_22_root"])!;
+
+        Assert.AreEqual("10.20.30.40", request.Host);
+        Assert.AreEqual(9527, request.Port);
+        Assert.AreEqual("#sso", request.Username);
+        Assert.AreEqual("1f4b9c2e7a", request.Password);
+        Assert.IsTrue(request.IsSupported);
+    }
+
+    [TestMethod]
+    public void Parse_CredentialsWithHashSlashOrQuestionMark_DoNotTruncateTheHost()
+    {
+        // 一次性口令是现发的随机串,# / ? 都可能原样出现在里面(调用方不会替我们转义)。
+        ExternalLaunchRequest request = XshellLaunchParser.TryParse(["-url", "sftp://ops#dev:a/b?c#d@10.0.3.21:2222"])!;
+
+        Assert.AreEqual("10.0.3.21", request.Host);
+        Assert.AreEqual(2222, request.Port);
+        Assert.AreEqual("ops#dev", request.Username);
+        Assert.AreEqual("a/b?c#d", request.Password);
+    }
+
+    [TestMethod]
+    public void Parse_AtSignInsidePath_IsNotMistakenForCredentials()
+    {
+        // 反过来也得站得住:没带凭据时,路径里的 @ 不能被当成主机分界。
+        ExternalLaunchRequest request = XshellLaunchParser.TryParse(["-url", "sftp://files.example.com:2222/home/ops@corp"])!;
+
+        Assert.AreEqual("files.example.com", request.Host);
+        Assert.AreEqual(2222, request.Port);
+        Assert.AreEqual(string.Empty, request.Username);
+    }
+
+    [TestMethod]
     public void Parse_IPv6Host_KeepsAddressWithoutBrackets()
     {
         ExternalLaunchRequest request = XshellLaunchParser.TryParse(["-url", "ssh://root@[fe80::1]:2222"])!;

--- a/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
@@ -1,4 +1,5 @@
 using NSubstitute;
+using ReactiveUI.Primitives;
 using VelaShell.Core.Models;
 using VelaShell.Core.Ssh;
 using VelaShell.Terminal;
@@ -318,5 +319,48 @@ public class TerminalTabViewModelTests
         Assert.IsFalse(_vm.ShowDisconnectedOverlay);
         _vm.ConnectionStatus = SessionStatus.Disconnected;
         Assert.IsTrue(_vm.ShowDisconnectedOverlay);
+    }
+
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public async Task CopyErrorCommand_CopiesTheWholeOverlayText_AndAcknowledges()
+    {
+        // 算法协商失败这类原因是多行的(双方的算法名单都列出来),正是照着屏幕抄不动、
+        // 必须能整段拿走的那种。复制的内容必须与覆盖层上显示的完全一致 ——
+        // 少一行就会让人以为漏复制了。
+        const string Failure = """
+            连接失败:probe@10.0.3.21:22
+            The connection could not be established - KeyExchangeFailed - No common encryption algorithm.
+            加密:对端提供 [aes128-ctr];本客户端支持 [aes256-gcm@openssh.com]
+            """;
+        string? copied = null;
+        _vm.CopyToClipboard = text =>
+        {
+            copied = text;
+            return Task.CompletedTask;
+        };
+
+        _vm.MarkConnectionFailed(Failure);
+        Assert.IsTrue(_vm.HasConnectionError);
+        Assert.IsFalse(_vm.ErrorCopied);
+
+        await _vm.CopyErrorCommand.Execute().FirstAsync();
+
+        Assert.AreEqual(_vm.DisconnectOverlayDetail, copied);
+        Assert.Contains("aes128-ctr", copied!, "多行原因必须整段进剪贴板,不能只留第一行。");
+        // 没有这句回执就分不清"复制成功了"和"按钮没反应",用户只会再点两下。
+        Assert.IsTrue(_vm.ErrorCopied);
+    }
+
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public async Task CopyErrorCommand_IsUnavailable_UntilThereIsAFailureToCopy()
+    {
+        // 普通掉线的覆盖层没有"失败原因"可言:按钮该是灰的,而不是复制一句空话。
+        Assert.IsFalse(await _vm.CopyErrorCommand.CanExecute.FirstAsync());
+
+        _vm.MarkConnectionFailed("Permission denied (publickey,password).");
+
+        Assert.IsTrue(await _vm.CopyErrorCommand.CanExecute.FirstAsync());
     }
 }


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次更新包括：
- 新增 SshAlgorithmProbe 和 SshAlgorithmDiagnostics，实现算法协商失败时自动探测和比对算法，生成详细差异说明，辅助定位“无共同算法”原因。
- TmdsSshClientWrapper 连接失败遇算法协商问题时，自动补充详细算法差异信息到错误消息。
- 多语言资源文件补充相关本地化字符串，完善算法协商失败及算法名称描述。
- 终端标签页新增“复制失败原因”按钮，支持一键复制详细错误信息并反馈“已复制”，便于问题排查。
- 断开/失败覆盖层 UI 优化，失败原因支持多行、滚动、可选中复制，卡片宽度和样式自适应错误状态。
- Xshell URL 解析器增强，修复用户名/密码含特殊字符时主机截断错误，补充单元测试覆盖边界情况。
- 新增 SshAlgorithmProbe 单元测试，覆盖正常、异常、边界等场景，提升算法探测与诊断健壮性。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
