### PR TITLE
终端控件性能与内存优化，减少堆分配

### DIFF
--- a/src/VelaShell.Controls/Controls/CircularProgressRing.cs
+++ b/src/VelaShell.Controls/Controls/CircularProgressRing.cs
@@ -124,6 +124,9 @@ public sealed class CircularProgressRing : Control
         }
     }
 
+    /// <summary>轨道与进度弧两支画笔的复用缓存 —— 不确定态每帧重绘,现建就是每帧两个对象。</summary>
+    private readonly PenCache _pens = new();
+
     /// <summary>绘制轨道与进度弧。</summary>
     public override void Render(DrawingContext context)
     {
@@ -138,7 +141,7 @@ public sealed class CircularProgressRing : Control
 
         if (TrackBrush is { } track)
         {
-            context.DrawEllipse(null, new Pen(track, thickness), center, radius, radius);
+            context.DrawEllipse(null, _pens.Get(track, thickness), center, radius, radius);
         }
         if (ArcBrush is not { } arc)
         {
@@ -163,7 +166,7 @@ public sealed class CircularProgressRing : Control
         }
 
         // 满圈单独走 DrawEllipse:圆弧的起终点重合时 ArcTo 画不出闭合圆(退化成不画)。
-        var pen = new Pen(arc, thickness, lineCap: PenLineCap.Round);
+        IPen pen = _pens.Get(arc, thickness, PenLineCap.Round);
         if (sweepDegrees >= 359.9)
         {
             context.DrawEllipse(null, pen, center, radius, radius);

--- a/src/VelaShell.Controls/Controls/LucideIcon.cs
+++ b/src/VelaShell.Controls/Controls/LucideIcon.cs
@@ -48,6 +48,8 @@ public class LucideIcon : Control
         return new(w, h);
     }
 
+    private readonly PenCache _pens = new();
+
     /// <summary>使用当前前景画刷绘制图标几何。</summary>
     public override void Render(DrawingContext context)
     {
@@ -67,7 +69,10 @@ public class LucideIcon : Control
         // 因此描边在任何尺寸下都保持 lucide 2/24 的粗细比例。
         double scale = Math.Min(w, h) / 24.0;
         var offset = new Point((w - 24 * scale) / 2, (h - 24 * scale) / 2);
-        var pen = new Pen(brush, 2, lineCap: PenLineCap.Round, lineJoin: PenLineJoin.Round);
+
+        // 画笔按 (颜色, 线宽, 端点, 拐角) 复用:图标在工具栏/会话树/文件浏览器里成百上千个,
+        // 每个每次重绘都新建一支可变 Pen(框架还要再快照一次)纯属白扔。
+        IPen pen = _pens.Get(brush, 2, PenLineCap.Round, PenLineJoin.Round);
         using (context.PushTransform(Matrix.CreateScale(scale, scale) * Matrix.CreateTranslation(offset.X, offset.Y)))
         {
             context.DrawGeometry(null, pen, geometry);

--- a/src/VelaShell.Controls/Controls/PenCache.cs
+++ b/src/VelaShell.Controls/Controls/PenCache.cs
@@ -1,0 +1,58 @@
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+
+namespace VelaShell.Controls.Controls;
+
+/// <summary>
+/// 每控件一份的画笔缓存:把 <c>Render</c> 里反复 <c>new Pen(...)</c> 换成按参数复用的
+/// <see cref="ImmutablePen" />。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Render</c> 每次失效都会重跑,而这些控件的画笔参数在整个生命周期里基本恒定
+/// (轨道色 + 进度色、网格线 + 中线、图标描边……)。原先每帧新建的 <c>Pen</c> 还是可变的
+/// <c>AvaloniaObject</c>,交给绘制上下文时框架要再快照一次,一次重绘两笔开销。
+/// </para>
+/// <para>
+/// <b>只缓存纯色画笔</b>:键里带上颜色值,因此即便调用方复用同一个 <see cref="SolidColorBrush" />
+/// 实例、只改了它的 <c>Color</c>(主题令牌就地改色、颜色动画),也不会取到旧画笔。
+/// 渐变等非纯色画笔无法这样廉价地判等,直接现建 —— 那些场景本就不在热路径上。
+/// </para>
+/// </remarks>
+internal sealed class PenCache
+{
+    /// <summary>缓存条目上限;越限直接清空重来(画笔种类恒定的控件永远到不了)。</summary>
+    private const int MaxEntries = 16;
+
+    private readonly Dictionary<(uint Color, double Thickness, PenLineCap Cap, PenLineJoin Join), ImmutablePen> _pens = [];
+
+    /// <summary>取一支画笔;参数完全相同即复用同一实例。</summary>
+    /// <param name="brush">描边画刷。非纯色画刷不缓存,每次现建。</param>
+    /// <param name="thickness">线宽。</param>
+    /// <param name="cap">线端样式。</param>
+    /// <param name="join">拐角样式。</param>
+    public IPen Get(
+        IBrush brush,
+        double thickness,
+        PenLineCap cap = PenLineCap.Flat,
+        PenLineJoin join = PenLineJoin.Miter)
+    {
+        if (brush is not ISolidColorBrush solid)
+        {
+            return new ImmutablePen(brush.ToImmutable(), thickness, null, cap, join);
+        }
+        uint color = solid.Color.ToUInt32();
+        (uint, double, PenLineCap, PenLineJoin) key = (color, thickness, cap, join);
+        if (_pens.TryGetValue(key, out ImmutablePen? cached))
+        {
+            return cached;
+        }
+        if (_pens.Count >= MaxEntries)
+        {
+            _pens.Clear();
+        }
+        var pen = new ImmutablePen(new ImmutableSolidColorBrush(solid.Color, solid.Opacity), thickness, null, cap, join);
+        _pens[key] = pen;
+        return pen;
+    }
+}

--- a/src/VelaShell.Controls/Controls/TimeSeriesChart.cs
+++ b/src/VelaShell.Controls/Controls/TimeSeriesChart.cs
@@ -71,6 +71,8 @@ public sealed class ChartSeries : Control
         set => SetValue(MirrorProperty, value);
     }
 
+    private readonly PenCache _pens = new();
+
     /// <summary>按父图表给定的量程绘制自身曲线。</summary>
     public override void Render(DrawingContext context)
     {
@@ -138,7 +140,7 @@ public sealed class ChartSeries : Control
             }
             ctx.EndFigure(false);
         }
-        context.DrawGeometry(null, new Pen(stroke, StrokeThickness, lineCap: PenLineCap.Round, lineJoin: PenLineJoin.Round), line);
+        context.DrawGeometry(null, _pens.Get(stroke, StrokeThickness, PenLineCap.Round, PenLineJoin.Round), line);
     }
 }
 
@@ -297,6 +299,8 @@ public sealed class TimeSeriesChart : Panel
 /// <summary>图表的网格层:只画水平/垂直网格与镜像中线,永远垫在曲线下方。</summary>
 internal sealed class ChartGridLayer : Control
 {
+    private readonly PenCache _pens = new();
+
     /// <summary>按父图表的配置绘制网格。</summary>
     public override void Render(DrawingContext context)
     {
@@ -311,7 +315,7 @@ internal sealed class ChartGridLayer : Control
         }
         if (chart.GridBrush is { } grid)
         {
-            var pen = new Pen(grid, 1);
+            IPen pen = _pens.Get(grid, 1);
             for (int i = 1; i < chart.GridRows; i++)
             {
                 double y = Math.Round(h * i / chart.GridRows) + 0.5;
@@ -326,7 +330,7 @@ internal sealed class ChartGridLayer : Control
         if (chart.Mirrored && chart.MidlineBrush is { } mid)
         {
             double y = Math.Round(h / 2) + 0.5;
-            context.DrawLine(new Pen(mid, 1), new(0, y), new(w, y));
+            context.DrawLine(_pens.Get(mid, 1), new(0, y), new(w, y));
         }
     }
 }

--- a/src/VelaShell.Controls/Controls/UsageHeatGrid.cs
+++ b/src/VelaShell.Controls/Controls/UsageHeatGrid.cs
@@ -501,7 +501,7 @@ public sealed class UsageHeatGrid : Control
             }
             if (i == selected && SelectionBrush is { } selectionBrush)
             {
-                context.DrawRectangle(null, new Pen(selectionBrush, 1), rect.Deflate(0.5), 3, 3);
+                context.DrawRectangle(null, _pens.Get(selectionBrush, 1), rect.Deflate(0.5), 3, 3);
             }
             if (!showValue)
             {
@@ -510,20 +510,9 @@ public sealed class UsageHeatGrid : Control
             string label = labels is not null && i < labels.Count
                                ? labels[i]
                                : LabelPrefix + i.ToString(CultureInfo.InvariantCulture);
-            var text = new FormattedText(
-                value.ToString("F0", CultureInfo.InvariantCulture) + "%",
-                CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                typeface,
-                valueSize,
-                labelBrush);
-            var index = new FormattedText(
-                label,
-                CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                typeface,
-                indexSize,
-                labelBrush);
+            FormattedText text = ShapedText(
+                value.ToString("F0", CultureInfo.InvariantCulture) + "%", typeface, valueSize, labelBrush);
+            FormattedText index = ShapedText(label, typeface, indexSize, labelBrush);
             if (sparkline)
             {
                 // 折线要占满格子,文字压在左上/右下角,不居中盖住曲线;各垫一层底片保证读得清。
@@ -542,6 +531,47 @@ public sealed class UsageHeatGrid : Control
                 context.DrawText(index, new(rect.Center.X - (index.Width / 2), rect.Center.Y - text.Height - 1));
             }
         }
+    }
+
+    // ---- 文本塑形缓存 --------------------------------------------------------
+
+    /// <summary>
+    /// 已塑形的读数/标签文本,键为 (文本, 字号)。
+    /// </summary>
+    /// <remarks>
+    /// 每格两条文本(百分比 + 核心号),没有缓存就是每次刷新做 2×核心数 次文本塑形 ——
+    /// 128 核的机器每秒 256 次,而内容其实高度重复:百分比只有 "0%".."100%" 一百来种,
+    /// 核心标签按索引固定不变。字号随格子大小变化,故一并入键;画刷变了(主题切换)整表失效。
+    /// </remarks>
+    private readonly PenCache _pens = new();
+
+    private readonly Dictionary<(string Text, double Size), FormattedText> _textCache = [];
+    private Typeface _textCacheTypeface;
+    private IBrush? _textCacheBrush;
+
+    /// <summary>取一条已塑形的文本;字体/画刷变化时整表重建。</summary>
+    private FormattedText ShapedText(string text, Typeface typeface, double size, IBrush brush)
+    {
+        if (!ReferenceEquals(_textCacheBrush, brush) || _textCacheTypeface != typeface)
+        {
+            _textCache.Clear();
+            _textCacheBrush = brush;
+            _textCacheTypeface = typeface;
+        }
+        if (_textCache.TryGetValue((text, size), out FormattedText? cached))
+        {
+            return cached;
+        }
+
+        // 上限保险丝:自定义标签理论上可以无界(插件下发),满了直接重置。
+        if (_textCache.Count > 512)
+        {
+            _textCache.Clear();
+        }
+        var formatted = new FormattedText(
+            text, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, size, brush);
+        _textCache[(text, size)] = formatted;
+        return formatted;
     }
 
     /// <summary>给压在曲线上的文字垫一层底片。</summary>
@@ -593,12 +623,11 @@ public sealed class UsageHeatGrid : Control
         }
         if (LineBrush is { } stroke)
         {
-            context.DrawGeometry(null, new Pen(stroke, 1.2, lineJoin: PenLineJoin.Round), line);
+            context.DrawGeometry(null, _pens.Get(stroke, 1.2, PenLineCap.Flat, PenLineJoin.Round), line);
         }
     }
 
     /// <summary>按列数摊分可用宽度,并夹到 <see cref="MaxCellWidth" />(核心少时不铺满整行)。</summary>
-
 
     private IBrush? LevelBrush(double value) => value switch
     {

--- a/src/VelaShell.Controls/VelaShell.Controls.csproj
+++ b/src/VelaShell.Controls/VelaShell.Controls.csproj
@@ -18,4 +18,9 @@
     <AvaloniaResource Include="Assets/Fonts/**" />
   </ItemGroup>
 
+  <!-- 见 VelaShell.Terminal.csproj 同处注释:签名构建(Release)省略友元声明,非签名构建保留。 -->
+  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+    <InternalsVisibleTo Include="VelaShell.Controls.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/VelaShell.Core/Sftp/SftpService.cs
+++ b/src/VelaShell.Core/Sftp/SftpService.cs
@@ -144,16 +144,25 @@ public class SftpService(
             remoteStream.Seek(resumeOffset, SeekOrigin.Begin);
 
             // 32KB 一次往返对高延迟链路太小;续传路径是自己搬字节,块大些能显著减少往返次数。
-            byte[] buffer = new byte[256 * 1024];
-            long bytesRead = 0;
-            int read;
-            while ((read = await remoteStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+            // 缓冲走池:256KB 超过 85KB 的大对象堆阈值,每次续传新开一个就是往 LOH 里丢一块
+            // (LOH 不压缩,累积成碎片);池的最大桶是 1MB,这个尺寸正好落在池内。
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(256 * 1024);
+            try
             {
-                await localStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
-                bytesRead += read;
-                reporter.Report(resumeOffset + bytesRead);
+                long bytesRead = 0;
+                int read;
+                while ((read = await remoteStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    await localStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                    bytesRead += read;
+                    reporter.Report(resumeOffset + bytesRead);
+                }
+                reporter.ReportFinal(resumeOffset + bytesRead);
             }
-            reporter.ReportFinal(resumeOffset + bytesRead);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
         else
         {

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using VelaShell.PluginSdk;
@@ -185,23 +186,36 @@ internal sealed class PluginCapabilityRouter : IDisposable
                     }
                     // 单块上限 512KB:base64 后 ~700KB,远低于帧上限,又不至于块太碎。
                     int count = Math.Clamp(request.MaxBytes, 1, 512 * 1024);
-                    byte[] buffer = new byte[count];
-                    int read = 0;
-                    while (read < count)
+
+                    // 缓冲走池:512KB 远超 85KB 的大对象堆阈值,按块新开会让插件拉一个大文件的
+                    // 全过程都在 LOH 上反复申请/回收(LOH 不压缩,直接喂出碎片与 gen2 回收)。
+                    // 池的最大桶是 1MB,512KB 正好落在池内。
+                    byte[] buffer = ArrayPool<byte>.Shared.Rent(count);
+                    try
                     {
-                        int n = await stream.ReadAsync(buffer.AsMemory(read, count - read), cancellationToken).ConfigureAwait(false);
-                        if (n == 0)
+                        int read = 0;
+                        while (read < count)
                         {
-                            break;
+                            int n = await stream.ReadAsync(buffer.AsMemory(read, count - read), cancellationToken).ConfigureAwait(false);
+                            if (n == 0)
+                            {
+                                break;
+                            }
+                            read += n;
                         }
-                        read += n;
+                        bool eof = read == 0;
+                        if (eof && _openStreams.TryRemove(request.StreamId, out Stream? finished))
+                        {
+                            await finished.DisposeAsync().ConfigureAwait(false); // 流尽即释放,插件忘关也不泄漏
+                        }
+                        return new FsStreamReadResponse(Convert.ToBase64String(buffer, 0, read), eof);
                     }
-                    bool eof = read == 0;
-                    if (eof && _openStreams.TryRemove(request.StreamId, out Stream? finished))
+                    finally
                     {
-                        await finished.DisposeAsync().ConfigureAwait(false); // 流尽即释放,插件忘关也不泄漏
+                        // 租来的数组可能比 count 长,且必然带着上一位租客的数据:
+                        // 上面一律按 read 长度截取,不会把多余字节读出去。
+                        ArrayPool<byte>.Shared.Return(buffer);
                     }
-                    return new FsStreamReadResponse(Convert.ToBase64String(buffer, 0, read), eof);
                 }
             case PluginRpc.FsStreamClose:
                 {

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO.Compression;
@@ -744,21 +745,31 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
 
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         Span<byte> frame = stackalloc byte[8];
-        foreach (string file in files.OrderBy(f => Path.GetRelativePath(fullRoot, f).Replace('\\', '/'), StringComparer.Ordinal))
+
+        // 读缓冲在循环外开一次并跨文件复用:原先每个文件都新开 64 KB,一个两百来个文件的
+        // 插件光在这里就扔掉十几 MB 垃圾,而这条路径是安装/校验时的启动开销。
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
         {
-            byte[] path = Encoding.UTF8.GetBytes(Path.GetRelativePath(fullRoot, file).Replace('\\', '/'));
-            BinaryPrimitives.WriteInt32LittleEndian(frame, path.Length);
-            hash.AppendData(frame[..4]);
-            hash.AppendData(path);
-            using FileStream stream = File.OpenRead(file);
-            BinaryPrimitives.WriteInt64LittleEndian(frame, stream.Length);
-            hash.AppendData(frame);
-            byte[] buffer = new byte[64 * 1024];
-            int read;
-            while ((read = stream.Read(buffer)) > 0)
+            foreach (string file in files.OrderBy(f => Path.GetRelativePath(fullRoot, f).Replace('\\', '/'), StringComparer.Ordinal))
             {
-                hash.AppendData(buffer.AsSpan(0, read));
+                byte[] path = Encoding.UTF8.GetBytes(Path.GetRelativePath(fullRoot, file).Replace('\\', '/'));
+                BinaryPrimitives.WriteInt32LittleEndian(frame, path.Length);
+                hash.AppendData(frame[..4]);
+                hash.AppendData(path);
+                using FileStream stream = File.OpenRead(file);
+                BinaryPrimitives.WriteInt64LittleEndian(frame, stream.Length);
+                hash.AppendData(frame);
+                int read;
+                while ((read = stream.Read(buffer)) > 0)
+                {
+                    hash.AppendData(buffer.AsSpan(0, read));
+                }
             }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
         return Convert.ToHexStringLower(hash.GetHashAndReset());
     }
@@ -794,22 +805,30 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     }
 
     /// <summary>把条目内容拷进目标流,超出预算即中止并抛出。返回实际写出的字节数。</summary>
+    /// <remarks>本方法按 zip 条目逐个调用,缓冲走池:上千条目的包不必扔掉上千个 80 KB 数组。</remarks>
     private static long CopyBounded(Stream source, Stream destination, long budget, string entryName)
     {
-        byte[] buffer = new byte[81920];
-        long written = 0;
-        int read;
-        while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
         {
-            written += read;
-            if (written > budget)
+            long written = 0;
+            int read;
+            while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
             {
-                throw new InvalidOperationException(
-                    $"Rejected package: unpacked size exceeds {MaxUnpackedBytes} bytes (while extracting '{entryName}').");
+                written += read;
+                if (written > budget)
+                {
+                    throw new InvalidOperationException(
+                        $"Rejected package: unpacked size exceeds {MaxUnpackedBytes} bytes (while extracting '{entryName}').");
+                }
+                destination.Write(buffer, 0, read);
             }
-            destination.Write(buffer, 0, read);
+            return written;
         }
-        return written;
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     /// <summary>删除某插件的 DB 命名空间与数据目录(卸载/覆盖安装时)。</summary>

--- a/src/VelaShell.Terminal/BufferSearch.cs
+++ b/src/VelaShell.Terminal/BufferSearch.cs
@@ -26,17 +26,31 @@ public static class BufferSearch
         }
         var hits = new List<BufferSearchHit>();
         int totalRows = screen.TotalRows;
+
+        // 逐行文本写进一个复用缓冲,而不是每行 GetText() 造一个 string:本方法在搜索框
+        // 每次按键时对整个缓冲区(回滚 + 屏幕,默认上限 1 万行)跑一遍,原写法每敲一个
+        // 字符就分配上万个 StringBuilder + string(长会话下每次按键约 1.6 MB),
+        // 直接表现为搜索框打字卡顿。现在整次搜索只有这一个缓冲。
+        char[] buffer = new char[Math.Max(256, screen.Columns * 2)];
         for (int row = 0; row < totalRows; row++)
         {
-            string text = screen.ViewLine(row).GetText();
-            int index = 0;
-            while (true)
+            TerminalRow line = screen.ViewLine(row);
+            int length;
+            while ((length = line.CopyTextTo(buffer)) < 0)
             {
-                int found = text.IndexOf(query, index, StringComparison.OrdinalIgnoreCase);
+                // 组合标记可以让一行的字符数超过列数,故按需扩容(极罕见,只发生一次)。
+                buffer = new char[buffer.Length * 2];
+            }
+            ReadOnlySpan<char> text = buffer.AsSpan(0, length);
+            int index = 0;
+            while (index < text.Length)
+            {
+                int found = text[index..].IndexOf(query, StringComparison.OrdinalIgnoreCase);
                 if (found < 0)
                 {
                     break;
                 }
+                found += index;
                 hits.Add(new(row, found, query.Length));
                 index = found + Math.Max(1, query.Length);
             }

--- a/src/VelaShell.Terminal/Emulation/CharWidth.cs
+++ b/src/VelaShell.Terminal/Emulation/CharWidth.cs
@@ -60,6 +60,15 @@ public static class CharWidth
             case >= 0x7F and < 0xA0:
                 return 0;
         }
+        // ASCII / Latin-1 / 拉丁扩展一律宽度 1:0x0300 以下没有任何零宽或宽字符区间
+        // (最低的零宽区间是组合变音符号 U+0300,最低的宽字符区间是 Hangul U+1100)。
+        // 这条早退让绝大多数字符只做一次比较,免掉下面两趟二分 —— 本方法在每个打印字符
+        // (TerminalEmulator.Print)与每个渲染格子(VelaTerminalControl.RenderLine)上各调一次,
+        // 是全仓最热的叶子函数之一。
+        if (rune < 0x0300)
+        {
+            return 1;
+        }
         if (InRanges(rune, ZeroWidth))
         {
             return 0;

--- a/src/VelaShell.Terminal/Emulation/CombiningPool.cs
+++ b/src/VelaShell.Terminal/Emulation/CombiningPool.cs
@@ -14,8 +14,12 @@ namespace VelaShell.Terminal.Emulation;
 /// </remarks>
 internal static class CombiningPool
 {
-    /// <summary>池上限:正常使用永远到不了;是对抗性输入的无界增长保险丝。</summary>
-    private const int MaxEntries = 65536;
+    /// <summary>
+    /// 池上限:正常使用永远到不了;是对抗性输入的无界增长保险丝。
+    /// 取 ushort.MaxValue 而非 65536 —— 索引存在 <see cref="TerminalCell.CombiningIndex" /> 的
+    /// <c>ushort</c> 里(把单元格从 20 字节压到 16 字节的一半功劳),65536 会溢出成 0。
+    /// </summary>
+    private const int MaxEntries = ushort.MaxValue;
 
     private static readonly Lock Gate = new();
     private static readonly Dictionary<string, int> Lookup = [];
@@ -23,7 +27,7 @@ internal static class CombiningPool
     private static int _count = 1;
 
     /// <summary>驻留一段组合标记,返回其索引;null/空串返回 0;池满返回 0(丢弃标记)。</summary>
-    public static int Intern(string? marks)
+    public static ushort Intern(string? marks)
     {
         if (string.IsNullOrEmpty(marks))
         {
@@ -33,7 +37,7 @@ internal static class CombiningPool
         {
             if (Lookup.TryGetValue(marks, out int existing))
             {
-                return existing;
+                return (ushort)existing;
             }
             if (_count >= MaxEntries)
             {
@@ -49,7 +53,7 @@ internal static class CombiningPool
             _byIndex[index] = marks;
             _count = index + 1;
             Lookup[marks] = index;
-            return index;
+            return (ushort)index;
         }
     }
 

--- a/src/VelaShell.Terminal/Emulation/TerminalCell.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalCell.cs
@@ -5,6 +5,14 @@ namespace VelaShell.Terminal.Emulation;
 /// <summary>
 /// 终端网格中的一个字符单元格。采用值类型,使行可被存为连续数组并被廉价清空。
 /// </summary>
+/// <remarks>
+/// <b>字段声明顺序即内存布局,不要随手调整。</b>本结构含自定义结构体字段
+/// (<see cref="TerminalColor" />),此时 CLR 的自动布局不再按大小重排字段、而是沿用声明顺序;
+/// 把两个 2 字节字段(<see cref="CombiningIndex" />、<see cref="Flags" />)分开写会各自吃掉
+/// 一个 4 字节槽,结构从 16 字节涨到 20。当前顺序 4+4+4+2+2 = 16 字节,恰好塞满。
+/// 回滚缓冲默认每标签页 1 万行 × 上百列,这 4 字节按整个缓冲区放大。
+/// 由 <c>TerminalCellMemoryTests.TerminalCell_StaysWithinPackedSize</c> 把守。
+/// </remarks>
 public struct TerminalCell : IEquatable<TerminalCell>
 {
     /// <summary>
@@ -13,11 +21,26 @@ public struct TerminalCell : IEquatable<TerminalCell>
     /// </summary>
     public int Rune;
 
+    /// <summary>单元格的前景(文字)颜色。</summary>
+    public TerminalColor Foreground;
+
+    /// <summary>单元格的背景颜色。</summary>
+    public TerminalColor Background;
+
     /// <summary>
     /// 组合标记在 <see cref="CombiningPool" /> 中的索引;0 = 无。存索引而非字符串引用,
     /// 使本结构不含托管引用:回滚缓冲的数百万格从此不被 GC 逐格扫描,每格再省 4 字节。
+    /// <para>
+    /// 宽度取 <c>ushort</c> 而非 <c>int</c>:与打包成 4 字节的 <see cref="TerminalColor" /> 合力,
+    /// 把本结构从 20 字节压到 16 字节(回滚缓冲省 20% 内存)。池上限
+    /// <c>CombiningPool.MaxEntries</c> 已相应对齐为 <see cref="ushort.MaxValue" />。
+    /// </para>
     /// </summary>
-    public int CombiningIndex;
+    public ushort CombiningIndex;
+
+    /// <summary>单元格的渲染属性位(加粗、反显、宽字符尾格等)。</summary>
+    /// <remarks>紧跟 <see cref="CombiningIndex" /> 声明:两个 2 字节字段合用一个槽,见类型注释。</remarks>
+    public CellFlags Flags;
 
     /// <summary>追加在 <see cref="Rune" /> 之后的可选组合标记。常见情况下为 Null。</summary>
     public string? Combining
@@ -25,15 +48,6 @@ public struct TerminalCell : IEquatable<TerminalCell>
         readonly get => CombiningPool.Get(CombiningIndex);
         set => CombiningIndex = CombiningPool.Intern(value);
     }
-
-    /// <summary>单元格的前景(文字)颜色。</summary>
-    public TerminalColor Foreground;
-
-    /// <summary>单元格的背景颜色。</summary>
-    public TerminalColor Background;
-
-    /// <summary>单元格的渲染属性位(加粗、反显、宽字符尾格等)。</summary>
-    public CellFlags Flags;
 
     /// <summary>一个使用默认颜色、无属性的空单元格。</summary>
     public static TerminalCell Empty => new()
@@ -69,6 +83,55 @@ public struct TerminalCell : IEquatable<TerminalCell>
             return char.ConvertFromUtf32(Rune);
         }
         return char.ConvertFromUtf32(Rune) + Combining;
+    }
+
+    /// <summary>
+    /// 把单元格文本(基础字符及组合标记)写入 <paramref name="destination" />,返回写入的字符数;
+    /// 宽字符尾格写入 0 个字符。空间不足时不写入任何内容并返回 -1(调用方据此扩容重试)。
+    /// </summary>
+    /// <remarks>
+    /// 与 <see cref="AppendText(StringBuilder)" /> 语义逐字一致,只是写进调用方自备的缓冲。
+    /// 渲染热路径(<c>VelaTerminalControl.ComputeSemanticColumns</c> 逐行重建行文本)用它
+    /// 避免为了做一次语义匹配而物化 StringBuilder + string。两者的一致性由
+    /// <c>TerminalCellMemoryTests.AppendTo_MatchesAppendText</c> 把守。
+    /// </remarks>
+    /// <param name="destination">接收单元格文本的目标缓冲。</param>
+    /// <returns>写入的字符数;缓冲不足时为 -1。</returns>
+    public readonly int AppendTo(Span<char> destination)
+    {
+        if (IsWideTrailing)
+        {
+            return 0;
+        }
+        string? combining = Combining;
+        int baseLength = Rune is 0 or <= 0xFFFF ? 1 : 2;
+        int needed = baseLength + (combining?.Length ?? 0);
+        if (destination.Length < needed)
+        {
+            return -1;
+        }
+        int written = 0;
+        if (Rune == 0)
+        {
+            destination[written++] = ' ';
+        }
+        else if (Rune <= 0xFFFF)
+        {
+            destination[written++] = (char)Rune;
+        }
+        else
+        {
+            // 补充平面:手工拆代理对,免掉 char.ConvertFromUtf32 的 string 分配。
+            int offset = Rune - 0x10000;
+            destination[written++] = (char)(0xD800 + (offset >> 10));
+            destination[written++] = (char)(0xDC00 + (offset & 0x3FF));
+        }
+        if (combining is not null)
+        {
+            combining.CopyTo(destination[written..]);
+            written += combining.Length;
+        }
+        return written;
     }
 
     /// <summary>将单元格文本(基础字符及组合标记)追加到指定的 <see cref="StringBuilder" />;宽字符尾格不追加内容。</summary>

--- a/src/VelaShell.Terminal/Emulation/TerminalColor.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalColor.cs
@@ -19,52 +19,61 @@ public enum TerminalColorKind : byte
 /// 与任何具体调色板都无关的颜色。渲染层会针对当前生效的 <see cref="TerminalPalette" />
 /// 来解析 <see cref="TerminalColorKind.Default" /> 与 <see cref="TerminalColorKind.Indexed" />。
 /// </summary>
+/// <remarks>
+/// <b>内存布局是本结构的契约</b>:整个字段集打包进单个 <c>uint</c>(0xKKRRGGBB —— 高字节存
+/// <see cref="Kind" />,低 24 位按 Kind 解释为 RGB 或调色板索引)。五个独立字节字段时本结构占
+/// 5 字节,而 <see cref="TerminalCell" /> 里放两份,受对齐影响会把单元格撑到 20 字节;
+/// 打包成 4 字节后单元格降到 16 字节 —— 回滚缓冲(默认每标签页 1 万行)整整省下 20% 内存。
+/// 见 <c>TerminalCellMemoryTests.TerminalCell_StaysWithinPackedSize</c>。
+/// <para>
+/// 各 Kind 下未使用的位恒为 0(Default 全 0;Indexed 只用低 8 位;Rgb 只用低 24 位),
+/// 因此"比较 <see cref="_packed" />"与逐字段比较完全等价 —— 相等性由此退化为一次整数比较。
+/// </para>
+/// </remarks>
 public readonly struct TerminalColor : IEquatable<TerminalColor>
 {
+    private readonly uint _packed;
+
+    private TerminalColor(uint packed) => _packed = packed;
+
     /// <summary>该颜色解析为屏幕上实际颜色的方式。</summary>
-    public TerminalColorKind Kind { get; }
+    public TerminalColorKind Kind => (TerminalColorKind)(byte)(_packed >> 24);
 
-    /// <summary>当 <see cref="Kind" /> 为 Indexed 时的调色板索引。</summary>
-    public byte Index { get; }
+    /// <summary>当 <see cref="Kind" /> 为 Indexed 时的调色板索引;其余 Kind 下为 0。</summary>
+    public byte Index => Kind == TerminalColorKind.Indexed ? (byte)_packed : (byte)0;
 
-    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的红色通道。</summary>
-    public byte R { get; }
+    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的红色通道;其余 Kind 下为 0。</summary>
+    public byte R => Kind == TerminalColorKind.Rgb ? (byte)(_packed >> 16) : (byte)0;
 
-    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的绿色通道。</summary>
-    public byte G { get; }
+    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的绿色通道;其余 Kind 下为 0。</summary>
+    public byte G => Kind == TerminalColorKind.Rgb ? (byte)(_packed >> 8) : (byte)0;
 
-    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的蓝色通道。</summary>
-    public byte B { get; }
-
-    private TerminalColor(TerminalColorKind kind, byte index, byte r, byte g, byte b)
-    {
-        Kind = kind;
-        Index = index;
-        R = r;
-        G = g;
-        B = b;
-    }
+    /// <summary>当 <see cref="Kind" /> 为 Rgb 时的蓝色通道;其余 Kind 下为 0。</summary>
+    public byte B => Kind == TerminalColorKind.Rgb ? (byte)_packed : (byte)0;
 
     /// <summary>终端默认前景/背景色哨兵值。</summary>
-    public static TerminalColor Default => new(TerminalColorKind.Default, 0, 0, 0, 0);
+    public static TerminalColor Default => new(0);
 
     /// <summary>由 256 色调色板索引创建索引色(钳制到 0-255)。</summary>
-    public static TerminalColor FromIndex(int index) => new(TerminalColorKind.Indexed, (byte)Math.Clamp(index, 0, 255), 0, 0, 0);
+    public static TerminalColor FromIndex(int index) =>
+        new(((uint)TerminalColorKind.Indexed << 24) | (byte)Math.Clamp(index, 0, 255));
 
     /// <summary>由给定的红、绿、蓝通道创建 24 位真彩色。</summary>
-    public static TerminalColor FromRgb(byte r, byte g, byte b) => new(TerminalColorKind.Rgb, 0, r, g, b);
+    public static TerminalColor FromRgb(byte r, byte g, byte b) =>
+        new(((uint)TerminalColorKind.Rgb << 24) | ((uint)r << 16) | ((uint)g << 8) | b);
 
     /// <summary>该颜色是否为终端默认哨兵值。</summary>
-    public bool IsDefault => Kind == TerminalColorKind.Default;
+    public bool IsDefault => _packed == 0; // Default 的打包表示恒为全 0。
 
     /// <summary>判断该颜色是否与另一个颜色相等。</summary>
-    public bool Equals(TerminalColor other) => Kind == other.Kind && Index == other.Index && R == other.R && G == other.G && B == other.B;
+    /// <remarks>未使用位恒为 0(见类型注释),故整数比较与逐字段比较等价,且省去 5 次取值。</remarks>
+    public bool Equals(TerminalColor other) => _packed == other._packed;
 
     /// <summary>判断该颜色是否与给定对象相等。</summary>
     public override bool Equals(object? obj) => obj is TerminalColor other && Equals(other);
 
-    /// <summary>返回合并所有颜色分量的哈希码。</summary>
-    public override int GetHashCode() => HashCode.Combine((byte)Kind, Index, R, G, B);
+    /// <summary>返回该颜色的哈希码。</summary>
+    public override int GetHashCode() => (int)_packed;
 
     /// <summary>判断两个颜色是否相等。</summary>
     public static bool operator ==(TerminalColor left, TerminalColor right) => left.Equals(right);

--- a/src/VelaShell.Terminal/Emulation/TerminalRow.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalRow.cs
@@ -138,6 +138,57 @@ public sealed class TerminalRow(int columns)
         return sb.ToString();
     }
 
+    /// <summary>
+    /// 把 <see cref="GetText" /> 的内容写进 <paramref name="destination" />,返回写入的字符数;
+    /// 空间不足时返回 -1(调用方据此扩容重试,已写入的内容作废)。
+    /// </summary>
+    /// <remarks>
+    /// 与 <see cref="GetText" /> 逐字等价,只是不物化 string。整缓冲区扫描的场合
+    /// (<see cref="BufferSearch.FindAll" /> 每次按键要过一遍全部回滚行)用它,把
+    /// "每行一个 StringBuilder + 一个 string"降为"每次搜索一个复用缓冲"。
+    /// 一致性由 <c>BufferSearchTests.CopyTextTo_MatchesGetText</c> 把守。
+    /// </remarks>
+    /// <param name="destination">接收行文本的目标缓冲。</param>
+    /// <returns>写入的字符数;缓冲不足时为 -1。</returns>
+    public int CopyTextTo(Span<char> destination)
+    {
+        int lastNonBlank = LastNonBlank();
+        int written = 0;
+        for (int i = 0; i <= lastNonBlank; i++)
+        {
+            int n = _cells[i].AppendTo(destination[written..]);
+            if (n < 0)
+            {
+                return -1;
+            }
+            written += n;
+        }
+        return written;
+    }
+
+    /// <summary>
+    /// 把本行原地复位成指定宽度的空白行(等价于 <c>new TerminalRow(columns)</c> 后 <see cref="Fill" />),
+    /// 宽度不变时连单元格数组都不重新分配。
+    /// </summary>
+    /// <remarks>
+    /// 供 <see cref="TerminalScreen" /> 的 reflow 回收复用旧行对象。改列宽会对整个缓冲区重排,
+    /// 每次都为上万行各 new 一个 <see cref="TerminalCell" /> 数组(1 万行 × 200 列 × 16B ≈ 32MB),
+    /// 而拖拽改宽会连着触发几十次 —— 那些数组多数能活过一次 gen0 回收被提升,代价远不止分配本身。
+    /// <b>只能对确定已经没人引用的行调用</b>(reflow 里旧行的内容已复制进收集缓冲,即为此)。
+    /// </remarks>
+    /// <param name="columns">复位后的列数。</param>
+    /// <param name="blank">用于填充的空白单元格。</param>
+    public void ResetFor(int columns, in TerminalCell blank)
+    {
+        if (_cells.Length != columns)
+        {
+            _cells = new TerminalCell[columns];
+        }
+        _cells.AsSpan().Fill(blank);
+        Wrapped = false;
+        Timestamp = null;
+    }
+
     /// <summary>创建本行的深拷贝,保留单元格、wrapped 标志与时间戳。</summary>
     public TerminalRow Clone()
     {

--- a/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
@@ -508,6 +508,7 @@ public sealed class TerminalScreen
                 break;
             }
             physical.RemoveAt(physical.Count - 1);
+            Recycle(last); // 这些行到此确定无人引用,直接进回收池。
         }
 
         // 2. 按新宽度重新生成逻辑行。
@@ -548,6 +549,15 @@ public sealed class TerminalScreen
                     cursorOffset = cells.Count + cursorCol;
                 }
                 cells.AddRange(row.Span[..len]);
+            }
+
+            // 内容已整段复制进 cells,physical[i..j] 这些行对象到此确定无人再读 ——
+            // 立刻回收,下面 EmitLogicalLine 就地取用。滚动回收使池的驻留量只有
+            // 「一条逻辑行所跨的物理行数」(通常 1~3 行),不额外占内存:
+            // physical 本来就把全部旧行持有到本方法结束,2 倍峰值是既有事实,这里只是不再重新分配。
+            for (int r = i; r <= j; r++)
+            {
+                Recycle(physical[r]);
             }
             int emittedStart = rebuilt.Count;
             EmitLogicalLine(cells, cursorOffset, newCols, blank, rebuilt, ref newCursorRow, ref newCursorCol);
@@ -598,13 +608,16 @@ public sealed class TerminalScreen
         ScrollBottom = newRows - 1;
         CursorY = Math.Clamp(newCursorRow - screenStart, 0, newRows - 1);
         CursorX = Math.Clamp(newCursorCol, 0, newCols - 1);
+
+        // 回收池不跨调用驻留:留着就等于让屏幕长期多占一份行内存,而它的收益只在本次重排内。
+        _reflowPool.Clear();
     }
 
     /// <summary>
     /// 把一条逻辑行的单元格换行成若干 <paramref name="cols" /> 宽的行,使宽字符的前导/尾随成对
     /// 留在同一行,除最后一行外每行都标记为软换行,并报告 <paramref name="cursorOffset" /> 落点。
     /// </summary>
-    private static void EmitLogicalLine(List<TerminalCell> cells,
+    private void EmitLogicalLine(List<TerminalCell> cells,
         int cursorOffset,
         int cols,
         in TerminalCell blank,
@@ -657,8 +670,26 @@ public sealed class TerminalScreen
         }
     }
 
-    private static TerminalRow NewBlankRow(int cols, in TerminalCell blank)
+    /// <summary>
+    /// reflow 期间的行对象回收池。
+    /// </summary>
+    /// <remarks>
+    /// 只在 <see cref="ReflowResize" /> 这一次调用内有效,方法结束即清空 —— 不跨调用驻留,
+    /// 因此不会让屏幕长期多占一份行内存。往里放的必须是「内容已复制走、确定无人引用」的行。
+    /// </remarks>
+    private readonly Stack<TerminalRow> _reflowPool = new();
+
+    /// <summary>把一个确定已无人引用的行交还回收池。</summary>
+    private void Recycle(TerminalRow row) => _reflowPool.Push(row);
+
+    /// <summary>取一个指定宽度的空白行:优先复用回收池里的旧行对象。</summary>
+    private TerminalRow NewBlankRow(int cols, in TerminalCell blank)
     {
+        if (_reflowPool.TryPop(out TerminalRow? recycled))
+        {
+            recycled.ResetFor(cols, blank);
+            return recycled;
+        }
         var row = new TerminalRow(cols);
         row.Fill(blank);
         return row;

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -46,25 +46,38 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     // 输出只从很小的字符集绘制,因此命中率约 100%,每帧文本塑形 ——
     // 这一主要渲染开销 —— 实际上消失了。字体/字号变化时清空。
     private readonly Dictionary<GlyphKey, FormattedText> _glyphCache = [];
-    private readonly List<char> _runChars = [];
+    // 待发出的 GlyphRun 内容。两者都跨 run、跨帧复用(见 FlushGlyphRun 对所有权的说明):
+    // 字符缓冲手工扩容以便按精确长度切 ReadOnlyMemory;字形表直接以 List 交出去 ——
+    // List<T> 本身就是长度精确的 IReadOnlyList<T>,不必再 ToArray 一份。
+    private char[] _runChars = new char[256];
+    private int _runCharCount;
     private readonly List<GlyphInfo> _runGlyphs = [];
 
     // 客户端语义着色(URL、IP、错误/警告/成功词、选项标志、数字),针对
     // 远端程序留在默认颜色下的文本,使普通日志/MOTD 也能被高亮,
     // 且绝不破坏显式 SGR 颜色(ls --color、git 等)。正则结果按行文本缓存,
     // 因为可见行每一帧都会被重新扫描(光标闪烁、输出)。
-    private readonly Dictionary<string, IReadOnlyList<SemanticSpan>> _semanticSpanCache = [];
+    // 用 StringComparer.Ordinal 建表是为了能取到 span 备用查找(GetAlternateLookup):
+    // 缓存命中路径因此不必先把行文本物化成 string 才查得了表 —— 只有 miss 时才建键。
+    private readonly Dictionary<string, IReadOnlyList<SemanticSpan>> _semanticSpanCache =
+        new(StringComparer.Ordinal);
+
+    private Dictionary<string, IReadOnlyList<SemanticSpan>>.AlternateLookup<ReadOnlySpan<char>>
+        _semanticSpanCacheBySpan;
 
     // 侧栏文本(时间戳/行号/折叠标记)的 FormattedText 缓存:这些文本帧间高度重复
     // (行号在滚动稳定时完全不变),不缓存则每行每帧做一次文本塑形。
     // 键为文本本身;暗色画刷随主题变化时整体失效(见 GutterText)。
-    private readonly Dictionary<string, FormattedText> _gutterTextCache = [];
+    private readonly Dictionary<string, FormattedText> _gutterTextCache = new(StringComparer.Ordinal);
+    private Dictionary<string, FormattedText>.AlternateLookup<ReadOnlySpan<char>> _gutterTextCacheBySpan;
     private ImmutableSolidColorBrush? _gutterTextCacheBrush;
 
     // ComputeSemanticColumns 的复用缓冲:该方法对每个可见行、每一帧都会执行,
     // 若每次都 new StringBuilder/List/数组,全屏 TUI 下就是每帧几百次堆分配直喂 GC。
     // 三者都只在 UI 线程的渲染路径内短暂使用,跨行复用安全。
-    private readonly StringBuilder _semanticLineBuilder = new();
+    // 行文本用裸 char[] 而非 StringBuilder:语义匹配与缓存查表全程走 span,
+    // 命中路径因此一个字符串都不产生(见 SemanticSpansFor)。
+    private char[] _semanticLineChars = new char[256];
     private readonly List<int> _semanticColByChar = [];
     private SemanticKind?[] _semanticByColumn = [];
 
@@ -140,8 +153,36 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     public VelaTerminalControl()
         : this(new(120, 32)) { }
 
+    /// <summary>
+    /// 光标/幽灵叠加层。挂在 <c>VisualChildren</c> 上(而非仅 LogicalChildren):只有可视子元素
+    /// 才会被渲染器访问并拿到自己的绘制记录 —— 这正是它能独立于正文失效的前提。
+    /// 排在正文之后加入,因此恒画在正文之上。
+    /// </summary>
+    private readonly CursorOverlay _overlay;
+
+    /// <summary>
+    /// 失效整个终端(正文 + 光标/幽灵叠加层)。
+    /// </summary>
+    /// <remarks>
+    /// <b>本类内部一律用它,不要直接写 <c>InvalidateVisual()</c></b>:光标与幽灵住在独立的
+    /// <see cref="CursorOverlay" /> 里,只失效正文会让光标停在旧位置(输入时光标不跟手)。
+    /// 唯一的例外是光标闪烁计时器 —— 它只失效叠加层,这正是拆层的意义。
+    /// 外部宿主强制重绘时同样应当调本方法(见 <c>TerminalTabView.ForceFullRepaint</c>)。
+    /// </remarks>
+    public void InvalidateTerminal()
+    {
+        InvalidateVisual();
+        _overlay.InvalidateVisual();
+    }
+
     private VelaTerminalControl(TerminalEmulator emulator)
     {
+        // span 备用查找必须在字典建好之后取一次并留住:它是个包住底层桶的结构体视图,
+        // 每次现取虽然也对,但在每行每帧的热路径上白白多做一次比较器类型检查。
+        _semanticSpanCacheBySpan = _semanticSpanCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        _gutterTextCacheBySpan = _gutterTextCache.GetAlternateLookup<ReadOnlySpan<char>>();
+        _overlay = new(this);
+        VisualChildren.Add(_overlay);
         Emulator = emulator;
         Focusable = true;
         ClipToBounds = true;
@@ -175,7 +216,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             if (field != value)
             {
                 field = value;
-                InvalidateVisual();
+                InvalidateTerminal();
             }
         }
         // 默认值与设置模型(TerminalBehaviorOptions.CursorStyle)一致;运行时由
@@ -217,7 +258,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             field = clamped;
             RecomputeMetrics();
             RelayoutFromBounds();
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     } = 1.0;
 
@@ -333,7 +374,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             }
             field = sanitized;
             RelayoutFromBounds();
-            InvalidateVisual();
+            InvalidateTerminal();
             LayoutPaddingChanged?.Invoke();
         }
     } = DefaultRightPadding;
@@ -367,7 +408,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             }
             field = sanitized;
             RelayoutFromBounds();
-            InvalidateVisual();
+            InvalidateTerminal();
             LayoutPaddingChanged?.Invoke();
         }
     }
@@ -393,7 +434,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         field = value;
         RelayoutFromBounds();
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>侧栏右键菜单改动部件开关后上报(时间戳, 行号, 折叠标记, 空白),供上层持久化。</summary>
@@ -422,7 +463,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 return;
             }
             _scrollOffset = clamped;
-            InvalidateVisual();
+            InvalidateTerminal();
             ScrollChanged?.Invoke();
         }
     }
@@ -459,7 +500,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             field = value;
             RecomputeMetrics();
             RelayoutFromBounds();
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     } = new("fonts:VelaShell#Cascadia Mono, Cascadia Mono, JetBrains Mono, Consolas, Microsoft YaHei, Segoe UI, monospace");
 
@@ -472,7 +513,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             field = value;
             RecomputeMetrics();
             RelayoutFromBounds();
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     } = 14;
 
@@ -502,7 +543,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         // 选区的行索引是绝对的,会在调整大小时偏移;与其让陈旧的范围
         // 标记(或复制)错误的文本,不如直接丢弃它。
         ClearSelection();
-        InvalidateVisual();
+        InvalidateTerminal();
         ScrollChanged?.Invoke();
     }
 
@@ -691,7 +732,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     {
         ApplyDesignPalette(Emulator.Palette, ActualThemeVariant == ThemeVariant.Light);
         ApplyPaletteOverrides(Emulator.Palette);
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     private void ApplyPaletteOverrides(TerminalPalette palette)
@@ -775,8 +816,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         if (BellMode == "visual")
         {
             _bellFlashUntil = DateTime.UtcNow.AddMilliseconds(120);
-            InvalidateVisual();
-            DispatcherTimer.RunOnce(InvalidateVisual, TimeSpan.FromMilliseconds(140));
+            InvalidateTerminal();
+            DispatcherTimer.RunOnce(InvalidateTerminal, TimeSpan.FromMilliseconds(140));
         }
         else if (BellMode == "system" && OperatingSystem.IsWindows())
         {
@@ -798,11 +839,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             _cursorBlinkTimer ??= new(
                 TimeSpan.FromMilliseconds(530),
                 DispatcherPriority.Background,
-                (_, _) =>
-                {
-                    _cursorBlinkVisible = !_cursorBlinkVisible;
-                    InvalidateVisual();
-                }
+                (_, _) => BlinkTick()
             );
             if (!_cursorBlinkTimer.IsEnabled)
             {
@@ -817,9 +854,30 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 return;
             }
             _cursorBlinkVisible = true;
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     }
+
+    /// <summary>
+    /// 翻转闪烁相位并<b>只</b>失效光标叠加层。
+    /// </summary>
+    /// <remarks>
+    /// 这是拆出 <see cref="CursorOverlay" /> 的全部意义所在:闪烁不改变正文一个像素,
+    /// 却曾经每 530ms 逼着整屏(1 万格的解析色 + 逐行语义扫描 + 全部 GlyphRun)重记录一遍。
+    /// 本方法是本类里唯一允许绕过 <see cref="InvalidateTerminal" /> 的地方。
+    /// internal 供 <c>CursorOverlayUiTests</c> 免去等待真实计时器。
+    /// </remarks>
+    internal void BlinkTick()
+    {
+        _cursorBlinkVisible = !_cursorBlinkVisible;
+        _overlay.InvalidateVisual();
+    }
+
+    /// <summary>本控件正文(不含叠加层)的累计渲染次数,仅供 headless 测试断言重绘范围。</summary>
+    internal int BodyRenderCountForTest { get; private set; }
+
+    /// <summary>光标/幽灵叠加层的累计渲染次数,仅供 headless 测试断言重绘范围。</summary>
+    internal int OverlayRenderCountForTest { get; private set; }
 
     /// <summary>输入会重置闪烁相位,使光标在输入落点处立即可见。</summary>
     private void ResetCursorBlink()
@@ -832,7 +890,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         if (!_cursorBlinkVisible)
         {
             _cursorBlinkVisible = true;
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     }
 
@@ -873,7 +931,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         bool scrollStateChanged = scrollback != _lastScrollbackCount || _scrollOffset != offsetBefore;
         _lastScrollbackCount = scrollback;
-        InvalidateVisual();
+        InvalidateTerminal();
         // 滚动几何没变(如 htop 原地重绘、进度条刷新)就不惊动滚动条等订阅者:
         // 稳态输出下这是每次 Feed 一趟的下游刷新,省掉是纯赚。
         if (scrollStateChanged)
@@ -948,7 +1006,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             return;
         }
         _ghostFull = full;
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>清除幽灵候选(立即重绘;移除叠画不会引发位置抖动)。</summary>
@@ -959,7 +1017,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             return;
         }
         _ghostFull = null;
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>
@@ -1097,7 +1155,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 return;
             }
             field = clamped;
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     } = 1.0;
 
@@ -1294,13 +1352,32 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 );
             }
         }
-        _runGlyphs.Add(new(glyphId, _runChars.Count, width * CellWidthForTest));
-        _runChars.Add(ch);
+        _runGlyphs.Add(new(glyphId, _runCharCount, width * CellWidthForTest));
+        if (_runCharCount == _runChars.Length)
+        {
+            Array.Resize(ref _runChars, _runChars.Length * 2);
+        }
+        _runChars[_runCharCount++] = ch;
         _runPrevCol = col;
         _runPrevWidth = width;
     }
 
     /// <summary>将待处理的字形运行(若有)作为单次 DrawGlyphRun 发出,并重置缓冲区。</summary>
+    /// <remarks>
+    /// <b>为什么可以把复用缓冲直接交给 GlyphRun</b>:此处原先是
+    /// <c>_runChars.ToArray().AsMemory()</c> + <c>_runGlyphs.ToArray()</c> —— 每个 run、每帧两个
+    /// 定长数组,而彩色输出(ls --color、提示符)一行会拆成好几个 run,是正文重绘里最大的一笔分配。
+    /// <para>
+    /// 之所以能安全复用:Avalonia 的延迟渲染在 <c>DrawGlyphRun</c> 里就地取用
+    /// <c>GlyphRun.PlatformImpl</c>(把字形塑形成平台的不可变文本 blob),而落进渲染数据的
+    /// <c>DrawGlyphRunPayload</c> 只存一个 <c>Int32</c> 资源索引 —— 不持有任何托管数组。
+    /// 也就是说 <c>DrawGlyphRun</c> 返回之后,这两个缓冲就与已记录的绘制无关了。
+    /// </para>
+    /// <para>
+    /// headless 测试平台不做真实绘制,这条路径无法在测试里验证像素;改动它之后请在真机上
+    /// 扫一眼终端文本(尤其粗体/斜体与彩色混排的行)。
+    /// </para>
+    /// </remarks>
     private void FlushGlyphRun(DrawingContext context, double y)
     {
         if (_runGlyphs.Count == 0)
@@ -1312,11 +1389,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             try
             {
+                // List<GlyphInfo> 已经是长度精确的 IReadOnlyList<GlyphInfo>,直接交出去;
+                // 字符缓冲按实际长度切片。两者都不再复制。
                 var run = new GlyphRun(
                     gtf,
                     FontSize,
-                    _runChars.ToArray().AsMemory(),
-                    _runGlyphs.ToArray(),
+                    _runChars.AsMemory(0, _runCharCount),
+                    _runGlyphs,
                     new Point(_runStartCol * CellWidthForTest, y + _baselineOffset)
                 );
                 context.DrawGlyphRun(_runBrush, run);
@@ -1327,11 +1406,11 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 // 并在会话余下时间改为重绘,使一切经由逐单元 FormattedText 路径重新渲染
                 // (结果正确,只是更慢)。
                 _glyphRunUnsupported = true;
-                Dispatcher.UIThread.Post(InvalidateVisual);
+                Dispatcher.UIThread.Post(InvalidateTerminal);
             }
         }
         _runGlyphs.Clear();
-        _runChars.Clear();
+        _runCharCount = 0;
         _runStyle = -1;
     }
 
@@ -1339,6 +1418,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     protected override Size ArrangeOverride(Size finalSize)
     {
         Size result = base.ArrangeOverride(finalSize);
+
+        // 叠加层铺满整个控件:它内部再套与正文相同的平移,坐标系因此完全一致。
+        // 手工挂在 VisualChildren 上的子元素不参与默认的测量/排布,必须自己走这两步,
+        // 否则它拿不到 Bounds、渲染器直接跳过 —— 表现为光标彻底消失。
+        _overlay.Measure(finalSize);
+        _overlay.Arrange(new Rect(finalSize));
         ApplyLayoutSize(finalSize);
         return result;
     }
@@ -1413,7 +1498,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         ClearFolds(); // reflow 会重建行对象,折叠引用失效。
         // reflow 会移动绝对行;陈旧的选区会标记(并复制)错误的文本。
         ClearSelection();
-        InvalidateVisual();
+        InvalidateTerminal();
         ScrollChanged?.Invoke();
         PtySizeChanged?.Invoke(cols, rows);
     }
@@ -1450,7 +1535,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         _lastScrollbackCount = Emulator.Screen.ScrollbackCount;
         ClearFolds();
         ClearSelection();
-        InvalidateVisual();
+        InvalidateTerminal();
         ScrollChanged?.Invoke();
         PtySizeChanged?.Invoke(cols, rows);
     }
@@ -1488,6 +1573,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// <param name="context"></param>
     public override void Render(DrawingContext context)
     {
+        BodyRenderCountForTest++;
         TerminalScreen screen = Emulator.Screen;
         TerminalPalette palette = Emulator.Palette;
         RefreshPixelGrid();
@@ -1524,17 +1610,54 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 double y = screenRow * CellHeightForTest;
                 RenderLine(context, palette, line, cols, y, absoluteRow, spans);
             }
-            if (_scrollOffset == 0)
-            {
-                RenderCursor(context, screen, palette);
-                RenderGhostText(context, screen, palette, cols);
-            }
         }
 
         // 视觉 BEL:整个终端上的一次短暂半透明闪烁(§终端 → 视觉闪烁)。
         if (_bellFlashUntil > DateTime.UtcNow)
         {
             context.FillRectangle(BellFlashBrush, new(Bounds.Size));
+        }
+
+        // 光标与幽灵文本不在这里画,由 _overlay 这个独立可视子元素承担 —— 见 CursorOverlay。
+    }
+
+    /// <summary>
+    /// 光标 + 幽灵文本的叠加层:一个独立的可视子元素,画在正文之上。
+    /// </summary>
+    /// <remarks>
+    /// <b>为什么要单独一层</b>:光标闪烁每 530ms 翻一次相位,而 Avalonia 没有"局部失效"——
+    /// 在同一个控件里就意味着为了一个格子重新记录整屏(200×50 = 1 万格的解析色 + 逐行语义扫描
+    /// + 全部 GlyphRun)。拆成子元素后,闪烁只失效这一层,正文的绘制记录原样复用。
+    /// <para>
+    /// 顺序上光标先画、幽灵后画(与拆分前一致):块状光标落在 CursorX 上,幽灵文本正是从 CursorX
+    /// 起向右铺,幽灵必须压在光标块之上,否则补全的第一个字符会被光标盖住。两者同层才能保住这个次序,
+    /// 所以幽灵一并搬了过来。
+    /// </para>
+    /// <para>
+    /// <b>失效必须成对</b>:本层的内容(光标位置、幽灵剩余)由屏幕状态现算,正文一变它就过期。
+    /// 因此正文的每一次失效都要连带失效本层 —— 全走 <see cref="InvalidateTerminal" />,
+    /// 不要在本类里直接写 <c>InvalidateVisual()</c>(唯一的例外是闪烁计时器,它只失效本层)。
+    /// </para>
+    /// </remarks>
+    private sealed class CursorOverlay(VelaTerminalControl owner) : Control
+    {
+        public override void Render(DrawingContext context)
+        {
+            owner.OverlayRenderCountForTest++;
+            if (owner._scrollOffset != 0)
+            {
+                return; // 回滚查看历史时不画光标/幽灵(与拆分前的可见性条件一致)。
+            }
+            TerminalScreen screen = owner.Emulator.Screen;
+            TerminalPalette palette = owner.Emulator.Palette;
+
+            // 与正文同一套平移,使 col*_cellWidth 的坐标计算保持不变。
+            using (context.PushTransform(
+                       Matrix.CreateTranslation(owner.ContentPadding + owner.GutterWidth(), owner.ContentPadding)))
+            {
+                owner.RenderCursor(context, screen, palette);
+                owner.RenderGhostText(context, screen, palette, screen.Columns);
+            }
         }
     }
 
@@ -1657,14 +1780,18 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// 画刷实例变化(主题切换/画刷缓存重建)时整体失效;字体/字号变化时随
     /// <c>_glyphCache</c> 一起清空。上限防长会话滚动把历史行号无界积累。
     /// </summary>
-    private FormattedText GutterText(string text, Typeface typeface, ImmutableSolidColorBrush brush)
+    /// <remarks>
+    /// 取 span 而非 string:调用方在栈上拼好 "[HH:mm:ss] " / 右对齐行号,命中缓存时
+    /// (滚动稳定期几乎恒命中)连缓存键都不必物化。只有 miss 才 <c>ToString()</c> 建键。
+    /// </remarks>
+    private FormattedText GutterText(ReadOnlySpan<char> text, Typeface typeface, ImmutableSolidColorBrush brush)
     {
         if (!ReferenceEquals(_gutterTextCacheBrush, brush))
         {
             _gutterTextCache.Clear();
             _gutterTextCacheBrush = brush;
         }
-        if (_gutterTextCache.TryGetValue(text, out FormattedText? cached))
+        if (_gutterTextCacheBySpan.TryGetValue(text, out FormattedText? cached))
         {
             return cached;
         }
@@ -1672,10 +1799,50 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             _gutterTextCache.Clear();
         }
+        string key = new(text);
         var formatted = new FormattedText(
-            text, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, brush);
-        _gutterTextCache[text] = formatted;
+            key, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, typeface, FontSize, brush);
+        _gutterTextCache[key] = formatted;
         return formatted;
+    }
+
+    /// <summary>
+    /// 把行时间戳写成 <c>"[HH:mm:ss] "</c>,返回 <paramref name="buffer" /> 中写好的那一段。
+    /// 缓冲至少需要 <c>GutterTimeFormat.Length + 3</c> 个字符。
+    /// </summary>
+    /// <remarks>
+    /// 这些文本只是 <see cref="GutterText" /> 的缓存键,却在每个可见行、每一帧上重算
+    /// (光标闪烁也会重绘)。写进调用方的栈缓冲,把原先每行 2 个中间 string 降为零。
+    /// internal 是为了让 <c>GutterTextFormattingTests</c> 直接锁住与原 <c>PadLeft</c> 写法的逐字等价。
+    /// </remarks>
+    internal static ReadOnlySpan<char> FormatGutterTimestamp(DateTime timestamp, Span<char> buffer)
+    {
+        buffer[0] = '[';
+        timestamp.TryFormat(buffer[1..], out int length, GutterTimeFormat, CultureInfo.InvariantCulture);
+        buffer[++length] = ']';
+        buffer[++length] = ' ';
+        return buffer[..++length];
+    }
+
+    /// <summary>
+    /// 把绝对缓冲行号写成右对齐到 <see cref="GutterLayout.NumberDigits" /> 位、尾随一个空格的形式
+    /// (与原先的 <c>(row + 1).ToString().PadLeft(NumberDigits) + " "</c> 逐字等价),
+    /// 返回 <paramref name="buffer" /> 中写好的那一段。位数超出时不截断,自然变宽。
+    /// </summary>
+    /// <inheritdoc cref="FormatGutterTimestamp" path="/remarks" />
+    internal static ReadOnlySpan<char> FormatGutterLineNumber(int absoluteRow, Span<char> buffer)
+    {
+        buffer.Fill(' '); // 缓冲跨行复用,先抹掉上一行的残留。
+        (absoluteRow + 1).TryFormat(buffer, out int digits, provider: CultureInfo.InvariantCulture);
+        int width = Math.Max(digits, GutterLayout.NumberDigits);
+        if (digits < width)
+        {
+            // TryFormat 从头写起,右移到该宽度的末尾;CopyTo 是 memmove 语义,区间重叠安全。
+            buffer[..digits].CopyTo(buffer[(width - digits)..]);
+            buffer[..(width - digits)].Fill(' ');
+        }
+        buffer[width] = ' ';
+        return buffer[..(width + 1)];
     }
 
     private void RenderGutter(DrawingContext context, TerminalScreen screen, TerminalPalette palette, int rows)
@@ -1688,6 +1855,11 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         double numberLeft = Gutter.NumberLeft;
         int lastContentRow = -1; // 最后一行有内容的屏幕行:分隔线/折叠线只画到这里,空屏不画侧栏。
         int cursorAbsoluteRow = screen.ScrollbackCount + screen.CursorY;
+
+        // 时间戳/行号的栈缓冲在循环外开一次(stackalloc 不随迭代释放,CA2014):
+        // 逐行复用即可,内容每行现写。
+        Span<char> stampBuffer = stackalloc char[GutterTimeFormat.Length + 3];
+        Span<char> numberBuffer = stackalloc char[GutterLayout.NumberDigits + 16];
         for (int screenRow = 0; screenRow < rows; screenRow++)
         {
             int absoluteRow = _screenToAbs[screenRow];
@@ -1702,19 +1874,17 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             TerminalRow line = screen.ViewLine(absoluteRow);
             lastContentRow = screenRow;
             double y = screenRow * CellHeightForTest + _glyphYOffset;
+            // 时间戳与行号都在栈上拼:两者原先各拼 2~3 个中间 string,而它们只是缓存键 ——
+            // 每个可见行、每一帧(光标闪烁也算)白扔一轮。栈缓冲足够容下最长形态。
             if (ShowLineTimestamp && line.Timestamp is { } ts)
             {
-                string stamp =
-                    "[" + ts.ToString(GutterTimeFormat, CultureInfo.InvariantCulture) + "] ";
-                context.DrawText(GutterText(stamp, typeface, dimBrush), new Point(0, y));
+                context.DrawText(GutterText(FormatGutterTimestamp(ts, stampBuffer), typeface, dimBrush), new Point(0, y));
             }
             if (ShowLineNumber)
             {
-                string number =
-                    (absoluteRow + 1)
-                        .ToString(CultureInfo.InvariantCulture)
-                        .PadLeft(GutterLayout.NumberDigits) + " ";
-                context.DrawText(GutterText(number, typeface, dimBrush), new Point(numberLeft, y));
+                context.DrawText(
+                    GutterText(FormatGutterLineNumber(absoluteRow, numberBuffer), typeface, dimBrush),
+                    new Point(numberLeft, y));
             }
         }
         if (lastContentRow < 0)
@@ -1855,7 +2025,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     private void AfterFoldChange()
     {
-        InvalidateVisual();
+        InvalidateTerminal();
         ScrollChanged?.Invoke();
     }
 
@@ -2086,9 +2256,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         {
             return null;
         }
-        StringBuilder sb = _semanticLineBuilder.Clear();
         List<int> colByChar = _semanticColByChar;
         colByChar.Clear();
+        int length = 0;
         for (int i = 0; i <= lastNonBlank; i++)
         {
             TerminalCell cell = line[i];
@@ -2096,14 +2266,23 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 continue;
             }
-            int before = sb.Length;
-            cell.AppendText(sb);
-            for (int k = before; k < sb.Length; k++)
+
+            // 缓冲不足时扩容重试同一格。单元格最多贡献 2(代理对)+ 组合标记长度个字符,
+            // 上界无法预先精确算出,故按"写失败即翻倍"处理。
+            int written = cell.AppendTo(_semanticLineChars.AsSpan(length));
+            if (written < 0)
+            {
+                Array.Resize(ref _semanticLineChars, Math.Max(_semanticLineChars.Length * 2, length + 64));
+                i--;
+                continue;
+            }
+            for (int k = 0; k < written; k++)
             {
                 colByChar.Add(i);
             }
+            length += written;
         }
-        IReadOnlyList<SemanticSpan> spans = SemanticSpansFor(sb.ToString());
+        IReadOnlyList<SemanticSpan> spans = SemanticSpansFor(_semanticLineChars.AsSpan(0, length));
         if (spans.Count == 0)
         {
             return null;
@@ -2131,9 +2310,13 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         return byColumn;
     }
 
-    private IReadOnlyList<SemanticSpan> SemanticSpansFor(string text)
+    /// <remarks>
+    /// 查表走 span 备用查找:命中时(可见行帧间基本不变,这是绝大多数情况)一个字符串都不分配。
+    /// 只有 miss 才 <c>ToString()</c> 建缓存键 —— 从"每行每帧一个 string"降到"每行内容变化一次"。
+    /// </remarks>
+    private IReadOnlyList<SemanticSpan> SemanticSpansFor(ReadOnlySpan<char> text)
     {
-        if (_semanticSpanCache.TryGetValue(text, out IReadOnlyList<SemanticSpan>? cached))
+        if (_semanticSpanCacheBySpan.TryGetValue(text, out IReadOnlyList<SemanticSpan>? cached))
         {
             return cached;
         }
@@ -2144,7 +2327,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             _semanticSpanCache.Clear();
         }
         IReadOnlyList<SemanticSpan> spans = SemanticMatcher.Match(text);
-        _semanticSpanCache[text] = spans;
+        _semanticSpanCache[new(text)] = spans;
         return spans;
     }
 
@@ -2368,7 +2551,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             spans.Add((hit.StartCol, hit.StartCol + hit.Length, i == currentIndex));
         }
         _searchHighlights = map;
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>移除所有搜索命中高亮并重新绘制。</summary>
@@ -2379,7 +2562,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             return;
         }
         _searchHighlights = null;
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>
@@ -2397,7 +2580,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         int desiredTop = Math.Max(0, hit.Row - rows / 2);
         int maxTop = Math.Max(0, totalRows - rows);
         ScrollOffset = maxTop - Math.Min(desiredTop, maxTop);
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>
@@ -2489,7 +2672,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         base.OnGotFocus(e);
         _hasFocus = true;
         UpdateCursorBlinkTimer();
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>标记控件未聚焦,停止闪烁并绘制空心光标。</summary>
@@ -2498,7 +2681,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         base.OnLostFocus(e);
         _hasFocus = false;
         UpdateCursorBlinkTimer();
-        InvalidateVisual();
+        InvalidateTerminal();
     }
 
     /// <summary>对提交的文本输入进行编码并发送往 PTY。</summary>
@@ -2698,7 +2881,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 _selecting = true;
                 _selectionAnchor = PointToCell(point);
                 _selectionCaret = _selectionAnchor;
-                InvalidateVisual();
+                InvalidateTerminal();
                 e.Handled = true;
                 return;
             }
@@ -2711,7 +2894,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 _selectionCaret = PointToCell(point);
                 _selecting = true;
-                InvalidateVisual();
+                InvalidateTerminal();
                 e.Handled = true;
                 return;
             }
@@ -2723,7 +2906,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             _selecting = true;
             _selectionAnchor = PointToCell(point);
             _selectionCaret = _selectionAnchor;
-            InvalidateVisual();
+            InvalidateTerminal();
         }
         else if (props.IsRightButtonPressed && RightClickPaste)
         {
@@ -2778,7 +2961,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         _selectionCaret = (cell.Row, end);
         _selecting = false;
         _blockSelection = false;
-        InvalidateVisual();
+        InvalidateTerminal();
         if (CopyOnSelect)
         {
             _ = CopyAsync();
@@ -2820,7 +3003,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             if (hover != _foldHoverAbs)
             {
                 _foldHoverAbs = hover;
-                InvalidateVisual();
+                InvalidateTerminal();
             }
         }
 
@@ -2851,7 +3034,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 }
             case true:
                 _selectionCaret = PointToCell(e.GetPosition(this));
-                InvalidateVisual();
+                InvalidateTerminal();
                 break;
         }
     }
@@ -2863,7 +3046,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         if (_foldHoverAbs != -1)
         {
             _foldHoverAbs = -1;
-            InvalidateVisual();
+            InvalidateTerminal();
         }
     }
 
@@ -2939,7 +3122,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         int delta = (int)(e.Delta.Y * WheelScrollLines * multiplier);
         int maxOffset = Emulator.Screen.ScrollbackCount;
         _scrollOffset = Math.Clamp(_scrollOffset + delta, 0, maxOffset);
-        InvalidateVisual();
+        InvalidateTerminal();
         ScrollChanged?.Invoke();
         e.Handled = true;
     }
@@ -3021,7 +3204,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         }
         _ = CopyAsync();
         ClearSelection();
-        InvalidateVisual();
+        InvalidateTerminal();
         return true;
     }
 

--- a/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
+++ b/src/VelaShell.Terminal/Semantics/SemanticMatcher.cs
@@ -75,9 +75,16 @@ public sealed partial class SemanticMatcher
     /// (例如 IP 内的数字,或 URL 内的 IP),优先级更高的类别胜出:
     /// Url &gt; IpAddress &gt; Error &gt; Warning &gt; Success &gt; Option &gt; Number。
     /// </summary>
-    public static IReadOnlyList<SemanticSpan> Match(string? line)
+    public static IReadOnlyList<SemanticSpan> Match(string? line) => Match(line.AsSpan());
+
+    /// <inheritdoc cref="Match(string?)" />
+    /// <remarks>
+    /// Span 重载是渲染热路径的入口(<c>VelaTerminalControl.ComputeSemanticColumns</c> 逐行调用),
+    /// 让调用方不必为了匹配而先把行文本物化成 string。
+    /// </remarks>
+    public static IReadOnlyList<SemanticSpan> Match(ReadOnlySpan<char> line)
     {
-        if (string.IsNullOrEmpty(line))
+        if (line.IsEmpty)
         {
             return [];
         }
@@ -127,19 +134,26 @@ public sealed partial class SemanticMatcher
         {
             return null;
         }
-        foreach (Match m in UrlRegex().Matches(line))
+        foreach (ValueMatch m in UrlRegex().EnumerateMatches(line))
         {
             if (offset >= m.Index && offset < m.Index + m.Length)
             {
-                return m.Value;
+                return line.Substring(m.Index, m.Length);
             }
         }
         return null;
     }
 
-    private static void Collect(List<SemanticSpan> into, Regex regex, string line, SemanticKind kind)
+    /// <remarks>
+    /// 用 <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})" /> 而非 <c>Matches</c>:
+    /// 后者每个命中都要实例化一个 <see cref="System.Text.RegularExpressions.Match" />
+    /// (还挂着 Group/Capture 集合),而这里只用
+    /// 到 Index/Length —— 正是 <see cref="ValueMatch" /> 结构体给的两个字段。七条正则 × 每行 ×
+    /// 帧率下,这是纯白扔的对象。
+    /// </remarks>
+    private static void Collect(List<SemanticSpan> into, Regex regex, ReadOnlySpan<char> line, SemanticKind kind)
     {
-        foreach (Match m in regex.Matches(line))
+        foreach (ValueMatch m in regex.EnumerateMatches(line))
         {
             if (m.Length > 0)
             {

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Threading.Channels;
 using Avalonia.Threading;
 using VelaShell.Core.Ssh;
@@ -11,7 +12,25 @@ namespace VelaShell.Terminal;
 public class SshTerminalBridge : IDisposable
 {
     private readonly CancellationTokenSource _cts;
-    private readonly List<byte[]> _pending = [];
+    /// <summary>
+    /// 一块待喂入终端的输出。
+    /// </summary>
+    /// <param name="Buffer">承载字节的数组。<b>可能比实际数据长</b>(池租的数组只保证 ≥ 请求长度)。</param>
+    /// <param name="Length">有效字节数 —— 一律以它为准,绝不能用 <c>Buffer.Length</c>。</param>
+    /// <param name="Pooled">
+    /// 该数组是否租自 <see cref="ArrayPool{T}" />。为 true 时排空后必须归还;
+    /// 转交路由(ZMODEM)产出的数组不是池的,归还就会污染池。
+    /// </param>
+    private readonly record struct PendingChunk(byte[] Buffer, int Length, bool Pooled);
+
+    private readonly List<PendingChunk> _pending = [];
+
+    /// <summary>
+    /// <see cref="FlushPending" /> 从 <see cref="_pending" /> 摘下来的待处理块。
+    /// 提出来是为了让拼接与归还都在锁外做(锁只护摘取这一下),同时保住"归还必发生"的时机 ——
+    /// 池数组只有在 Feed 同步消费完之后才能还。仅 UI 线程访问。
+    /// </summary>
+    private readonly List<PendingChunk> _draining = [];
 
     // 出站写队列:所有发往 PTY 的字节(击键 + SendRaw 注入)先入队,由唯一的写循环按序
     // 逐段 await 后刷出。绝不能对底层流并发 WriteAsync —— Tmds.Ssh 的 SshChannel.WriteAsync
@@ -248,7 +267,7 @@ public class SshTerminalBridge : IDisposable
     private async Task ReadLoopAsync(CancellationToken token)
     {
         // 更大的读取缓冲意味着更少的 await 与更大的自然批次。
-        byte[] buffer = new byte[16384];
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(16384);
         bool remoteClosed = false;
         try
         {
@@ -261,21 +280,32 @@ public class SshTerminalBridge : IDisposable
                     remoteClosed = true;
                     break;
                 }
-                byte[] data = new byte[bytesRead];
-                Array.Copy(buffer, data, bytesRead);
+
+                // 每块仍要一份自己的副本(读缓冲下一轮就被覆写,而 UI 线程晚一点才排空),
+                // 但副本租自池:这里原先是 `new byte[bytesRead]`,cat 一个大文件时它就是
+                // 整条输出链路上最大的一笔分配(每秒上千块、每块至多 16KB)。
+                // 归还发生在 FlushPending 把它喂完之后,见 PendingChunk.Pooled。
+                byte[] data = ArrayPool<byte>.Shared.Rent(bytesRead);
+                buffer.AsSpan(0, bytesRead).CopyTo(data);
+
                 // 记录/回放拿到的流与屏幕一致:注入的初始化脚本回显在此剥除。
                 // 无论有无订阅者都要跑,否则抑制器的跨块状态会与实际流脱节。
                 // 整块被剥光(或被扣下等下一块续判)时无事可记。
-                byte[] logged = SuppressTapEcho(data);
-                if (logged.Length > 0)
+                // 抑制器与订阅者的签名都是精确长度的 byte[],故此处才物化 —— 两者都是
+                // 冷路径(抑制器只活在连接后的最初几秒,日志/录制默认关闭),稳态不经过。
+                if (_tapEchoSuppressor is not null || DataReceived is not null)
                 {
-                    try
+                    byte[] logged = SuppressTapEcho(data.AsSpan(0, bytesRead).ToArray());
+                    if (logged.Length > 0)
                     {
-                        DataReceived?.Invoke(logged);
-                    }
-                    catch
-                    {
-                        // 日志订阅者异常不允许打断读循环。
+                        try
+                        {
+                            DataReceived?.Invoke(logged);
+                        }
+                        catch
+                        {
+                            // 日志订阅者异常不允许打断读循环。
+                        }
                     }
                 }
 
@@ -284,17 +314,20 @@ public class SshTerminalBridge : IDisposable
                 // ZMODEM 路由优先:会话期间返回空终端字节(全部转交引擎),
                 // 命中时仅把引导前的字节嗂终端;未启用时原样嗂入。
                 FileTransfer.TerminalTransferRouter? router = TransferRouter;
-                if (router is null || router.CanPassThrough(data))
+                if (router is null || router.CanPassThrough(data.AsSpan(0, bytesRead)))
                 {
-                    // 常态直通:无 ZMODEM 引导迹象时原始块零拷贝进合批队列。
-                    EnqueueForFeed(data);
+                    // 常态直通:无 ZMODEM 引导迹象时原始块零拷贝进合批队列(所有权移交队列)。
+                    EnqueueForFeed(new(data, bytesRead, Pooled: true));
                 }
                 else
                 {
-                    FileTransfer.TransferRouteResult route = router.ProcessIncoming(data);
+                    FileTransfer.TransferRouteResult route = router.ProcessIncoming(data.AsMemory(0, bytesRead));
+
+                    // 路由产出的是它自己的数组,不属于池;本块的池数组到此为止,当场归还。
+                    ArrayPool<byte>.Shared.Return(data);
                     if (route.TerminalBytes.Length > 0)
                     {
-                        EnqueueForFeed(route.TerminalBytes);
+                        EnqueueForFeed(new(route.TerminalBytes, route.TerminalBytes.Length, Pooled: false));
                     }
                 }
             }
@@ -317,6 +350,10 @@ public class SshTerminalBridge : IDisposable
         {
             remoteClosed = true;
             Error?.Invoke(ex);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         // 表示远端主动关闭,但不包括我们自身 Dispose() 驱动的拆除。
@@ -362,11 +399,11 @@ public class SshTerminalBridge : IDisposable
         return merged;
     }
 
-    private void EnqueueForFeed(byte[] data)
+    private void EnqueueForFeed(PendingChunk chunk)
     {
         lock (_pendingLock)
         {
-            _pending.Add(data);
+            _pending.Add(chunk);
         }
 
         // 最多只调度一次待处理的 UI 刷新;后续分块搭它的便车。
@@ -384,26 +421,35 @@ public class SshTerminalBridge : IDisposable
     {
         // 先重置,使排空期间到达的分块能调度一次全新刷新。
         Interlocked.Exchange(ref _flushScheduled, 0);
-        byte[] buffer;
-        int length;
+
+        // 只在锁内摘取,拼接/喂入/归还都在锁外做 —— 读线程不会被 UI 的这段活儿挡住。
         lock (_pendingLock)
         {
-            int count = _pending.Count;
-            if (count == 0)
+            if (_pending.Count == 0)
             {
                 return;
             }
-            if (count == 1)
+            _draining.AddRange(_pending);
+            _pending.Clear();
+        }
+        try
+        {
+            if (_disposed)
             {
-                buffer = _pending[0];
-                length = buffer.Length;
+                return;
+            }
+            byte[] buffer;
+            int length;
+            if (_draining.Count == 1)
+            {
+                (buffer, length, _) = _draining[0];
             }
             else
             {
                 int total = 0;
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < _draining.Count; i++)
                 {
-                    total += _pending[i].Length;
+                    total += _draining[i].Length;
                 }
                 if (_combineBuffer.Length < total)
                 {
@@ -411,46 +457,55 @@ public class SshTerminalBridge : IDisposable
                     _combineBuffer = new byte[Math.Max(total, _combineBuffer.Length * 2)];
                 }
                 int offset = 0;
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < _draining.Count; i++)
                 {
-                    byte[] chunk = _pending[i];
-                    Array.Copy(chunk, 0, _combineBuffer, offset, chunk.Length);
+                    PendingChunk chunk = _draining[i];
+                    Array.Copy(chunk.Buffer, 0, _combineBuffer, offset, chunk.Length);
                     offset += chunk.Length;
                 }
                 buffer = _combineBuffer;
                 length = total;
             }
-            _pending.Clear();
-        }
-        if (_disposed)
-        {
-            return;
-        }
-        if (_echoSuppressor is { } suppressor)
-        {
-            // 抑制窗只覆盖连接后的最初几秒:此路径物化精确数组无妨,稳态热路径不经过。
-            byte[] exact = length == buffer.Length ? buffer : buffer[..length];
-            exact = suppressor.Process(exact);
-            if (suppressor.Expired)
+            if (_echoSuppressor is { } suppressor)
             {
-                exact = AppendHeldTail(exact, suppressor);
-                _echoSuppressor = null;
+                // 抑制窗只覆盖连接后的最初几秒:此路径物化精确数组无妨,稳态热路径不经过。
+                byte[] exact = buffer.AsSpan(0, length).ToArray();
+                exact = suppressor.Process(exact);
+                if (suppressor.Expired)
+                {
+                    exact = AppendHeldTail(exact, suppressor);
+                    _echoSuppressor = null;
+                }
+                if (exact.Length == 0)
+                {
+                    return;
+                }
+                buffer = exact;
+                length = exact.Length;
             }
-            if (exact.Length == 0)
+            try
             {
-                return;
+                // 每次刷新只 Feed 一次 => 一次 Updated => 一次重绘,与分块数量无关。
+                FeedTerminal(buffer, length);
             }
-            buffer = exact;
-            length = exact.Length;
+            catch (Exception ex)
+            {
+                Error?.Invoke(ex);
+            }
         }
-        try
+        finally
         {
-            // 每次刷新只 Feed 一次 => 一次 Updated => 一次重绘,与分块数量无关。
-            FeedTerminal(buffer, length);
-        }
-        catch (Exception ex)
-        {
-            Error?.Invoke(ex);
+            // 归还必须发生在 Feed 之后(它同步消费,不留引用),且每条退出路径都要走到 ——
+            // 提前 return(已 Dispose、抑制器把整块吃光)同样得还,否则就是池泄漏。
+            for (int i = 0; i < _draining.Count; i++)
+            {
+                PendingChunk chunk = _draining[i];
+                if (chunk.Pooled)
+                {
+                    ArrayPool<byte>.Shared.Return(chunk.Buffer);
+                }
+            }
+            _draining.Clear();
         }
     }
 

--- a/src/VelaShell/Services/SessionRecorder.cs
+++ b/src/VelaShell/Services/SessionRecorder.cs
@@ -20,7 +20,12 @@ public sealed class SessionRecorder : IDisposable
     private readonly Timer _flushTimer;
     private readonly SemaphoreSlim _writeGate = new(1, 1);
 
-    private MemoryStream _buffer = new();
+    /// <summary>
+    /// 攒批缓冲。<b>跨刷盘复用同一个实例</b>(<see cref="Flush" /> 里 <c>SetLength(0)</c> 而非
+    /// 换新):MemoryStream 靠倍增扩容,从 0 长到 64KB 阈值要经过约 9 个中间数组(合计 ~128KB),
+    /// 每次刷盘都重来一遍就是每 600ms 白扔一轮。复用后容量稳定在阈值附近,不再扩容。
+    /// </summary>
+    private readonly MemoryStream _buffer = new(FlushThresholdBytes);
     private long _bufferStartOffsetMs;
     private long _lastFlushedOffsetMs = -1;
     private bool _disposed;
@@ -93,6 +98,7 @@ public sealed class SessionRecorder : IDisposable
             {
                 return;
             }
+            // payload 必须是独立副本:它要交给后台的异步写入,而 _buffer 紧接着就被清空复用。
             payload = _buffer.ToArray();
 
             // 块的存储时间 = 开始时刻 + 偏移,而同一录制同一毫秒只存得下一个点(后写覆盖先写)。
@@ -100,7 +106,11 @@ public sealed class SessionRecorder : IDisposable
             // 递增,否则前一块被后一块悄悄顶掉,回放时那段输出凭空消失。
             offset = Math.Max(_bufferStartOffsetMs, _lastFlushedOffsetMs + 1);
             _lastFlushedOffsetMs = offset;
-            _buffer = new();
+
+            // 清空复用而非换新实例:保住已经长到 64KB 的容量,免掉下一轮的倍增扩容链。
+            // Position 也要归零 —— SetLength 只截长度,写指针留在原处会在开头留下一段空洞。
+            _buffer.SetLength(0);
+            _buffer.Position = 0;
         }
         _ = PersistAsync(async () =>
         {

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -68,7 +68,7 @@ public partial class TerminalTabView : UserControl
         // 幽灵/列表状态会与本类脱钩;订阅 Closed 统一对账,防止"看不见却仍拦键"的
         // 僵尸弹层
         SuggestPopup.Closed += (_, _) => OnSuggestPopupClosedByPlatform();
-        SearchBox.TextChanged += (_, _) => RunSearch();
+        SearchBox.TextChanged += (_, _) => ScheduleSearch();
         SearchNext.Click += (_, _) => MoveHit(+1);
         SearchPrev.Click += (_, _) => MoveHit(-1);
         SearchClose.Click += (_, _) => CloseSearch();
@@ -723,6 +723,8 @@ public partial class TerminalTabView : UserControl
 
     private void CloseSearch()
     {
+        // DispatcherTimer 被调度器强引用,不停表会让关掉的搜索栏继续按时唤醒本视图。
+        _searchDebounce?.Stop();
         SearchBar.IsVisible = false;
         _searchHits = [];
         _searchIndex = -1;
@@ -730,8 +732,45 @@ public partial class TerminalTabView : UserControl
         FocusTerminal();
     }
 
+    /// <summary>
+    /// 搜索防抖间隔。<see cref="RunSearch" /> 要在 UI 线程上扫过整个缓冲区(回滚 + 屏幕,
+    /// 默认上限 1 万行);逐键直跑会让长会话下搜索框自己打字都发卡。取 150ms:低于连续
+    /// 击键的间隔,又短到松手即出结果。
+    /// </summary>
+    private static readonly TimeSpan SearchDebounce = TimeSpan.FromMilliseconds(150);
+
+    private DispatcherTimer? _searchDebounce;
+
+    /// <summary>把一次搜索排进防抖窗口;窗口内的后续击键只是把它往后推。</summary>
+    private void ScheduleSearch()
+    {
+        if (_searchDebounce is null)
+        {
+            _searchDebounce = new(SearchDebounce, DispatcherPriority.Input, (_, _) => RunSearch());
+        }
+        else
+        {
+            _searchDebounce.Stop(); // 重启计时 = 推迟到最后一次击键之后。
+        }
+        _searchDebounce.Start();
+    }
+
+    /// <summary>
+    /// 立即跑掉待处理的防抖搜索。Enter(下一处)/Esc 之类需要"此刻的结果"的动作先调它,
+    /// 否则会拿着上一次击键前的命中集做导航。
+    /// </summary>
+    private void FlushPendingSearch()
+    {
+        if (_searchDebounce is { IsEnabled: true })
+        {
+            _searchDebounce.Stop();
+            RunSearch();
+        }
+    }
+
     private void RunSearch()
     {
+        _searchDebounce?.Stop(); // 直接调用(打开搜索栏)时也要吃掉待处理的那一次。
         if (_termControl is null || !SearchBar.IsVisible)
         {
             return;
@@ -744,6 +783,7 @@ public partial class TerminalTabView : UserControl
 
     private void MoveHit(int delta)
     {
+        FlushPendingSearch(); // 导航必须基于当前输入的命中集,不能用防抖窗口前的旧结果。
         if (_searchHits.Count == 0)
         {
             return;
@@ -839,7 +879,7 @@ public partial class TerminalTabView : UserControl
         // ① 立即重绘终端 + 下一拍强制整棵可视树重绘(DWM 表面恢复可能晚于激活事件;
         //    整树重绘确保合成器一定提交一整帧新画面到 DWM,兜住单控件 InvalidateVisual
         //    被"内容未变"优化掉、或空白区跨出终端边界的情形)。激活不频繁,代价可忽略。
-        _termControl?.InvalidateVisual();
+        _termControl?.InvalidateTerminal();
         DispatcherTimer.RunOnce(ForceFullRepaint, TimeSpan.FromMilliseconds(120));
 
         // ② 顺带收口可能残留的僵尸弹层(内容消失常与输入死亡耦合出现)。
@@ -858,7 +898,7 @@ public partial class TerminalTabView : UserControl
     {
         if (_hostWindow is not { } window)
         {
-            _termControl?.InvalidateVisual();
+            _termControl?.InvalidateTerminal();
             return;
         }
         window.InvalidateVisual();

--- a/tests/VelaShell.Controls.Tests/PenCacheTests.cs
+++ b/tests/VelaShell.Controls.Tests/PenCacheTests.cs
@@ -1,0 +1,97 @@
+using Avalonia.Media;
+using VelaShell.Controls.Controls;
+
+namespace VelaShell.Controls.Tests;
+
+/// <summary>
+/// <see cref="PenCache" /> 的回归。这类缓存最典型的坑是"复用出了旧颜色":
+/// 若按画刷实例引用做键,而调用方就地改了 <c>SolidColorBrush.Color</c>(主题令牌改色、
+/// 颜色动画),控件就会一直画着上一版颜色。这里把颜色入键这条不变量钉死。
+/// </summary>
+[TestClass]
+[TestCategory("PenCache")]
+public class PenCacheTests
+{
+    [TestMethod]
+    public void SameParameters_ReturnSameInstance()
+    {
+        var cache = new PenCache();
+        IPen first = cache.Get(Brushes.Red, 2, PenLineCap.Round, PenLineJoin.Round);
+        IPen second = cache.Get(Brushes.Red, 2, PenLineCap.Round, PenLineJoin.Round);
+        Assert.AreSame(first, second, "参数完全相同时应复用同一支画笔 —— 否则缓存等于没做。");
+    }
+
+    [TestMethod]
+    public void DifferingParameters_ReturnDistinctPens()
+    {
+        var cache = new PenCache();
+        IPen thin = cache.Get(Brushes.Red, 1);
+        IPen thick = cache.Get(Brushes.Red, 2);
+        IPen rounded = cache.Get(Brushes.Red, 1, PenLineCap.Round);
+        IPen joined = cache.Get(Brushes.Red, 1, PenLineCap.Flat, PenLineJoin.Round);
+
+        Assert.AreNotSame(thin, thick);
+        Assert.AreNotSame(thin, rounded);
+        Assert.AreNotSame(thin, joined);
+        Assert.AreEqual(1, thin.Thickness);
+        Assert.AreEqual(2, thick.Thickness);
+        Assert.AreEqual(PenLineCap.Round, rounded.LineCap);
+        Assert.AreEqual(PenLineJoin.Round, joined.LineJoin);
+    }
+
+    [TestMethod]
+    public void MutatedBrushColor_YieldsFreshPen_NotTheStaleOne()
+    {
+        // 关键不变量:同一个画刷实例被就地改色后,必须拿到新颜色的画笔。
+        var brush = new SolidColorBrush(Colors.Red);
+        var cache = new PenCache();
+
+        IPen before = cache.Get(brush, 2);
+        Assert.AreEqual(Colors.Red, ((ISolidColorBrush)before.Brush!).Color);
+
+        brush.Color = Colors.Lime;
+        IPen after = cache.Get(brush, 2);
+
+        Assert.AreNotSame(before, after, "画刷就地改色后仍复用旧画笔 —— 控件会一直画着旧颜色。");
+        Assert.AreEqual(Colors.Lime, ((ISolidColorBrush)after.Brush!).Color);
+    }
+
+    [TestMethod]
+    public void NonSolidBrush_IsNotCached_ButStillProducesUsablePen()
+    {
+        // 渐变画刷判等不便宜,直接现建;这些场景本就不在热路径上,但不能因此画不出来。
+        var gradient = new LinearGradientBrush
+        {
+            GradientStops =
+            [
+                new GradientStop(Colors.Red, 0),
+                new GradientStop(Colors.Blue, 1)
+            ]
+        };
+        var cache = new PenCache();
+
+        IPen first = cache.Get(gradient, 3);
+        IPen second = cache.Get(gradient, 3);
+
+        Assert.AreNotSame(first, second, "非纯色画刷不入缓存(实现约定)。");
+        Assert.IsNotNull(first.Brush);
+        Assert.AreEqual(3, first.Thickness);
+    }
+
+    [TestMethod]
+    public void ManyDistinctColors_DoNotGrowUnbounded()
+    {
+        // 上限保险丝:插件下发的自定义配色理论上可以无界,缓存必须自己收口。
+        var cache = new PenCache();
+        for (int i = 0; i < 200; i++)
+        {
+            IPen pen = cache.Get(new SolidColorBrush(Color.FromRgb((byte)i, 0, 0)), 1);
+            Assert.IsNotNull(pen);
+        }
+
+        // 清空过之后仍然照常工作(不是清完就废)。
+        IPen a = cache.Get(Brushes.Red, 1);
+        IPen b = cache.Get(Brushes.Red, 1);
+        Assert.AreSame(a, b);
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/BufferSearchTests.cs
+++ b/tests/VelaShell.Terminal.Tests/BufferSearchTests.cs
@@ -15,6 +15,48 @@ public class BufferSearchTests
     }
 
     [TestMethod]
+    public void CopyTextTo_MatchesGetText()
+    {
+        // FindAll 已改为逐行写进复用缓冲(不再每行 GetText() 造 string),
+        // 这里锁住这条零分配路径与 GetText 的逐字等价 —— 含尾部裁剪、宽字符与组合标记。
+        TerminalEmulator e = Feed(
+            "plain ascii",
+            "中文宽字符 mixed 混排",
+            "é 组合标记",
+            "",
+            "trailing spaces then nothing");
+
+        Span<char> buffer = stackalloc char[512];
+        for (int row = 0; row < e.Screen.TotalRows; row++)
+        {
+            TerminalRow line = e.Screen.ViewLine(row);
+            int written = line.CopyTextTo(buffer);
+            Assert.IsGreaterThanOrEqualTo(0, written, $"第 {row} 行放不进 512 字符缓冲。");
+            Assert.AreEqual(line.GetText(), new string(buffer[..written]), $"第 {row} 行两条路径产出不一致。");
+        }
+    }
+
+    [TestMethod]
+    public void CopyTextTo_ReturnsNegativeOne_WhenBufferTooSmall()
+    {
+        TerminalEmulator e = Feed("this line is definitely longer than eight characters");
+        Span<char> tooSmall = stackalloc char[8];
+        Assert.AreEqual(-1, e.Screen.ViewLine(0).CopyTextTo(tooSmall));
+    }
+
+    [TestMethod]
+    public void FindAll_HandlesWideCharsAndCombiningMarks()
+    {
+        // 缓冲按 Columns*2 起步、命中 -1 才扩容,这条覆盖"一行字符数可能超过列数"的扩容分支。
+        TerminalEmulator e = Feed("needle 中文中文中文 ééé needle");
+
+        IReadOnlyList<BufferSearchHit> hits = BufferSearch.FindAll(e.Screen, "needle");
+
+        Assert.HasCount(2, hits);
+        Assert.AreEqual(0, hits[0].StartCol);
+    }
+
+    [TestMethod]
     public void FindAll_FindsHits_CaseInsensitive_WithPositions()
     {
         TerminalEmulator e = Feed("hello world", "no match here", "WORLD of Hello");

--- a/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 光标/幽灵叠加层的 headless 端到端回归。
+/// <para>
+/// 光标与幽灵文本被拆到一个独立的可视子元素上,好让 530ms 一次的闪烁只失效那一层,
+/// 而不是为了一个格子重新记录整屏(1 万格的解析色 + 逐行语义扫描 + 全部 GlyphRun)。
+/// 这里同时锁住拆层的两条契约 —— 收益侧「闪烁不碰正文」与正确性侧「正文一变光标必须跟着重画」,
+/// 后者漏掉就是输入时光标停在旧位置不跟手。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("CursorOverlay")]
+public class CursorOverlayUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>建好一个已显示、已渲染过一帧的终端控件。</summary>
+    private static (VelaTerminalControl Control, Window Window) ShowTerminal()
+    {
+        var control = new VelaTerminalControl();
+        control.Feed(Encoding.UTF8.GetBytes("abc"));
+        var window = new Window { Width = 480, Height = 320, Content = control };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.CaptureRenderedFrame(); // 逼出一帧真实渲染(headless 平台下返回 null,取的是副作用)
+        return (control, window);
+    }
+
+    [TestMethod]
+    public void CursorOverlay_IsArrangedAsVisualChild_CoveringTheControl()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal();
+
+            Visual[] children = [.. control.GetVisualChildren()];
+            Assert.HasCount(1, children, "终端控件应恰好挂着一个叠加层可视子元素。");
+
+            Visual overlay = children[0];
+
+            // 手工挂在 VisualChildren 上的子元素不参与默认的测量/排布:漏掉任一步它的 Bounds
+            // 就是空的,渲染器直接整层跳过 —— 表现为光标彻底消失,而单元测试完全看不出来。
+            Assert.IsGreaterThan(0, overlay.Bounds.Width, "叠加层没被排布(Bounds 为空)→ 渲染器会整层跳过,光标将不可见。");
+            Assert.AreEqual(control.Bounds.Width, overlay.Bounds.Width, 0.01, "叠加层应铺满控件宽度。");
+            Assert.AreEqual(control.Bounds.Height, overlay.Bounds.Height, 0.01, "叠加层应铺满控件高度。");
+
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void CursorOverlay_RendersAtLeastOnce_WhenShown()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal();
+
+            Assert.IsGreaterThan(0, control.BodyRenderCountForTest, "正文应至少渲染过一次。");
+            Assert.IsGreaterThan(
+                0,
+                control.OverlayRenderCountForTest,
+                "叠加层一次都没渲染 —— 说明它没被渲染器访问到,光标不会出现在屏幕上。");
+
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void BlinkTick_RepaintsOverlayOnly_LeavingBodyUntouched()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal();
+            int bodyBefore = control.BodyRenderCountForTest;
+            int overlayBefore = control.OverlayRenderCountForTest;
+
+            control.BlinkTick();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            Assert.IsGreaterThan(
+                overlayBefore,
+                control.OverlayRenderCountForTest,
+                "闪烁应当重绘叠加层。");
+            Assert.AreEqual(
+                bodyBefore,
+                control.BodyRenderCountForTest,
+                "闪烁重绘了正文 —— 拆层的收益(不为一个格子重记录整屏)已经丢失。");
+
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void InvalidateTerminal_RepaintsBodyAndOverlayTogether()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal();
+            int bodyBefore = control.BodyRenderCountForTest;
+            int overlayBefore = control.OverlayRenderCountForTest;
+
+            control.InvalidateTerminal();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            Assert.IsGreaterThan(bodyBefore, control.BodyRenderCountForTest, "InvalidateTerminal 应重绘正文。");
+            Assert.IsGreaterThan(
+                overlayBefore,
+                control.OverlayRenderCountForTest,
+                "InvalidateTerminal 没有连带重绘叠加层 —— 光标会停在旧位置(输入时不跟手)。");
+
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void Output_RepaintsOverlay_SoCursorFollowsText()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal();
+            int overlayBefore = control.OverlayRenderCountForTest;
+
+            // 走真实输出路径(而不是直接调 InvalidateTerminal):这条才是日常输入时走的链路,
+            // 它必须把叠加层一起带上,否则光标会落后于刚打出来的字符。
+            control.Feed(Encoding.UTF8.GetBytes("defgh"));
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame();
+
+            Assert.IsGreaterThan(
+                overlayBefore,
+                control.OverlayRenderCountForTest,
+                "有新输出后叠加层没有重绘 —— 光标会停在输出前的位置。");
+
+            window.Close();
+        });
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
@@ -28,6 +28,55 @@ public class TerminalCellMemoryTests
     }
 
     [TestMethod]
+    public void TerminalCell_StaysWithinPackedSize()
+    {
+        // 另一半内存契约:单元格必须保持 16 字节。回滚缓冲默认每标签页 1 万行 × 上百列,
+        // 每涨 4 字节就是每标签页数 MB。当前布局 = Rune(4) + 前景(4) + 背景(4)
+        // + CombiningIndex(2) + Flags(2);任何一个字段放宽都会被这条断言挡下。
+        // 历史:TerminalColor 曾是 5 个独立字节字段(结构本身 5 字节),两份加对齐把单元格
+        // 撑到 20 字节;打包成单个 uint 后降到 16。
+        Assert.AreEqual(
+            16,
+            Unsafe.SizeOf<TerminalCell>(),
+            "TerminalCell 超出 16 字节:回滚缓冲的内存开销会按比例上涨,请检查新增/放宽的字段。");
+    }
+
+    [TestMethod]
+    public void TerminalColor_PackedRoundTrip_PreservesAllKinds()
+    {
+        // 打包后 Kind/Index/RGB 全走位运算解出,这里锁住三种 Kind 的往返与相等性语义:
+        // 各 Kind 下未使用的位必须恒为 0,否则"比较 packed"就不再等价于逐字段比较。
+        Assert.IsTrue(TerminalColor.Default.IsDefault);
+        Assert.AreEqual(TerminalColorKind.Default, TerminalColor.Default.Kind);
+        Assert.AreEqual(0, (int)TerminalColor.Default.Index);
+
+        var indexed = TerminalColor.FromIndex(196);
+        Assert.AreEqual(TerminalColorKind.Indexed, indexed.Kind);
+        Assert.AreEqual(196, (int)indexed.Index);
+        Assert.AreEqual(0, (int)indexed.R, "Indexed 色的 RGB 通道必须读作 0(与打包前语义一致)。");
+        Assert.AreEqual(0, (int)indexed.G);
+        Assert.AreEqual(0, (int)indexed.B);
+        Assert.IsFalse(indexed.IsDefault);
+
+        var rgb = TerminalColor.FromRgb(0x12, 0x34, 0x56);
+        Assert.AreEqual(TerminalColorKind.Rgb, rgb.Kind);
+        Assert.AreEqual(0x12, (int)rgb.R);
+        Assert.AreEqual(0x34, (int)rgb.G);
+        Assert.AreEqual(0x56, (int)rgb.B);
+        Assert.AreEqual(0, (int)rgb.Index, "Rgb 色的调色板索引必须读作 0。");
+
+        // 索引钳制。
+        Assert.AreEqual(255, (int)TerminalColor.FromIndex(999).Index);
+        Assert.AreEqual(0, (int)TerminalColor.FromIndex(-5).Index);
+
+        // 跨 Kind 绝不相等,即使低位数值相同(Indexed 5 vs Rgb 0,0,5)。
+        Assert.AreNotEqual(TerminalColor.FromIndex(5), TerminalColor.FromRgb(0, 0, 5));
+        Assert.AreEqual(TerminalColor.FromIndex(5), TerminalColor.FromIndex(5));
+        Assert.AreEqual(TerminalColor.FromRgb(1, 2, 3), TerminalColor.FromRgb(1, 2, 3));
+        Assert.AreEqual(TerminalColor.FromIndex(5).GetHashCode(), TerminalColor.FromIndex(5).GetHashCode());
+    }
+
+    [TestMethod]
     public void Combining_RoundTripsThroughPool_AndPreservesEqualitySemantics()
     {
         TerminalCell cell = TerminalCell.Empty;
@@ -49,7 +98,57 @@ public class TerminalCellMemoryTests
 
         cell.Combining = null;
         Assert.IsNull(cell.Combining);
-        Assert.AreEqual(0, cell.CombiningIndex);
+        Assert.AreEqual(0, (int)cell.CombiningIndex);
+    }
+
+    [TestMethod]
+    public void AppendTo_MatchesAppendText()
+    {
+        // AppendTo 是 AppendText 的零分配孪生实现(渲染与搜索热路径用它)。
+        // 两套代码并行存在就必须有断言钉住语义一致,否则迟早各走各的。
+        (int Rune, string? Combining, CellFlags Flags)[] samples =
+        [
+            (0, null, CellFlags.None),                       // 空格
+            ('a', null, CellFlags.None),                     // ASCII
+            ('中', null, CellFlags.None),                    // BMP 宽字符
+            (0x1F600, null, CellFlags.None),                 // 补充平面(代理对)
+            ('e', AcuteAccent, CellFlags.None),              // 基础字符 + 组合标记
+            ('a', AcuteAccent + Diaeresis, CellFlags.None),  // 多个组合标记
+            (0x1F600, GraveAccent, CellFlags.None),          // 代理对 + 组合标记
+            ('X', null, CellFlags.WideTrailing)              // 宽字符尾格:两者都不产出内容
+        ];
+
+        Span<char> buffer = stackalloc char[16];
+        foreach ((int rune, string? combining, CellFlags flags) in samples)
+        {
+            TerminalCell cell = TerminalCell.Empty;
+            cell.Rune = rune;
+            cell.Combining = combining;
+            cell.Flags = flags;
+
+            var sb = new StringBuilder();
+            cell.AppendText(sb);
+            int written = cell.AppendTo(buffer);
+            Assert.IsGreaterThanOrEqualTo(0, written, "样例应当放得进 16 字符缓冲。");
+            Assert.AreEqual(
+                sb.ToString(),
+                new string(buffer[..written]),
+                $"AppendTo 与 AppendText 对 rune=0x{rune:X}、combining={combining ?? "<null>"} 的产出不一致。");
+        }
+    }
+
+    [TestMethod]
+    public void AppendTo_ReturnsNegativeOne_WhenBufferTooSmall()
+    {
+        // 缓冲不足必须报 -1 让调用方扩容重试,而不是截断 —— 截断会让语义匹配/搜索悄悄错位。
+        TerminalCell cell = TerminalCell.Empty;
+        cell.Rune = 0x1F600; // 需要 2 个字符
+        Span<char> tooSmall = stackalloc char[1];
+        Assert.AreEqual(-1, cell.AppendTo(tooSmall));
+
+        cell.Combining = AcuteAccent; // 现在需要 3 个
+        Span<char> stillTooSmall = stackalloc char[2];
+        Assert.AreEqual(-1, cell.AppendTo(stillTooSmall));
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/GutterTextFormattingTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterTextFormattingTests.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 侧栏时间戳/行号的栈上格式化回归:这两段文本原先用字符串拼接产生
+/// (<c>"[" + ts.ToString("HH:mm:ss") + "] "</c>、<c>n.ToString().PadLeft(5) + " "</c>),
+/// 为消掉"每个可见行、每一帧两三个中间 string"改成写进调用方的栈缓冲。
+/// 这里逐字锁死与原写法的等价性 —— 手写的右对齐逻辑没有断言守着就是隐患。
+/// </summary>
+[TestClass]
+[TestCategory("Gutter")]
+public class GutterTextFormattingTests
+{
+    private const int NumberBufferSize = GutterLayout.NumberDigits + 16;
+    private const int StampBufferSize = 8 + 3; // "HH:mm:ss" 8 位 + '[' + ']' + 尾随空格
+
+    [TestMethod]
+    public void FormatGutterTimestamp_MatchesLegacyConcatenation()
+    {
+        DateTime[] samples =
+        [
+            new(2026, 8, 28, 0, 0, 0),
+            new(2026, 8, 28, 9, 5, 3),
+            new(2026, 8, 28, 23, 59, 59),
+            new(2026, 1, 1, 12, 34, 56)
+        ];
+        Span<char> buffer = stackalloc char[StampBufferSize];
+        foreach (DateTime ts in samples)
+        {
+            string expected = "[" + ts.ToString("HH:mm:ss", CultureInfo.InvariantCulture) + "] ";
+            string actual = new(VelaTerminalControl.FormatGutterTimestamp(ts, buffer));
+            Assert.AreEqual(expected, actual, $"时间戳 {ts:O} 的侧栏文本与原拼接写法不一致。");
+        }
+    }
+
+    [TestMethod]
+    public void FormatGutterLineNumber_MatchesLegacyPadLeft()
+    {
+        // 覆盖:补空格档(1 位到 5 位)、恰好占满、以及超宽自然变宽(6 位起不截断)。
+        int[] rows = [0, 8, 98, 998, 9998, 9999, 99998, 999998, 9999998, int.MaxValue - 1];
+        Span<char> buffer = stackalloc char[NumberBufferSize];
+        foreach (int row in rows)
+        {
+            string expected = (row + 1)
+                .ToString(CultureInfo.InvariantCulture)
+                .PadLeft(GutterLayout.NumberDigits) + " ";
+            string actual = new(VelaTerminalControl.FormatGutterLineNumber(row, buffer));
+            Assert.AreEqual(expected, actual, $"行号 {row + 1} 的侧栏文本与原 PadLeft 写法不一致。");
+        }
+    }
+
+    [TestMethod]
+    public void FormatGutterLineNumber_ReusedBuffer_LeavesNoResidueFromWiderRow()
+    {
+        // 缓冲跨行复用:先写一个宽行号,再写一个窄的,窄的绝不能带出上一行的尾巴。
+        Span<char> buffer = stackalloc char[NumberBufferSize];
+        _ = VelaTerminalControl.FormatGutterLineNumber(9999998, buffer);
+        string narrow = new(VelaTerminalControl.FormatGutterLineNumber(0, buffer));
+        Assert.AreEqual("    1 ", narrow, "复用缓冲后残留了上一行的数字。");
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
@@ -22,6 +22,80 @@ public class ResizePreservationTests
     private static string Line(TerminalEmulator e, int row) => e.Screen.ActiveLine(row).GetText();
 
     [TestMethod]
+    public void Reflow_RecycledRows_AreNeverAliasedIntoTheBufferTwice()
+    {
+        // reflow 会把旧行对象回收复用(避免每次重排为整个缓冲区重新分配上万个单元格数组)。
+        // 这类复用出错的典型症状就是"同一个行对象被塞进缓冲区两处":一处改写会连带另一处
+        // 一起变,画面上表现为某一行的内容莫名其妙复制到别处。这里直接按引用identity 查重。
+        var e = New(40, 8);
+        for (int i = 0; i < 40; i++)
+        {
+            Feed(e, $"line-{i} with enough text to wrap when the terminal gets narrow\r\n");
+        }
+
+        // 拖拽改宽:来回多次,每次都验证一遍(池只在单次调用内有效,反复调用才压得到边界)。
+        foreach (int width in new[] { 20, 60, 15, 80, 33, 40 })
+        {
+            e.Resize(width, 8);
+
+            var seen = new HashSet<TerminalRow>(ReferenceEqualityComparer.Instance);
+            for (int row = 0; row < e.Screen.TotalRows; row++)
+            {
+                TerminalRow line = e.Screen.ViewLine(row);
+                Assert.IsTrue(
+                    seen.Add(line),
+                    $"宽度 {width} 下,同一个 TerminalRow 实例在缓冲区里出现了两次(第 {row} 行)—— 行回收把仍在使用的行发了出去。");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Reflow_RepeatedWidthChanges_PreserveTextExactly()
+    {
+        // 行回收之后的内容回归:反复改宽再回到原宽,文本必须逐字不变。
+        //
+        // 刻意只用 ASCII:宽字符另有一条与本用例无关的既有行为 —— 双宽字符放不进行尾时
+        // 会在那里留下一个空白格,再变宽重排时该空白被并进逻辑行,于是 "触发" 变成 "触 发"。
+        // 那是 reflow 收集逻辑本身的老问题(在改行回收之前就能复现),不该由这条用例来断言;
+        // 混进来只会让它变成一条测两件事、且长期红着的用例。
+        var e = New(60, 6);
+        string[] written =
+        [
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet",
+            "short",
+            "kilo lima mike november oscar papa quebec romeo sierra tango",
+            "the quick brown fox jumps over the lazy dog again and again"
+        ];
+        foreach (string line in written)
+        {
+            Feed(e, line + "\r\n");
+        }
+        string before = BufferText(e);
+
+        foreach (int width in new[] { 25, 100, 17, 60 })
+        {
+            e.Resize(width, 6);
+        }
+
+        Assert.AreEqual(before, BufferText(e), "反复改宽再回到原宽后,缓冲区文本必须逐字一致。");
+    }
+
+    /// <summary>把整个缓冲区(回滚 + 屏幕)取成文本,逐行去尾空格、丢掉尾部空行。</summary>
+    private static string BufferText(TerminalEmulator e)
+    {
+        List<string> lines = [];
+        for (int row = 0; row < e.Screen.TotalRows; row++)
+        {
+            lines.Add(e.Screen.ViewLine(row).GetText().TrimEnd());
+        }
+        while (lines.Count > 0 && lines[^1].Length == 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+        return string.Join('\n', lines);
+    }
+
+    [TestMethod]
     public void NarrowResize_ReflowsInsteadOfTruncating()
     {
         TerminalEmulator e = New(80, 4);

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -350,6 +351,57 @@ public class TerminalBridgeTests
                         chunk.CopyTo(call.ArgAt<byte[]>(0), call.ArgAt<int>(1));
                         return chunk.Length;
                     });
+    }
+
+    [TestMethod]
+    public void ReadLoop_PooledChunks_NeverLeakBytesBeyondTheReadLength()
+    {
+        // 读循环的每块副本改成租自 ArrayPool 之后,拿到的数组几乎总是比请求的长
+        // (池按 2 的幂分桶:请求 13 字节给 16 字节),而且带着上一位租客的残留数据。
+        // 任何一处用 Buffer.Length 而非实际读到的长度,就会把这些垃圾字节当成服务器输出
+        // 送进终端/录制。这里先把池里的桶全填成 0xFF,再断言旁路记录到的字节逐字精确。
+        for (int size = 16; size <= 32 * 1024; size *= 2)
+        {
+            byte[] poison = ArrayPool<byte>.Shared.Rent(size);
+            poison.AsSpan().Fill(0xFF);
+            ArrayPool<byte>.Shared.Return(poison);
+        }
+
+        byte[] first = Encoding.UTF8.GetBytes("hello");        // 5 字节 → 池至少给 16
+        byte[] second = Encoding.UTF8.GetBytes("world!");       // 6 字节
+        ScriptReads(first, second);
+
+        var logged = new MemoryStream();
+        using var bridge = new SshTerminalBridge(_terminal, _shellStream);
+        bridge.DataReceived += chunk =>
+        {
+            lock (logged)
+            {
+                logged.Write(chunk);
+            }
+        };
+        bridge.Start();
+
+        WaitUntil(() =>
+        {
+            lock (logged)
+            {
+                return logged.Length >= first.Length + second.Length;
+            }
+        });
+
+        lock (logged)
+        {
+            byte[] actual = logged.ToArray();
+            Assert.AreEqual(
+                "helloworld!",
+                Encoding.UTF8.GetString(actual),
+                "旁路记录混进了读长度之外的字节 —— 池租数组的尾部残留被当成服务器输出了。");
+            Assert.DoesNotContain(
+                (byte)0xFF,
+                actual,
+                "记录里出现了池毒化字节,说明某处用了 Buffer.Length 而不是实际读到的长度。");
+        }
     }
 
     [TestMethod]


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

- 光标与幽灵文本渲染拆分至 CursorOverlay，减少全屏重绘，新增 InvalidateTerminal() 统一失效逻辑
- TerminalCell 字段紧凑排列，单元格降至 16 字节，TerminalColor 打包为 uint，CombiningPool 索引类型优化
- 文本处理零分配化，热路径全程走 span，避免频繁 string/StringBuilder 分配
- 新增 PenCache，控件内 Pen 实例参数化复用，防止主题切换/动画时复用旧色
- 大块字节缓冲统一走 ArrayPool<byte>，防止 LOH 分配，确保无脏数据泄漏
- 终端行对象回收池复用旧行，提升 reflow/resizing 性能
- 侧栏文本格式化零分配，直接写入栈缓冲
- 其它：会话录制缓冲区复用，搜索栏输入防抖，语义高亮等路径结构体枚举
- 大量单元测试覆盖，确保行为一致性与正确性

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [x] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试(或说明为什么不需要)
- [x] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
