### PR TITLE
文件浏览器支持复制当前文件夹路径，优化 SSH Shell 流健壮性

### DIFF
--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -220,6 +220,9 @@
   <data name="CopyFileName" xml:space="preserve">
     <value>名前をコピー</value>
   </data>
+  <data name="CopyCurrentFolderPath" xml:space="preserve">
+    <value>現在のフォルダーのパスをコピー</value>
+  </data>
   <data name="CopyFilePath" xml:space="preserve">
     <value>パスをコピー</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -220,6 +220,9 @@
   <data name="CopyFileName" xml:space="preserve">
     <value>이름 복사</value>
   </data>
+  <data name="CopyCurrentFolderPath" xml:space="preserve">
+    <value>현재 폴더 경로 복사</value>
+  </data>
   <data name="CopyFilePath" xml:space="preserve">
     <value>경로 복사</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -668,6 +668,9 @@
   <data name="SftpCopyToPrompt" xml:space="preserve">
     <value>Enter destination path for copy</value>
   </data>
+  <data name="CopyCurrentFolderPath" xml:space="preserve">
+    <value>Copy Current Folder Path</value>
+  </data>
   <data name="CopyFilePath" xml:space="preserve">
     <value>Copy Path</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -760,6 +760,9 @@
   <data name="SftpCopyToPrompt" xml:space="preserve">
     <value>输入复制目标路径</value>
   </data>
+  <data name="CopyCurrentFolderPath" xml:space="preserve">
+    <value>复制当前文件夹路径</value>
+  </data>
   <data name="CopyFilePath" xml:space="preserve">
     <value>复制文件路径</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -220,6 +220,9 @@
   <data name="CopyFileName" xml:space="preserve">
     <value>複製名稱</value>
   </data>
+  <data name="CopyCurrentFolderPath" xml:space="preserve">
+    <value>複製目前資料夾路徑</value>
+  </data>
   <data name="CopyFilePath" xml:space="preserve">
     <value>複製路徑</value>
   </data>

--- a/src/VelaShell.Infrastructure/Ssh/ShellStreamWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/ShellStreamWrapper.cs
@@ -11,13 +11,14 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
     private readonly RemoteProcess _process = process ?? throw new ArgumentNullException(nameof(process));
     private Stream? _outputStream;
     private volatile bool _disposed;
+    private volatile bool _channelClosed;
     private bool _readEof;
 
     /// <summary>读端发出 EOF 前始终保持可读(Stream ReadAsync 返回 0 表示 EOF)。</summary>
     public bool CanRead => !_disposed && !_readEof;
 
-    /// <summary>RemoteProcess 存活期间均可写入。</summary>
-    public bool CanWrite => !_disposed;
+    /// <summary>RemoteProcess 存活且通道未断时可写入。</summary>
+    public bool CanWrite => !_disposed && !_channelClosed;
 
     /// <summary>当前是否有数据可读而不阻塞(对 Stream 式 IO 无意义)。</summary>
     public bool DataAvailable => false;
@@ -49,20 +50,37 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
         catch (OperationCanceledException) { _readEof = true; return 0; }
     }
 
-    /// <summary>向远程进程标准输入写入原始字节。通道已关闭时标记 _disposed 并抛出 ObjectDisposedException。</summary>
+    /// <summary>
+    /// 向远程进程标准输入写入原始字节。通道已断 / 已释放时静默丢弃并把 <see cref="CanWrite" />
+    /// 置为 false —— 与读端 EOF 返回 0 对称,也与另一个实现
+    /// <c>PluginTerminalShellStream.WriteAsync</c> 的约定一致:「会话已断这件事由读循环收到 EOF
+    /// 去改标签状态,写端不必再抛一遍」。
+    /// <para>
+    /// 旧实现在这里把 <c>SshChannelClosedException</c> 转成新建的 <c>ObjectDisposedException</c>
+    /// 再抛,而唯一的消费者(桥的写循环)只是把它 catch 掉丢弃 —— 纯粹拿异常做控制流,
+    /// 一次断线要多制造两条首次机会异常;更糟的是它顺手把 <c>_disposed</c> 置了位,
+    /// 使随后真正的 <see cref="Dispose" /> 直接短路返回,<c>RemoteProcess</c> 再也不会被确定性释放。
+    /// </para>
+    /// </summary>
     public async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_disposed || _channelClosed)
+        {
+            return;
+        }
         try
         {
             await _process.WriteAsync(
                 new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken)
                 .ConfigureAwait(false);
         }
-        catch (SshChannelClosedException)
+        catch (Exception ex) when (ex is SshChannelClosedException
+                                       or SshConnectionClosedException
+                                       or ObjectDisposedException
+                                       or IOException)
         {
-            _disposed = true;
-            throw new ObjectDisposedException(nameof(ShellStreamWrapper));
+            // 通道已断:后续写入一律短路,不再逐次去撞库内异常(断线时键盘输入仍在入队)。
+            _channelClosed = true;
         }
     }
 
@@ -72,8 +90,23 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
     /// <summary>发送 window-change 请求以调整远程终端尺寸。</summary>
     public void Resize(int columns, int rows)
     {
-        if (_disposed || columns <= 0 || rows <= 0) return;
-        try { _process.SetTerminalSize(columns, rows); } catch { }
+        // 通道已断时不再尝试:SetTerminalSize 会在库内抛,而这里除了吞掉它什么也做不了。
+        if (_disposed || _channelClosed || columns <= 0 || rows <= 0) return;
+        try
+        {
+            _process.SetTerminalSize(columns, rows);
+        }
+        catch (Exception ex) when (ex is SshChannelClosedException
+                                      or SshConnectionClosedException
+                                      or ObjectDisposedException)
+        {
+            // 只有"通道确实没了"才短路后续调用;其它原因(参数、瞬时状态)照旧吞掉,不永久禁写。
+            _channelClosed = true;
+        }
+        catch
+        {
+            // 调整尺寸失败不影响会话本身。
+        }
     }
 
     /// <summary>释放底层 RemoteProcess。</summary>

--- a/src/VelaShell/ViewModels/FileBrowserViewModel.cs
+++ b/src/VelaShell/ViewModels/FileBrowserViewModel.cs
@@ -116,6 +116,7 @@ public class FileBrowserViewModel : ReactiveObject
         CopyToCommand = ReactiveCommand.CreateFromTask<RemoteFileInfoViewModel>(CopyToAsync);
         CopyPathCommand = ReactiveCommand.CreateFromTask<RemoteFileInfoViewModel>(CopyPathAsync);
         CopyNameCommand = ReactiveCommand.CreateFromTask<RemoteFileInfoViewModel>(CopyNameAsync);
+        CopyCurrentPathCommand = ReactiveCommand.CreateFromTask(CopyCurrentPathAsync);
         InvokeProtocolActionCommand = ReactiveCommand.CreateFromTask<ProtocolActionViewModel>(InvokeProtocolActionAsync);
         PropertiesCommand = ReactiveCommand.CreateFromTask<RemoteFileInfoViewModel>(
             ShowPropertiesAsync
@@ -842,6 +843,13 @@ public class FileBrowserViewModel : ReactiveObject
 
     /// <summary>把选中条目的名称复制到剪贴板。</summary>
     public ReactiveCommand<RemoteFileInfoViewModel, RxVoid> CopyNameCommand { get; }
+
+    /// <summary>
+    /// 把<b>当前所在目录</b>的完整远程路径复制到剪贴板(空白区右键)。
+    /// 与 <see cref="CopyPathCommand" /> 的区别是它不需要选中任何条目 ——
+    /// 否则想拿当前目录的路径就得先退回上级、再右键那个文件夹。
+    /// </summary>
+    public ReactiveCommand<RxVoid, RxVoid> CopyCurrentPathCommand { get; }
 
     /// <summary>
     /// 执行一条协议专属动作(插件协议贡献的右键菜单项,如 S3 的「复制分享链接」)。
@@ -2891,6 +2899,15 @@ public class FileBrowserViewModel : ReactiveObject
             return;
         }
         await CopyToClipboard(file.Name);
+    }
+
+    private async Task CopyCurrentPathAsync(CancellationToken ct = default)
+    {
+        if (CopyToClipboard is null || string.IsNullOrEmpty(CurrentPath))
+        {
+            return;
+        }
+        await CopyToClipboard(CurrentPath);
     }
 
     /// <summary>

--- a/src/VelaShell/Views/FileBrowserView.axaml
+++ b/src/VelaShell/Views/FileBrowserView.axaml
@@ -509,6 +509,15 @@
                                  Foreground="{DynamicResource VelaTextTertiary}" />
                 </MenuItem.Icon>
               </MenuItem>
+              <Separator />
+              <!-- 复制「当前所在目录」的路径。条目菜单里的「复制路径」需要先选中某一行,
+                   拿当前目录的路径就得先退回上级再右键它;这一项省掉那趟往返。 -->
+              <MenuItem Header="{loc:Localize CopyCurrentFolderPath}" Command="{Binding CopyCurrentPathCommand}">
+                <MenuItem.Icon>
+                  <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.copy}"
+                                 Foreground="{DynamicResource VelaTextTertiary}" />
+                </MenuItem.Icon>
+              </MenuItem>
             </ContextMenu>
           </ListBox.ContextMenu>
           <ListBox.ItemTemplate>

--- a/tests/VelaShell.Tests/Integration/TransferRealChannelIntegrationTests.cs
+++ b/tests/VelaShell.Tests/Integration/TransferRealChannelIntegrationTests.cs
@@ -143,6 +143,63 @@ public class TransferRealChannelIntegrationTests
         }
     }
 
+    /// <summary>
+    /// 连接被拆掉之后往 shell 流里写,必须是<b>静默空操作</b>并把 <c>CanWrite</c> 翻假。
+    /// <para>
+    /// 回归:<c>ShellStreamWrapper.WriteAsync</c> 曾把库里的 <c>SshChannelClosedException</c>
+    /// 转成新建的 <c>ObjectDisposedException</c> 再抛出,而唯一的消费者(桥的写循环)只是
+    /// catch 掉丢弃 —— 纯粹拿异常做控制流;更糟的是它顺手把 <c>_disposed</c> 置了位,
+    /// 让随后真正的 <c>Dispose()</c> 直接短路返回,<c>RemoteProcess</c> 再也不会被确定性释放。
+    /// 断开的通道只能用真实链路造出来,所以这条用例落在这套 Docker 夹具里。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    [TestCategory("DockerIntegration")]
+    [Timeout(60_000)]
+    public async Task WriteAfterConnectionTornDown_IsSilentNoOp_AndFlipsCanWrite()
+    {
+        if (SkipIfDockerOrSshMissing())
+        {
+            return;
+        }
+
+        TmdsSshClientWrapper client = await ConnectAsync();
+        IShellStreamWrapper shell = await client.CreateShellStreamAsync("xterm-256color", 120, 32, 0, 0, 16384);
+        Assert.IsTrue(shell.CanWrite, "刚开出来的 shell 流应可写。");
+
+        // 整条连接拆掉:此后任何写入在库内必然失败。
+        client.Dispose();
+
+        byte[] payload = "echo still-here\r"u8.ToArray();
+
+        // 关键断言:不抛。抛了就说明又退回了「拿异常做控制流」。
+        await shell.WriteAsync(payload, 0, payload.Length, CancellationToken.None);
+        Assert.IsFalse(shell.CanWrite, "通道已断后 CanWrite 必须翻假,上层才会短路后续写入。");
+
+        // 短路之后再写也不该抛,更不该再去撞一次库内异常。
+        await shell.WriteAsync(payload, 0, payload.Length, CancellationToken.None);
+
+        // 写失败过之后,真正的 Dispose 仍须走到底(旧实现会因 _disposed 已置位而直接返回)。
+        shell.Dispose();
+        Assert.IsFalse(shell.CanRead, "Dispose 后不应再声称可读。");
+    }
+
+    /// <summary>只需要 Docker + SSH 服务器的用例用这个门(不涉及 lrzsz)。</summary>
+    private bool SkipIfDockerOrSshMissing()
+    {
+        if (!DockerAvailable.Value)
+        {
+            TestContext.WriteLine("[SKIP] Docker 不可用。运行 'docker compose -f docker-compose.test.yml up -d' 以启用。");
+            return true;
+        }
+        if (!IsSshServerReachable())
+        {
+            TestContext.WriteLine($"[SKIP] SSH 测试服务器 {TestHost}:{TestPort} 不可达。");
+            return true;
+        }
+        return false;
+    }
+
     private static async Task<TmdsSshClientWrapper> ConnectAsync()
     {
         var settings = new SshClientSettings($"{TestUser}@{TestHost}")
@@ -226,7 +283,32 @@ public class TransferRealChannelIntegrationTests
         }
     }
 
-    private static bool IsSshServerReachable()
+    /// <summary>
+    /// 判据是「能不能真的建起一个 SSH 会话」,而不是「TCP 端口通不通」。
+    /// Docker 的端口代理<b>永远</b>接受 TCP 连接,哪怕后端 sshd 根本握不上手 ——
+    /// 只探端口会让本该跳过的用例带着 10 秒连接超时红掉,把环境问题伪装成代码问题。
+    /// 探测本身要花一次真实握手,所以缓存起来整轮只做一次。
+    /// </summary>
+    private static bool IsSshServerReachable() => SshLoginWorks.Value;
+
+    private static readonly Lazy<bool> SshLoginWorks = new(() =>
+    {
+        if (!IsPortOpen())
+        {
+            return false;
+        }
+        try
+        {
+            using var probe = ConnectAsync().GetAwaiter().GetResult();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    });
+
+    private static bool IsPortOpen()
     {
         try
         {

--- a/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
@@ -781,6 +781,28 @@ public class FileBrowserViewModelTests
         Assert.AreEqual("readme.txt", copied);
     }
 
+    /// <summary>
+    /// 空白区右键的「复制当前文件夹路径」不需要选中任何条目 —— 它取的是 <c>CurrentPath</c>。
+    /// 没有它,想拿当前目录的路径就得先退回上级、再右键那个文件夹。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public async Task CopyCurrentPath_CopiesCurrentDirectoryWithoutSelection()
+    {
+        string? copied = null;
+        _vm.CopyToClipboard = text =>
+        {
+            copied = text;
+            return Task.CompletedTask;
+        };
+        _vm.CurrentPath = "/root/nginx-backup-before-ubuntu-package";
+        _vm.SelectedFiles.Clear();
+
+        await _vm.CopyCurrentPathCommand.Execute().FirstAsync();
+
+        Assert.AreEqual("/root/nginx-backup-before-ubuntu-package", copied);
+    }
+
     [TestMethod]
     [TestCategory("FileBrowser")]
     public async Task Properties_InvokesViewCallback()


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次更新实现了文件浏览器空白区右键菜单“复制当前文件夹路径”功能，完善多语言支持，并新增相关单元测试。优化了 SSH ShellStreamWrapper 写入和 Resize 行为，断开后静默丢弃写入且正确切换 CanWrite 状态，提升健壮性和资源释放确定性。补充了 SSH 通道断开场景的集成测试及测试辅助方法，增强测试可靠性。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
