### PR TITLE
终端设置新增“上报终端工作目录”开关

### DIFF
--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -636,6 +636,17 @@ public class TerminalBehaviorOptions : ObservableOptions
         get;
         set => Set(ref field, value);
     } = "";
+
+    /// <summary>
+    /// 连接后静默注入 bash 目录上报钩子(OSC 7),默认开(#286)。
+    /// 关 = 一个字节都不注入,终端里再不会出现那串 <c>test -n "$BASH_VERSION" &amp;&amp; eval ...</c>;
+    /// 代价是 SFTP 文件浏览器的「跟随终端目录」(map-pin)拿不到 cwd,除非用户自己的提示符发 OSC 7。
+    /// </summary>
+    public bool ReportWorkingDirectory
+    {
+        get;
+        set => Set(ref field, value);
+    } = true;
 }
 
 /// <summary>设置 - 文件传输(设计 HGwa7)。</summary>

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2445,6 +2445,12 @@
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>例: cd /var/www</value>
   </data>
+  <data name="SetTerm_ReportWorkingDirectory" xml:space="preserve">
+    <value>ターミナルの作業ディレクトリを通知</value>
+  </data>
+  <data name="SetTerm_ReportWorkingDirectoryDesc" xml:space="preserve">
+    <value>接続後に bash へ OSC 7 フックをサイレント設定し、ファイルブラウザーの「ターミナルのディレクトリに追従」で使用します。オフにすると一切注入しません</value>
+  </data>
   <data name="SetTerm_Subtitle" xml:space="preserve">
     <value>// ターミナルの表示と動作を設定</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2445,6 +2445,12 @@
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>예: cd /var/www</value>
   </data>
+  <data name="SetTerm_ReportWorkingDirectory" xml:space="preserve">
+    <value>터미널 작업 디렉터리 보고</value>
+  </data>
+  <data name="SetTerm_ReportWorkingDirectoryDesc" xml:space="preserve">
+    <value>연결 후 bash에 OSC 7 훅을 조용히 설치하여 파일 브라우저의 「터미널 디렉터리 따라가기」에 사용합니다. 끄면 아무 명령도 주입하지 않습니다</value>
+  </data>
   <data name="SetTerm_Subtitle" xml:space="preserve">
     <value>// 터미널 표시 및 동작 설정</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2545,6 +2545,12 @@ Paste anyway?</value>
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>e.g. cd /var/www</value>
   </data>
+  <data name="SetTerm_ReportWorkingDirectory" xml:space="preserve">
+    <value>Report terminal working directory</value>
+  </data>
+  <data name="SetTerm_ReportWorkingDirectoryDesc" xml:space="preserve">
+    <value>Silently installs an OSC 7 hook in bash after connecting so the file browser can follow the terminal directory; turn off to inject nothing at all</value>
+  </data>
   <data name="SetTerm_Subtitle" xml:space="preserve">
     <value>// Configure terminal display and behavior</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2636,6 +2636,12 @@
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>如 cd /var/www</value>
   </data>
+  <data name="SetTerm_ReportWorkingDirectory" xml:space="preserve">
+    <value>上报终端工作目录</value>
+  </data>
+  <data name="SetTerm_ReportWorkingDirectoryDesc" xml:space="preserve">
+    <value>连接后向 bash 静默安装 OSC 7 钩子,供文件浏览器「跟随终端目录」使用;关闭则不注入任何命令</value>
+  </data>
   <data name="SetTerm_Subtitle" xml:space="preserve">
     <value>// 配置终端的显示和行为</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2445,6 +2445,12 @@
   <data name="SetTerm_StartupCommandPlaceholder" xml:space="preserve">
     <value>例如 cd /var/www</value>
   </data>
+  <data name="SetTerm_ReportWorkingDirectory" xml:space="preserve">
+    <value>回報終端機工作目錄</value>
+  </data>
+  <data name="SetTerm_ReportWorkingDirectoryDesc" xml:space="preserve">
+    <value>連線後向 bash 靜默安裝 OSC 7 掛鉤,供檔案瀏覽器「跟隨終端機目錄」使用;關閉則不注入任何指令</value>
+  </data>
   <data name="SetTerm_Subtitle" xml:space="preserve">
     <value>// 設定終端機的顯示與行為</value>
   </data>

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>
     /// bash 提示符目录上报钩子(内置、静默注入):每次提示符出现时发送 OSC 7,
     /// 供 SFTP 文件浏览器的「跟随终端目录」功能读取当前工作目录。
+    /// 由「设置 → 终端 → 会话 → 上报终端工作目录」开关控制,关掉即一字节不注入(#286)。
     /// </summary>
     /// <remarks>
     /// bash 代码放在单引号包裹的 eval 参数里,避免 fish 等 shell 预解析函数体时报错;
@@ -2361,19 +2362,36 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     }
 
     /// <summary>
-    /// 连接成功后静默注入目录上报钩子,并追加用户配置的"连接后执行命令"
+    /// 连接成功后按设置注入目录上报钩子,并追加用户配置的"连接后执行命令"
     /// (设置 → 终端 → 会话)。PTY 输入由内核缓冲,shell 就绪后才会读取,
     /// 无需等待提示符。
     /// </summary>
     private static void SendStartupCommand(TerminalTabViewModel tab, AppSettings settings)
     {
-        tab.SendSilentCommand(BuildStartupCommand(settings.TerminalBehavior.StartupCommand));
+        tab.SendSilentCommand(
+            BuildStartupCommand(
+                settings.TerminalBehavior.StartupCommand,
+                settings.TerminalBehavior.ReportWorkingDirectory
+            )
+        );
     }
 
-    /// <summary>组合内置目录上报钩子与用户启动命令;保持一次注入以共用同一个回显抑制窗口。</summary>
-    internal static string BuildStartupCommand(string? userCommand)
+    /// <summary>
+    /// 组合内置目录上报钩子与用户启动命令;保持一次注入以共用同一个回显抑制窗口。
+    /// </summary>
+    /// <param name="userCommand">用户配置的"连接后执行命令";空则只剩钩子。</param>
+    /// <param name="reportWorkingDirectory">
+    /// 是否注入 OSC 7 目录上报钩子(设置 → 终端 → 会话,#286)。关掉时两者皆空 =
+    /// 返回空串,<see cref="TerminalTabViewModel.SendSilentCommand" /> 对空串直接不发,
+    /// 连回车都不会多出来。
+    /// </param>
+    internal static string BuildStartupCommand(string? userCommand, bool reportWorkingDirectory = true)
     {
         string user = userCommand?.Trim() ?? string.Empty;
+        if (!reportWorkingDirectory)
+        {
+            return user;
+        }
         return user.Length == 0 ? WorkingDirectoryReportHook : WorkingDirectoryReportHook + "; " + user;
     }
 

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml
@@ -155,6 +155,13 @@
                  Text="{loc:Localize SetTerm_StartupCommandDesc}" />
       <TextBox Text="{Binding TerminalBehavior.StartupCommand}" PlaceholderText="{loc:Localize SetTerm_StartupCommandPlaceholder}" />
     </StackPanel>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetTerm_ReportWorkingDirectory}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetTerm_ReportWorkingDirectoryDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding TerminalBehavior.ReportWorkingDirectory}" VerticalAlignment="Center" />
+    </Grid>
 
     <Border Classes="sep" />
 

--- a/tests/VelaShell.Tests/ViewModels/MainWindowSshFeatureTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowSshFeatureTests.cs
@@ -34,6 +34,30 @@ public sealed class MainWindowSshFeatureTests
         Assert.EndsWith("; cd /srv/app", command);
     }
 
+    /// <summary>
+    /// 关掉「上报终端工作目录」后必须一个字节都不注入(#286):用户报的就是每次开窗
+    /// 终端里都要闪一串 test -n "$BASH_VERSION"。空串在 SendSilentCommand 里被直接丢弃,
+    /// 连多余的回车都不会有。
+    /// </summary>
+    [TestMethod]
+    public void BuildStartupCommand_WhenReportingDisabled_WithoutUserCommand_InjectsNothing()
+    {
+        string command = MainWindowViewModel.BuildStartupCommand(null, reportWorkingDirectory: false);
+
+        Assert.IsEmpty(command);
+    }
+
+    /// <summary>关掉钩子不该连累用户自己的"连接后执行命令" —— 那是两件事。</summary>
+    [TestMethod]
+    public void BuildStartupCommand_WhenReportingDisabled_KeepsUserCommandOnly()
+    {
+        string command = MainWindowViewModel.BuildStartupCommand("  cd /srv/app  ", reportWorkingDirectory: false);
+
+        Assert.AreEqual("cd /srv/app", command);
+        Assert.DoesNotContain("vela_shell_osc7", command);
+        Assert.DoesNotContain("BASH_VERSION", command);
+    }
+
     [TestMethod]
     public async Task ConnectProfileAsync_AddsTerminalTab_AndUpdatesStatusBar()
     {


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次变更为终端设置新增了“上报终端工作目录”（ReportWorkingDirectory）开关，默认开启，用于控制是否在连接后注入 bash OSC 7 钩子，便于文件浏览器跟随终端目录。关闭后不会注入相关命令，解决终端开窗闪现钩子命令的问题（#286）。
- AppSettings.cs：TerminalBehaviorOptions 增加 ReportWorkingDirectory 属性及注释
- MainWindowViewModel.cs：调整 SendStartupCommand 和 BuildStartupCommand，支持新开关，保证用户自定义命令不受影响
- TerminalSettingsPage.axaml：新增 UI 控件及多语言描述
- Strings.resx 及各语言资源文件：补充名称和说明文本
- MainWindowSshFeatureTests.cs：增加单元测试，确保开关关闭时不注入钩子命令，用户自定义命令正常

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #286

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
