### PR TITLE
优化已信任主机列表显示与滚动体验

### DIFF
--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -1215,6 +1215,9 @@ public class SettingsViewModel : ReactiveObject
         {
             List<KnownHost> hosts = await _hostKeyService.GetKnownHostsAsync();
             KnownHosts.Clear();
+            // 先置可见再入列:IsVisible=false 期间灌进 ItemsControl 的行会占住布局高度却
+            // 画不出来。列表限高滚动后这条尤其致命——表现为“有滚动条但内容一片空白”。
+            HasKnownHosts = hosts.Count > 0;
             foreach (
                 KnownHost host in hosts
                     .OrderBy(h => h.Host, StringComparer.OrdinalIgnoreCase)

--- a/src/VelaShell/Views/Settings/SecurityAuditPage.axaml
+++ b/src/VelaShell/Views/Settings/SecurityAuditPage.axaml
@@ -66,46 +66,53 @@
     </Grid>
     <TextBlock Classes="row-desc" Text="{loc:Localize SetSecurity_NoKnownHosts}"
                IsVisible="{Binding !HasKnownHosts}" />
+    <!-- 列表限高约 6 行(单行 ≈50px:12,8 内边距 + 两行文本 + 1px 分隔线),其余在框内滚动:
+         上百台已信任主机时不会把整页撑长到滚不到底部的设置项。 -->
     <Border Classes="table" IsVisible="{Binding HasKnownHosts}">
-      <ItemsControl ItemsSource="{Binding KnownHosts}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate x:DataType="models:KnownHost">
-            <Border Padding="12,8"
-                    BorderBrush="{DynamicResource VelaBorderPrimary}"
-                    BorderThickness="0,0,0,1">
-              <Grid ColumnDefinitions="*,Auto">
-                <StackPanel Spacing="2" VerticalAlignment="Center">
-                  <StackPanel Orientation="Horizontal" Spacing="8">
-                    <!-- 地址脱敏:掩码为固定长度,不暴露真实地址的位数;
-                         按指纹区分各条目(指纹是服务器公钥哈希,非敏感信息)。 -->
-                    <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
-                               Foreground="{DynamicResource VelaTextPrimary}"
-                               IsVisible="{Binding !$parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}">
-                      <Run Text="{Binding Host}" /><Run Text=":" /><Run Text="{Binding Port}" />
-                    </TextBlock>
-                    <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
-                               Foreground="{DynamicResource VelaTextPrimary}"
-                               Text="••••••••••:•••"
-                               IsVisible="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}" />
-                    <TextBlock FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
+      <ScrollViewer MaxHeight="300" VerticalScrollBarVisibility="Auto">
+        <ItemsControl ItemsSource="{Binding KnownHosts}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="models:KnownHost">
+              <!-- 右内边距 20 > 滚动条展开宽 16(VelaScrollBarSize):滚动条是覆盖式的,
+                   悬停展开时会盖住行的右边缘,不留出这段就压到“删除”按钮上。
+                   留白走内边距而非外边距,底部分隔线仍铺满整行宽度。 -->
+              <Border Padding="12,8,20,8"
+                      BorderBrush="{DynamicResource VelaBorderPrimary}"
+                      BorderThickness="0,0,0,1">
+                <Grid ColumnDefinitions="*,Auto">
+                  <StackPanel Spacing="2" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                      <!-- 地址脱敏:掩码为固定长度,不暴露真实地址的位数;
+                           按指纹区分各条目(指纹是服务器公钥哈希,非敏感信息)。 -->
+                      <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
+                                 Foreground="{DynamicResource VelaTextPrimary}"
+                                 IsVisible="{Binding !$parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}">
+                        <Run Text="{Binding Host}" /><Run Text=":" /><Run Text="{Binding Port}" />
+                      </TextBlock>
+                      <TextBlock FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
+                                 Foreground="{DynamicResource VelaTextPrimary}"
+                                 Text="••••••••••:•••"
+                                 IsVisible="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).MaskKnownHostAddresses}" />
+                      <TextBlock FontSize="{DynamicResource VelaFontSize10}" VerticalAlignment="Center"
+                                 Foreground="{DynamicResource VelaTextMuted}"
+                                 Text="{Binding KeyType}" />
+                    </StackPanel>
+                    <TextBlock FontSize="{DynamicResource VelaFontSize10}"
+                               FontFamily="{DynamicResource VelaUiMonoFont}"
                                Foreground="{DynamicResource VelaTextMuted}"
-                               Text="{Binding KeyType}" />
+                               TextWrapping="Wrap"
+                               Text="{Binding Fingerprint}" />
                   </StackPanel>
-                  <TextBlock FontSize="{DynamicResource VelaFontSize10}"
-                             FontFamily="{DynamicResource VelaUiMonoFont}"
-                             Foreground="{DynamicResource VelaTextMuted}"
-                             TextWrapping="Wrap"
-                             Text="{Binding Fingerprint}" />
-                </StackPanel>
-                <Button Grid.Column="1" Classes="dlg-danger" Content="{loc:Localize Delete}"
-                        VerticalAlignment="Center"
-                        Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).RemoveKnownHostCommand}"
-                        CommandParameter="{Binding}" />
-              </Grid>
-            </Border>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
+                  <Button Grid.Column="1" Classes="dlg-danger" Content="{loc:Localize Delete}"
+                          VerticalAlignment="Center"
+                          Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).RemoveKnownHostCommand}"
+                          CommandParameter="{Binding}" />
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
     </Border>
 
     <Border Classes="sep" />


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

- 修复 SettingsViewModel.cs 中 KnownHosts 渲染时机，避免滚动条内容空白问题
- SecurityAuditPage.axaml 中列表加 ScrollViewer，最大高度 300px，超出可滚动
- 优化每行右内边距，防止滚动条遮挡“删除”按钮
- 调整主机信息结构，KeyType 与 Fingerprint 显示更合理，Fingerprint 支持换行
- 保留地址脱敏逻辑，按“掩码”选项切换显示

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
