### PR TITLE
终端文件传输检测零扣留重构及健壮性增强

### DIFF
--- a/src/VelaShell.Terminal/EchoSuppressor.cs
+++ b/src/VelaShell.Terminal/EchoSuppressor.cs
@@ -41,6 +41,26 @@ public sealed class EchoSuppressor
     public bool Expired => _hitsLeft <= 0 || DateTime.UtcNow > _deadline;
 
     /// <summary>
+    /// 取回并清空当前扣住的块尾部分命中,交还终端。
+    /// <para>
+    /// 扣住的字节只会在<b>下一次</b> <see cref="Process" /> 里放出来;调用方一旦因
+    /// <see cref="Expired" /> 弃用本实例,就再也没有下一次——不在此处取回,那几个字节
+    /// 就被永久吞掉了(抑制窗恰好在扣住的同一块内到期时发生)。
+    /// </para>
+    /// </summary>
+    /// <returns>此前扣住、尚未喂终端的字节;没有则为空数组。</returns>
+    public byte[] TakeHeld()
+    {
+        if (_held == 0)
+        {
+            return [];
+        }
+        byte[] result = _needle[.._held];
+        _held = 0;
+        return result;
+    }
+
+    /// <summary>
     /// 处理一块输出字节,剥除其中匹配到的命令回显;块尾的部分命中会被扣下,合并进下一块续判。
     /// </summary>
     public byte[] Process(byte[] data)

--- a/src/VelaShell.Terminal/Emulation/VtParser.cs
+++ b/src/VelaShell.Terminal/Emulation/VtParser.cs
@@ -14,6 +14,28 @@ public sealed class VtParser(IVtActions actions)
 {
     private const int MaxParams = 32;
 
+    /// <summary>
+    /// OSC / DCS 字符串载荷的字符数上限。越限即判定为「没有终结符的坏序列」:丢弃载荷、
+    /// 回到 ground。
+    /// <para>
+    /// 没有上限时,一条不带终结符的 OSC(坏掉的提示符脚本忘了发 BEL/ST,或 <c>cat</c> 到
+    /// 二进制里的 <c>1B 5D</c>)会把其后<b>全部输出</b>吸进这个 StringBuilder —— 内存无限
+    /// 增长,屏幕一直死着,而终结符可能永远不来。
+    /// </para>
+    /// <para>
+    /// 取 128 KiB:合法 OSC 远低于此,含最大的 OSC 52 剪贴板写入
+    /// (<c>TerminalEmulator.MaxOsc52Bytes</c> = 64 KiB 解码后,base64 约 87 KiB)。
+    /// </para>
+    /// </summary>
+    private const int MaxStringPayload = 128 * 1024;
+
+    /// <summary>
+    /// 中间字节个数上限(与 xterm 一致)。合法序列最多 1 个(<c>CSI ! p</c>、<c>CSI SP q</c>
+    /// 之类),超出即为畸形;不设限时 <c>ESC [</c> 后跟一长串空格(0x20 也是中间字节)
+    /// 同样能撑爆缓冲。
+    /// </summary>
+    private const int MaxIntermediates = 2;
+
     private readonly StringBuilder _intermediates = new(4);
     private readonly StringBuilder _oscOrDcs = new(64);
 
@@ -218,7 +240,9 @@ public sealed class VtParser(IVtActions actions)
         switch (rune)
         {
             case >= 0x20 and <= 0x2F:
-                _intermediates.Append((char)rune);
+                // ESC 没有 ignore 态,超限就只是不再收集(EscDispatch 只看 intermediates[0],
+                // 而带 3 个以上中间字节的 ESC 序列现实中不存在):缓冲有界即可。
+                _ = CollectIntermediate(rune);
                 return;
             case >= 0x30 and <= 0x7E:
                 actions.EscDispatch(_intermediates.ToString(), (char)rune);
@@ -301,7 +325,10 @@ public sealed class VtParser(IVtActions actions)
         switch (rune)
         {
             case >= 0x20 and <= 0x2F:
-                _intermediates.Append((char)rune);
+                if (!CollectIntermediate(rune))
+                {
+                    _state = State.CsiIgnore;
+                }
                 return;
             case >= 0x40 and <= 0x7E:
                 FinishParam();
@@ -340,9 +367,37 @@ public sealed class VtParser(IVtActions actions)
                 _state = State.Ground;
                 return;
             case >= 0x20:
-                _oscOrDcs.Append(char.ConvertFromUtf32(rune));
+                AppendStringPayload(rune);
                 break;
         }
+    }
+
+    /// <summary>
+    /// 往 OSC/DCS 载荷追加一个字符;越过 <see cref="MaxStringPayload" /> 即中止整条序列
+    /// (丢弃载荷并回到 ground,理由见该常量注释)。
+    /// </summary>
+    private void AppendStringPayload(int rune)
+    {
+        if (_oscOrDcs.Length >= MaxStringPayload)
+        {
+            Reset(); // 丢弃载荷、回 ground:其后的字节照常显示,终端自己缓过来。
+            return;
+        }
+        _oscOrDcs.Append(char.ConvertFromUtf32(rune));
+    }
+
+    /// <summary>
+    /// 收集一个中间字节;已达 <see cref="MaxIntermediates" /> 时返回 false —— 调用方据此把
+    /// 整条序列判为畸形,转入对应的 ignore 态(继续吞到终结字节,但不分发)。
+    /// </summary>
+    private bool CollectIntermediate(int rune)
+    {
+        if (_intermediates.Length >= MaxIntermediates)
+        {
+            return false;
+        }
+        _intermediates.Append((char)rune);
+        return true;
     }
 
     private void DispatchOsc()
@@ -412,7 +467,10 @@ public sealed class VtParser(IVtActions actions)
         switch (rune)
         {
             case >= 0x20 and <= 0x2F:
-                _intermediates.Append((char)rune);
+                if (!CollectIntermediate(rune))
+                {
+                    _state = State.DcsIgnore;
+                }
                 return;
             case >= 0x40 and <= 0x7E:
                 FinishParam();
@@ -439,7 +497,7 @@ public sealed class VtParser(IVtActions actions)
             case 0x09:
             case 0x0A:
             case 0x0D:
-                _oscOrDcs.Append(char.ConvertFromUtf32(rune));
+                AppendStringPayload(rune);
                 break;
         }
     }

--- a/src/VelaShell.Terminal/FileTransfer/TerminalTransferRouter.cs
+++ b/src/VelaShell.Terminal/FileTransfer/TerminalTransferRouter.cs
@@ -68,6 +68,14 @@ public sealed class TerminalTransferRouter(
     private readonly ZModemDetector _detector = new();
     private readonly Lock _gate = new();
 
+    /// <summary>
+    /// 敲过 <c>sz</c>/<c>rz</c> 后放宽 ZMODEM 判据的时长。够远端把命令跑起来、把引导吐出来,
+    /// 又不至于长到让后面无关的输出继续享受宽松判据。
+    /// </summary>
+    private static readonly TimeSpan CommandArmWindow = TimeSpan.FromSeconds(30);
+
+    private DateTime _relaxDetectorUntil = DateTime.MinValue;
+
     private TransferRoutingState _state = TransferRoutingState.Normal;
     private ShellStreamByteDuplex? _duplex;
     private CancellationTokenSource? _sessionCts;
@@ -129,6 +137,9 @@ public sealed class TerminalTransferRouter(
                 return new([], false);
             }
 
+            // 命令行武装窗内放宽尾锚定(见 NoteCommandSubmitted);过期即自动收回。
+            _detector.AcceptUnanchoredHeader = DateTime.UtcNow < _relaxDetectorUntil;
+
             ZModemDetectResult detect = _detector.Process(data.Span);
             if (!detect.Detected)
             {
@@ -178,12 +189,44 @@ public sealed class TerminalTransferRouter(
             {
                 return TransferStartFailure.NotWired;
             }
-            // 检测器里可能扣着几个字节(疑似 ZMODEM 引导前缀),它们属于终端而不属于本次会话;
-            // 这里主动清掉,避免它们在会话结束时被当成"残余"再喂一次。
-            _ = _detector.Flush();
+            // 检测器的跨分片匹配状态属于上一段输出,与本次会话无关,清掉重来。
+            _detector.Reset();
             StartSession(protocol, direction, []);
             return TransferStartFailure.None;
         }
+    }
+
+    /// <summary>
+    /// 告知路由器:用户刚提交了一行命令。这是与输出流嗅探完全独立的第二路信号,用途有二。
+    /// <para>
+    /// <b>一、X/YMODEM 自动触发。</b>这两个协议在链路上没有任何引导序列,基于输出的自动检测
+    /// 必然误触发(见类注释);但用户敲的 <c>sx</c>/<c>rx</c>/<c>sb</c>/<c>rb</c> 是确定无疑的意图,
+    /// 据此直接开会话即可。握手有 30 秒上限(<c>XYModemOptions</c>),敲错了也会自己退出来。
+    /// </para>
+    /// <para>
+    /// <b>二、ZMODEM 判据放宽。</b>敲过 <c>sz</c>/<c>rz</c> 之后的一小段时间内,把检测器的尾锚定
+    /// 要求关掉:此时误报代价远低于漏检。<b>刻意做成"加分信号"而非硬闸门</b> —— 脚本、别名、
+    /// <c>make upload</c> 里调 <c>sz</c> 的场景压根不会经过这里,它们仍须照常被自动检测到。
+    /// </para>
+    /// </summary>
+    /// <param name="commandLine">用户提交的整行命令。</param>
+    /// <returns>据此启动了会话时为 true(仅 X/YMODEM 会启动)。</returns>
+    public bool NoteCommandSubmitted(string? commandLine)
+    {
+        if (TransferCommandParser.Parse(commandLine) is not { } intent)
+        {
+            return false;
+        }
+        TransferTrace.Log($"COMMAND intent protocol={intent.Protocol} direction={intent.Direction}");
+        if (intent.Protocol == TerminalTransferProtocol.ZModem)
+        {
+            lock (_gate)
+            {
+                _relaxDetectorUntil = DateTime.UtcNow + CommandArmWindow;
+            }
+            return false;
+        }
+        return StartManualSession(intent.Protocol, intent.Direction) == TransferStartFailure.None;
     }
 
     private void StartSession(
@@ -262,8 +305,8 @@ public sealed class TerminalTransferRouter(
             _duplex = null;
             _sessionCts?.Dispose();
             _sessionCts = null;
-            // 复位检测器,丢弃可能残留的扣留字节(会话字节不应回流终端)。
-            _ = _detector.Flush();
+            // 复位检测器:会话期间的字节不属于常态输出流,跨分片匹配状态必须清干净。
+            _detector.Reset();
         }
     }
 

--- a/src/VelaShell.Terminal/FileTransfer/TransferCommandParser.cs
+++ b/src/VelaShell.Terminal/FileTransfer/TransferCommandParser.cs
@@ -1,0 +1,127 @@
+using VelaShell.Core.FileTransfer.Model;
+
+namespace VelaShell.Terminal.FileTransfer;
+
+/// <summary>从用户敲下的命令行推断出的传输意图。</summary>
+/// <param name="Protocol">将要使用的协议变体。</param>
+/// <param name="Direction">本地扮演的方向(远端 <c>s*</c> 发文件 = 本地接收)。</param>
+public readonly record struct TransferCommandIntent(
+    TerminalTransferProtocol Protocol,
+    FileTransferDirection Direction);
+
+/// <summary>
+/// 把用户键入的命令行解析成传输意图。
+/// <para>
+/// 存在的理由:XMODEM / YMODEM 在链路上<b>没有任何引导序列</b> —— <c>sb</c>/<c>sx</c> 启动后静默
+/// 等接收方发 <c>'C'</c>,<c>rb</c>/<c>rx</c> 只吐裸 <c>'C'</c>,在终端输出里与普通字符毫无区别,
+/// 任何基于输出流的自动检测都必然误触发。但「用户敲了什么命令」是另一路完全独立的信号:
+/// <see cref="Input.TerminalInputTracker" /> 已经逐字重建了命令行,拿来判断即可。WindTerm 对
+/// <c>rx</c>/<c>sx</c>/<c>rb</c>/<c>sb</c> 做自动触发,只可能是同一思路。
+/// </para>
+/// <para>
+/// 对 ZMODEM 则不用它启动会话(输出流里有引导,自动检测更可靠),只用来在其后的一小段时间里
+/// 放宽检测判据(见 <see cref="ZModemDetector.AcceptUnanchoredHeader" />)。
+/// </para>
+/// </summary>
+public static class TransferCommandParser
+{
+    /// <summary>
+    /// 解析一行命令;不是传输命令时返回 <c>null</c>。
+    /// </summary>
+    /// <param name="commandLine">用户键入并提交的整行命令。</param>
+    public static TransferCommandIntent? Parse(string? commandLine)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine))
+        {
+            return null;
+        }
+        string[] tokens = commandLine.Split(
+            (char[])[' ', '\t'],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        int i = SkipPrefixTokens(tokens);
+        if (i >= tokens.Length)
+        {
+            return null;
+        }
+
+        // 允许带路径调用(/usr/bin/sz);取基名后必须精确等于已知工具名,
+        // 免得 "myszcript"、"echo sz" 之类被误判。
+        string tool = BaseName(tokens[i]);
+        FileTransferDirection direction;
+        TerminalTransferProtocol protocol;
+        switch (tool)
+        {
+            case "sz":
+                (direction, protocol) = (FileTransferDirection.Receive, TerminalTransferProtocol.ZModem);
+                break;
+            case "rz":
+                (direction, protocol) = (FileTransferDirection.Send, TerminalTransferProtocol.ZModem);
+                break;
+            case "sx":
+                (direction, protocol) = (FileTransferDirection.Receive, TerminalTransferProtocol.XModem);
+                break;
+            case "rx":
+                (direction, protocol) = (FileTransferDirection.Send, TerminalTransferProtocol.XModem);
+                break;
+            case "sb":
+                (direction, protocol) = (FileTransferDirection.Receive, TerminalTransferProtocol.YModem);
+                break;
+            case "rb":
+                (direction, protocol) = (FileTransferDirection.Send, TerminalTransferProtocol.YModem);
+                break;
+            default:
+                return null;
+        }
+
+        // lrzsz 的 sz/rz 可以用开关切到 X/YMODEM(sz -X file、rz --ymodem)。
+        return new(OverrideProtocol(protocol, tokens.AsSpan(i + 1)), direction);
+    }
+
+    /// <summary>跳过环境变量赋值前缀与 <c>sudo</c>,定位到真正的命令名。</summary>
+    private static int SkipPrefixTokens(ReadOnlySpan<string> tokens)
+    {
+        int i = 0;
+        while (i < tokens.Length)
+        {
+            string token = tokens[i];
+            bool isEnvAssignment = token.Contains('=', StringComparison.Ordinal)
+                && !token.StartsWith('-');
+            if (isEnvAssignment || BaseName(token) is "sudo" or "command")
+            {
+                i++;
+                continue;
+            }
+            break;
+        }
+        return i;
+    }
+
+    /// <summary>按 <c>-X</c> / <c>--ymodem</c> 之类的开关改写协议变体;<c>--</c> 之后不再解析。</summary>
+    private static TerminalTransferProtocol OverrideProtocol(
+        TerminalTransferProtocol protocol,
+        ReadOnlySpan<string> arguments)
+    {
+        foreach (string argument in arguments)
+        {
+            if (argument == "--")
+            {
+                break;
+            }
+            protocol = argument switch
+            {
+                "-X" or "--xmodem" => TerminalTransferProtocol.XModem,
+                "-Y" or "--ymodem" => TerminalTransferProtocol.YModem,
+                "-Z" or "--zmodem" => TerminalTransferProtocol.ZModem,
+                _ => protocol
+            };
+        }
+        return protocol;
+    }
+
+    private static string BaseName(string token)
+    {
+        int cut = token.LastIndexOfAny(['/', '\\']);
+        return cut < 0 ? token : token[(cut + 1)..];
+    }
+}

--- a/src/VelaShell.Terminal/FileTransfer/ZModemDetector.cs
+++ b/src/VelaShell.Terminal/FileTransfer/ZModemDetector.cs
@@ -16,7 +16,7 @@ public enum ZModemTrigger
 }
 
 /// <summary>一次检测扫描的结果:应喂给终端的字节,以及是否命中 ZMODEM 启动。</summary>
-/// <param name="TerminalBytes">应正常喂入 VT 终端的字节(命中时为引导前的部分)。</param>
+/// <param name="TerminalBytes">应正常喂入 VT 终端的字节(命中时为引导前、且尚未喂过的部分)。</param>
 /// <param name="Trigger">命中的引导类型;<see cref="ZModemTrigger.None" /> 表示未命中。</param>
 /// <param name="ProtocolBytes">命中时,从引导序列起、应交给 ZMODEM 引擎的字节。</param>
 public readonly record struct ZModemDetectResult(
@@ -30,120 +30,213 @@ public readonly record struct ZModemDetectResult(
 
 /// <summary>
 /// 在终端输出字节流中检测 ZMODEM 自动启动:远端 <c>sz</c> 注入的 <c>ZRQINIT</c> 引导
-/// (<c>** ZDLE 'B' '0' '0'</c>,本地转接收),或远端 <c>rz</c> 注入的 <c>ZRINIT</c> 引导
-/// (<c>** ZDLE 'B' '0' '1'</c>,本地转发送)。采用滚动缓冲:当分片尾部可能是被切断的引导前缀时,
-/// 扣留最多 <c>SignatureLength-1</c> 字节不喂终端,等下一分片续上,避免把协议引导错误渲染到屏幕。
+/// (十六进制帧头 <c>** ZDLE 'B' "00" …</c>,本地转接收),或远端 <c>rz</c> 注入的 <c>ZRINIT</c>
+/// 引导(<c>** ZDLE 'B' "01" …</c>,本地转发送)。
+/// <para>
+/// <b>零扣留</b>:字节一律照常喂终端,检测只靠一份 ≤<see cref="MaxCarry" /> 字节的尾部副本
+/// (<see cref="_carry" />)做跨分片匹配。扣留用户数据等下一分片是 #291 的根因 —— 引导头两字节
+/// 正是 <c>'*' '*'</c>,SSH 下逐字回显的星号会被无限期扣住,表现为「敲 <c>*</c> 不回显、光标不动」。
+/// 代价只是引导被分片切开时屏幕上多出一两个已经画出的 <c>'*'</c>。zmodem.js 的 Sentry 亦是此策略
+/// (「If there is no active or pending ZMODEM session, the text is all output」)。
+/// </para>
+/// <para>
+/// <b>判据是完整帧头而非 6 字节引导</b>:必须是一个格式良好的十六进制帧头(<see cref="HexHeaderLength" />
+/// 字节,后 14 位全为十六进制数字),且默认还要求它<b>锚在分片末尾</b>(其后只允许 CR/LF/XON)——
+/// <c>sz</c>/<c>rz</c> 写完帧头就阻塞等应答,真引导天然满足;而 <c>cat</c> 到二进制里恰好凑出这
+/// 六个字节的误报则几乎不可能同时满足。尾锚定可由 <see cref="AcceptUnanchoredHeader" /> 放宽。
+/// </para>
 /// </summary>
 public sealed class ZModemDetector
 {
+    /// <summary>
+    /// 十六进制帧头长度:<c>ZPAD ZPAD ZDLE ZHEX</c> 4 字节 + (帧类型 + 4 个参数 + CRC16)
+    /// 每字节两位十六进制共 14 字节 = 18(见 <c>ZModemFrameWriter.WriteHex</c>)。
+    /// </summary>
+    private const int HexHeaderLength = 18;
+
+    /// <summary>帧头之后允许出现的收尾字节:CR、LF、XON(lrzsz 补 XON 释放流控)。</summary>
+    private const int MaxTrailerLength = 3;
+
+    /// <summary>
+    /// 跨分片保留的尾部副本上限 = 完整帧头 + 收尾。与 zmodem.js 的
+    /// <c>MAX_ZM_HEX_START_LENGTH = 21</c> 同值。
+    /// </summary>
+    private const int MaxCarry = HexHeaderLength + MaxTrailerLength;
+
     private static readonly byte[] ReceiveSignature = ZModemConstants.ReceiveInitSignature.ToArray();
     private static readonly byte[] SendSignature = ZModemConstants.SendInitSignature.ToArray();
 
-    // 两个引导等长(都是 ZPAD ZPAD ZDLE ZHEX + 两位十六进制类型),扣留长度按其一即可。
+    // 两个引导等长(都是 ZPAD ZPAD ZDLE ZHEX + 两位十六进制类型)。
     private static readonly int SignatureLength = ReceiveSignature.Length;
 
     // 两个引导只在最后一字节不同('0' = ZRQINIT / '1' = ZRINIT),前 5 字节完全一致。
     // 因此整块只需扫一遍公共前缀,命中后看第 6 字节定方向 —— 比逐个签名各扫一遍省一半。
     private static readonly byte[] CommonPrefix = ReceiveSignature[..^1];
 
-    /// <summary>扣留的、可能属于被切断引导前缀的尾部字节。</summary>
-    private readonly List<byte> _held = [];
+    /// <summary>
+    /// 已经喂过终端、仅留作跨分片匹配的尾部副本(疑似被切断的帧头,或其前缀)。
+    /// 长度恒 ≤ <see cref="MaxCarry" />。
+    /// </summary>
+    private readonly List<byte> _carry = [];
 
     /// <summary>
-    /// 常态零拷贝快路径判定:无扣留尾部、块内无任一引导、且块尾与引导前缀无重叠时为
-    /// true——调用方可把原始块原样喂终端,跳过 <see cref="Process" /> 的窗口拼接与切片拷贝。
+    /// 放宽尾锚定:为 true 时,格式良好的帧头出现在分片任意位置都算命中。
+    /// 由路由器在用户刚敲过 <c>sz</c>/<c>rz</c> 的时间窗内置位(见
+    /// <see cref="TerminalTransferRouter.NoteCommandSubmitted" />)—— 此时误报代价远低于漏检。
+    /// </summary>
+    public bool AcceptUnanchoredHeader { get; set; }
+
+    /// <summary>
+    /// 常态零拷贝快路径判定:无待续尾部、且块内既无引导前缀、块尾也不与前缀重叠时为 true——
+    /// 调用方可把原始块原样喂终端,跳过 <see cref="Process" /> 的窗口拼接与切片拷贝。
     /// 该检测器挂在所有会话的输出链路上,绝大多数输出块都应走此路径。
     /// </summary>
     public bool CanPassThrough(ReadOnlySpan<byte> incoming) =>
-        _held.Count == 0
-        && FindSignature(incoming).Index < 0
-        && LongestSignaturePrefixSuffix(incoming) == 0;
+        _carry.Count == 0
+        && incoming.IndexOf(CommonPrefix) < 0
+        && LongestPrefixSuffix(incoming) == 0;
 
     /// <summary>处理一段新到达的输出字节,判断是否命中 ZMODEM 引导。</summary>
     /// <param name="incoming">本次到达的原始输出字节。</param>
     /// <returns>检测结果:待喂终端字节、命中的引导类型、以及命中后交给引擎的协议字节。</returns>
     public ZModemDetectResult Process(ReadOnlySpan<byte> incoming)
     {
-        // 把先前扣留的尾部与新数据拼成一个连续窗口做匹配。
-        byte[] window = new byte[_held.Count + incoming.Length];
-        _held.CopyTo(window);
-        incoming.CopyTo(window.AsSpan(_held.Count));
-        _held.Clear();
+        // 窗口 = 已喂过的尾部副本 + 新数据。窗口开头 fedOffset 字节已经进过终端,
+        // 只参与匹配,绝不能再喂第二遍。
+        int fedOffset = _carry.Count;
+        byte[] window = new byte[fedOffset + incoming.Length];
+        _carry.CopyTo(window);
+        incoming.CopyTo(window.AsSpan(fedOffset));
+        _carry.Clear();
 
-        // 单遍扫描取最靠前的那个引导(两个引导共用前 5 字节,第 6 字节定方向)。
-        (int idx, ZModemTrigger trigger) = FindSignature(window);
-        if (idx < 0)
+        (int idx, ZModemTrigger trigger, int pendingFrom) = Scan(window);
+        if (idx >= 0)
         {
-            // 未命中:扣留可能是被切断引导前缀的尾部,其余喂终端。
-            int holdLen = LongestSignaturePrefixSuffix(window);
-            int feedLen = window.Length - holdLen;
-            byte[] feed = window[..feedLen];
-            if (holdLen > 0)
-            {
-                _held.AddRange(window.AsSpan(feedLen));
-            }
-            return new(feed, ZModemTrigger.None, []);
+            // 命中:引导之前「尚未喂过」的部分照常进终端,引导及其后全部交给引擎。
+            return new(idx > fedOffset ? window[fedOffset..idx] : [], trigger, window[idx..]);
         }
 
-        // 命中:引导之前的部分照常进终端,引导及其后全部交给引擎。
-        return new(window[..idx], trigger, window[idx..]);
-    }
-
-    /// <summary>会话结束或路由复位时,取回并清空当前扣留的字节(交回终端,避免吞字节)。</summary>
-    /// <returns>此前被扣留、尚未喂终端的字节。</returns>
-    public byte[] Flush()
-    {
-        if (_held.Count == 0)
+        // 未命中:字节全部照喂,只留一份尾部副本等下一分片续判。
+        // 续判起点取「不完整候选帧头的起点」,没有候选时退化为「与引导前缀重叠的块尾」。
+        int carryFrom = pendingFrom >= 0
+            ? pendingFrom
+            : window.Length - LongestPrefixSuffix(window);
+        carryFrom = Math.Max(carryFrom, window.Length - MaxCarry);
+        if (carryFrom < window.Length)
         {
-            return [];
+            _carry.AddRange(window.AsSpan(carryFrom));
         }
-        byte[] result = [.. _held];
-        _held.Clear();
-        return result;
+        return new(fedOffset == 0 ? window : window[fedOffset..], ZModemTrigger.None, []);
     }
 
     /// <summary>
-    /// 单遍定位最靠前的完整引导。先用向量化的 <see cref="MemoryExtensions.IndexOf{T}(ReadOnlySpan{T}, ReadOnlySpan{T})" />
-    /// 找 5 字节公共前缀,再看第 6 字节判方向;第 6 字节既非 <c>'0'</c> 也非 <c>'1'</c> 就跳过继续找。
+    /// 会话开始 / 结束或路由复位时丢弃跨分片匹配状态。
+    /// <para>
+    /// 不返回任何字节:本检测器从不扣留 —— 副本里的字节早已喂过终端,再交还一次就是重影。
+    /// </para>
+    /// </summary>
+    public void Reset() => _carry.Clear();
+
+    /// <summary>
+    /// 单遍扫描定位最靠前的、合格的十六进制引导帧头。
     /// 这条路径挂在所有会话的输出链路上,每个输出块都要走一次,故按热路径写。
     /// </summary>
     /// <param name="window">待扫描的窗口。</param>
-    /// <returns>引导起始下标与方向;未命中时下标为 <c>-1</c>。</returns>
-    private static (int Index, ZModemTrigger Trigger) FindSignature(ReadOnlySpan<byte> window)
+    /// <returns>
+    /// <c>Index</c> ≥ 0 表示命中;否则 <c>PendingFrom</c> ≥ 0 表示窗口尾部有个「引导已现、帧头未完」
+    /// 的候选,其起点须留作下一分片续判(两者都为负则窗口里什么都没有)。
+    /// </returns>
+    private (int Index, ZModemTrigger Trigger, int PendingFrom) Scan(ReadOnlySpan<byte> window)
     {
         int offset = 0;
-        while (offset <= window.Length - SignatureLength)
+        while (offset <= window.Length - CommonPrefix.Length)
         {
             int hit = window[offset..].IndexOf(CommonPrefix);
             if (hit < 0)
             {
-                return (-1, ZModemTrigger.None);
+                break;
             }
             int abs = offset + hit;
+
+            // 第 6 字节定方向;帧头还没到齐就留到下一分片续判(它已经喂过终端了,不影响显示)。
             if (abs + SignatureLength > window.Length)
             {
-                // 尾部只有半个引导:交给 LongestSignaturePrefixSuffix 扣留,等下一分片续上。
-                return (-1, ZModemTrigger.None);
+                return (-1, ZModemTrigger.None, abs);
             }
-            byte discriminator = window[abs + CommonPrefix.Length];
-            if (discriminator == ReceiveSignature[^1])
+            ZModemTrigger trigger = window[abs + CommonPrefix.Length] switch
             {
-                return (abs, ZModemTrigger.Receive);
-            }
-            if (discriminator == SendSignature[^1])
+                var d when d == ReceiveSignature[^1] => ZModemTrigger.Receive,
+                var d when d == SendSignature[^1] => ZModemTrigger.Send,
+                _ => ZModemTrigger.None
+            };
+            if (trigger == ZModemTrigger.None)
             {
-                return (abs, ZModemTrigger.Send);
+                offset = abs + 1;
+                continue;
             }
-            offset = abs + 1;
+            if (abs + HexHeaderLength > window.Length)
+            {
+                return (-1, ZModemTrigger.None, abs);
+            }
+
+            // 帧头剩下的 12 位必须全是十六进制数字,否则这六个字节只是巧合。
+            if (!IsHexRun(window[(abs + SignatureLength)..(abs + HexHeaderLength)]))
+            {
+                offset = abs + 1;
+                continue;
+            }
+
+            // 尾锚定:帧头之后只允许 CR/LF/XON,且到此为止或紧接着另一个 ZMODEM 帧。
+            if (!AcceptUnanchoredHeader && !IsFrameBoundary(window[(abs + HexHeaderLength)..]))
+            {
+                offset = abs + 1;
+                continue;
+            }
+            return (abs, trigger, -1);
         }
-        return (-1, ZModemTrigger.None);
+        return (-1, ZModemTrigger.None, -1);
+    }
+
+    /// <summary>整段是否都是 ASCII 十六进制数字。</summary>
+    private static bool IsHexRun(ReadOnlySpan<byte> span)
+    {
+        foreach (byte b in span)
+        {
+            bool hex = b is >= (byte)'0' and <= (byte)'9'
+                or >= (byte)'a' and <= (byte)'f'
+                or >= (byte)'A' and <= (byte)'F';
+            if (!hex)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// 帧头之后是不是一个干净的帧边界:跳过收尾字节(CR / LF / XON)后,要么到此为止
+    /// (<c>sz</c>/<c>rz</c> 写完引导就阻塞等应答,常态如此),要么紧接着另一个 ZMODEM 帧
+    /// (所有帧都以 ZPAD 起头 —— 对端把引导和后续帧塞进同一次写时如此)。
+    /// <para>
+    /// 落在这两者之外的(帧头后面跟着普通 shell 输出),判为巧合而非真引导:典型如
+    /// <c>cat</c> 一份 ZMODEM 抓包文件,不该把终端交出去。
+    /// </para>
+    /// </summary>
+    private static bool IsFrameBoundary(ReadOnlySpan<byte> span)
+    {
+        int i = 0;
+        while (i < span.Length && span[i] is 0x0D or 0x0A or ZModemConstants.XON)
+        {
+            i++;
+        }
+        return i == span.Length || span[i] == ZModemConstants.ZPAD;
     }
 
     /// <summary>
     /// 求 <paramref name="window" /> 的末尾与引导前缀的最长重叠长度(0..SignatureLength-1),
-    /// 即需要扣留、等后续分片续接的尾部长度。两个引导只在最后一字节不同,故按公共前缀判断即可。
+    /// 即需要留作下一分片续判的尾部长度。两个引导只在最后一字节不同,故按公共前缀判断即可。
     /// </summary>
-    private static int LongestSignaturePrefixSuffix(ReadOnlySpan<byte> window)
+    private static int LongestPrefixSuffix(ReadOnlySpan<byte> window)
     {
         int max = Math.Min(SignatureLength - 1, window.Length);
         for (int len = max; len > 0; len--)

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -338,9 +338,28 @@ public class SshTerminalBridge : IDisposable
         byte[] result = suppressor.Process(data);
         if (suppressor.Expired)
         {
+            result = AppendHeldTail(result, suppressor);
             _tapEchoSuppressor = null;
         }
         return result;
+    }
+
+    /// <summary>
+    /// 弃用抑制器前把它扣住的块尾交还输出流。扣住的字节本该在下一次 Process 里放出来,
+    /// 实例一弃用就没有下一次了——不接回来就是永久吞字节(与 #291 的 ZMODEM 扣留同源)。
+    /// 扣住的必然是本块的尾巴,故追加在后面。
+    /// </summary>
+    private static byte[] AppendHeldTail(byte[] head, EchoSuppressor suppressor)
+    {
+        byte[] tail = suppressor.TakeHeld();
+        if (tail.Length == 0)
+        {
+            return head;
+        }
+        byte[] merged = new byte[head.Length + tail.Length];
+        head.CopyTo(merged, 0);
+        tail.CopyTo(merged, head.Length);
+        return merged;
     }
 
     private void EnqueueForFeed(byte[] data)
@@ -414,6 +433,7 @@ public class SshTerminalBridge : IDisposable
             exact = suppressor.Process(exact);
             if (suppressor.Expired)
             {
+                exact = AppendHeldTail(exact, suppressor);
                 _echoSuppressor = null;
             }
             if (exact.Length == 0)

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -262,6 +262,10 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
 
     private void OnTrackedCommandSubmitted(string command)
     {
+        // 传输意图先于回显校验处理:远端的 sz/rz 引导可能在几毫秒内就到,等 200ms 二次校验
+        // 就晚了。这一路只认命令名,密码行不可能解析成 sz/rz(解析失败即无副作用)。
+        NoteTransferCommand(command);
+
         // 回显校验:所键入的文本应已被 shell 回显到屏上;密码提示符不回显 → 不记录,
         // 防止口令进历史。注意桥接层的输出是按帧合并 Feed 的——Enter 瞬间最后几个
         // 字符的回显可能还在队列里,同步校验失败时延迟 200ms 后在整个可视区做二次
@@ -301,12 +305,31 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
             string? command = ExtractCommandAfterPrompt(control.GetBufferLine(control.CursorRow));
             if (!string.IsNullOrWhiteSpace(command))
             {
+                // 未知态同样要认传输命令:"sz fi<Tab>" 补全后行内容就不可知了,
+                // 而带 Tab 补全的文件名恰恰是最常见的敲法。
+                NoteTransferCommand(command);
                 CommandLineSubmitted?.Invoke(command);
             }
         }
         catch
         {
             // 读缓冲失败时宁可漏记不误记。
+        }
+    }
+
+    /// <summary>
+    /// 把用户提交的命令行转给路由器:X/YMODEM 据此自动开会话(它们在链路上没有引导,
+    /// 只能靠这一路),ZMODEM 据此放宽检测判据。不是传输命令时是空操作。
+    /// </summary>
+    private void NoteTransferCommand(string command)
+    {
+        try
+        {
+            _ = TransferRouter?.NoteCommandSubmitted(command);
+        }
+        catch
+        {
+            // 传输意图识别失败不得影响命令历史等其余处理。
         }
     }
 

--- a/tests/VelaShell.Terminal.Tests/EchoSuppressorTests.cs
+++ b/tests/VelaShell.Terminal.Tests/EchoSuppressorTests.cs
@@ -81,4 +81,26 @@ public class EchoSuppressorTests
         byte[] result = s.Process(Encoding.UTF8.GetBytes("pi@host:~$ pr"));
         Assert.AreEqual("pi@host:~$ pr", Encoding.UTF8.GetString(result));
     }
+
+    /// <summary>
+    /// 宿主一旦发现抑制器失效就会弃用实例(<c>SshTerminalBridge</c>),此时块尾扣住的部分命中
+    /// 必须取得回来——否则再没有下一次 Process 放行它们,那几个字节被永久吞掉
+    /// (与 #291 的 ZMODEM 扣留同源)。
+    /// </summary>
+    [TestMethod]
+    public void ExpiredWithHeldTail_TakeHeldReturnsBytesInsteadOfLosingThem()
+    {
+        var s = new EchoSuppressor(Needle, 2, TimeSpan.FromMilliseconds(1));
+        string prefix = Payload[..10];
+        byte[] first = s.Process(Encoding.UTF8.GetBytes(prefix));
+
+        // 扣住了:本次一个字节都没放出来。
+        Assert.IsEmpty(first);
+        Thread.Sleep(30);
+        Assert.IsTrue(s.Expired);
+
+        // 宿主弃用实例前把扣住的尾巴取回来交还终端;取一次即清空。
+        Assert.AreEqual(prefix, Encoding.UTF8.GetString(s.TakeHeld()));
+        Assert.IsEmpty(s.TakeHeld());
+    }
 }

--- a/tests/VelaShell.Terminal.Tests/Emulation/VtParserLimitTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/VtParserLimitTests.cs
@@ -1,0 +1,148 @@
+using System.Text;
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Tests.Emulation;
+
+/// <summary>
+/// VT 解析器的缓冲上限:没有终结符的 OSC/DCS 字符串,以及畸形的超长中间字节串,
+/// 都不允许把缓冲撑到无限大、也不允许让屏幕永久死住。
+/// </summary>
+[TestClass]
+[TestCategory("Emulator")]
+public class VtParserLimitTests
+{
+    /// <summary>与 <c>VtParser.MaxStringPayload</c> 一致(该常量为 private,这里按契约取同值)。</summary>
+    private const int MaxStringPayload = 128 * 1024;
+
+    /// <summary>与 <c>VtParser.MaxIntermediates</c> 一致。</summary>
+    private const int MaxIntermediates = 2;
+
+    private static TerminalEmulator New(int cols = 40, int rows = 6) => new(cols, rows);
+
+    private static void Feed(TerminalEmulator e, string s) => e.Feed(Encoding.UTF8.GetBytes(s));
+
+    private static string Line(TerminalEmulator e, int row) => e.Screen.ActiveLine(row).GetText().TrimEnd();
+
+    /// <summary>正常长度的 OSC 仍须原样吞掉并分发,不能被上限逻辑误伤。</summary>
+    [TestMethod]
+    public void TerminatedOsc_IsStillConsumedAndDispatched()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1b]0;window title\avisible");
+        Assert.AreEqual("visible", Line(e, 0));
+
+        var rec = new RecordingActions();
+        new VtParser(rec).Parse("\x1b]0;window title\a");
+        Assert.AreSequenceEqual(["0", "window title"], rec.Osc[0]);
+    }
+
+    /// <summary>
+    /// 没有终结符的 OSC:超过上限后必须丢弃载荷回到 ground,其后的字节照常显示。
+    /// 回归:不设限时坏掉的提示符脚本(<c>printf '\e]0;'</c> 忘了发 BEL)会把之后
+    /// 全部输出吸进 StringBuilder —— 内存无限涨,屏幕一直是死的。
+    /// </summary>
+    [TestMethod]
+    public void UnterminatedOsc_RecoversAfterPayloadLimit()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1b]0;");
+        Feed(e, new string('x', MaxStringPayload + 16));
+
+        // 越限那一刻回 ground,后续字节照常进屏幕。
+        Feed(e, "\r\nrecovered");
+        Assert.AreEqual("recovered", Line(e, e.CursorY));
+    }
+
+    /// <summary>越限的 OSC 载荷绝不能被分发出去(半截的 OSC 52 会往剪贴板写垃圾)。</summary>
+    [TestMethod]
+    public void OverlongOsc_IsDiscardedNotDispatched()
+    {
+        var rec = new RecordingActions();
+        var parser = new VtParser(rec);
+        parser.Parse("\x1b]52;c;" + new string('A', MaxStringPayload + 16) + "\a");
+
+        Assert.IsEmpty(rec.Osc);
+    }
+
+    /// <summary>DCS 直通载荷同样受限,恢复方式一致。</summary>
+    [TestMethod]
+    public void UnterminatedDcs_RecoversAfterPayloadLimit()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1bP");
+        Feed(e, new string('y', MaxStringPayload + 16));
+
+        Feed(e, "\r\nrecovered");
+        Assert.AreEqual("recovered", Line(e, e.CursorY));
+    }
+
+    /// <summary>
+    /// <c>ESC [</c> 后跟一长串空格:0x20 也是中间字节,不设限就会一直往中间字节缓冲里堆
+    /// (终结字节一到照样分发,屏幕看不出异常 —— 纯粹是内存在涨,所以这里必须直接量
+    /// 中间字节串本身,量屏幕是量不出来的)。超限即把整条序列判为畸形,不再分发。
+    /// </summary>
+    [TestMethod]
+    public void OverlongCsiIntermediates_AreCappedAndSequenceIgnored()
+    {
+        var rec = new RecordingActions();
+        new VtParser(rec).Parse("\x1b[" + new string(' ', 5000) + "q");
+
+        Assert.IsEmpty(rec.Csi); // 转 CsiIgnore,不分发。
+    }
+
+    /// <summary>DCS 的中间字节同样有帽子。</summary>
+    [TestMethod]
+    public void OverlongDcsIntermediates_AreCappedAndSequenceIgnored()
+    {
+        var rec = new RecordingActions();
+        new VtParser(rec).Parse("\x1bP" + new string(' ', 5000) + "q payload\x1b\\");
+
+        Assert.IsEmpty(rec.Dcs);
+    }
+
+    /// <summary>畸形序列被忽略后,流要能自己缓过来,后续输出照常显示。</summary>
+    [TestMethod]
+    public void AfterOverlongCsiIntermediates_StreamRecovers()
+    {
+        TerminalEmulator e = New();
+        Feed(e, "\x1b[" + new string(' ', 5000) + "q");
+        Feed(e, "recovered");
+
+        Assert.AreEqual("recovered", Line(e, 0));
+    }
+
+    /// <summary>合法的中间字节序列(DECSCUSR <c>CSI SP q</c>)不受影响,照常分发。</summary>
+    [TestMethod]
+    public void SingleIntermediateSequence_StillDispatches()
+    {
+        var rec = new RecordingActions();
+        new VtParser(rec).Parse("\x1b[2 q");
+
+        Assert.HasCount(1, rec.Csi);
+        Assert.AreEqual(" ", rec.Csi[0].Intermediates);
+        Assert.AreEqual('q', rec.Csi[0].Final);
+        Assert.IsLessThanOrEqualTo(MaxIntermediates, rec.Csi[0].Intermediates.Length);
+    }
+
+    /// <summary>只记录分发事件的假动作接收端。</summary>
+    private sealed class RecordingActions : IVtActions
+    {
+        public List<(string Intermediates, char Final)> Csi { get; } = [];
+        public List<(string Intermediates, char Final, string Data)> Dcs { get; } = [];
+        public List<IReadOnlyList<string>> Osc { get; } = [];
+
+        public void Print(int rune) { }
+
+        public void Execute(char control) { }
+
+        public void EscDispatch(string intermediates, char final) { }
+
+        public void CsiDispatch(char prefix, IReadOnlyList<int> parameters, string intermediates, char final) =>
+            Csi.Add((intermediates, final));
+
+        public void OscDispatch(IReadOnlyList<string> parameters) => Osc.Add(parameters);
+
+        public void DcsDispatch(char prefix, IReadOnlyList<int> parameters, string intermediates, char final, string data) =>
+            Dcs.Add((intermediates, final, data));
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/TransferCommandParserTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TransferCommandParserTests.cs
@@ -1,0 +1,87 @@
+using VelaShell.Core.FileTransfer.Model;
+using VelaShell.Terminal.FileTransfer;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 命令行传输意图解析:X/YMODEM 在链路上没有引导序列,自动触发只能靠「用户敲了什么」。
+/// 这一路信号必须既灵(常见敲法都认)又稳(绝不能把普通命令误判成传输)。
+/// </summary>
+[TestClass]
+[TestCategory("ZModem")]
+public class TransferCommandParserTests
+{
+    private static void AssertIntent(
+        string commandLine,
+        TerminalTransferProtocol protocol,
+        FileTransferDirection direction)
+    {
+        TransferCommandIntent? intent = TransferCommandParser.Parse(commandLine);
+
+        Assert.IsNotNull(intent, $"\"{commandLine}\" should parse as a transfer command");
+        Assert.AreEqual(protocol, intent.Value.Protocol, commandLine);
+        Assert.AreEqual(direction, intent.Value.Direction, commandLine);
+    }
+
+    /// <summary>远端 <c>s*</c> 发文件 = 本地接收;<c>r*</c> 收文件 = 本地发送。</summary>
+    [TestMethod]
+    public void BareTools_MapToProtocolAndDirection()
+    {
+        AssertIntent("sz report.pdf", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
+        AssertIntent("rz", TerminalTransferProtocol.ZModem, FileTransferDirection.Send);
+        AssertIntent("sx firmware.bin", TerminalTransferProtocol.XModem, FileTransferDirection.Receive);
+        AssertIntent("rx out.bin", TerminalTransferProtocol.XModem, FileTransferDirection.Send);
+        AssertIntent("sb a.log b.log", TerminalTransferProtocol.YModem, FileTransferDirection.Receive);
+        AssertIntent("rb", TerminalTransferProtocol.YModem, FileTransferDirection.Send);
+    }
+
+    /// <summary>lrzsz 的 <c>sz</c>/<c>rz</c> 可用开关切到 X/YMODEM(WindTerm 文档里的敲法)。</summary>
+    [TestMethod]
+    public void VariantFlags_OverrideProtocol()
+    {
+        AssertIntent("sz -X kernel.img", TerminalTransferProtocol.XModem, FileTransferDirection.Receive);
+        AssertIntent("sz --xmodem kernel.img", TerminalTransferProtocol.XModem, FileTransferDirection.Receive);
+        AssertIntent("rz --ymodem", TerminalTransferProtocol.YModem, FileTransferDirection.Send);
+        AssertIntent("sz --ymodem a b", TerminalTransferProtocol.YModem, FileTransferDirection.Receive);
+        AssertIntent("sz -Z x", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
+    }
+
+    /// <summary>带路径调用、前置环境变量、<c>sudo</c> 都是常见敲法,必须认得。</summary>
+    [TestMethod]
+    public void PathQualifiedAndPrefixedInvocations_AreRecognized()
+    {
+        AssertIntent("/usr/bin/sz file", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
+        AssertIntent("sudo rz", TerminalTransferProtocol.ZModem, FileTransferDirection.Send);
+        AssertIntent("LC_ALL=C sz file", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
+        AssertIntent("  sb   spaced.log ", TerminalTransferProtocol.YModem, FileTransferDirection.Receive);
+    }
+
+    /// <summary>
+    /// <c>--</c> 之后是文件名而不是开关:名为 <c>-X</c> 的文件不得把协议改掉。
+    /// </summary>
+    [TestMethod]
+    public void FlagsAfterDoubleDash_AreNotParsed()
+    {
+        AssertIntent("sz -- -X", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
+    }
+
+    /// <summary>
+    /// 误判的代价是把终端交给引擎最多 30 秒,所以宁可漏认也不能错认:
+    /// 工具名必须<b>精确</b>匹配,不能是子串或参数。
+    /// </summary>
+    [TestMethod]
+    public void NonTransferCommands_AreRejected()
+    {
+        foreach (string line in (string[])
+                 [
+                     "", "   ", "ls -la", "echo sz", "cat rz.txt", "szechuan --spicy",
+                     "myrz", "vim sx.c", "git rebase", "grep -r sb ."
+                 ])
+        {
+            Assert.IsNull(TransferCommandParser.Parse(line), $"\"{line}\" must not parse as a transfer command");
+        }
+    }
+
+    [TestMethod]
+    public void NullInput_IsRejected() => Assert.IsNull(TransferCommandParser.Parse(null));
+}

--- a/tests/VelaShell.Terminal.Tests/TransferRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TransferRouterTests.cs
@@ -14,6 +14,14 @@ public class TransferRouterTests
 {
     private static readonly byte[] Signature = ZModemConstants.ReceiveInitSignature.ToArray();
 
+    /// <summary>远端 <c>sz</c> 注入的真 ZRQINIT 十六进制帧头(18 字节 + CR LF XON)。</summary>
+    private static byte[] Zrqinit() =>
+        ZModemFrameWriter.Write(ZModemHeader.Empty(ZModemFrameType.ZRQINIT), ZModemHeaderFormat.Hex);
+
+    /// <summary>远端 <c>rz</c> 注入的真 ZRINIT 十六进制帧头。</summary>
+    private static byte[] Zrinit() =>
+        ZModemFrameWriter.Write(ZModemHeader.Empty(ZModemFrameType.ZRINIT), ZModemHeaderFormat.Hex);
+
     [TestMethod]
     public void Detector_PlainOutput_PassesThroughUnchanged()
     {
@@ -27,85 +35,199 @@ public class TransferRouterTests
     }
 
     [TestMethod]
-    public void Detector_SignatureInStream_SplitsTerminalAndProtocol()
+    public void Detector_HeaderInStream_SplitsTerminalAndProtocol()
     {
         var detector = new ZModemDetector();
         byte[] prefix = "rz\r"u8.ToArray();
-        byte[] input = [.. prefix, .. Signature, 0x30, 0x31];
+        byte[] header = Zrqinit();
 
-        ZModemDetectResult result = detector.Process(input);
-
-        Assert.IsTrue(result.Detected);
-        Assert.AreSequenceEqual(prefix, result.TerminalBytes);
-        Assert.HasCount(Signature.Length + 2, result.ProtocolBytes);
-        Assert.AreSequenceEqual(Signature, result.ProtocolBytes[..Signature.Length]);
-    }
-
-    [TestMethod]
-    public void Detector_SignatureSplitAcrossChunks_WithholdsThenDetects()
-    {
-        var detector = new ZModemDetector();
-        // First chunk ends mid-signature: "**\x18" then next chunk "B00".
-        byte[] first = [.. "noise"u8.ToArray(), Signature[0], Signature[1], Signature[2]];
-        ZModemDetectResult r1 = detector.Process(first);
-
-        Assert.IsFalse(r1.Detected);
-        // The 3 signature-prefix bytes must be withheld, only "noise" fed.
-        Assert.AreSequenceEqual("noise"u8.ToArray(), r1.TerminalBytes);
-
-        byte[] second = [Signature[3], Signature[4], Signature[5], 0x30, 0x30];
-        ZModemDetectResult r2 = detector.Process(second);
-
-        Assert.IsTrue(r2.Detected);
-        Assert.IsEmpty(r2.TerminalBytes);
-        Assert.AreSequenceEqual(Signature, r2.ProtocolBytes[..Signature.Length]);
-    }
-
-    [TestMethod]
-    public void Detector_FalsePrefixAtEnd_IsReleasedOnFlush()
-    {
-        var detector = new ZModemDetector();
-        // Ends with the first 2 signature bytes ("**") — withheld pending more.
-        byte[] input = [.. "data**"u8.ToArray()];
-        ZModemDetectResult r = detector.Process(input);
-        Assert.IsFalse(r.Detected);
-        Assert.AreSequenceEqual("data"u8.ToArray(), r.TerminalBytes);
-
-        // If the session never materializes, Flush returns the withheld bytes.
-        byte[] flushed = detector.Flush();
-        Assert.AreSequenceEqual("**"u8.ToArray(), flushed);
-    }
-
-    /// <summary>
-    /// 远端 <c>rz</c> 发的是 ZRINIT(<c>**\x18B01</c>)而不是 ZRQINIT,必须被识别为「本地发送」。
-    /// 回归:检测器此前只匹配 ZRQINIT,<c>rz</c> 完全检测不到 —— 它的 ZRINIT 会被当成普通输出
-    /// 渲染成满屏乱码,上传功能形同不存在。
-    /// </summary>
-    [TestMethod]
-    public void Detector_RzZrinitSignature_TriggersSendDirection()
-    {
-        var detector = new ZModemDetector();
-        byte[] zrinit = ZModemConstants.SendInitSignature.ToArray();
-        byte[] input = [.. "rz waiting to receive.**\b\b\b"u8.ToArray(), .. zrinit, 0x30, 0x30];
-
-        ZModemDetectResult result = detector.Process(input);
-
-        Assert.IsTrue(result.Detected);
-        Assert.AreEqual(ZModemTrigger.Send, result.Trigger);
-        Assert.AreSequenceEqual(zrinit, result.ProtocolBytes[..zrinit.Length]);
-    }
-
-    /// <summary>远端 <c>sz</c> 的 ZRQINIT 必须被识别为「本地接收」。</summary>
-    [TestMethod]
-    public void Detector_SzZrqinitSignature_TriggersReceiveDirection()
-    {
-        var detector = new ZModemDetector();
-        byte[] input = [.. "rz\r"u8.ToArray(), .. Signature, 0x30, 0x30];
-
-        ZModemDetectResult result = detector.Process(input);
+        ZModemDetectResult result = detector.Process([.. prefix, .. header]);
 
         Assert.IsTrue(result.Detected);
         Assert.AreEqual(ZModemTrigger.Receive, result.Trigger);
+        Assert.AreSequenceEqual(prefix, result.TerminalBytes);
+        Assert.AreSequenceEqual(header, result.ProtocolBytes);
+    }
+
+    /// <summary>远端 <c>rz</c> 的 ZRINIT 必须被识别为「本地发送」(上传)。</summary>
+    [TestMethod]
+    public void Detector_RzZrinitHeader_TriggersSendDirection()
+    {
+        var detector = new ZModemDetector();
+        byte[] header = Zrinit();
+
+        ZModemDetectResult result = detector.Process(
+            [.. "rz waiting to receive.\b\b\b"u8.ToArray(), .. header]);
+
+        Assert.IsTrue(result.Detected);
+        Assert.AreEqual(ZModemTrigger.Send, result.Trigger);
+        Assert.AreSequenceEqual(header, result.ProtocolBytes);
+    }
+
+    /// <summary>
+    /// 引导被分片切开时仍须识别;而且被切在前半段的字节<b>照常喂进终端</b>(零扣留),
+    /// 不再等下一分片 —— 那正是 #291 的根因。
+    /// </summary>
+    [TestMethod]
+    public void Detector_HeaderSplitAcrossChunks_StillDetectsAndWithholdsNothing()
+    {
+        var detector = new ZModemDetector();
+        byte[] header = Zrqinit();
+        byte[] first = [.. "noise"u8.ToArray(), .. header[..8]];
+
+        ZModemDetectResult r1 = detector.Process(first);
+        Assert.IsFalse(r1.Detected);
+        Assert.AreSequenceEqual(first, r1.TerminalBytes); // 一个字节都没扣。
+
+        ZModemDetectResult r2 = detector.Process(header.AsSpan()[8..]);
+        Assert.IsTrue(r2.Detected);
+        Assert.IsEmpty(r2.TerminalBytes);                 // 已喂过的部分不重喂。
+        Assert.AreSequenceEqual(header, r2.ProtocolBytes); // 协议种子仍是完整帧头。
+    }
+
+    /// <summary>
+    /// 回归 #291:用户敲的 <c>*</c> 必须立刻回显。检测器此前把任何与引导前缀重叠的块尾都扣下来,
+    /// 而引导前两字节正是 <c>'*' '*'</c> —— SSH 里逐字回显的星号被无限期扣住,表现为
+    /// 「输入 * 不显示、光标不动,按方向键才一次冒出来」。连敲三次只应显示三次,一个都不能少。
+    /// </summary>
+    [TestMethod]
+    public void Detector_TypedAsterisksEchoedOneByOne_AreNeverWithheld()
+    {
+        var detector = new ZModemDetector();
+        for (int i = 1; i <= 3; i++)
+        {
+            ZModemDetectResult r = detector.Process("*"u8);
+            Assert.IsFalse(r.Detected);
+            Assert.AreSequenceEqual("*"u8.ToArray(), r.TerminalBytes, $"asterisk #{i} was swallowed");
+        }
+    }
+
+    /// <summary>
+    /// 零扣留的总不变量:未命中期间,<b>进来几个字节就吐出几个字节</b>,无论怎么切分片。
+    /// 这里刻意逐字节喂一段满是 <c>*</c> 与 ZDLE 的、永远凑不成合法帧头的流。
+    /// </summary>
+    [TestMethod]
+    public void Detector_WhileUndetected_OutputLengthAlwaysEqualsInputLength()
+    {
+        var detector = new ZModemDetector();
+        byte[] stream = [.. "**\x18B0zz ***\x18\x18B00 ls *.txt\r\n**"u8.ToArray()];
+
+        var echoed = new List<byte>();
+        foreach (byte b in stream)
+        {
+            ZModemDetectResult r = detector.Process([b]);
+            Assert.IsFalse(r.Detected);
+            Assert.HasCount(1, r.TerminalBytes);
+            echoed.AddRange(r.TerminalBytes);
+        }
+
+        Assert.AreSequenceEqual(stream, echoed);
+    }
+
+    /// <summary>
+    /// 逐字节喂一个真帧头(最恶劣的分片):每一步都不能吞字节;帧头第 18 字节到齐的那一刻命中,
+    /// 且交给引擎的协议种子是完整的 18 字节帧头(含此前已经回显过的部分)。
+    /// </summary>
+    [TestMethod]
+    public void Detector_HeaderFedByteByByte_DetectsWhenHeaderCompletes()
+    {
+        var detector = new ZModemDetector();
+        byte[] header = Zrqinit();
+        const int HexHeaderLength = 18;
+
+        for (int i = 0; i < HexHeaderLength - 1; i++)
+        {
+            ZModemDetectResult step = detector.Process([header[i]]);
+            Assert.IsFalse(step.Detected, $"detected too early at byte {i}");
+            Assert.AreSequenceEqual([header[i]], step.TerminalBytes);
+        }
+
+        ZModemDetectResult last = detector.Process([header[HexHeaderLength - 1]]);
+
+        Assert.IsTrue(last.Detected);
+        Assert.AreEqual(ZModemTrigger.Receive, last.Trigger);
+        Assert.AreSequenceEqual(header[..HexHeaderLength], last.ProtocolBytes);
+    }
+
+    /// <summary>
+    /// 判据是<b>完整且格式良好</b>的十六进制帧头,不是 6 字节引导:后 12 位不全是十六进制数字
+    /// 的,只是巧合,不得接管终端。
+    /// </summary>
+    [TestMethod]
+    public void Detector_MalformedHexHeader_IsNotDetected()
+    {
+        var detector = new ZModemDetector();
+        byte[] input = [.. Signature, .. "not-hex-here"u8.ToArray()];
+
+        ZModemDetectResult result = detector.Process(input);
+
+        Assert.IsFalse(result.Detected);
+        Assert.AreSequenceEqual(input, result.TerminalBytes);
+    }
+
+    /// <summary>
+    /// 尾锚定(借鉴 zmodem.js):<c>sz</c>/<c>rz</c> 写完帧头就阻塞等应答,真引导后面只会跟
+    /// CR/LF/XON。后面还跟着普通输出的,几乎必然是 <c>cat</c> 到二进制里凑出来的巧合 —— 不接管。
+    /// </summary>
+    [TestMethod]
+    public void Detector_HeaderFollowedByShellOutput_IsNotDetected()
+    {
+        var detector = new ZModemDetector();
+        byte[] input = [.. Zrqinit(), .. "user@host:~$ "u8.ToArray()];
+
+        ZModemDetectResult result = detector.Process(input);
+
+        Assert.IsFalse(result.Detected);
+        Assert.AreSequenceEqual(input, result.TerminalBytes);
+    }
+
+    /// <summary>
+    /// 但用户刚敲过 <c>sz</c>/<c>rz</c> 时(路由器置位 <c>AcceptUnanchoredHeader</c>),
+    /// 同样的输入必须识别得到:此时误报代价远低于漏检。
+    /// </summary>
+    [TestMethod]
+    public void Detector_UnanchoredHeader_IsDetectedWhenArmed()
+    {
+        var detector = new ZModemDetector { AcceptUnanchoredHeader = true };
+        byte[] header = Zrqinit();
+
+        ZModemDetectResult result = detector.Process([.. header, .. "user@host:~$ "u8.ToArray()]);
+
+        Assert.IsTrue(result.Detected);
+        Assert.AreEqual(ZModemTrigger.Receive, result.Trigger);
+        Assert.AreSequenceEqual(header, result.ProtocolBytes[..header.Length]);
+    }
+
+    /// <summary>
+    /// 块尾是星号时下一块不得走零拷贝快路径,否则跨分片的引导会被整块直喂终端而漏检。
+    /// </summary>
+    [TestMethod]
+    public void Detector_AfterTrailingAsterisk_NextChunkTakesSlowPath()
+    {
+        var detector = new ZModemDetector();
+        Assert.IsTrue(detector.CanPassThrough("plain output\r\n"u8));
+
+        _ = detector.Process("echo **"u8);
+
+        Assert.IsFalse(detector.CanPassThrough(Zrqinit().AsSpan(2)));
+    }
+
+    /// <summary>复位丢弃跨分片匹配状态,且不交还任何字节(从不扣留 → 交还就是重影)。</summary>
+    [TestMethod]
+    public void Detector_Reset_DropsCarryWithoutReplayingBytes()
+    {
+        var detector = new ZModemDetector();
+        byte[] header = Zrqinit();
+
+        ZModemDetectResult r = detector.Process(header.AsSpan()[..8]);
+        Assert.AreSequenceEqual(header[..8], r.TerminalBytes);
+
+        detector.Reset();
+
+        // 复位后残缺前缀不再参与匹配,后半段自成一段普通输出。
+        ZModemDetectResult after = detector.Process(header.AsSpan()[8..]);
+        Assert.IsFalse(after.Detected);
+        Assert.AreSequenceEqual(header[8..], after.TerminalBytes);
     }
 
     /// <summary>
@@ -127,6 +249,116 @@ public class TransferRouterTests
         Assert.IsFalse(route.SessionStarted);
         Assert.IsFalse(router.IsInSession);
         Assert.AreSequenceEqual(zrinit, route.TerminalBytes);
+    }
+
+    private static TerminalTransferRouter NewRouter(bool withUploadPicker = false)
+    {
+        IShellStreamWrapper shell = Substitute.For<IShellStreamWrapper>();
+        shell.CanWrite.Returns(true);
+        return new(shell, () => new RouterTestSink(), withUploadPicker ? () => new RouterTestSource() : null);
+    }
+
+    /// <summary>
+    /// X/YMODEM 在链路上没有任何引导序列,自动触发只能靠命令行这一路信号:用户敲下
+    /// <c>sb file</c> 就该直接开会话(WindTerm 对 <c>rx</c>/<c>sx</c>/<c>rb</c>/<c>sb</c> 同此)。
+    /// </summary>
+    [TestMethod]
+    public void Router_UserTypedSb_StartsYModemSessionFromCommandLine()
+    {
+        TerminalTransferRouter router = NewRouter();
+        try
+        {
+            Assert.IsTrue(router.NoteCommandSubmitted("sb payload.log"));
+            Assert.IsTrue(router.IsInSession);
+
+            // 会话已接管:入站字节全部转交引擎,终端不再喂。
+            TransferRouteResult route = router.ProcessIncoming("protocol bytes"u8.ToArray());
+            Assert.IsEmpty(route.TerminalBytes);
+        }
+        finally
+        {
+            router.CancelActiveSession();
+        }
+    }
+
+    /// <summary>上传方向没接线文件选择器时不得开会话(否则引擎起来就没文件可发)。</summary>
+    [TestMethod]
+    public void Router_UserTypedRb_WithoutUploadPicker_DoesNotStart()
+    {
+        TerminalTransferRouter router = NewRouter();
+
+        Assert.IsFalse(router.NoteCommandSubmitted("rb"));
+        Assert.IsFalse(router.IsInSession);
+    }
+
+    /// <summary>普通命令不得触发任何东西。</summary>
+    [TestMethod]
+    public void Router_OrdinaryCommand_StartsNothing()
+    {
+        TerminalTransferRouter router = NewRouter(withUploadPicker: true);
+
+        Assert.IsFalse(router.NoteCommandSubmitted("ls -la *.txt"));
+        Assert.IsFalse(router.IsInSession);
+    }
+
+    /// <summary>
+    /// ZMODEM 不靠命令行启动(输出流里有引导,自动检测更可靠),命令行只用来放宽判据:
+    /// 敲过 <c>sz</c> 之后,帧头后面跟着别的输出也照样认。
+    /// </summary>
+    [TestMethod]
+    public void Router_UserTypedSz_RelaxesDetectorWithoutStartingSession()
+    {
+        TerminalTransferRouter router = NewRouter();
+        try
+        {
+            Assert.IsFalse(router.NoteCommandSubmitted("sz report.pdf"));
+            Assert.IsFalse(router.IsInSession);
+
+            byte[] input = [.. Zrqinit(), .. "trailing shell output"u8.ToArray()];
+            TransferRouteResult route = router.ProcessIncoming(input);
+
+            Assert.IsTrue(route.SessionStarted);
+        }
+        finally
+        {
+            router.CancelActiveSession();
+        }
+    }
+
+    /// <summary>
+    /// 同样的字节,没敲过命令时不认(尾锚定生效)—— 这正是「<c>cat</c> 到 ZMODEM 抓包
+    /// 不该劫持终端」那条守卫。
+    /// </summary>
+    [TestMethod]
+    public void Router_WithoutCommandSignal_UnanchoredHeaderIsNotHijacked()
+    {
+        TerminalTransferRouter router = NewRouter();
+        byte[] input = [.. Zrqinit(), .. "trailing shell output"u8.ToArray()];
+
+        TransferRouteResult route = router.ProcessIncoming(input);
+
+        Assert.IsFalse(route.SessionStarted);
+        Assert.AreSequenceEqual(input, route.TerminalBytes);
+    }
+
+    /// <summary>
+    /// 命令行是<b>加分信号而非硬闸门</b>:脚本 / 别名 / <c>make upload</c> 里调起的 <c>sz</c>
+    /// 压根不经过命令行这一路,它的引导仍须照常被自动检测到。
+    /// </summary>
+    [TestMethod]
+    public void Router_ScriptInvokedSz_StillDetectedWithoutCommandSignal()
+    {
+        TerminalTransferRouter router = NewRouter();
+        try
+        {
+            TransferRouteResult route = router.ProcessIncoming(Zrqinit());
+
+            Assert.IsTrue(route.SessionStarted);
+        }
+        finally
+        {
+            router.CancelActiveSession();
+        }
     }
 
     [TestMethod]
@@ -193,6 +425,16 @@ public class TransferRouterTests
         wire.AddRange(ZModemFrameWriter.Write(ZModemHeader.Empty(ZModemFrameType.ZFIN), ZModemHeaderFormat.Hex));
         wire.AddRange([0x4F, 0x4F]);
         return [.. wire];
+    }
+
+    /// <summary>上传方向的最小桩:只用来证明「接线了就能起会话」,不发任何文件。</summary>
+    private sealed class RouterTestSource : IFileTransferSource
+    {
+        public ValueTask<IReadOnlyList<OutgoingTransferFile>> GetFilesAsync(CancellationToken cancellationToken) =>
+            ValueTask.FromResult<IReadOnlyList<OutgoingTransferFile>>([]);
+
+        public ValueTask<Stream> OpenReadAsync(OutgoingTransferFile file, CancellationToken cancellationToken) =>
+            ValueTask.FromResult<Stream>(new MemoryStream());
     }
 
     private sealed class RouterTestSink : IFileTransferSink


### PR DESCRIPTION
- ZMODEM 检测器采用零扣留策略，移除尾部字节扣留，升级帧头判据，新增 `AcceptUnanchoredHeader` 属性，避免误报与重影
- 新增 `TransferCommandParser`，准确识别 sz/rz/sx/rx/sb/rb 及其变体，支持协议参数，路由器支持命令意图通知
- VT 解析器为 OSC/DCS/CSI 等加缓冲上限，防止异常序列导致内存溢出或死锁
- 回显抑制器新增 `TakeHeld`，防止永久吞字节，SshTerminalBridge 弃用前自动合并尾部
- 补充完善多项单元测试，覆盖边界与异常场景
- 注释与文档优化，提升可读性与维护性

显著提升文件传输检测准确性与健壮性，杜绝回显丢失和终端卡死，为 X/YMODEM 自动触发提供支持

<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #291 

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
