### PR TITLE
会话录制支持空间清理及相关优化

### DIFF
--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -88,6 +88,15 @@ public class AppSettings
         {
             Transfer.LocalDownloadDirectory = string.Empty;
         }
+
+        // 会话录制早年默认开启,把终端原始输出整份落库,不少用户因此攒下几个 GB 还不知情。
+        // 现改为默认关闭:存量配置统一关一次(旧的 true 分不清是用户选的还是旧默认值),
+        // 打上标记后就不再插手,用户此后开关几次都算数。
+        if (!Security.RecordingOptInMigrated)
+        {
+            Security.RecordProductionSessions = false;
+            Security.RecordingOptInMigrated = true;
+        }
     }
 }
 
@@ -829,8 +838,18 @@ public class TransferOptions : ObservableOptions
 /// <summary>设置 - 安全审计(设计 glqQE;策略项持久化,审计数据在 SonnetDB audit_log)。</summary>
 public class SecurityOptions : ObservableOptions
 {
-    /// <summary>规划中(会话录制):仅持久化,当前无运行时消费者,不出现在设置界面(设置审计 R-11)。</summary>
-    public bool RecordProductionSessions { get; set; } = true;
+    /// <summary>
+    /// 会话录制总开关(设置 → 安全审计 / 回放中心标题栏)。默认关闭:录制把终端原始输出
+    /// 整份落库,一天挂几个会话就是几个 GB,默认开着等于替用户把磁盘吃满。要用的人自己开。
+    /// </summary>
+    public bool RecordProductionSessions { get; set; }
+
+    /// <summary>
+    /// 录制"改为默认关闭"的一次性迁移标记。此开关早年默认开启且从未征求过用户同意,
+    /// 存量配置里的 <see langword="true" /> 分不清是用户选的还是旧默认值带的 ——
+    /// 于是统一关一次并打上标记,之后完全听用户的(见 <see cref="AppSettings.Normalize" />)。
+    /// </summary>
+    public bool RecordingOptInMigrated { get; set; }
 
     /// <summary>规划中(输入脱敏,依赖会话录制):仅持久化,不出现在设置界面(设置审计 R-12)。</summary>
     public bool MaskSensitiveInput { get; set; } = true;

--- a/src/VelaShell.Core/Recording/ISessionRecordingStore.cs
+++ b/src/VelaShell.Core/Recording/ISessionRecordingStore.cs
@@ -31,6 +31,34 @@ public class SessionRecording
 public sealed record RecordingChunk(long OffsetMs, byte[] Data);
 
 /// <summary>
+/// 录制数据的占用快照(回放中心"清理"入口的决策依据)。
+/// </summary>
+/// <param name="RecordingCount">现存录制条数。</param>
+/// <param name="LiveBytes">现存录制的逻辑字节数(各条元数据 ByteSize 之和)。</param>
+/// <param name="DiskBytes">数据库目录在磁盘上的实际占用。</param>
+public readonly record struct RecordingStorageUsage(int RecordingCount, long LiveBytes, long DiskBytes)
+{
+    /// <summary>
+    /// 预计可回收的字节数:磁盘占用减去现存录制的逻辑体积。删除只写墓碑不腾空间,
+    /// 差额即"已删除但仍占着盘"的孤儿数据(也含审计日志等其它时序数据,故只是估算)。
+    /// </summary>
+    public long ReclaimableBytes => Math.Max(0, DiskBytes - LiveBytes);
+}
+
+/// <summary>
+/// 一次清理的结果。
+/// </summary>
+/// <param name="RemovedRecordings">被删除的录制条数。</param>
+/// <param name="DiskBytesBefore">清理前的数据库磁盘占用。</param>
+/// <param name="DiskBytesAfter">清理后的数据库磁盘占用(受内存映射影响,可能要下次启动才降下来)。</param>
+/// <param name="DeferredToRestart">段文件仍被内存映射占用,字节数要等下次启动才真正释放。</param>
+public readonly record struct RecordingCleanupResult(
+    int RemovedRecordings,
+    long DiskBytesBefore,
+    long DiskBytesAfter,
+    bool DeferredToRestart);
+
+/// <summary>
 /// 会话录制存储(设置 → 安全审计 → 会话录制):
 /// 元数据存文档集合,输出块存 SonnetDB 时序 measurement(时间 = 开始时刻 + 偏移)。
 /// </summary>
@@ -53,4 +81,23 @@ public interface ISessionRecordingStore
 
     /// <summary>清理超过保留天数的录制(随会话日志保留天数,启动时调用)。</summary>
     Task CleanupExpiredAsync(int retentionDays, CancellationToken cancellationToken = default);
+
+    /// <summary>录制数据的占用快照(条数 / 逻辑体积 / 磁盘占用)。</summary>
+    Task<RecordingStorageUsage> GetStorageUsageAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 真正腾空间的清理:只保留最近 <paramref name="keepDays" /> 天的录制,其余连同
+    /// 历史删除留下的孤儿数据块一并抹掉。
+    /// <para>
+    /// 时序库的 DELETE 只写墓碑、不回收字节,唯一能腾出空间的是整块 drop 掉 measurement。
+    /// 因此实现为"存活数据先落到磁盘暂存文件 → drop 重建 measurement → 回灌"三步:
+    /// 内存占用只与单个数据块有关,与录制总量无关。
+    /// </para>
+    /// </summary>
+    /// <param name="keepDays">
+    /// 保留窗口(天)。<c>0</c> = 一条不留(最快,直接 drop 重建);
+    /// <see cref="int.MaxValue" /> = 全部保留,只回收已删除录制占的空间。
+    /// </param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    Task<RecordingCleanupResult> ReclaimSpaceAsync(int keepDays, CancellationToken cancellationToken = default);
 }

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -2044,7 +2044,7 @@
     <value>すべてのセッションを自動録画</value>
   </data>
   <data name="SetSecurity_AutoRecordDesc" xml:space="preserve">
-    <value>// ターミナル出力をローカルデータベースに記録し、監査と再生に利用。以後に確立した接続に適用され、保持日数は「一般 → ターミナルセッションログの保持日数」に従います</value>
+    <value>// 端末の出力をローカルデータベースに記録し、監査と再生に使います。既定はオフ:録画は急速に増え、よく使う週なら数 GB になります。以降に確立した接続に適用され、保持日数は「一般 → 端末セッションログの保持日数」に従います</value>
   </data>
   <data name="SetSecurity_BlockOnChange" xml:space="preserve">
     <value>フィンガープリント変更時にブロックして警告</value>
@@ -3989,5 +3989,43 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   </data>
   <data name="SetSecurity_ClearTrustedLaunchTargets" xml:space="preserve">
     <value>消去</value>
+  </data>
+  <data name="Recorder_Cleanup" xml:space="preserve">
+    <value>クリーンアップ</value>
+  </data>
+  <data name="Recorder_CleanupTip" xml:space="preserve">
+    <value>録画を削除し、占有しているディスク領域を実際に解放します</value>
+  </data>
+  <data name="Recorder_CleanupTitle" xml:space="preserve">
+    <value>録画データのクリーンアップ</value>
+  </data>
+  <data name="Recorder_CleanupMessage" xml:space="preserve">
+    <value>録画 {0} 件、内容は合計 {1} です。データベースのディレクトリはディスク上で {2} を占有しており、そのうち約 {3} は以前削除した録画の残骸です。録画の削除は印を付けるだけで、バイトはディスクに返却されません。
+
+クリーンアップの範囲を選んでください。いずれの選択肢もストレージを再構築し、領域を実際に返却します。</value>
+  </data>
+  <data name="Recorder_CleanupKeepAll" xml:space="preserve">
+    <value>削除済みのみ回収</value>
+  </data>
+  <data name="Recorder_CleanupKeepRecent" xml:space="preserve">
+    <value>直近 7 日間を保持</value>
+  </data>
+  <data name="Recorder_CleanupPurgeAll" xml:space="preserve">
+    <value>すべての録画を削除</value>
+  </data>
+  <data name="Recorder_CleanupPurgeConfirm" xml:space="preserve">
+    <value>すべての録画が完全に削除され、復元できません。続行しますか?</value>
+  </data>
+  <data name="Recorder_CleanupBusy" xml:space="preserve">
+    <value>クリーンアップ中…</value>
+  </data>
+  <data name="Recorder_CleanupDone" xml:space="preserve">
+    <value>録画 {0} 件をクリーンアップし、{1} を解放しました。</value>
+  </data>
+  <data name="Recorder_CleanupDoneDeferred" xml:space="preserve">
+    <value>録画 {0} 件をクリーンアップしました。データは削除済みで、ディスク領域は次回 VelaShell 起動時に解放されます。</value>
+  </data>
+  <data name="Recorder_CleanupFailed" xml:space="preserve">
+    <value>クリーンアップに失敗しました: {0}</value>
   </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -2044,7 +2044,7 @@
     <value>모든 세션 자동 녹화</value>
   </data>
   <data name="SetSecurity_AutoRecordDesc" xml:space="preserve">
-    <value>// 터미널 출력을 로컬 데이터베이스에 기록해 감사와 재생에 사용; 이후 연결부터 적용되며 보관 일수는 '일반 → 터미널 세션 로그 보관 일수'를 따릅니다</value>
+    <value>// 터미널 출력을 로컬 데이터베이스에 기록해 감사와 재생에 사용합니다. 기본값은 꺼짐: 녹화는 빠르게 커져 많이 쓰는 주에는 수 GB가 됩니다. 이후 맺는 연결에 적용되며 보관 일수는 「일반 → 터미널 세션 로그 보관 일수」를 따릅니다</value>
   </data>
   <data name="SetSecurity_BlockOnChange" xml:space="preserve">
     <value>지문 변경 시 차단 및 경고</value>
@@ -3989,5 +3989,43 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   </data>
   <data name="SetSecurity_ClearTrustedLaunchTargets" xml:space="preserve">
     <value>지우기</value>
+  </data>
+  <data name="Recorder_Cleanup" xml:space="preserve">
+    <value>정리</value>
+  </data>
+  <data name="Recorder_CleanupTip" xml:space="preserve">
+    <value>녹화를 삭제하고 차지하던 디스크 공간을 실제로 해제합니다</value>
+  </data>
+  <data name="Recorder_CleanupTitle" xml:space="preserve">
+    <value>녹화 데이터 정리</value>
+  </data>
+  <data name="Recorder_CleanupMessage" xml:space="preserve">
+    <value>녹화 {0}개, 내용은 총 {1}입니다. 데이터베이스 디렉터리는 디스크에서 {2}를 차지하며 그중 약 {3}은 이전에 삭제한 녹화가 남긴 것입니다. 녹화 삭제는 표시만 할 뿐 바이트를 디스크에 돌려주지 않습니다.
+
+정리 범위를 선택하세요. 아래 항목은 모두 저장소를 재구축해 공간을 실제로 돌려줍니다.</value>
+  </data>
+  <data name="Recorder_CleanupKeepAll" xml:space="preserve">
+    <value>삭제된 것만 회수</value>
+  </data>
+  <data name="Recorder_CleanupKeepRecent" xml:space="preserve">
+    <value>최근 7일만 보관</value>
+  </data>
+  <data name="Recorder_CleanupPurgeAll" xml:space="preserve">
+    <value>모든 녹화 삭제</value>
+  </data>
+  <data name="Recorder_CleanupPurgeConfirm" xml:space="preserve">
+    <value>모든 녹화가 영구적으로 삭제되며 복구할 수 없습니다. 계속할까요?</value>
+  </data>
+  <data name="Recorder_CleanupBusy" xml:space="preserve">
+    <value>정리하는 중…</value>
+  </data>
+  <data name="Recorder_CleanupDone" xml:space="preserve">
+    <value>녹화 {0}개를 정리하고 {1}을 해제했습니다.</value>
+  </data>
+  <data name="Recorder_CleanupDoneDeferred" xml:space="preserve">
+    <value>녹화 {0}개를 정리했습니다. 데이터는 삭제되었고 디스크 공간은 VelaShell을 다시 시작할 때 해제됩니다.</value>
+  </data>
+  <data name="Recorder_CleanupFailed" xml:space="preserve">
+    <value>정리 실패: {0}</value>
   </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -2144,7 +2144,7 @@ Paste anyway?</value>
     <value>Auto-record all sessions</value>
   </data>
   <data name="SetSecurity_AutoRecordDesc" xml:space="preserve">
-    <value>// Record terminal output to a local database for audit and replay; applies to connections opened afterwards, retention follows General → Terminal session log retention</value>
+    <value>// Record terminal output to a local database for audit and replay. Off by default: recordings grow fast — a busy week can be several GB. Applies to connections opened afterwards; retention follows General → Terminal session log retention</value>
   </data>
   <data name="SetSecurity_BlockOnChange" xml:space="preserve">
     <value>Block and alert on fingerprint change</value>
@@ -3990,5 +3990,43 @@ Trusting it will also trust future packages signed by the same key. Plugins can 
   </data>
   <data name="SetSecurity_ClearTrustedLaunchTargets" xml:space="preserve">
     <value>Clear</value>
+  </data>
+  <data name="Recorder_Cleanup" xml:space="preserve">
+    <value>Clean up</value>
+  </data>
+  <data name="Recorder_CleanupTip" xml:space="preserve">
+    <value>Delete recordings and actually release the disk space they occupy</value>
+  </data>
+  <data name="Recorder_CleanupTitle" xml:space="preserve">
+    <value>Clean up recording data</value>
+  </data>
+  <data name="Recorder_CleanupMessage" xml:space="preserve">
+    <value>{0} recording(s), {1} of content. The database directory occupies {2} on disk, of which about {3} is left over from recordings you already deleted — deleting a recording only marks it, it never releases the bytes.
+
+Choose how much to clean up. Every option rebuilds the store so the space is genuinely returned.</value>
+  </data>
+  <data name="Recorder_CleanupKeepAll" xml:space="preserve">
+    <value>Reclaim deleted only</value>
+  </data>
+  <data name="Recorder_CleanupKeepRecent" xml:space="preserve">
+    <value>Keep last 7 days</value>
+  </data>
+  <data name="Recorder_CleanupPurgeAll" xml:space="preserve">
+    <value>Delete all recordings</value>
+  </data>
+  <data name="Recorder_CleanupPurgeConfirm" xml:space="preserve">
+    <value>Every recording will be deleted permanently and cannot be recovered. Continue?</value>
+  </data>
+  <data name="Recorder_CleanupBusy" xml:space="preserve">
+    <value>Cleaning up…</value>
+  </data>
+  <data name="Recorder_CleanupDone" xml:space="preserve">
+    <value>Cleaned up {0} recording(s), {1} released.</value>
+  </data>
+  <data name="Recorder_CleanupDoneDeferred" xml:space="preserve">
+    <value>Cleaned up {0} recording(s). The data is gone; the disk space is released the next time VelaShell starts.</value>
+  </data>
+  <data name="Recorder_CleanupFailed" xml:space="preserve">
+    <value>Cleanup failed: {0}</value>
   </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -2235,7 +2235,7 @@
     <value>自动录制所有会话</value>
   </data>
   <data name="SetSecurity_AutoRecordDesc" xml:space="preserve">
-    <value>// 记录终端输出到本地数据库供审计与回放;对之后建立的连接生效,保留天数随「常规 → 终端会话日志保留天数」</value>
+    <value>// 记录终端输出到本地数据库供审计与回放。默认关闭:录制体积增长很快,用得多时一周就是几个 GB。对之后建立的连接生效,保留天数随「常规 → 终端会话日志保留天数」</value>
   </data>
   <data name="SetSecurity_BlockOnChange" xml:space="preserve">
     <value>指纹变更时阻断并告警</value>
@@ -4081,5 +4081,43 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   </data>
   <data name="SetSecurity_ClearTrustedLaunchTargets" xml:space="preserve">
     <value>清空</value>
+  </data>
+  <data name="Recorder_Cleanup" xml:space="preserve">
+    <value>清理</value>
+  </data>
+  <data name="Recorder_CleanupTip" xml:space="preserve">
+    <value>删除录制并真正把占用的磁盘空间释放出来</value>
+  </data>
+  <data name="Recorder_CleanupTitle" xml:space="preserve">
+    <value>清理录制数据</value>
+  </data>
+  <data name="Recorder_CleanupMessage" xml:space="preserve">
+    <value>现有 {0} 条录制,内容共 {1}。数据库目录占用磁盘 {2},其中约 {3} 是此前删除的录制残留下来的 —— 删除录制只是打个标记,并不会把字节还给磁盘。
+
+请选择清理力度,以下每一档都会重建存储,把空间真正还回去。</value>
+  </data>
+  <data name="Recorder_CleanupKeepAll" xml:space="preserve">
+    <value>只回收已删除的</value>
+  </data>
+  <data name="Recorder_CleanupKeepRecent" xml:space="preserve">
+    <value>仅保留最近 7 天</value>
+  </data>
+  <data name="Recorder_CleanupPurgeAll" xml:space="preserve">
+    <value>删除全部录制</value>
+  </data>
+  <data name="Recorder_CleanupPurgeConfirm" xml:space="preserve">
+    <value>全部录制将被永久删除且无法恢复,确定继续吗?</value>
+  </data>
+  <data name="Recorder_CleanupBusy" xml:space="preserve">
+    <value>正在清理…</value>
+  </data>
+  <data name="Recorder_CleanupDone" xml:space="preserve">
+    <value>已清理 {0} 条录制,释放 {1}。</value>
+  </data>
+  <data name="Recorder_CleanupDoneDeferred" xml:space="preserve">
+    <value>已清理 {0} 条录制。数据已清除,磁盘空间将在下次启动 VelaShell 时释放。</value>
+  </data>
+  <data name="Recorder_CleanupFailed" xml:space="preserve">
+    <value>清理失败:{0}</value>
   </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -2044,7 +2044,7 @@
     <value>自動錄製所有工作階段</value>
   </data>
   <data name="SetSecurity_AutoRecordDesc" xml:space="preserve">
-    <value>// 記錄終端機輸出到本機資料庫供稽核與回放;對之後建立的連線生效,保留天數隨「一般 → 終端機工作階段日誌保留天數」</value>
+    <value>// 記錄終端輸出到本機資料庫供稽核與回放。預設關閉:錄製體積成長很快,用得多時一週就是幾個 GB。對之後建立的連線生效,保留天數隨「一般 → 終端工作階段記錄保留天數」</value>
   </data>
   <data name="SetSecurity_BlockOnChange" xml:space="preserve">
     <value>指紋變更時阻斷並告警</value>
@@ -3989,5 +3989,43 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   </data>
   <data name="SetSecurity_ClearTrustedLaunchTargets" xml:space="preserve">
     <value>清空</value>
+  </data>
+  <data name="Recorder_Cleanup" xml:space="preserve">
+    <value>清理</value>
+  </data>
+  <data name="Recorder_CleanupTip" xml:space="preserve">
+    <value>刪除錄製並真正把佔用的磁碟空間釋放出來</value>
+  </data>
+  <data name="Recorder_CleanupTitle" xml:space="preserve">
+    <value>清理錄製資料</value>
+  </data>
+  <data name="Recorder_CleanupMessage" xml:space="preserve">
+    <value>現有 {0} 筆錄製,內容共 {1}。資料庫目錄佔用磁碟 {2},其中約 {3} 是先前刪除的錄製殘留下來的 —— 刪除錄製只是做個標記,並不會把位元組還給磁碟。
+
+請選擇清理力度,以下每一檔都會重建儲存,把空間真正還回去。</value>
+  </data>
+  <data name="Recorder_CleanupKeepAll" xml:space="preserve">
+    <value>只回收已刪除的</value>
+  </data>
+  <data name="Recorder_CleanupKeepRecent" xml:space="preserve">
+    <value>僅保留最近 7 天</value>
+  </data>
+  <data name="Recorder_CleanupPurgeAll" xml:space="preserve">
+    <value>刪除全部錄製</value>
+  </data>
+  <data name="Recorder_CleanupPurgeConfirm" xml:space="preserve">
+    <value>全部錄製將被永久刪除且無法復原,確定要繼續嗎?</value>
+  </data>
+  <data name="Recorder_CleanupBusy" xml:space="preserve">
+    <value>正在清理…</value>
+  </data>
+  <data name="Recorder_CleanupDone" xml:space="preserve">
+    <value>已清理 {0} 筆錄製,釋放 {1}。</value>
+  </data>
+  <data name="Recorder_CleanupDoneDeferred" xml:space="preserve">
+    <value>已清理 {0} 筆錄製。資料已清除,磁碟空間將在下次啟動 VelaShell 時釋放。</value>
+  </data>
+  <data name="Recorder_CleanupFailed" xml:space="preserve">
+    <value>清理失敗:{0}</value>
   </data>
 </root>

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbEngine.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbEngine.cs
@@ -49,6 +49,16 @@ public sealed class SonnetDbEngine : IDisposable
     /// <summary>会话录制分块数据时序 measurement 名。</summary>
     public const string RecordingChunksMeasurement = "session_recording_chunks";
 
+    /// <summary>
+    /// 段文件改走内存映射的体积阈值。SonnetDB 默认只对大于 64MB 的段用 mmap,比这小的段在
+    /// <c>Tsdb.Open</c> 里整个读进托管堆 —— 而会话录制每次刷盘都落一个新段,几 GB 录制数据
+    /// 就是几十上百个不足 64MB 的小段,于是"开库即全量入堆",内存直接顶到数据体积。
+    /// 实测:60 个 10MB 段(共 600MB)在默认阈值下开库后托管堆 601.7MB,阈值改成 1MB 后只剩 0.4MB。
+    /// 代价:Windows 上被映射的段文件删不掉,DropMeasurement 腾出的字节要等下次开库才真正落盘
+    /// (清理入口据此提示"重启后彻底释放")。
+    /// </summary>
+    private const long SegmentMemoryMapThresholdBytes = 1024 * 1024;
+
     private readonly Tsdb _db;
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly ConcurrentDictionary<string, DocumentCollectionStore> _stores = new(StringComparer.Ordinal);
@@ -66,9 +76,21 @@ public sealed class SonnetDbEngine : IDisposable
             throw new ArgumentException(@"SonnetDB root directory is required.", nameof(rootDirectory));
         }
         Directory.CreateDirectory(rootDirectory);
-        _db = Tsdb.Open(new() { RootDirectory = rootDirectory });
+        RootDirectory = rootDirectory;
+        _db = Tsdb.Open(new()
+        {
+            RootDirectory = rootDirectory,
+            SegmentReaderOptions = new()
+            {
+                UseMemoryMappedFileForLargeSegments = true,
+                MemoryMappedFileThresholdBytes = SegmentMemoryMapThresholdBytes
+            }
+        });
         EnsureSchema();
     }
+
+    /// <summary>数据库根目录(统计磁盘占用用)。</summary>
+    public string RootDirectory { get; }
 
     /// <summary>释放所有文档集合存储与底层数据库句柄;线程安全且幂等。</summary>
     public void Dispose()
@@ -301,6 +323,24 @@ public sealed class SonnetDbEngine : IDisposable
         catch
         {
             return false;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// 把内存表立刻刷成段文件。批量回灌大量数据时必须周期性调用 —— 否则写进去的点会一直堆在
+    /// 内存表里(默认要攒满 100 万点或 5 分钟才自动刷),搬运几 GB 录制就等于把几 GB 顶进内存。
+    /// </summary>
+    public async Task FlushAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfDisposed();
+            _db.FlushNow();
         }
         finally
         {

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbSessionRecordingStore.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbSessionRecordingStore.cs
@@ -1,4 +1,5 @@
 using SonnetDB.Model;
+using SonnetDB.Sql;
 using SonnetDB.Sql.Execution;
 using VelaShell.Core.Recording;
 
@@ -11,6 +12,23 @@ namespace VelaShell.Infrastructure.Persistence;
 /// </summary>
 public sealed class SonnetDbSessionRecordingStore(SonnetDbEngine engine) : ISessionRecordingStore
 {
+    /// <summary>过期数据攒到这个量,启动清理才顺带做一次真正的空间回收(重建要搬两趟存活数据)。</summary>
+    private const long AutoReclaimThresholdBytes = 64L * 1024 * 1024;
+
+    /// <summary>回收时逐页读取数据块的页大小(行)。单块上限 64KB,一页约 16MB 封顶。</summary>
+    private const int ChunkPageRows = 256;
+
+    /// <summary>
+    /// 回灌时单批攒够多少字节就落库并刷盘一次。写进去的点会赖在内存表里等自动刷盘
+    /// (默认攒满 100 万点或 5 分钟),搬运几 GB 就等于把几 GB 顶进内存 —— 正是这次清理
+    /// 要解决的毛病。实测搬运 1.2GB:完全不主动刷盘峰值 3.6GB 托管堆,按 8MB 一批刷则峰值
+    /// 减半至 1.4GB、且刚写完只留 81MB(峰值来自随后的后台压实,约一分钟内自行落回)。
+    /// </summary>
+    private const long RestoreBatchBytes = 8L * 1024 * 1024;
+
+    /// <summary>暂存文件的读写缓冲。</summary>
+    private const int SpoolBufferBytes = 1 << 20;
+
     private readonly SonnetDbEngine _engine = engine ?? throw new ArgumentNullException(nameof(engine));
 
     /// <summary>保存(新增或覆盖)一条会话录制的元数据文档。</summary>
@@ -39,9 +57,23 @@ public sealed class SonnetDbSessionRecordingStore(SonnetDbEngine engine) : ISess
             ["data"] = FieldValue.FromString(Convert.ToBase64String(data))
         };
         return _engine.WritePointAsync(SonnetDbEngine.RecordingChunksMeasurement,
-            new DateTimeOffset(DateTime.SpecifyKind(startedAtUtc, DateTimeKind.Utc)).AddMilliseconds(offsetMs),
-            tags, fields, cancellationToken);
+            ChunkTimestamp(startedAtUtc, offsetMs), tags, fields, cancellationToken);
     }
+
+    /// <summary>数据块的写入时刻 = 录制开始时刻 + 偏移(回放时间轴即由此还原)。</summary>
+    private static DateTimeOffset ChunkTimestamp(DateTime startedAtUtc, long offsetMs) =>
+        new DateTimeOffset(DateTime.SpecifyKind(startedAtUtc, DateTimeKind.Utc)).AddMilliseconds(offsetMs);
+
+    /// <summary>构造一个数据块数据点(回灌批量写入用,与 <see cref="AppendChunkAsync" /> 同构)。</summary>
+    private static Point BuildChunkPoint(Guid recordingId, DateTime startedAtUtc, long offsetMs, byte[] data) =>
+        Point.Create(SonnetDbEngine.RecordingChunksMeasurement,
+            ChunkTimestamp(startedAtUtc, offsetMs).ToUnixTimeMilliseconds(),
+            new Dictionary<string, string> { ["recording_id"] = recordingId.ToString("D") },
+            new Dictionary<string, FieldValue>
+            {
+                ["offset_ms"] = FieldValue.FromLong(offsetMs),
+                ["data"] = FieldValue.FromString(Convert.ToBase64String(data))
+            });
 
     /// <summary>列出所有会话录制元数据,按开始时间倒序排列。</summary>
     public async Task<List<SessionRecording>> ListRecordingsAsync(CancellationToken cancellationToken = default)
@@ -67,23 +99,9 @@ public sealed class SonnetDbSessionRecordingStore(SonnetDbEngine engine) : ISess
         var chunks = new List<RecordingChunk>(result.Rows.Count);
         foreach (IReadOnlyList<object?> row in result.Rows)
         {
-            if (offsetIndex >= row.Count || dataIndex >= row.Count)
+            if (DecodeChunk(row, offsetIndex, dataIndex) is { } chunk)
             {
-                continue;
-            }
-            long offset = Convert.ToInt64(row[offsetIndex] ?? 0L);
-            string? base64 = row[dataIndex]?.ToString();
-            if (string.IsNullOrEmpty(base64))
-            {
-                continue;
-            }
-            try
-            {
-                chunks.Add(new(offset, Convert.FromBase64String(base64)));
-            }
-            catch (FormatException)
-            {
-                // 单块损坏跳过,不影响其余回放。
+                chunks.Add(chunk);
             }
         }
         chunks.Sort((a, b) => a.OffsetMs.CompareTo(b.OffsetMs));
@@ -105,7 +123,8 @@ public sealed class SonnetDbSessionRecordingStore(SonnetDbEngine engine) : ISess
     }
 
     /// <summary>
-    /// 清理超过保留天数的过期录制;若数据块无法直接删除,则对存活录制执行压缩重建以回收孤儿字节。
+    /// 清理超过保留天数的过期录制。删除只写墓碑不腾空间,因此过期数据体积可观时
+    /// (超过 <see cref="AutoReclaimThresholdBytes" />)顺带跑一次真正的空间回收。
     /// </summary>
     public async Task CleanupExpiredAsync(int retentionDays, CancellationToken cancellationToken = default)
     {
@@ -120,48 +139,250 @@ public sealed class SonnetDbSessionRecordingStore(SonnetDbEngine engine) : ISess
         {
             return;
         }
-        bool chunkDeleteFailed = false;
+
+        // 过期数据够大才做重建:重建要把存活数据搬两趟,为了几 MB 的过期块不值当,
+        // 留给用户手动清理或下一轮攒够量再说。
+        if (expired.Sum(r => r.ByteSize) >= AutoReclaimThresholdBytes)
+        {
+            await ReclaimSpaceAsync(retentionDays, cancellationToken).ConfigureAwait(false);
+            return;
+        }
         foreach (SessionRecording recording in expired)
         {
-            await DeleteMetadataAsync(recording.Id, cancellationToken).ConfigureAwait(false);
-            if (!await TryDeleteChunksAsync(recording.Id, cancellationToken).ConfigureAwait(false))
-            {
-                chunkDeleteFailed = true;
-            }
-        }
-
-        // SQL DELETE 不可用时,孤儿数据块会让磁盘只增不减:改走压缩重建 ——
-        // 读出存活录制的数据块 → drop 重建 measurement → 回写,孤儿字节随 drop 回收。
-        if (chunkDeleteFailed)
-        {
-            await CompactChunksAsync([.. all.Where(r => r.StartedAtUtc >= cutoff)], cancellationToken).ConfigureAwait(false);
+            await DeleteRecordingAsync(recording.Id, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    /// <summary>
-    /// 压缩重建数据块 measurement:仅在删除失败(方言不支持 DELETE)时执行。
-    /// 存活数据先整体载入内存再重建,超过安全上限(256MB)时跳过本次压缩,
-    /// 等保留窗口滚动、存活数据变小后的下次清理再试。
-    /// </summary>
-    private async Task CompactChunksAsync(List<SessionRecording> survivors, CancellationToken cancellationToken)
+    /// <summary>录制数据的占用快照(条数 / 逻辑体积 / 数据库目录磁盘占用)。</summary>
+    public async Task<RecordingStorageUsage> GetStorageUsageAsync(CancellationToken cancellationToken = default)
     {
-        const long maxCompactBytes = 256L * 1024 * 1024;
-        if (survivors.Sum(r => r.ByteSize) > maxCompactBytes)
+        List<SessionRecording> all = await ListRecordingsAsync(cancellationToken).ConfigureAwait(false);
+        return new(all.Count, all.Sum(r => r.ByteSize), MeasureDiskBytes());
+    }
+
+    /// <summary>
+    /// 真正腾空间的清理。时序库的 DELETE 只写墓碑,唯一能把字节还给磁盘的是整块 drop 掉
+    /// measurement,所以走"存活数据落磁盘暂存 → drop 重建 → 回灌"三步:峰值内存只与单个
+    /// 数据块有关,与录制总量无关(几 GB 录制也不会把内存顶起来)。
+    /// </summary>
+    /// <param name="keepDays">
+    /// 保留窗口(天)。<c>0</c> = 一条不留(跳过暂存,直接 drop 重建);
+    /// <see cref="int.MaxValue" /> = 全部保留,只回收已删除录制留下的孤儿字节。
+    /// </param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    public async Task<RecordingCleanupResult> ReclaimSpaceAsync(int keepDays, CancellationToken cancellationToken = default)
+    {
+        long diskBefore = MeasureDiskBytes();
+        List<SessionRecording> all = await ListRecordingsAsync(cancellationToken).ConfigureAwait(false);
+        List<SessionRecording> survivors = keepDays switch
+        {
+            <= 0 => [],
+            int.MaxValue => all,
+            _ => [.. all.Where(r => r.StartedAtUtc >= DateTime.UtcNow.AddDays(-keepDays))]
+        };
+        var survivorIds = survivors.Select(r => r.Id).ToHashSet();
+
+        string? spoolPath = null;
+        try
+        {
+            // 1) 存活数据块先流到磁盘暂存文件(边查边写,内存里只留当前一页)。
+            if (survivors.Count > 0)
+            {
+                spoolPath = Path.Combine(Path.GetTempPath(), $"velashell-recspool-{Guid.NewGuid():N}.bin");
+                await SpoolSurvivorsAsync(survivors, spoolPath, cancellationToken).ConfigureAwait(false);
+            }
+
+            // 2) drop 重建 measurement:墓碑、孤儿块与全部历史字节一起没。
+            await _engine.ResetMeasurementAsync(SonnetDbEngine.RecordingChunksMeasurement, cancellationToken).ConfigureAwait(false);
+
+            // 3) 回灌存活数据。
+            if (spoolPath is not null)
+            {
+                await RestoreSpoolAsync(spoolPath, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            TryDeleteFile(spoolPath);
+        }
+
+        // 元数据收尾:被清掉的录制不能再留在列表里。
+        foreach (SessionRecording recording in all.Where(r => !survivorIds.Contains(r.Id)))
+        {
+            await DeleteMetadataAsync(recording.Id, cancellationToken).ConfigureAwait(false);
+        }
+
+        long diskAfter = MeasureDiskBytes();
+
+        // 段文件走内存映射后,Windows 上 drop 掉的文件在本进程退出前删不掉 —— SonnetDB 会在
+        // 下次开库时把它们清掉。此时磁盘没降,得如实告诉用户"重启后彻底释放"。
+        return new(all.Count - survivors.Count, diskBefore, diskAfter, diskAfter >= diskBefore);
+    }
+
+    /// <summary>把存活录制的数据块逐页写入暂存文件(每条记录:录制 Id、起始时刻、偏移、数据)。</summary>
+    private async Task SpoolSurvivorsAsync(List<SessionRecording> survivors, string spoolPath, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.None,
+            SpoolBufferBytes, FileOptions.SequentialScan);
+        await using var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true);
+        foreach (SessionRecording recording in survivors)
+        {
+            await foreach (RecordingChunk chunk in ReadChunksPagedAsync(recording.Id, cancellationToken).ConfigureAwait(false))
+            {
+                writer.Write(recording.Id.ToByteArray());
+                writer.Write(DateTime.SpecifyKind(recording.StartedAtUtc, DateTimeKind.Utc).Ticks);
+                writer.Write(chunk.OffsetMs);
+                writer.Write(chunk.Data.Length);
+                writer.Write(chunk.Data);
+            }
+        }
+    }
+
+    /// <summary>把暂存文件回灌进重建后的 measurement,按批写入以摊薄引擎加锁开销。</summary>
+    private async Task RestoreSpoolAsync(string spoolPath, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(spoolPath, FileMode.Open, FileAccess.Read, FileShare.None,
+            SpoolBufferBytes, FileOptions.SequentialScan);
+        using var reader = new BinaryReader(stream, System.Text.Encoding.UTF8, true);
+        var batch = new List<Point>();
+        long batchBytes = 0;
+        byte[] guidBuffer = new byte[16];
+        while (stream.Position < stream.Length)
+        {
+            if (reader.Read(guidBuffer, 0, 16) != 16)
+            {
+                break;
+            }
+            var id = new Guid(guidBuffer);
+            var startedAtUtc = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
+            long offsetMs = reader.ReadInt64();
+            byte[] data = reader.ReadBytes(reader.ReadInt32());
+            batch.Add(BuildChunkPoint(id, startedAtUtc, offsetMs, data));
+            batchBytes += data.Length;
+            if (batchBytes < RestoreBatchBytes)
+            {
+                continue;
+            }
+            await WriteBatchAsync(batch, cancellationToken).ConfigureAwait(false);
+            batchBytes = 0;
+        }
+        await WriteBatchAsync(batch, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>落一批数据点并立刻刷盘,随后清空批次(刷盘的必要性见 <see cref="RestoreBatchBytes" />)。</summary>
+    private async Task WriteBatchAsync(List<Point> batch, CancellationToken cancellationToken)
+    {
+        if (batch.Count == 0)
         {
             return;
         }
-        var kept = new List<(SessionRecording Recording, List<RecordingChunk> Chunks)>(survivors.Count);
-        foreach (SessionRecording recording in survivors)
+        await _engine.WriteManyAsync(batch, cancellationToken).ConfigureAwait(false);
+        await _engine.FlushAsync(cancellationToken).ConfigureAwait(false);
+        batch.Clear();
+    }
+
+    /// <summary>
+    /// 按 time 游标逐页读取一条录制的数据块。同一序列同一时刻只存得下一个点(后写覆盖先写),
+    /// 因此"下一页从 lastTime + 1 起"既不漏也不重 —— 实测 500 块在 7/64/1000 三种页大小下
+    /// 都是精确等价的时间升序全集。
+    /// </summary>
+    private async IAsyncEnumerable<RecordingChunk> ReadChunksPagedAsync(Guid recordingId,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        long cursor = long.MinValue;
+        while (true)
         {
-            kept.Add((recording, await GetChunksAsync(recording.Id, cancellationToken).ConfigureAwait(false)));
-        }
-        await _engine.ResetMeasurementAsync(SonnetDbEngine.RecordingChunksMeasurement, cancellationToken).ConfigureAwait(false);
-        foreach ((SessionRecording recording, List<RecordingChunk> chunks) in kept)
-        {
-            foreach (RecordingChunk chunk in chunks)
+            var parameters = new SqlParameters();
+            parameters.AddNamed("rid", recordingId.ToString("D"));
+            string cursorClause = "";
+            if (cursor != long.MinValue)
             {
-                await AppendChunkAsync(recording.Id, recording.StartedAtUtc, chunk.OffsetMs, chunk.Data, cancellationToken).ConfigureAwait(false);
+                cursorClause = " AND time >= @cursor";
+                parameters.AddNamed("cursor", cursor);
             }
+            SelectExecutionResult result = await _engine.QueryAsync(
+                                               $"SELECT time, offset_ms, data FROM {SonnetDbEngine.RecordingChunksMeasurement} " +
+                                               $"WHERE recording_id = @rid{cursorClause} LIMIT {ChunkPageRows}",
+                                               parameters, cancellationToken).ConfigureAwait(false);
+            if (result.Rows.Count == 0)
+            {
+                yield break;
+            }
+            int timeIndex = IndexOf(result, "time");
+            int offsetIndex = IndexOf(result, "offset_ms");
+            int dataIndex = IndexOf(result, "data");
+            long lastTime = cursor;
+            foreach (IReadOnlyList<object?> row in result.Rows)
+            {
+                if (timeIndex < row.Count)
+                {
+                    lastTime = Convert.ToInt64(row[timeIndex] ?? 0L);
+                }
+                if (DecodeChunk(row, offsetIndex, dataIndex) is { } chunk)
+                {
+                    yield return chunk;
+                }
+            }
+
+            // 不足一页 = 已到末尾;时间戳没往前走则说明再翻也是同一页,就此打住防死循环。
+            if (result.Rows.Count < ChunkPageRows || lastTime == long.MinValue || lastTime + 1 <= cursor)
+            {
+                yield break;
+            }
+            cursor = lastTime + 1;
+        }
+    }
+
+    /// <summary>数据库目录的磁盘占用;目录被并发改动时按已统计到的部分返回。</summary>
+    private long MeasureDiskBytes()
+    {
+        try
+        {
+            return new DirectoryInfo(_engine.RootDirectory)
+                .EnumerateFiles("*", SearchOption.AllDirectories)
+                .Sum(f => f.Length);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+        {
+            return 0;
+        }
+    }
+
+    private static void TryDeleteFile(string? path)
+    {
+        if (path is null)
+        {
+            return;
+        }
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // 暂存文件在临时目录,删不掉交给系统清理。
+        }
+    }
+
+    private static RecordingChunk? DecodeChunk(IReadOnlyList<object?> row, int offsetIndex, int dataIndex)
+    {
+        if (offsetIndex >= row.Count || dataIndex >= row.Count)
+        {
+            return null;
+        }
+        string? base64 = row[dataIndex]?.ToString();
+        if (string.IsNullOrEmpty(base64))
+        {
+            return null;
+        }
+        try
+        {
+            return new(Convert.ToInt64(row[offsetIndex] ?? 0L), Convert.FromBase64String(base64));
+        }
+        catch (FormatException)
+        {
+            // 单块损坏跳过,不影响其余数据。
+            return null;
         }
     }
 

--- a/src/VelaShell/Services/SessionRecorder.cs
+++ b/src/VelaShell/Services/SessionRecorder.cs
@@ -22,6 +22,7 @@ public sealed class SessionRecorder : IDisposable
 
     private MemoryStream _buffer = new();
     private long _bufferStartOffsetMs;
+    private long _lastFlushedOffsetMs = -1;
     private bool _disposed;
     private bool _failed;
 
@@ -93,7 +94,12 @@ public sealed class SessionRecorder : IDisposable
                 return;
             }
             payload = _buffer.ToArray();
-            offset = _bufferStartOffsetMs;
+
+            // 块的存储时间 = 开始时刻 + 偏移,而同一录制同一毫秒只存得下一个点(后写覆盖先写)。
+            // 满 64KB 会立刻触发刷盘,爆发输出下两次刷盘落在同一毫秒完全可能 —— 偏移必须严格
+            // 递增,否则前一块被后一块悄悄顶掉,回放时那段输出凭空消失。
+            offset = Math.Max(_bufferStartOffsetMs, _lastFlushedOffsetMs + 1);
+            _lastFlushedOffsetMs = offset;
             _buffer = new();
         }
         _ = PersistAsync(async () =>

--- a/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
+++ b/src/VelaShell/ViewModels/RecordingPlayerViewModel.cs
@@ -211,6 +211,33 @@ public class RecordingPlayerViewModel : ReactiveObject
     /// <summary>切换自动录制开关命令。</summary>
     public ReactiveCommand<RxVoid, RxVoid> ToggleAutoRecordCommand { get; }
 
+    /// <summary>
+    /// 录制数据的占用快照(条数 / 逻辑体积 / 磁盘占用),供清理入口展示。
+    /// 统计要遍历整个数据库目录,丢到后台线程,别让几 GB 的目录枚举卡住界面。
+    /// </summary>
+    public Task<RecordingStorageUsage> GetStorageUsageAsync() => Task.Run(() => _store.GetStorageUsageAsync());
+
+    /// <summary>
+    /// 执行清理并刷新列表。<paramref name="keepDays" /> 语义见
+    /// <see cref="ISessionRecordingStore.ReclaimSpaceAsync" />(0 = 一条不留,
+    /// <see cref="int.MaxValue" /> = 只回收已删除录制占的空间)。
+    /// <para>
+    /// 整个回收扔到后台线程:引擎的锁未被占用时那些 await 会同步走完,搬运几 GB 数据
+    /// 就直接在 UI 线程上跑,界面一动不动。回来后再刷列表(await 会回到 UI 线程)。
+    /// </para>
+    /// </summary>
+    public async Task<RecordingCleanupResult> CleanupAsync(int keepDays)
+    {
+        Pause();
+        SelectedRecording = null;
+        RecordingCleanupResult result = await Task.Run(() => _store.ReclaimSpaceAsync(keepDays));
+        await RefreshAsync();
+        return result;
+    }
+
+    /// <summary>把状态栏文本换成给定内容(清理结果回显)。</summary>
+    public void SetStatus(string status) => Status = status;
+
     /// <summary>初始化:加载录制列表并读取自动录制设置。</summary>
     public async Task InitializeAsync()
     {

--- a/src/VelaShell/Views/RecordingPlayerView.axaml
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml
@@ -102,6 +102,11 @@
                     Click="ExportRecording_Click"
                     ToolTip.Tip="{loc:Localize Recorder_ExportTip}" />
             <Button Classes="dlg-outline" Content="{loc:Localize Refresh}" Command="{Binding RefreshCommand}" />
+            <!-- 清理:删除只写墓碑不腾空间,真正回收磁盘要靠这里的重建(见 ISessionRecordingStore.ReclaimSpaceAsync)。 -->
+            <Button x:Name="CleanupButton" Classes="dlg-outline" Content="{loc:Localize Recorder_Cleanup}"
+                    Click="Cleanup_Click"
+                    ToolTip.Placement="Top"
+                    ToolTip.Tip="{loc:Localize Recorder_CleanupTip}" />
             <Button Classes="dlg-accent" Content="{Binding AutoRecordText}"
                     Command="{Binding ToggleAutoRecordCommand}"
                     ToolTip.Tip="{loc:Localize Recorder_AutoRecordTip}" />

--- a/src/VelaShell/Views/RecordingPlayerView.axaml.cs
+++ b/src/VelaShell/Views/RecordingPlayerView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using VelaShell.Core.Recording;
 using VelaShell.Core.Resources;
 using VelaShell.Terminal.Rendering;
 using VelaShell.ViewModels;
@@ -16,6 +17,9 @@ public partial class RecordingPlayerView : Window
 {
     /// <summary>RIS(ESC c)完全重置:选择新录制/拖动时间轴时清屏重放。</summary>
     private static readonly byte[] RisResetSequence = [0x1B, (byte)'c'];
+
+    /// <summary>清理时"仅保留最近"档位的保留天数。</summary>
+    private const int RecentCleanupKeepDays = 7;
 
     private readonly VelaTerminalControl _terminal;
     private RecordingPlayerViewModel? _viewModel;
@@ -98,6 +102,96 @@ public partial class RecordingPlayerView : Window
 
     /// <summary>倍速按钮:按 VM 定义的档位循环(1x…16x)。</summary>
     private void CycleSpeed_Click(object? sender, RoutedEventArgs e) => _viewModel?.CycleSpeed();
+
+    /// <summary>
+    /// 清理录制数据:先摆出占用现状,再让用户选清理力度。
+    /// 时序库的删除只写墓碑不腾空间,所以这里给的三档都会走 drop 重建把字节真正还回去。
+    /// </summary>
+    private async void Cleanup_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is not { } vm)
+        {
+            return;
+        }
+        RecordingStorageUsage usage;
+        try
+        {
+            usage = await vm.GetStorageUsageAsync();
+        }
+        catch (Exception ex)
+        {
+            vm.SetStatus(Strings.Format("Recorder_CleanupFailed", ex.Message));
+            return;
+        }
+        int choice = await MessageDialog.ChooseAsync(this,
+            Strings.Get("Recorder_CleanupTitle"),
+            Strings.Format("Recorder_CleanupMessage",
+                usage.RecordingCount,
+                FormatBytes(usage.LiveBytes),
+                FormatBytes(usage.DiskBytes),
+                FormatBytes(usage.ReclaimableBytes)),
+            [
+                Strings.Get("Recorder_CleanupKeepAll"),
+                Strings.Get("Recorder_CleanupKeepRecent"),
+                Strings.Get("Recorder_CleanupPurgeAll")
+            ],
+            0,
+            -1,
+            MessageDialogKind.Warning);
+
+        // 保留全部 / 保留最近 7 天 / 一条不留;Esc 与关闭按钮回 -1。
+        int keepDays = choice switch
+        {
+            0 => int.MaxValue,
+            1 => RecentCleanupKeepDays,
+            2 => 0,
+            _ => -1
+        };
+        if (keepDays < 0)
+        {
+            return;
+        }
+        if (keepDays == 0 && !await MessageDialog.ConfirmAsync(this,
+                Strings.Get("Recorder_CleanupTitle"),
+                Strings.Get("Recorder_CleanupPurgeConfirm"),
+                Strings.Get("Recorder_CleanupPurgeAll"),
+                null,
+                MessageDialogKind.Warning,
+                true))
+        {
+            return;
+        }
+
+        CleanupButton.IsEnabled = false;
+        vm.SetStatus(Strings.Get("Recorder_CleanupBusy"));
+        try
+        {
+            RecordingCleanupResult result = await vm.CleanupAsync(keepDays);
+
+            // 段文件走内存映射后,腾出的文件在本进程退出前删不掉(SonnetDB 下次开库才清),
+            // 此时磁盘数字没降 —— 如实说"重启后释放",别让用户以为清了个寂寞。
+            vm.SetStatus(result.DeferredToRestart
+                ? Strings.Format("Recorder_CleanupDoneDeferred", result.RemovedRecordings)
+                : Strings.Format("Recorder_CleanupDone", result.RemovedRecordings,
+                    FormatBytes(result.DiskBytesBefore - result.DiskBytesAfter)));
+        }
+        catch (Exception ex)
+        {
+            vm.SetStatus(Strings.Format("Recorder_CleanupFailed", ex.Message));
+        }
+        finally
+        {
+            CleanupButton.IsEnabled = true;
+        }
+    }
+
+    private static string FormatBytes(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:0.#} KB",
+        < 1024L * 1024 * 1024 => $"{bytes / 1024.0 / 1024:0.#} MB",
+        _ => $"{bytes / 1024.0 / 1024 / 1024:0.##} GB"
+    };
 
     /// <summary>导出选中录制为 asciicast v2(.cast)文件。</summary>
     private async void ExportRecording_Click(object? sender, RoutedEventArgs e)

--- a/tests/VelaShell.Core.Tests/Models/AppSettingsNormalizeTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/AppSettingsNormalizeTests.cs
@@ -55,4 +55,39 @@ public class AppSettingsNormalizeTests
     [TestMethod]
     public void DefaultDownloadDirectory_IsEmpty_MeaningFollowSystem() =>
         Assert.AreEqual(string.Empty, new AppSettings().Transfer.LocalDownloadDirectory);
+
+    /// <summary>新装用户不该被默认打开录制:录制把终端原始输出整份落库,一开就是按 GB 长。</summary>
+    [TestMethod]
+    public void SessionRecording_IsOffByDefault() =>
+        Assert.IsFalse(new AppSettings().Security.RecordProductionSessions);
+
+    /// <summary>
+    /// 存量配置里的 <c>true</c> 分不清是用户选的还是旧默认值带的(这开关早年默认开启且从未征求同意),
+    /// 因此统一关一次。
+    /// </summary>
+    [TestMethod]
+    public void LegacyRecordingDefault_IsTurnedOffOnce()
+    {
+        AppSettings settings = new();
+        settings.Security.RecordProductionSessions = true;
+        settings.Security.RecordingOptInMigrated = false;
+
+        settings.Normalize();
+
+        Assert.IsFalse(settings.Security.RecordProductionSessions);
+        Assert.IsTrue(settings.Security.RecordingOptInMigrated, "迁移标记要落下,之后不再插手用户的选择");
+    }
+
+    /// <summary>迁移只做一次:用户此后自己打开录制,再次载入设置不能又给关掉。</summary>
+    [TestMethod]
+    public void RecordingOptIn_AfterMigration_IsRespected()
+    {
+        AppSettings settings = new();
+        settings.Security.RecordProductionSessions = true;
+        settings.Security.RecordingOptInMigrated = true;
+
+        settings.Normalize();
+
+        Assert.IsTrue(settings.Security.RecordProductionSessions);
+    }
 }

--- a/tests/VelaShell.Infrastructure.Tests/SessionRecordingStoreTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/SessionRecordingStoreTests.cs
@@ -1,0 +1,174 @@
+using System.Text;
+using VelaShell.Core.Recording;
+using VelaShell.Infrastructure.Persistence;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>
+/// 会话录制存储的落库与清理。重点在"清理要真的腾空间":时序库的 DELETE 只写墓碑,
+/// 唯一还字节的路径是 drop 重建 measurement,所以每个清理用例都得断言存活数据一字节不差地回来了。
+/// </summary>
+[TestClass]
+public sealed class SessionRecordingStoreTests : IDisposable
+{
+    private readonly SonnetDbEngine _engine;
+    private readonly SonnetDbSessionRecordingStore _store;
+    private readonly string _testDirectory;
+
+    public SessionRecordingStoreTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"velashell_rectest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+        _engine = new(Path.Combine(_testDirectory, "sonnetdb"));
+        _store = new(_engine);
+    }
+
+    public void Dispose()
+    {
+        _engine.Dispose();
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetChunks_RoundTripsWrittenBytes()
+    {
+        SessionRecording recording = await WriteRecordingAsync("web-01", DateTime.UtcNow.AddHours(-1), 3);
+        List<RecordingChunk> chunks = await _store.GetChunksAsync(recording.Id);
+        Assert.HasCount(3, chunks);
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.AreEqual(i * 600L, chunks[i].OffsetMs);
+            Assert.AreEqual(PayloadFor(recording.Id, i), Encoding.UTF8.GetString(chunks[i].Data));
+        }
+    }
+
+    [TestMethod]
+    public async Task ReclaimSpace_KeepAll_PreservesEveryChunkAndDropsOrphans()
+    {
+        SessionRecording kept = await WriteRecordingAsync("keep", DateTime.UtcNow.AddHours(-2), 5);
+        SessionRecording deleted = await WriteRecordingAsync("deleted", DateTime.UtcNow.AddHours(-3), 5);
+
+        // 常规删除:元数据没了,数据块只是被打了墓碑,字节还在盘上。
+        await _store.DeleteRecordingAsync(deleted.Id);
+
+        RecordingCleanupResult result = await _store.ReclaimSpaceAsync(int.MaxValue);
+
+        Assert.AreEqual(0, result.RemovedRecordings, "全部保留时不该删掉任何一条现存录制");
+        List<SessionRecording> remaining = await _store.ListRecordingsAsync();
+        Assert.HasCount(1, remaining);
+        Assert.AreEqual(kept.Id, remaining[0].Id);
+
+        List<RecordingChunk> chunks = await _store.GetChunksAsync(kept.Id);
+        Assert.HasCount(5, chunks, "存活录制的数据块必须原样回来");
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.AreEqual(i * 600L, chunks[i].OffsetMs);
+            Assert.AreEqual(PayloadFor(kept.Id, i), Encoding.UTF8.GetString(chunks[i].Data));
+        }
+        Assert.IsEmpty(await _store.GetChunksAsync(deleted.Id), "已删除录制的孤儿数据块应随重建一并消失");
+    }
+
+    [TestMethod]
+    public async Task ReclaimSpace_PurgeAll_LeavesNothingBehind()
+    {
+        SessionRecording first = await WriteRecordingAsync("a", DateTime.UtcNow.AddMinutes(-10), 4);
+        SessionRecording second = await WriteRecordingAsync("b", DateTime.UtcNow.AddMinutes(-5), 4);
+
+        RecordingCleanupResult result = await _store.ReclaimSpaceAsync(0);
+
+        Assert.AreEqual(2, result.RemovedRecordings);
+        Assert.IsEmpty(await _store.ListRecordingsAsync());
+        Assert.IsEmpty(await _store.GetChunksAsync(first.Id));
+        Assert.IsEmpty(await _store.GetChunksAsync(second.Id));
+    }
+
+    [TestMethod]
+    public async Task ReclaimSpace_KeepDays_DropsOnlyRecordingsOutsideTheWindow()
+    {
+        SessionRecording fresh = await WriteRecordingAsync("fresh", DateTime.UtcNow.AddDays(-2), 3);
+        SessionRecording stale = await WriteRecordingAsync("stale", DateTime.UtcNow.AddDays(-40), 3);
+
+        RecordingCleanupResult result = await _store.ReclaimSpaceAsync(7);
+
+        Assert.AreEqual(1, result.RemovedRecordings);
+        List<SessionRecording> remaining = await _store.ListRecordingsAsync();
+        Assert.HasCount(1, remaining);
+        Assert.AreEqual(fresh.Id, remaining[0].Id);
+        Assert.HasCount(3, await _store.GetChunksAsync(fresh.Id));
+        Assert.IsEmpty(await _store.GetChunksAsync(stale.Id));
+    }
+
+    /// <summary>
+    /// 回收时数据块按 time 游标逐页搬运(页大小 256 行),这里特意跨过两页多一点:
+    /// 分页只要漏一块或重一块,回放就会缺一段或串一段,而条数断言最容易漏掉这种错。
+    /// </summary>
+    [TestMethod]
+    public async Task ReclaimSpace_PreservesChunksAcrossPageBoundaries()
+    {
+        const int chunkCount = 600;
+        SessionRecording recording = await WriteRecordingAsync("long-session", DateTime.UtcNow.AddHours(-4), chunkCount);
+
+        await _store.ReclaimSpaceAsync(int.MaxValue);
+
+        List<RecordingChunk> chunks = await _store.GetChunksAsync(recording.Id);
+        Assert.HasCount(chunkCount, chunks, "跨页搬运不能漏块也不能重块");
+        for (int i = 0; i < chunkCount; i++)
+        {
+            Assert.AreEqual(i * 600L, chunks[i].OffsetMs, $"第 {i} 块的偏移错位");
+            Assert.AreEqual(PayloadFor(recording.Id, i), Encoding.UTF8.GetString(chunks[i].Data), $"第 {i} 块内容不符");
+        }
+    }
+
+    [TestMethod]
+    public async Task GetStorageUsage_ReportsCountAndLogicalBytes()
+    {
+        SessionRecording first = await WriteRecordingAsync("a", DateTime.UtcNow.AddMinutes(-9), 2);
+        SessionRecording second = await WriteRecordingAsync("b", DateTime.UtcNow.AddMinutes(-8), 3);
+
+        RecordingStorageUsage usage = await _store.GetStorageUsageAsync();
+
+        Assert.AreEqual(2, usage.RecordingCount);
+        Assert.AreEqual(first.ByteSize + second.ByteSize, usage.LiveBytes);
+        Assert.IsGreaterThan(0, usage.DiskBytes, "数据库目录应有实际磁盘占用");
+    }
+
+    [TestMethod]
+    public async Task CleanupExpired_RemovesExpiredAndKeepsRecent()
+    {
+        SessionRecording fresh = await WriteRecordingAsync("fresh", DateTime.UtcNow.AddDays(-1), 2);
+        await WriteRecordingAsync("stale", DateTime.UtcNow.AddDays(-90), 2);
+
+        await _store.CleanupExpiredAsync(30);
+
+        List<SessionRecording> remaining = await _store.ListRecordingsAsync();
+        Assert.HasCount(1, remaining);
+        Assert.AreEqual(fresh.Id, remaining[0].Id);
+        Assert.HasCount(2, await _store.GetChunksAsync(fresh.Id));
+    }
+
+    /// <summary>写入一条录制及其数据块;块内容按序号编码,便于逐块比对搬运是否忠实。</summary>
+    private async Task<SessionRecording> WriteRecordingAsync(string label, DateTime startedAtUtc, int chunkCount)
+    {
+        var recording = new SessionRecording
+        {
+            SessionLabel = label,
+            StartedAtUtc = DateTime.SpecifyKind(startedAtUtc, DateTimeKind.Utc),
+            EndedAtUtc = DateTime.UtcNow,
+            ChunkCount = chunkCount
+        };
+        for (int i = 0; i < chunkCount; i++)
+        {
+            byte[] payload = Encoding.UTF8.GetBytes(PayloadFor(recording.Id, i));
+            await _store.AppendChunkAsync(recording.Id, recording.StartedAtUtc, i * 600L, payload);
+            recording.ByteSize += payload.Length;
+            recording.DurationMs = i * 600L;
+        }
+        await _store.SaveRecordingAsync(recording);
+        return recording;
+    }
+
+    private static string PayloadFor(Guid recordingId, int index) => $"{recordingId:N}#{index:D5}";
+}

--- a/tests/VelaShell.Tests/Views/RecordingPlayerCleanupUiTests.cs
+++ b/tests/VelaShell.Tests/Views/RecordingPlayerCleanupUiTests.cs
@@ -1,0 +1,207 @@
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Recording;
+using VelaShell.Localization;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 回放中心标题栏的"清理"入口。这里守的是它真的画在可视树里 —— 时序库删除只写墓碑不腾空间,
+/// 这个按钮是用户把几个 GB 要回来的唯一路径,XAML 里写错名字或漏掉事件都不会报错,只是按钮消失。
+/// </summary>
+[TestClass]
+[TestCategory("RecorderUI")]
+public sealed class RecordingPlayerCleanupUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+    private static LocalizationService _localization = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(RecordingPlayerCleanupUiTests).Assembly);
+        _localization = new();
+        LocalizedStrings.Instance.Attach(_localization);
+    }
+
+    [TestMethod]
+    public void TitleBar_CarriesCleanupButton_WithVisibleLabel()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+
+            Button cleanup = fixture.Find<Button>("CleanupButton");
+            Assert.IsTrue(cleanup.IsVisible, "清理按钮必须真的画出来。");
+            Assert.IsTrue(cleanup.IsEnabled, "没有录制时也要能进清理:孤儿数据正是元数据已删的那部分。");
+            Assert.IsGreaterThan(0, cleanup.Bounds.Width, "按钮被挤成零宽等于没有。");
+            Assert.AreEqual("清理", cleanup.Content as string);
+            return Task.CompletedTask;
+        });
+    }
+
+    /// <summary>清空全部后列表要空,且"暂无录制"的空态要顶上来。</summary>
+    [TestMethod]
+    public void CleanupPurgeAll_EmptiesTheList()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+            Assert.IsTrue(fixture.ViewModel.HasRecordings, "前置:列表里本来有录制。");
+
+            Pump(fixture.ViewModel.CleanupAsync(0));
+            Dispatcher.UIThread.RunJobs();
+            fixture.Window.UpdateLayout();
+
+            Assert.IsFalse(fixture.ViewModel.HasRecordings);
+            Assert.IsEmpty(fixture.ViewModel.Recordings);
+            Assert.IsNull(fixture.ViewModel.SelectedRecording);
+            Assert.AreEqual(1, fixture.Store.ReclaimCalls);
+            Assert.AreEqual(0, fixture.Store.LastKeepDays);
+            return Task.CompletedTask;
+        });
+    }
+
+    /// <summary>"只回收已删除的"这一档必须原样保留现存录制,不能顺手把用户的东西删了。</summary>
+    [TestMethod]
+    public void CleanupKeepAll_KeepsExistingRecordings()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+
+            Pump(fixture.ViewModel.CleanupAsync(int.MaxValue));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.HasCount(2, fixture.ViewModel.Recordings);
+            Assert.AreEqual(int.MaxValue, fixture.Store.LastKeepDays);
+            return Task.CompletedTask;
+        });
+    }
+
+    private static void OnUi(Func<Task> action) => _session.Dispatch(action, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// 在 UI 线程上等一个异步操作完成。清理会把重活扔到后台线程,回来的续体要排进
+    /// UI 调度器 —— 直接 GetResult 会把 UI 线程堵死等一个只有 UI 线程才能推进的续体
+    /// (headless 全套测试共用这一条线程,一堵就是整套挂到超时)。这里改成边泵调度器边等。
+    /// </summary>
+    private static T Pump<T>(Task<T> task)
+    {
+        for (int i = 0; i < 10_000 && !task.IsCompleted; i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(1);
+        }
+        Assert.IsTrue(task.IsCompleted, "清理没能在超时内跑完。");
+        return task.GetAwaiter().GetResult();
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly CultureInfo _previousCulture = CultureInfo.CurrentCulture;
+        private readonly CultureInfo _previousUiCulture = CultureInfo.CurrentUICulture;
+
+        private Fixture(RecordingPlayerView window, RecordingPlayerViewModel viewModel, StubRecordingStore store)
+        {
+            Window = window;
+            ViewModel = viewModel;
+            Store = store;
+        }
+
+        public RecordingPlayerView Window { get; }
+
+        public RecordingPlayerViewModel ViewModel { get; }
+
+        public StubRecordingStore Store { get; }
+
+        public static Fixture Show()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("zh-CN");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("zh-CN");
+            _localization.SetLanguage("zh-CN");
+
+            var store = new StubRecordingStore();
+            var viewModel = new RecordingPlayerViewModel(store);
+            viewModel.InitializeAsync().GetAwaiter().GetResult();
+
+            var window = new RecordingPlayerView { DataContext = viewModel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            return new(window, viewModel, store);
+        }
+
+        public T Find<T>(string name)
+            where T : Control =>
+            Window.GetVisualDescendants().OfType<T>().Single(control => control.Name == name);
+
+        public void Dispose()
+        {
+            Window.Close();
+            CultureInfo.CurrentCulture = _previousCulture;
+            CultureInfo.CurrentUICulture = _previousUiCulture;
+        }
+    }
+
+    /// <summary>内存版录制存储:清理按保留窗口筛掉元数据,足够驱动界面这一层。</summary>
+    private sealed class StubRecordingStore : ISessionRecordingStore
+    {
+        private readonly List<SessionRecording> _recordings =
+        [
+            new() { SessionLabel = "web-01", StartedAtUtc = DateTime.UtcNow.AddDays(-1), ByteSize = 2048 },
+            new() { SessionLabel = "db-01", StartedAtUtc = DateTime.UtcNow.AddDays(-40), ByteSize = 4096 }
+        ];
+
+        public int ReclaimCalls { get; private set; }
+
+        public int LastKeepDays { get; private set; } = -1;
+
+        public Task SaveRecordingAsync(SessionRecording recording, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task AppendChunkAsync(Guid recordingId, DateTime startedAtUtc, long offsetMs, byte[] data,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<List<SessionRecording>> ListRecordingsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(_recordings.OrderByDescending(r => r.StartedAtUtc).ToList());
+
+        public Task<List<RecordingChunk>> GetChunksAsync(Guid recordingId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<RecordingChunk>());
+
+        public Task DeleteRecordingAsync(Guid recordingId, CancellationToken cancellationToken = default)
+        {
+            _recordings.RemoveAll(r => r.Id == recordingId);
+            return Task.CompletedTask;
+        }
+
+        public Task CleanupExpiredAsync(int retentionDays, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<RecordingStorageUsage> GetStorageUsageAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new RecordingStorageUsage(_recordings.Count, _recordings.Sum(r => r.ByteSize), 1024 * 1024));
+
+        public Task<RecordingCleanupResult> ReclaimSpaceAsync(int keepDays, CancellationToken cancellationToken = default)
+        {
+            ReclaimCalls++;
+            LastKeepDays = keepDays;
+            int before = _recordings.Count;
+            if (keepDays <= 0)
+            {
+                _recordings.Clear();
+            }
+            else if (keepDays != int.MaxValue)
+            {
+                DateTime cutoff = DateTime.UtcNow.AddDays(-keepDays);
+                _recordings.RemoveAll(r => r.StartedAtUtc < cutoff);
+            }
+            return Task.FromResult(new RecordingCleanupResult(before - _recordings.Count, 1024 * 1024, 0, false));
+        }
+    }
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

新增“清理”入口，支持释放数据库磁盘空间，包括统计占用、空间回收等接口及 UI 交互。录制默认关闭并迁移旧配置，补充多语言文案。优化大体积数据 mmap 阈值及刷盘，完善异常处理和磁盘统计。增加单元测试覆盖清理逻辑和 UI。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [x] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [x] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [x] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
