### PR TITLE
代码清理与测试断言现代化改造

### DIFF
--- a/src/VelaShell.Core/FileTransfer/Diagnostics/TransferTrace.cs
+++ b/src/VelaShell.Core/FileTransfer/Diagnostics/TransferTrace.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using VelaShell.Core.FileTransfer.Protocol;
 
 namespace VelaShell.Core.FileTransfer.Diagnostics;
 

--- a/src/VelaShell.Core/FileTransfer/Protocol/Crc16Xmodem.cs
+++ b/src/VelaShell.Core/FileTransfer/Protocol/Crc16Xmodem.cs
@@ -1,5 +1,3 @@
-using VelaShell.Core.FileTransfer.Protocol;
-
 namespace VelaShell.Core.FileTransfer.Protocol;
 
 /// <summary>

--- a/src/VelaShell.Core/XYModem/Protocol/XYModemReceiver.cs
+++ b/src/VelaShell.Core/XYModem/Protocol/XYModemReceiver.cs
@@ -164,7 +164,7 @@ public sealed class XYModemReceiver(
             // 0 号块坏了:NAK 请求重发,再等下一个引导。
             await WriteAsync([XYModemConstants.NAK], ct).ConfigureAwait(false);
             currentLead = await WaitForLeadAsync(handshaking: false, ct).ConfigureAwait(false);
-            if (currentLead < 0 || currentLead == XYModemConstants.CAN)
+            if (currentLead is < 0 or XYModemConstants.CAN)
             {
                 session.Status = currentLead == XYModemConstants.CAN
                     ? FileTransferState.Cancelled

--- a/src/VelaShell.Terminal/FileTransfer/ShellStreamByteDuplex.cs
+++ b/src/VelaShell.Terminal/FileTransfer/ShellStreamByteDuplex.cs
@@ -1,7 +1,7 @@
 using System.Threading.Channels;
-using VelaShell.Core.Ssh;
 using VelaShell.Core.FileTransfer.Abstractions;
 using VelaShell.Core.FileTransfer.Diagnostics;
+using VelaShell.Core.Ssh;
 
 namespace VelaShell.Terminal.FileTransfer;
 

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -1,7 +1,6 @@
 using System.Threading.Channels;
 using Avalonia.Threading;
 using VelaShell.Core.Ssh;
-using VelaShell.Core.FileTransfer.Model;
 
 namespace VelaShell.Terminal;
 

--- a/src/VelaShell/Services/FileTransfer/FolderTransferFileSink.cs
+++ b/src/VelaShell/Services/FileTransfer/FolderTransferFileSink.cs
@@ -1,7 +1,6 @@
-using VelaShell.Core.Models;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
 using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Models;
 
 namespace VelaShell.Services.FileTransfer;
 

--- a/src/VelaShell/Services/FileTransfer/PickedFilesTransferSource.cs
+++ b/src/VelaShell/Services/FileTransfer/PickedFilesTransferSource.cs
@@ -1,5 +1,4 @@
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
 using VelaShell.Core.FileTransfer.Model;
 
 namespace VelaShell.Services.FileTransfer;

--- a/src/VelaShell/Services/FileTransfer/TerminalTransferObserver.cs
+++ b/src/VelaShell/Services/FileTransfer/TerminalTransferObserver.cs
@@ -1,10 +1,9 @@
 using System.Collections.Concurrent;
 using Avalonia.Threading;
-using VelaShell.Core.Models;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
-using VelaShell.ViewModels;
 using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Models;
+using VelaShell.ViewModels;
 
 namespace VelaShell.Services.FileTransfer;
 

--- a/tests/VelaShell.Core.Tests/Ssh/SshAlgorithmProbeTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/SshAlgorithmProbeTests.cs
@@ -32,38 +32,38 @@ public class SshAlgorithmProbeTests
     [TestMethod]
     public async Task Probe_ReadsEveryListTheServerAdvertises()
     {
-        await using FakeSshServer server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
+        await using var server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
 
         SshPeerAlgorithms peer = (await SshAlgorithmProbe.TryProbeAsync(
-            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationTokenSource.Token))!;
+            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationToken))!;
 
         Assert.AreEqual(BastionVersion, peer.ServerVersion);
-        CollectionAssert.AreEqual(BastionKex, peer.KeyExchange.ToArray());
-        CollectionAssert.AreEqual(BastionHostKey, peer.HostKey.ToArray());
-        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionServerToClient.ToArray());
-        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionClientToServer.ToArray());
-        CollectionAssert.AreEqual(BastionMac, peer.MacServerToClient.ToArray());
+        Assert.AreSequenceEqual(BastionKex, [.. peer.KeyExchange]);
+        Assert.AreSequenceEqual(BastionHostKey, [.. peer.HostKey]);
+        Assert.AreSequenceEqual(BastionEncryption, [.. peer.EncryptionServerToClient]);
+        Assert.AreSequenceEqual(BastionEncryption, [.. peer.EncryptionClientToServer]);
+        Assert.AreSequenceEqual(BastionMac, [.. peer.MacServerToClient]);
     }
 
     [TestMethod]
     public async Task Probe_SkipsTheBannerLinesBeforeTheVersionString()
     {
         // 堡垒机与政企设备普遍在版本串之前先甩一段法律声明;认死第一行就什么也探不到了。
-        await using FakeSshServer server = FakeSshServer.Start(
+        await using var server = FakeSshServer.Start(
             (stream, ct) => ServeBastionKexInitAsync(stream, ct, banner: "*** 授权用户专用,操作全程审计 ***"));
 
         SshPeerAlgorithms peer = (await SshAlgorithmProbe.TryProbeAsync(
-            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationTokenSource.Token))!;
+            IPAddress.Loopback.ToString(), server.Port, ProbeTimeout, TestContext.CancellationToken))!;
 
         Assert.AreEqual(BastionVersion, peer.ServerVersion);
-        CollectionAssert.AreEqual(BastionEncryption, peer.EncryptionServerToClient.ToArray());
+        Assert.AreSequenceEqual(BastionEncryption, [.. peer.EncryptionServerToClient]);
     }
 
     [TestMethod]
     public async Task Probe_EndpointThatIsNotSsh_ReturnsNullInsteadOfThrowing()
     {
         // 端口填错(填到 HTTP 或 TLS 上)时诊断只该沉默,不能再抛一个异常盖掉真正的失败。
-        await using FakeSshServer server = FakeSshServer.Start(async (stream, ct) =>
+        await using var server = FakeSshServer.Start(async (stream, ct) =>
         {
             await WriteLineAsync(stream, "HTTP/1.1 400 Bad Request", ct);
             await WriteLineAsync(stream, "Content-Length: 0", ct);
@@ -71,13 +71,13 @@ public class SshAlgorithmProbeTests
 
         Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
                           IPAddress.Loopback.ToString(), server.Port, ProbeTimeout,
-                          TestContext.CancellationTokenSource.Token));
+                          TestContext.CancellationToken));
     }
 
     [TestMethod]
     public async Task Probe_PacketCutShort_ReturnsNullInsteadOfThrowing()
     {
-        await using FakeSshServer server = FakeSshServer.Start(async (stream, ct) =>
+        await using var server = FakeSshServer.Start(async (stream, ct) =>
         {
             await WriteLineAsync(stream, BastionVersion, ct);
             await ReadLineAsync(stream, ct);
@@ -89,7 +89,7 @@ public class SshAlgorithmProbeTests
 
         Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
                           IPAddress.Loopback.ToString(), server.Port, ProbeTimeout,
-                          TestContext.CancellationTokenSource.Token));
+                          TestContext.CancellationToken));
     }
 
     [TestMethod]
@@ -102,13 +102,13 @@ public class SshAlgorithmProbeTests
 
         Assert.IsNull(await SshAlgorithmProbe.TryProbeAsync(
                           IPAddress.Loopback.ToString(), port, ProbeTimeout,
-                          TestContext.CancellationTokenSource.Token));
+                          TestContext.CancellationToken));
     }
 
     [TestMethod]
     public async Task Describe_ReportsOnlyTheAlgorithmClassesWithNoOverlap()
     {
-        await using FakeSshServer server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
+        await using var server = FakeSshServer.Start((stream, ct) => ServeBastionKexInitAsync(stream, ct));
         var settings = new SshClientSettings("probe@127.0.0.1")
         {
             HostName = IPAddress.Loopback.ToString(),
@@ -116,7 +116,7 @@ public class SshAlgorithmProbeTests
         };
 
         string message = (await SshAlgorithmDiagnostics.TryDescribeAsync(
-            settings, TestContext.CancellationTokenSource.Token))!;
+            settings, TestContext.CancellationToken))!;
 
         Assert.Contains(BastionVersion, message, "对端版本要摆出来 —— 用户和厂商对线时就靠这一句。");
         Assert.Contains("aes128-ctr", message, "对端提供的加密算法必须原样列出。");
@@ -139,7 +139,7 @@ public class SshAlgorithmProbeTests
     {
         // 协商失败另有原因(比如对端在 KEXINIT 之后才出问题)时不能硬凑一段说明:
         // 指着一堆其实能用的算法说"没有交集"比不说更糟。
-        await using FakeSshServer server = FakeSshServer.Start((stream, ct) =>
+        await using var server = FakeSshServer.Start((stream, ct) =>
             ServeKexInitAsync(stream, ct, BastionVersion, BastionKex,
                               ["rsa-sha2-256"], ["chacha20-poly1305@openssh.com"], ["hmac-sha2-256"]));
         var settings = new SshClientSettings("probe@127.0.0.1")
@@ -149,7 +149,7 @@ public class SshAlgorithmProbeTests
         };
 
         Assert.IsNull(await SshAlgorithmDiagnostics.TryDescribeAsync(
-                          settings, TestContext.CancellationTokenSource.Token));
+                          settings, TestContext.CancellationToken));
     }
 
     public TestContext TestContext { get; set; } = null!;

--- a/tests/VelaShell.Core.Tests/XYModem/XYModemBlockTests.cs
+++ b/tests/VelaShell.Core.Tests/XYModem/XYModemBlockTests.cs
@@ -29,7 +29,7 @@ public class XYModemBlockTests
         Assert.AreEqual(0x01, wire[0], "128 字节块必须以 SOH(0x01)引导");
         Assert.AreEqual(0x00, wire[1], "块号");
         Assert.AreEqual(0xFF, wire[2], "块号取反");
-        CollectionAssert.AreEqual(payload, wire[3..131], "负载应原样上链(这一族协议不做转义)");
+        Assert.AreSequenceEqual(payload, wire[3..131], "负载应原样上链(这一族协议不做转义)");
         Assert.AreEqual(0x00, wire[131], "全零负载的 CRC-16/XMODEM 高字节必为 0");
         Assert.AreEqual(0x00, wire[132], "全零负载的 CRC-16/XMODEM 低字节必为 0");
     }
@@ -100,7 +100,7 @@ public class XYModemBlockTests
         XYModemBlock.Write(payload, 1, useCrc: true, first);
         XYModemBlock.Write(payload, 200, useCrc: true, second);
 
-        CollectionAssert.AreEqual(first[131..133], second[131..133], "块号变了但校验字段不该变");
+        Assert.AreSequenceEqual(first[131..133], second[131..133], "块号变了但校验字段不该变");
         // 与独立实现的 CRC 例程比对(Crc16Xmodem 自身有已知向量测试托底)。
         ushort expected = Crc16Xmodem.Compute(payload);
         Assert.AreEqual((byte)(expected >> 8), first[131]);

--- a/tests/VelaShell.Core.Tests/XYModem/XYModemInteropTests.cs
+++ b/tests/VelaShell.Core.Tests/XYModem/XYModemInteropTests.cs
@@ -114,9 +114,9 @@ public class XYModemInteropTests
         FileTransferSession session = await receiving;
 
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        CollectionAssert.AreEqual(new[] { "中文名.txt" }, sink.OfferedNames, "0 号块的 UTF-8 文件名应原样解出");
-        Assert.AreEqual((long)content.Length, sink.OfferedSizes[0], "0 号块声明的大小应被解析");
-        CollectionAssert.AreEqual(content, sink.Completed["中文名.txt"], "末块的 SUB 填充必须按声明大小裁掉");
+        Assert.AreSequenceEqual(new[] { "中文名.txt" }, sink.OfferedNames, "0 号块的 UTF-8 文件名应原样解出");
+        Assert.AreEqual(content.Length, sink.OfferedSizes[0], "0 号块声明的大小应被解析");
+        Assert.AreSequenceEqual(content, sink.Completed["中文名.txt"], "末块的 SUB 填充必须按声明大小裁掉");
     }
 
     /// <summary>
@@ -150,8 +150,8 @@ public class XYModemInteropTests
         FileTransferSession session = await receiving;
 
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        CollectionAssert.AreEqual(new[] { "download.bin" }, sink.OfferedNames);
-        CollectionAssert.AreEqual(content, sink.Completed["download.bin"]);
+        Assert.AreSequenceEqual(new[] { "download.bin" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(content, sink.Completed["download.bin"]);
     }
 
     /// <summary>XMODEM-1K 的 1024 字节块由 STX 引导,接收方应按引导字节自动识别块长。</summary>
@@ -187,7 +187,7 @@ public class XYModemInteropTests
         Assert.AreEqual(FileTransferState.Completed, session.Status);
         // 尾部是 24 个 SUB 填充,裁掉后应正好还原 1000 字节 —— 但内容末尾恰为 SUB 时会多裁,
         // 这是 XMODEM 不传大小的固有局限,此处的测试数据刻意避开了那种情形。
-        CollectionAssert.AreEqual(content, sink.Completed["big.bin"]);
+        Assert.AreSequenceEqual(content, sink.Completed["big.bin"]);
     }
 
     /// <summary>块校验失败时必须回 NAK 要求重发,重发正确后照常继续 —— 这是 XMODEM 的全部纠错手段。</summary>
@@ -222,7 +222,7 @@ public class XYModemInteropTests
 
         FileTransferSession session = await receiving;
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        CollectionAssert.AreEqual(content, sink.Completed["retry.bin"]);
+        Assert.AreSequenceEqual(content, sink.Completed["retry.bin"]);
     }
 
     /// <summary>
@@ -266,8 +266,8 @@ public class XYModemInteropTests
 
         byte[] landed = sink.Completed["dup.bin"];
         Assert.AreEqual(256, landed.Length, "重复块被写了两遍就会超过声明的 256 字节");
-        CollectionAssert.AreEqual(first, landed[..4]);
-        CollectionAssert.AreEqual(second, landed[128..132]);
+        Assert.AreSequenceEqual(first, landed[..4]);
+        Assert.AreSequenceEqual(second, landed[128..132]);
     }
 
     /// <summary>YMODEM-G 的握手字符是 <c>'G'</c> 而不是 <c>'C'</c>,且收到块后不逐块应答。</summary>
@@ -301,7 +301,7 @@ public class XYModemInteropTests
 
         FileTransferSession session = await receiving;
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        CollectionAssert.AreEqual(content, sink.Completed["g.bin"]);
+        Assert.AreSequenceEqual(content, sink.Completed["g.bin"]);
     }
 
     /// <summary>对端发来连续 CAN 时必须立刻中止,而不是把 CAN 当数据吞下去。</summary>
@@ -353,7 +353,7 @@ public class XYModemInteropTests
         Assert.AreEqual(0xFF, blockZero[2]);
         TransferFileMetadata parsed = TransferFileInfoCodec.Parse(blockZero.AsSpan(3, 128));
         Assert.AreEqual("up.txt", parsed.FileName);
-        Assert.AreEqual((long)content.Length, parsed.Size);
+        Assert.AreEqual(content.Length, parsed.Size);
         await peer.WriteAsync(new byte[] { ACK, C }, cts.Token);
 
         // 数据块:内容不足 128 时用 SOH 小块,尾部 SUB 填充。
@@ -361,7 +361,7 @@ public class XYModemInteropTests
         Assert.AreEqual(SOH, dataBlock[0], "不足 128 字节的尾块应降到 SOH 小块,不该发整整 1KB 填充");
         Assert.AreEqual(0x01, dataBlock[1]);
         Assert.AreEqual(0xFE, dataBlock[2]);
-        CollectionAssert.AreEqual(content, dataBlock[3..(3 + content.Length)]);
+        Assert.AreSequenceEqual(content, dataBlock[3..(3 + content.Length)]);
         Assert.AreEqual(SUB, dataBlock[3 + content.Length], "尾部必须用 SUB(0x1A)填充");
         Assert.IsTrue(
             XYModemBlock.Verify(dataBlock.AsSpan(3, 128), dataBlock.AsSpan(131, 2), useCrc: true),
@@ -378,7 +378,7 @@ public class XYModemInteropTests
         Assert.AreEqual(SOH, terminator[0]);
         Assert.AreEqual(0x00, terminator[1]);
         Assert.AreEqual(0xFF, terminator[2]);
-        CollectionAssert.AreEqual(new byte[128], terminator[3..131], "批结束块的负载必须是 128 个零");
+        Assert.AreSequenceEqual(new byte[128], terminator[3..131], "批结束块的负载必须是 128 个零");
         Assert.AreEqual(0x00, terminator[131]);
         Assert.AreEqual(0x00, terminator[132]);
         await peer.WriteAsync(new byte[] { ACK }, cts.Token);

--- a/tests/VelaShell.Core.Tests/XYModem/XYModemLoopbackTests.cs
+++ b/tests/VelaShell.Core.Tests/XYModem/XYModemLoopbackTests.cs
@@ -57,8 +57,8 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        Assert.AreEqual((long)data.Length, sink.OfferedSizes[0]);
-        CollectionAssert.AreEqual(data, sink.Completed["payload.bin"]);
+        Assert.AreEqual(data.Length, sink.OfferedSizes[0]);
+        Assert.AreSequenceEqual(data, sink.Completed["payload.bin"]);
     }
 
     /// <summary>YMODEM 的批量能力:一次会话连发三个文件,顺序与内容都不能串。</summary>
@@ -77,10 +77,10 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        CollectionAssert.AreEqual(new[] { "first.bin", "second.bin", "三个.txt" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(new[] { "first.bin", "second.bin", "三个.txt" }, sink.OfferedNames);
         foreach ((string name, byte[] data) in files)
         {
-            CollectionAssert.AreEqual(data, sink.Completed[name], $"{name} 内容不符");
+            Assert.AreSequenceEqual(data, sink.Completed[name], $"{name} 内容不符");
         }
         Assert.AreEqual(3, send.Items.Count);
     }
@@ -95,7 +95,7 @@ public class XYModemLoopbackTests
             await RoundTripAsync(TerminalTransferProtocol.YModem, [("wrap.bin", data)]);
 
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        CollectionAssert.AreEqual(data, sink.Completed["wrap.bin"], "块号回绕后内容错位");
+        Assert.AreSequenceEqual(data, sink.Completed["wrap.bin"], "块号回绕后内容错位");
     }
 
     /// <summary>XMODEM 单文件:没有文件名与大小,内容仍要能完整落地。</summary>
@@ -110,7 +110,7 @@ public class XYModemLoopbackTests
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
         Assert.IsNull(sink.OfferedSizes[0], "XMODEM 不传大小,元数据里的 Size 应为 null");
-        CollectionAssert.AreEqual(data, sink.Completed["classic.bin"]);
+        Assert.AreSequenceEqual(data, sink.Completed["classic.bin"]);
     }
 
     /// <summary>XMODEM-1K:发送端改用 1024 字节块,接收端按引导字节自适应。</summary>
@@ -123,7 +123,7 @@ public class XYModemLoopbackTests
             await RoundTripAsync(TerminalTransferProtocol.XModem1K, [("big.bin", data)]);
 
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        CollectionAssert.AreEqual(data, sink.Completed["big.bin"]);
+        Assert.AreSequenceEqual(data, sink.Completed["big.bin"]);
     }
 
     /// <summary>YMODEM-G:数据块不逐块应答,内容仍要完整。</summary>
@@ -137,7 +137,7 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        CollectionAssert.AreEqual(data, sink.Completed["stream.bin"]);
+        Assert.AreSequenceEqual(data, sink.Completed["stream.bin"]);
     }
 
     /// <summary>正好等于块长整数倍的文件不能多发一个空块、也不能少一块。</summary>
@@ -151,7 +151,7 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
         Assert.AreEqual(data.Length, sink.Completed["exact.bin"].Length);
-        CollectionAssert.AreEqual(data, sink.Completed["exact.bin"]);
+        Assert.AreSequenceEqual(data, sink.Completed["exact.bin"]);
     }
 
     /// <summary>空文件也要能走完流程(0 号块声明大小 0,随后直接 EOT)。</summary>

--- a/tests/VelaShell.Core.Tests/ZModem/CrcTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/CrcTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
-using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Core.FileTransfer.Protocol;
-using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/FrameCodecTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/FrameCodecTests.cs
@@ -1,5 +1,5 @@
-using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/LrzszInteropTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/LrzszInteropTests.cs
@@ -1,10 +1,10 @@
 using System.Text;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
-using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Core.FileTransfer.Model;
 using VelaShell.Core.FileTransfer.Protocol;
 using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Model;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/ReceiverTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ReceiverTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
-using VelaShell.Core.ZModem.Protocol;
-using VelaShell.Core.FileTransfer.Model;
 using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/SenderTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/SenderTests.cs
@@ -1,9 +1,8 @@
 using System.Text;
-using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
-using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Core.FileTransfer.Model;
 using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Model;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/SubpacketTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/SubpacketTests.cs
@@ -1,5 +1,5 @@
-using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Core.Tests.FileTransfer;
+using VelaShell.Core.ZModem.Protocol;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/TestSender.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/TestSender.cs
@@ -1,9 +1,6 @@
 using System.Text;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
 using VelaShell.Core.ZModem.Protocol;
-using VelaShell.Core.FileTransfer.Model;
-using VelaShell.Core.Tests.FileTransfer;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Core.Tests/ZModem/ZModemHardeningTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ZModemHardeningTests.cs
@@ -78,8 +78,8 @@ public class ZModemHardeningTests
             new ZModemSender(a, new InMemoryFileSource([("测试文件.txt", data)])).SendAsync(cts.Token);
         await Task.WhenAll(receive, send);
 
-        CollectionAssert.AreEqual(new[] { "测试文件.txt" }, sink.OfferedNames);
-        CollectionAssert.AreEqual(data, sink.Completed["测试文件.txt"]);
+        Assert.AreSequenceEqual(new[] { "测试文件.txt" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(data, sink.Completed["测试文件.txt"]);
     }
 
     /// <summary>
@@ -172,7 +172,7 @@ public class ZModemHardeningTests
 
         // 引擎在收尾时把没消费的字节 Unread 回通道,这里应能重新读出来。
         ReadOnlyMemory<byte> returned = await duplex.ReadAsync(CancellationToken.None);
-        CollectionAssert.AreEqual(tail, returned.ToArray(), "提示符字节必须原样退回,而不是随读取器一起丢掉");
+        Assert.AreSequenceEqual(tail, returned.ToArray(), "提示符字节必须原样退回,而不是随读取器一起丢掉");
     }
 
     /// <summary>
@@ -202,7 +202,7 @@ public class ZModemHardeningTests
             ZModemSubpacketResult result = await ZModemSubpacket.ReadAsync(reader, useCrc32, CancellationToken.None);
 
             Assert.AreEqual(ZModemSubpacketStatus.Ok, result.Status, $"crc32={useCrc32}");
-            CollectionAssert.AreEqual(payload, result.Data, $"crc32={useCrc32} 时负载不保真");
+            Assert.AreSequenceEqual(payload, result.Data, $"crc32={useCrc32} 时负载不保真");
         }
     }
 

--- a/tests/VelaShell.Core.Tests/ZModem/ZdleCodecTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ZdleCodecTests.cs
@@ -1,5 +1,4 @@
 using VelaShell.Core.ZModem.Protocol;
-using VelaShell.Core.Tests.FileTransfer;
 
 namespace VelaShell.Core.Tests.ZModem;
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
@@ -464,7 +464,7 @@ public sealed class PluginWorkspaceTests
 
         launcher.OnUnregistered(WorkspaceId);
 
-        CollectionAssert.AreEqual(new[] { session.SessionId }, abandoned);
+        Assert.AreSequenceEqual(new[] { session.SessionId }, abandoned);
         // 已经报过的会话不会再报第二次(界面关闭标签页时也会 Forget)。
         abandoned.Clear();
         launcher.OnUnregistered(WorkspaceId);

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteExecCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteExecCapabilityTests.cs
@@ -82,9 +82,8 @@ public class RemoteExecCapabilityTests
         // 顺序调 Report。换成 System.Progress<T> 就会 Post 到线程池,顺序当场没了 ——
         // 所以这个测试刻意不用它,SDK 的文档里也写明了别用。
         Assert.AreEqual(3, result.Lines);
-        CollectionAssert.AreEqual(
-            (string[])["first", "a warning", "second"],
-            lines.Items.Select(static l => l.Line).ToArray());
+        Assert.AreSequenceEqual(
+            (string[])["first", "a warning", "second"], [.. lines.Items.Select(static l => l.Line)]);
         Assert.AreEqual(ExecStream.StandardOutput, lines.Items[0].Stream);
         Assert.AreEqual(ExecStream.StandardError, lines.Items[1].Stream);
         Assert.AreEqual(ExecStream.StandardOutput, lines.Items[2].Stream);

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
@@ -227,7 +227,7 @@ public class RemoteTunnelCapabilityTests
         await stream.FlushAsync();
 
         // 二进制原样到达:这条通道存在的意义就是这些字节不被 UTF-8 与换行动过。
-        CollectionAssert.AreEqual(payload, inner.ToArray());
+        Assert.AreSequenceEqual(payload, inner.ToArray());
         await stream.DisposeAsync();
     }
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TerminalViewCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TerminalViewCapabilityTests.cs
@@ -69,7 +69,7 @@ public class TerminalViewCapabilityTests
         view.SimulateUserInput("ls -l\n");
 
         Assert.HasCount(1, seen);
-        CollectionAssert.AreEqual("ls -l\n"u8.ToArray(), seen[0]);
+        Assert.AreSequenceEqual("ls -l\n"u8.ToArray(), seen[0]);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
+++ b/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
@@ -88,10 +88,8 @@ public class DevicePixelGridTests
         }
 
         // 21.25 的行距只能落在 21 或 22 设备像素上;出现第三种值说明吸附把行距算飘了。
-        CollectionAssert.AreEquivalent(
-            new long[] { 21, 22 },
-            deviceHeights.OrderBy(h => h).ToArray(),
-            "行高应只在 21/22 设备像素之间浮动。"
+        Assert.AreSequenceEqual(
+            new long[] { 21, 22 }, [.. deviceHeights.OrderBy(h => h)], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "行高应只在 21/22 设备像素之间浮动。"
         );
     }
 

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -1,12 +1,11 @@
 using System.Text;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using VelaShell.Core.Ssh;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
+using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Ssh;
 using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Terminal.FileTransfer;
-using VelaShell.Core.FileTransfer.Model;
 
 namespace VelaShell.Terminal.Tests;
 

--- a/tests/VelaShell.Terminal.Tests/TransferRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TransferRouterTests.cs
@@ -1,11 +1,10 @@
 using System.Text;
 using NSubstitute;
-using VelaShell.Core.Ssh;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
+using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Ssh;
 using VelaShell.Core.ZModem.Protocol;
 using VelaShell.Terminal.FileTransfer;
-using VelaShell.Core.FileTransfer.Model;
 
 namespace VelaShell.Terminal.Tests;
 

--- a/tests/VelaShell.Tests/Integration/TransferRealChannelIntegrationTests.cs
+++ b/tests/VelaShell.Tests/Integration/TransferRealChannelIntegrationTests.cs
@@ -5,13 +5,12 @@ using System.Security.Cryptography;
 using System.Text;
 using NSubstitute;
 using Tmds.Ssh;
-using VelaShell.Core.Ssh;
 using VelaShell.Core.FileTransfer.Abstractions;
-using VelaShell.Core.ZModem.Model;
+using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Ssh;
 using VelaShell.Infrastructure.Ssh;
 using VelaShell.Terminal;
 using VelaShell.Terminal.FileTransfer;
-using VelaShell.Core.FileTransfer.Model;
 
 namespace VelaShell.Tests.Integration;
 
@@ -299,7 +298,7 @@ public class TransferRealChannelIntegrationTests
         }
         try
         {
-            using var probe = ConnectAsync().GetAwaiter().GetResult();
+            using TmdsSshClientWrapper probe = ConnectAsync().GetAwaiter().GetResult();
             return true;
         }
         catch

--- a/tests/VelaShell.Tests/Services/FolderTransferFileSinkTests.cs
+++ b/tests/VelaShell.Tests/Services/FolderTransferFileSinkTests.cs
@@ -1,7 +1,6 @@
-using VelaShell.Core.Models;
-using VelaShell.Core.ZModem.Model;
-using VelaShell.Services.FileTransfer;
 using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Core.Models;
+using VelaShell.Services.FileTransfer;
 
 namespace VelaShell.Tests.Services;
 

--- a/tests/VelaShell.Tests/Services/PickedFilesTransferSourceTests.cs
+++ b/tests/VelaShell.Tests/Services/PickedFilesTransferSourceTests.cs
@@ -1,6 +1,5 @@
-using VelaShell.Core.ZModem.Model;
-using VelaShell.Services.FileTransfer;
 using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Services.FileTransfer;
 
 namespace VelaShell.Tests.Services;
 

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -162,7 +162,7 @@ public sealed class ConnectionProfileViewModelTests
             Assert.IsTrue(vm.HostIsEditableChoice, "可手输:枚举不到的设备也必须填得进去。");
             Assert.IsTrue(vm.HostIsDynamicChoice, "动态:USB 转串口是热插拔的,得给刷新按钮。");
             Assert.IsFalse(vm.HostIsText);
-            CollectionAssert.AreEqual(new[] { "COM3", "COM7" }, vm.HostChoices.Select(choice => choice.Value).ToArray());
+            Assert.AreSequenceEqual(new[] { "COM3", "COM7" }, [.. vm.HostChoices.Select(choice => choice.Value)]);
             Assert.AreEqual("串口设备", vm.HostLabel);
         }
     }
@@ -181,7 +181,7 @@ public sealed class ConnectionProfileViewModelTests
 
             await vm.RefreshHostChoicesCommand.Execute().FirstAsync();
 
-            CollectionAssert.AreEqual(new[] { "COM3", "COM9" }, vm.HostChoices.Select(choice => choice.Value).ToArray());
+            Assert.AreSequenceEqual(new[] { "COM3", "COM9" }, [.. vm.HostChoices.Select(choice => choice.Value)]);
             Assert.AreEqual(2, terminal.Queries, "刷新必须是真的重取,而不是拿缓存糊弄。");
         }
     }

--- a/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
+++ b/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
@@ -136,11 +136,10 @@ public sealed class BreadcrumbUnderscoreUiTests
     /// <summary>核对窗口里 crumb 按钮的真实渲染:带下划线那段在、且没走助记符解析。</summary>
     private static void AssertBreadcrumbKeepsUnderscore(Window window, int minimumSegments)
     {
-        TextBlock[] crumbTexts = window.GetVisualDescendants()
+        TextBlock[] crumbTexts = [.. window.GetVisualDescendants()
                                       .OfType<Button>()
                                       .Where(b => b.Classes.Contains("crumb"))
-                                      .SelectMany(b => b.GetVisualDescendants().OfType<TextBlock>())
-                                      .ToArray();
+                                      .SelectMany(b => b.GetVisualDescendants().OfType<TextBlock>())];
 
         // 扫描本身得先成立:一个面包屑都没找到时,下面两条断言会空转成永远通过的空壳。
         Assert.IsGreaterThanOrEqualTo(minimumSegments, crumbTexts.Length,

--- a/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
@@ -133,7 +133,7 @@ public sealed class ScrollBarMarqueeUiTests
 
             // 刺激送达的凭据:光看"没框选"不算数,得先证明这一下确实按在了滚动条上。
             // (滑块在 headless 下拖不动滚动偏移,所以不能拿 Offset 当凭据。)
-            var pressedOnBar = false;
+            bool pressedOnBar = false;
             bar.AddHandler(
                 InputElement.PointerPressedEvent,
                 (_, _) => pressedOnBar = true,
@@ -147,7 +147,7 @@ public sealed class ScrollBarMarqueeUiTests
             Pump(window);
             window.MouseDown(start, MouseButton.Left);
             Pump(window);
-            var overlayEverVisible = false;
+            bool overlayEverVisible = false;
             for (int step = 1; step <= 6; step++)
             {
                 window.MouseMove(new(start.X, start.Y + (20.0 * step)));


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
