### PR TITLE
修复OnKeyDown异步处理导致事件冒泡问题

### DIFF
--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -2316,7 +2316,6 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         return false;
     }
 
-
     /// <summary>搜索整个缓冲区(回滚区 + 屏幕),不区分大小写(规范 §5.3)。</summary>
     public IReadOnlyList<BufferSearchHit> SearchBuffer(string query) =>
         BufferSearch.FindAll(Emulator.Screen, query);
@@ -2528,7 +2527,14 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// 分类决策(快捷键优先级、修饰键改写、编码)全在 <see cref="TerminalKeyRouter" />,
     /// 这里只执行动作 —— 改键位行为去改路由器,别在这里加分支。
     /// </summary>
-    protected override async void OnKeyDown(KeyEventArgs e)
+    /// <remarks>
+    /// <b>本方法必须保持同步,<c>e.Handled</c> 必须在任何 await 之前置位。</b>
+    /// 路由事件的处理器一旦 <c>await</c> 就地返回,事件随即继续冒泡 —— 此后再置 Handled 已经晚了。
+    /// 回归 #265:这里原本是 <c>async void</c> 且在 <c>await PasteAsync()</c> <b>之后</b>才置位,
+    /// 于是 Ctrl+Shift+V 冒泡到 <c>TerminalTabView.OnKeyDown</c> 又粘贴一次 ——
+    /// 用户看到两个多行确认框,点两次确定、粘贴两遍。
+    /// </remarks>
+    protected override void OnKeyDown(KeyEventArgs e)
     {
         TerminalKeyAction action = TerminalKeyRouter.Classify(
             e.Key,
@@ -2543,6 +2549,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 break; // 已提交文本会经 OnTextInput 单独送达。
 
             case TerminalKeyActionKind.CopySelection:
+                e.Handled = true;
                 // Ctrl+C 变体带"复制后清选区"的既有语义;Ctrl+Shift+C 保留选区。
                 if (e.KeyModifiers == KeyModifiers.Control)
                 {
@@ -2550,13 +2557,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 }
                 else
                 {
-                    await CopyAsync();
+                   _ = CopyAsync();
                 }
-                e.Handled = true;
                 return;
 
             case TerminalKeyActionKind.PasteClipboard:
-                await PasteAsync();
+                _ = PasteAsync();
                 e.Handled = true;
                 return;
 

--- a/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 回归 #265:Ctrl+Shift+V 的多行粘贴确认框弹两次、粘贴两遍。
+/// <para>
+/// 根因是路由事件与 <c>async void</c> 的经典冲突:<see cref="VelaTerminalControl.OnKeyDown" />
+/// 原本 <c>await PasteAsync()</c> 之后才置 <c>e.Handled</c>,而处理器一遇 await 就地返回 ——
+/// 事件带着 <c>Handled == false</c> 继续冒泡到 <c>TerminalTabView.OnKeyDown</c>,那里又粘贴一次。
+/// </para>
+/// <para>
+/// 因此断言落在「<b>RaiseEvent 同步返回时</b> Handled 是否已置位」以及「冒泡到父级时事件是否已被
+/// 标记消费」——这正是双弹窗的充要条件,比数弹窗次数更直接也更稳。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("PasteShortcutUi")]
+public class PasteShortcutUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    private static KeyEventArgs KeyDown(Key key, KeyModifiers modifiers) =>
+        new()
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = key,
+            KeyModifiers = modifiers
+        };
+
+    /// <summary>
+    /// 多行粘贴走确认框(会 await,必然让出),此时按键仍必须已被同步标记为已处理,
+    /// 且冒泡到父级时父级看到的是「已消费」—— 否则父级会再粘贴一次(#265)。
+    /// </summary>
+    [TestMethod]
+    public void CtrlShiftV_WithMultilineClipboard_IsHandledSynchronouslyAndDoesNotBubbleUnconsumed()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ConfirmMultilinePaste = true };
+            var window = new Window { Width = 480, Height = 320, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            control.Focus();
+
+            // 剪贴板必须真有多行文本,否则 PasteAsync 会提前 return、根本不 await,
+            // 测试就会因为"压根没走到异步"而假绿。
+            IClipboard clipboard = TopLevel.GetTopLevel(control)!.Clipboard!;
+            Task set = clipboard.SetTextAsync("hostname\r\nwhoami\r\n");
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsTrue(set.IsCompleted, "headless 剪贴板写入应同步完成。");
+
+            // 确认框永不完成:保证 PasteAsync 一定在此让出控制权。
+            var neverCompletes = new TaskCompletionSource<bool>();
+            int confirmCalls = 0;
+            control.MultilinePasteConfirmation = _ =>
+            {
+                confirmCalls++;
+                return neverCompletes.Task;
+            };
+
+            // 父级探针:模拟 TerminalTabView 那层的回退处理(它只在事件未被消费时才粘贴)。
+            int bubbledUnconsumed = 0;
+            window.AddHandler(
+                InputElement.KeyDownEvent,
+                (_, args) =>
+                {
+                    if (!args.Handled)
+                    {
+                        bubbledUnconsumed++;
+                    }
+                },
+                RoutingStrategies.Bubble,
+                handledEventsToo: true);
+
+            KeyEventArgs key = KeyDown(Key.V, KeyModifiers.Control | KeyModifiers.Shift);
+            control.RaiseEvent(key);
+
+            Assert.IsTrue(key.Handled, "Ctrl+Shift+V 必须在处理器同步返回前就标记为已处理。");
+            Assert.AreEqual(0, bubbledUnconsumed, "事件不得以未消费状态冒泡到父级,否则父级会再粘贴一次。");
+            Assert.AreEqual(1, confirmCalls, "多行确认框只应弹一次。");
+
+            neverCompletes.TrySetResult(false);
+            Dispatcher.UIThread.RunJobs();
+            window.Close();
+        });
+    }
+
+    /// <summary>Shift+Insert 是同一条粘贴路径(经典 X11 惯例),同样不得漏标已处理。</summary>
+    [TestMethod]
+    public void ShiftInsert_TakesSamePastePath_AndIsHandledSynchronously()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl { ConfirmMultilinePaste = true };
+            var window = new Window { Width = 480, Height = 320, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            control.Focus();
+
+            Task set = TopLevel.GetTopLevel(control)!.Clipboard!.SetTextAsync("a\r\nb\r\n");
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsTrue(set.IsCompleted);
+
+            var neverCompletes = new TaskCompletionSource<bool>();
+            control.MultilinePasteConfirmation = _ => neverCompletes.Task;
+
+            KeyEventArgs key = KeyDown(Key.Insert, KeyModifiers.Shift);
+            control.RaiseEvent(key);
+
+            Assert.IsTrue(key.Handled);
+
+            neverCompletes.TrySetResult(false);
+            Dispatcher.UIThread.RunJobs();
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// 结构守卫:<c>OnKeyDown</c> 不得是 <c>async</c>。
+    /// <para>
+    /// 上面两条行为测试只覆盖粘贴一条路径,复制路径(<c>await CopyAsync()</c>)在 headless 下
+    /// 剪贴板写入是同步完成的、根本不让出,行为测试对它<b>测不出来</b>(真机上才异步)。与其留一条
+    /// 永远绿的假测试,不如直接断言这个类的根本不变量:处理器一旦是 async,任何一条分支
+    /// 只要 await,<c>e.Handled</c> 就必然置晚 —— #265 的整类 bug 由此杜绝。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void OnKeyDown_IsNotAsync_SoHandledCanNeverBeSetTooLate()
+    {
+        MethodInfo? onKeyDown = typeof(VelaTerminalControl).GetMethod(
+            "OnKeyDown",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            [typeof(KeyEventArgs)]);
+
+        Assert.IsNotNull(onKeyDown);
+        Assert.IsNull(
+            onKeyDown.GetCustomAttribute<AsyncStateMachineAttribute>(),
+            "VelaTerminalControl.OnKeyDown 必须是同步方法:async 处理器一遇 await 就地返回,"
+            + "事件会带着 Handled == false 继续冒泡,父级于是重复执行同一个快捷键(#265)。");
+    }
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

将VelaTerminalControl.OnKeyDown由async void改为同步方法，确保e.Handled在await前被置位，防止重复粘贴。粘贴和复制快捷键改为fire-and-forget调用，避免await阻塞事件处理。新增PasteShortcutUiTests，验证多行粘贴事件同步标记和冒泡行为。增加结构性测试，断言OnKeyDown非async，彻底杜绝异步冒泡问题。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #265

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试(或说明为什么不需要)
- [x] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
