### PR TITLE
防止拖动滚动条时触发框选及相关测试

### DIFF
--- a/src/VelaShell/Views/MarqueeSelection.cs
+++ b/src/VelaShell/Views/MarqueeSelection.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
@@ -105,6 +106,10 @@ internal sealed class MarqueeSelection
         {
             return;
         }
+        if (IsWithinScrollBar(e.Source))
+        {
+            return;
+        }
         if (!_canStart(e))
         {
             return;
@@ -136,6 +141,26 @@ internal sealed class MarqueeSelection
                 _pressSelection.Add(item);
             }
         }
+    }
+
+    /// <summary>按下位置是否落在列表自己的滚动条里(含滑块、轨道与两端按钮)。</summary>
+    /// <remarks>
+    /// 滚动条长在 <see cref="ListBox" /> 的模板内,它的 PointerPressed 照样冒泡到列表,
+    /// 而框选是以 handledEventsToo 挂在列表上的 —— 不在这里拦掉,拖滚动条就会顺带拉出一个选区。
+    /// 这不是各视图的 start policy 能表达的事(滚动条在任何面板里都不是框选面),
+    /// 所以拦在公共入口,三处调用方一起受益。
+    /// </remarks>
+    private static bool IsWithinScrollBar(object? source)
+    {
+        for (var current = source as Visual; current is not null; current = current.GetVisualParent())
+        {
+            if (current is ScrollBar)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static bool IsDndSurface(object? source)

--- a/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
@@ -1,0 +1,226 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Models;
+using VelaShell.Core.Sftp;
+using VelaShell.Localization;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 拖动文件列表自己的滚动条不能起框选(用户报告:SFTP/FTP 面板拖滚动条会拉出选区)。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 滚动条长在 ListBox 自己的模板里,按下事件照样冒泡到 ListBox —— 而框选是以
+/// handledEventsToo 挂在 ListBox 上的,不把滚动条排除掉就一定会被它接走。
+/// </para>
+/// <para>
+/// 本地栏尤其明显:行的最后一列(修改时间)是 <c>HorizontalAlignment="Left"</c> 的
+/// dnd-surface,实际只有文字那么宽,右侧滚动条那一带谁都没盖 —— 于是 canStart 放行,框选起头。
+/// </para>
+/// <para>
+/// body 必须同步 + <c>return Task.CompletedTask</c>:传 async lambda 会绑到
+/// <c>Dispatch(Func&lt;TResult&gt;)</c>,断言一条都不会跑却全绿。
+/// </para>
+/// </remarks>
+[TestClass]
+[TestCategory("MarqueeUI")]
+public sealed class ScrollBarMarqueeUiTests
+{
+    /// <summary>行要够多,列表才滚得动、才有滑块可拖。</summary>
+    private const int FileCount = 60;
+
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(ScrollBarMarqueeUiTests).Assembly);
+        LocalizedStrings.Instance.Attach(new LocalizationService());
+    }
+
+    /// <summary>本地栏(双栏左侧)—— 用户实际报的那一条。</summary>
+    [TestMethod]
+    public void LocalPane_DraggingTheScrollBar_DoesNotMarquee()
+    {
+        using var root = new TempDirectory();
+        for (int i = 0; i < FileCount; i++)
+        {
+            File.WriteAllText(Path.Combine(root.Path, $"f{i:D2}.txt"), "x");
+        }
+
+        OnUi(() =>
+        {
+            var vm = new LocalFilePaneViewModel(
+                new TransferOptions { LocalDownloadDirectory = root.Path },
+                rootProvider: new TestRootProvider(new LocalRootEntry("~", root.Path, true, root.Path)));
+            PumpUntilComplete(vm.LoadInitialAsync());
+
+            var view = new LocalFilePaneView { DataContext = vm };
+            RunScrollBarDrag(view, () => vm.SelectedEntries.Count);
+        });
+    }
+
+    /// <summary>远端栏走的是同一个 MarqueeSelection,同样不该被滚动条起框。</summary>
+    [TestMethod]
+    public void RemotePane_DraggingTheScrollBar_DoesNotMarquee()
+    {
+        OnUi(() =>
+        {
+            ISftpService sftp = Substitute.For<ISftpService>();
+            var sessionId = Guid.NewGuid();
+            List<RemoteFileInfo> files =
+            [
+                .. Enumerable.Range(1, FileCount).Select(i => new RemoteFileInfo
+                {
+                    Name = $"f{i:D2}.txt",
+                    FullPath = $"/home/user/f{i:D2}.txt",
+                    Size = i,
+                    Permissions = "-rw-r--r--",
+                    IsDirectory = false,
+                    LastModified = DateTime.UtcNow,
+                    Owner = "user",
+                    Group = "user",
+                }),
+            ];
+            sftp.ListDirectoryAsync(sessionId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(files));
+
+            var vm = new FileBrowserViewModel(sftp, sessionId)
+            {
+                IsVisible = true,
+                IsDragEnabled = true,
+                TransferOptions = new(),
+                CurrentPath = "/home/user",
+            };
+            vm.RefreshCommand.Execute().Subscribe();
+            PumpUntil(() => vm.Files.Count > 0, "目录列举没能在预期时间内完成。");
+
+            var view = new FileBrowserView { DataContext = vm };
+            RunScrollBarDrag(view, () => vm.SelectedFiles.Count);
+        });
+    }
+
+    /// <summary>
+    /// 把视图挂进窗口,按住纵向滚动条的滑块往下拖,全程不得出现框选矩形、不得选中任何行。
+    /// </summary>
+    private static void RunScrollBarDrag(Control view, Func<int> selectedCount)
+    {
+        var window = new Window { Width = 900, Height = 600, Content = view };
+        try
+        {
+            window.Show();
+            Pump(window);
+
+            ListBox list = window.GetVisualDescendants().OfType<ListBox>().Single(l => l.Name == "FileList");
+            Border overlay = window.GetVisualDescendants().OfType<Border>().Single(b => b.Name == "MarqueeOverlay");
+            ScrollBar bar = list.GetVisualDescendants().OfType<ScrollBar>()
+                                .Single(b => b.Orientation == Orientation.Vertical);
+            Thumb thumb = bar.GetVisualDescendants().OfType<Thumb>().Single();
+            Assert.IsGreaterThan(0, thumb.Bounds.Height, "没量到滑块 —— 列表八成没溢出,滚动条不存在。");
+
+            // 刺激送达的凭据:光看"没框选"不算数,得先证明这一下确实按在了滚动条上。
+            // (滑块在 headless 下拖不动滚动偏移,所以不能拿 Offset 当凭据。)
+            var pressedOnBar = false;
+            bar.AddHandler(
+                InputElement.PointerPressedEvent,
+                (_, _) => pressedOnBar = true,
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+                handledEventsToo: true);
+
+            // 必须落在滑块上:压在轨道上会启动滚动条的连续翻页计时器,RunJobs 再也排不空。
+            Point start = thumb.TranslatePoint(new(thumb.Bounds.Width / 2, thumb.Bounds.Height / 2), window)!.Value;
+
+            window.MouseMove(start);
+            Pump(window);
+            window.MouseDown(start, MouseButton.Left);
+            Pump(window);
+            var overlayEverVisible = false;
+            for (int step = 1; step <= 6; step++)
+            {
+                window.MouseMove(new(start.X, start.Y + (20.0 * step)));
+                Pump(window);
+                overlayEverVisible |= overlay.IsVisible;
+            }
+            window.MouseUp(new(start.X, start.Y + 120), MouseButton.Left);
+            Pump(window);
+
+            Assert.IsTrue(pressedOnBar, "按下没落到滚动条上 —— 这条用例什么都没测。");
+            Assert.IsFalse(overlayEverVisible, "拖滚动条时冒出了框选矩形。");
+            Assert.AreEqual(0, selectedCount(), "拖滚动条不该选中任何文件。");
+        }
+        finally
+        {
+            // 不关窗整个 headless 套件会永久卡死。
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    /// <summary>在 UI 线程上把异步准备跑完(body 必须保持同步,不能 await)。</summary>
+    private static void PumpUntilComplete(Task task)
+    {
+        PumpUntil(() => task.IsCompleted, "本地栏初始化没能在预期时间内完成。");
+        task.GetAwaiter().GetResult();
+    }
+
+    private static void PumpUntil(Func<bool> done, string message)
+    {
+        for (int i = 0; i < 5000 && !done(); i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(1);
+        }
+        Assert.IsTrue(done(), message);
+    }
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    private sealed class TestRootProvider(params LocalRootEntry[] roots) : ILocalRootProvider
+    {
+        public Task<IReadOnlyList<LocalRootEntry>> EnumerateAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<LocalRootEntry>>(roots);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"velashell-sbmarquee-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
在 MarqueeSelection.cs 新增 IsWithinScrollBar 方法，阻止 PointerPressed 事件在滚动条上时触发框选。新增 ScrollBarMarqueeUiTests，验证本地和远端文件栏拖动滚动条不会触发框选或选中行，覆盖用户反馈场景。

<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
