### PR TITLE
终端渲染测试项目与宽字符处理修正

### DIFF
--- a/VelaShell.slnx
+++ b/VelaShell.slnx
@@ -52,6 +52,7 @@
     <Project Path="tests/VelaShell.Infrastructure.Tests/VelaShell.Infrastructure.Tests.csproj" />
     <Project Path="tests/VelaShell.Plugin.Ai.Tests/VelaShell.Plugin.Ai.Tests.csproj" />
     <Project Path="tests/VelaShell.Presentation.Tests/VelaShell.Presentation.Tests.csproj" />
+    <Project Path="tests/VelaShell.Terminal.RenderTests/VelaShell.Terminal.RenderTests.csproj" />
     <Project Path="tests/VelaShell.Terminal.Tests/VelaShell.Terminal.Tests.csproj" />
     <Project Path="tests/VelaShell.Tests/VelaShell.Tests.csproj" />
     <File Path="tests/fixtures/README.md" />

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
@@ -118,7 +118,7 @@ public partial class SettingsView : UserControl
     /// <b>不落盘</b>:它说的是"刚才那一次连通",隔天再打开时那句话已经不成立了 ——
     /// 与其显示一个可能过期的绿点,不如老实退回灰点。
     /// </summary>
-    private readonly Dictionary<string, (bool Ok, DateTime At)> _testResults = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, (bool Ok, DateTime At)> _testResults = [with(StringComparer.Ordinal)];
 
     /// <summary>左栏图标的三档描边色(见 <see cref="ApplyTints" />),装载后解析一次。</summary>
     private IBrush? _providerTint;

--- a/src/VelaShell.Terminal/Emulation/TerminalRow.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalRow.cs
@@ -126,6 +126,34 @@ public sealed class TerminalRow(int columns)
         return -1;
     }
 
+    /// <summary>
+    /// 最后一个<b>被占用</b>的单元格索引 —— 有字符的格,或双宽字符的尾格;全空行返回 -1。
+    /// </summary>
+    /// <remarks>
+    /// 与 <see cref="LastNonBlank" /> 的区别只在双宽字符的尾格上:尾格自身不承载字形
+    /// (<c>Rune == 0</c>),但它是那个宽字符的一半,不能与"从没写过的空格子"混为一谈。
+    /// <para>
+    /// reflow 的收集步骤靠它区分两种同样 <c>Rune == 0</c> 的格子:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>宽字符尾格</b> —— 必须保留,否则前导格会被当成单宽字符,宽字符就散了。</item>
+    /// <item><b>换行填充格</b> —— 双宽字符在行尾只剩一列放不下时,自动换行会在那里留下一个
+    /// 永远不会被写入的空格子。它不是内容,重排时必须丢掉,否则每经一次 reflow 就在
+    /// 断点处凭空多出一个空格(<c>"触发"</c> 变 <c>"触 发"</c>)。</item>
+    /// </list>
+    /// </remarks>
+    public int LastOccupied()
+    {
+        for (int i = _cells.Length - 1; i >= 0; i--)
+        {
+            if (_cells[i].Rune != 0 || _cells[i].IsWideTrailing)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     /// <summary>本行截至最后一个非空单元格的文本(尾部空格已裁剪)。</summary>
     public string GetText()
     {

--- a/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalScreen.cs
@@ -541,7 +541,16 @@ public sealed class TerminalScreen
                 {
                     lineTimestamp = t;
                 }
-                int len = r < j ? row.Columns : row.LastNonBlank() + 1;
+                // 取到"最后一个被占用的格"为止,而不是整行宽度。
+                //
+                // 被换行的段落原先按 row.Columns 整行收:对普通换行没差别(整行都是内容),
+                // 但双宽字符在行尾只剩一列放不下时,自动换行会在那里留下一个永远不会被写入的
+                // 空格子 —— 按整行收就把这个填充格当成了内容,每经一次 reflow 就在断点处多出
+                // 一个空格("触发" → "触 发",反复拖拽改宽会越积越多)。
+                //
+                // 不能改用 LastNonBlank:宽字符的尾格 Rune 同样是 0,砍掉它前导格就会被当成
+                // 单宽字符,宽字符散架。LastOccupied 正是为区分这两者而设。
+                int len = row.LastOccupied() + 1;
                 if (r == cursorAbs)
                 {
                     int cursorCol = Math.Min(CursorX, row.Columns - 1);

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -59,17 +59,15 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     // 因为可见行每一帧都会被重新扫描(光标闪烁、输出)。
     // 用 StringComparer.Ordinal 建表是为了能取到 span 备用查找(GetAlternateLookup):
     // 缓存命中路径因此不必先把行文本物化成 string 才查得了表 —— 只有 miss 时才建键。
-    private readonly Dictionary<string, IReadOnlyList<SemanticSpan>> _semanticSpanCache =
-        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReadOnlyList<SemanticSpan>> _semanticSpanCache = [with(StringComparer.Ordinal)];
 
-    private Dictionary<string, IReadOnlyList<SemanticSpan>>.AlternateLookup<ReadOnlySpan<char>>
-        _semanticSpanCacheBySpan;
+    private readonly Dictionary<string, IReadOnlyList<SemanticSpan>>.AlternateLookup<ReadOnlySpan<char>> _semanticSpanCacheBySpan;
 
     // 侧栏文本(时间戳/行号/折叠标记)的 FormattedText 缓存:这些文本帧间高度重复
     // (行号在滚动稳定时完全不变),不缓存则每行每帧做一次文本塑形。
     // 键为文本本身;暗色画刷随主题变化时整体失效(见 GutterText)。
-    private readonly Dictionary<string, FormattedText> _gutterTextCache = new(StringComparer.Ordinal);
-    private Dictionary<string, FormattedText>.AlternateLookup<ReadOnlySpan<char>> _gutterTextCacheBySpan;
+    private readonly Dictionary<string, FormattedText> _gutterTextCache = [with(StringComparer.Ordinal)];
+    private readonly Dictionary<string, FormattedText>.AlternateLookup<ReadOnlySpan<char>> _gutterTextCacheBySpan;
     private ImmutableSolidColorBrush? _gutterTextCacheBrush;
 
     // ComputeSemanticColumns 的复用缓冲:该方法对每个可见行、每一帧都会执行,
@@ -1374,8 +1372,15 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// 也就是说 <c>DrawGlyphRun</c> 返回之后,这两个缓冲就与已记录的绘制无关了。
     /// </para>
     /// <para>
-    /// headless 测试平台不做真实绘制,这条路径无法在测试里验证像素;改动它之后请在真机上
-    /// 扫一眼终端文本(尤其粗体/斜体与彩色混排的行)。
+    /// <b>GlyphRun 必须释放</b>:它实现 <see cref="IDisposable" />,内部持有引用计数的原生
+    /// 文本 blob(<c>IRef&lt;IGlyphRunImpl&gt;</c>),而 <c>GlyphRun</c> 自身<b>没有终结器</b> ——
+    /// 兜底只剩 <c>RefCountable.Ref&lt;T&gt;</c> 的终结器。原生内存不计入 GC 压力,GC 因此没有
+    /// 理由及时跑,漏掉的引用会一路堆到某次 gen2 才释放:每帧每个 run 泄漏一个文本 blob。
+    /// 释放是安全的 —— 上面说的 <c>Clone()</c> 已经让渲染数据自持一份引用,这里放掉的只是我们自己那份。
+    /// </para>
+    /// <para>
+    /// 以上两点(缓冲复用、画完即释放)都只有真实光栅化才验得到,由
+    /// <c>VelaShell.Terminal.RenderTests.GlyphRenderingTests</c> 按像素把守。
     /// </para>
     /// </remarks>
     private void FlushGlyphRun(DrawingContext context, double y)
@@ -1391,7 +1396,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             {
                 // List<GlyphInfo> 已经是长度精确的 IReadOnlyList<GlyphInfo>,直接交出去;
                 // 字符缓冲按实际长度切片。两者都不再复制。
-                var run = new GlyphRun(
+                using var run = new GlyphRun(
                     gtf,
                     FontSize,
                     _runChars.AsMemory(0, _runCharCount),

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -16,6 +16,11 @@
     <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.5.0" />
     <PackageVersion Include="Avalonia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
+    <!-- 真实光栅化后端。headless 平台默认 UseHeadlessDrawing=true(绘制是空操作,
+         CaptureRenderedFrame 返回 null),因此终端的字形绘制路径在测试里一个像素都验不到 ——
+         GlyphRun 批处理改动只能靠人眼在真机上扫。挂上 Skia 走软件光栅即可按像素断言。
+         仅 VelaShell.Terminal.RenderTests 使用(见该项目注释:为什么要单独一个项目)。 -->
+    <PackageVersion Include="Avalonia.Skia" Version="12.1.1" />
     <!-- 菜单等控件的模板由主题提供:没有它 MenuItem 无模板、不可命中,真实点击测不了。 -->
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <!-- AI 插件的输入框是 AvaloniaEdit,而插件只在编译期引用它(运行时按 ALC 规则回落到

--- a/tests/VelaShell.Controls.Tests/ThemeTokenContrastTests.cs
+++ b/tests/VelaShell.Controls.Tests/ThemeTokenContrastTests.cs
@@ -39,8 +39,8 @@ public class ThemeTokenContrastTests
     {
         var byVariant = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
         {
-            ["Dark"] = new(StringComparer.Ordinal),
-            ["Light"] = new(StringComparer.Ordinal),
+            ["Dark"] = [with(StringComparer.Ordinal)],
+            ["Light"] = [with(StringComparer.Ordinal)],
         };
         XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
         foreach (string file in new[] { "VelaTokens.axaml", "VelaShellTokens.axaml" })

--- a/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
+++ b/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
@@ -1,0 +1,229 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Themes.Fluent;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.RenderTests;
+
+/// <summary>
+/// 终端字形绘制的<b>像素级</b>回归。
+/// <para>
+/// 覆盖的是 <c>VelaTerminalControl.AppendGlyph</c> / <c>FlushGlyphRun</c> 这条批处理路径:
+/// 连续同风格同色的格子攒成一个 <see cref="GlyphRun" /> 一次画出。这条路径有两个改动
+/// 无法靠逻辑测试证伪、只会在屏幕上表现出来:
+/// </para>
+/// <list type="number">
+/// <item>交给 GlyphRun 的字符/字形缓冲改成了跨帧复用(不再每个 run 各 ToArray 一份)。
+/// 若 Avalonia 其实是延后取用这些数组,画出来的就是错乱字形。</item>
+/// <item>GlyphRun 画完即 Dispose(它持有引用计数的原生文本 blob,不释放就是泄漏)。
+/// 若渲染数据没有自持引用,提前释放会让文本整片消失或直接崩。</item>
+/// </list>
+/// <para>
+/// 两者都只有真实光栅化才验得到,故本项目挂 Skia 软件后端(见 csproj 注释)。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("GlyphRendering")]
+public class GlyphRenderingTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(SkiaHeadlessApp));
+
+    [ClassCleanup]
+    public static void Cleanup() => _session.Dispose();
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>渲染一帧并返回 BGRA 像素。</summary>
+    private static (uint[] Pixels, int Width, int Height) RenderFrame(VelaTerminalControl control, Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        using WriteableBitmap bitmap = window.CaptureRenderedFrame()
+            ?? throw new AssertFailedException(
+                "没有拿到渲染帧。若 Skia 后端未生效(UseHeadlessDrawing 仍为 true),这里恒为 null。");
+
+        int width = bitmap.PixelSize.Width;
+        int height = bitmap.PixelSize.Height;
+        const int bytesPerPixel = 4;
+        int bufferSize = checked(width * height * bytesPerPixel);
+        IntPtr buffer = Marshal.AllocHGlobal(bufferSize);
+        try
+        {
+            bitmap.CopyPixels(new PixelRect(0, 0, width, height), buffer, bufferSize, width * bytesPerPixel);
+            uint[] pixels = new uint[width * height];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (uint)Marshal.ReadInt32(buffer, i * bytesPerPixel);
+            }
+            return (pixels, width, height);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    /// <summary>统计与背景色不同的像素数(= 画出来的"墨水量")。</summary>
+    private static int InkPixels(uint[] pixels)
+    {
+        // 取出现次数最多的颜色当作背景(终端底色铺满全窗)。
+        Dictionary<uint, int> histogram = [];
+        foreach (uint p in pixels)
+        {
+            histogram[p] = histogram.GetValueOrDefault(p) + 1;
+        }
+        uint background = 0;
+        int best = -1;
+        foreach ((uint color, int count) in histogram)
+        {
+            if (count > best)
+            {
+                best = count;
+                background = color;
+            }
+        }
+        int ink = 0;
+        foreach (uint p in pixels)
+        {
+            if (p != background)
+            {
+                ink++;
+            }
+        }
+        return ink;
+    }
+
+    private static (VelaTerminalControl Control, Window Window) ShowTerminal(string text)
+    {
+        var control = new VelaTerminalControl
+        {
+            ShowLineNumber = false,
+            ShowLineTimestamp = false,
+            ShowFoldMarker = false,
+            CursorBlink = false
+        };
+        control.Feed(Encoding.UTF8.GetBytes(text));
+        var window = new Window { Width = 640, Height = 360, Content = control };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (control, window);
+    }
+
+    [TestMethod]
+    public void PlainText_IsActuallyRasterized()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowTerminal("hello world");
+            (uint[] withText, _, _) = RenderFrame(control, window);
+            window.Close();
+
+            (VelaTerminalControl empty, Window emptyWindow) = ShowTerminal("");
+            (uint[] blank, _, _) = RenderFrame(empty, emptyWindow);
+            emptyWindow.Close();
+
+            int textInk = InkPixels(withText);
+            int blankInk = InkPixels(blank);
+
+            // "hello world" 是 11 个字形,墨水量必须显著高于空屏(空屏只有光标那一小块)。
+            Assert.IsGreaterThan(
+                blankInk + 200,
+                textInk,
+                $"渲染出的墨水量({textInk})没有明显超过空屏({blankInk}) —— 字形没有真正画出来。");
+        });
+    }
+
+    [TestMethod]
+    public void ManyStyledRuns_AllRasterize_SoBufferReuseDoesNotCorruptEarlierRuns()
+    {
+        OnUi(() =>
+        {
+            // 一行里塞进多段不同 SGR 颜色/粗体 → 强制拆成多个 GlyphRun,每段各走一次
+            // FlushGlyphRun。缓冲是跨 run 复用的:若 Avalonia 延后取用,先发出的那几个 run
+            // 会被后面的内容覆写,墨水量随之塌陷。这里用"单色单 run"作对照基准。
+            var many = new StringBuilder();
+            for (int i = 0; i < 12; i++)
+            {
+                many.Append("[3").Append((char)('1' + (i % 7))).Append('m');
+                many.Append(i % 2 == 0 ? "[1m" : "[22m");
+                many.Append("SEGMENT");
+            }
+            many.Append("[0m");
+
+            (VelaTerminalControl multi, Window multiWindow) = ShowTerminal(many.ToString());
+            (uint[] multiPixels, _, _) = RenderFrame(multi, multiWindow);
+            multiWindow.Close();
+
+            // 对照:同样多的字符,但全程单一风格 → 单个 run。
+            (VelaTerminalControl single, Window singleWindow) =
+                ShowTerminal(string.Concat(Enumerable.Repeat("SEGMENT", 12)));
+            (uint[] singlePixels, _, _) = RenderFrame(single, singleWindow);
+            singleWindow.Close();
+
+            int multiInk = InkPixels(multiPixels);
+            int singleInk = InkPixels(singlePixels);
+
+            Assert.IsGreaterThan(500, multiInk, "多段彩色文本几乎没画出东西。");
+
+            // 字形数量相同,墨水量应当同量级(粗体略粗,故给一半的宽容度)。
+            // 若复用缓冲被延后取用,先前的 run 会画错或画空,这个比值会明显塌陷。
+            Assert.IsGreaterThan(
+                singleInk / 2,
+                multiInk,
+                $"多 run({multiInk})相对单 run({singleInk})墨水量塌陷 —— 说明先发出的 GlyphRun 被复用缓冲覆写了。");
+        });
+    }
+
+    [TestMethod]
+    public void RepeatedRepaints_KeepRasterizingText()
+    {
+        OnUi(() =>
+        {
+            // GlyphRun 画完即释放:若渲染数据没有自持引用,第一帧之后原生文本 blob 就没了,
+            // 后续帧会画不出文本(或崩)。连画多帧,每帧都必须有同等墨水量。
+            (VelaTerminalControl control, Window window) = ShowTerminal("persistent text across frames");
+
+            int first = InkPixels(RenderFrame(control, window).Pixels);
+            Assert.IsGreaterThan(200, first, "首帧就没画出文本。");
+
+            for (int frame = 0; frame < 5; frame++)
+            {
+                control.InvalidateTerminal();
+                int ink = InkPixels(RenderFrame(control, window).Pixels);
+                Assert.IsGreaterThan(
+                    first / 2,
+                    ink,
+                    $"第 {frame + 2} 帧的墨水量({ink})相对首帧({first})塌陷 —— 文本 blob 可能被提前释放了。");
+            }
+
+            window.Close();
+        });
+    }
+}
+
+/// <summary>挂 Skia 软件光栅的 headless 宿主:与逻辑测试项目的空绘制后端刻意分开。</summary>
+public class SkiaHeadlessApp : Application
+{
+    /// <inheritdoc />
+    public override void Initialize() => Styles.Add(new FluentTheme());
+
+    /// <summary>供 <see cref="HeadlessUnitTestSession" /> 反射调用。</summary>
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<SkiaHeadlessApp>()
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
+}

--- a/tests/VelaShell.Terminal.RenderTests/VelaShell.Terminal.RenderTests.csproj
+++ b/tests/VelaShell.Terminal.RenderTests/VelaShell.Terminal.RenderTests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!--
+    ============ 为什么终端渲染测试要单独一个项目 ============
+    Avalonia 的平台注册(AvaloniaLocator)是进程级的,而 HeadlessUnitTestSession 是按测试类
+    各起一个。同一个程序集里混用两种平台配置(VelaShell.Terminal.Tests 用的是默认
+    UseHeadlessDrawing=true 的空绘制后端,这里要的是 Skia 软件光栅)会互相踩,
+    典型症状是整个套件挂死而不是失败。分开程序集,两边各自独占一套配置。
+
+    分工:
+      VelaShell.Terminal.Tests       —— 逻辑与交互(事件投递、命中、几何记账),不看像素
+      VelaShell.Terminal.RenderTests —— 只看像素:字形到底画没画出来、颜色对不对
+  -->
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VelaShell.Terminal\VelaShell.Terminal.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/VelaShell.Terminal.Tests/BlockSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/BlockSelectionTests.cs
@@ -16,14 +16,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("BlockSelection")]
 public sealed class BlockSelectionTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     [TestMethod]
     public void Normalize_Block_TakesRectangleCorners_RegardlessOfDragDirection()

--- a/tests/VelaShell.Terminal.Tests/BroadcastInputEncodingTests.cs
+++ b/tests/VelaShell.Terminal.Tests/BroadcastInputEncodingTests.cs
@@ -9,14 +9,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Broadcast")]
 public sealed class BroadcastInputEncodingTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action action) =>
         _session

--- a/tests/VelaShell.Terminal.Tests/ContentPaddingTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ContentPaddingTests.cs
@@ -17,13 +17,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("TerminalPadding")]
 public class ContentPaddingTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
@@ -21,13 +21,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("CursorOverlay")]
 public class CursorOverlayUiTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
+++ b/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
@@ -13,14 +13,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Input")]
 public sealed class FastWheelScrollTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     [TestMethod]
     public void AltWheel_ScrollsFiveTimesFartherThanPlainWheel()

--- a/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
@@ -13,14 +13,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Ghost")]
 public sealed class GhostTextRemainderTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     /// <summary>CSI CUB:把光标左移 n 格,用来构造"光标右侧还有内容"的屏幕状态。</summary>
     private static string CursorBack(int n) => $"\u001b[{n}D";

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -18,13 +18,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("GutterFoldUi")]
 public class GutterFoldUiTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>
@@ -230,14 +225,4 @@ public class GutterFoldUiTests
             Assert.AreEqual(0, control.FoldCountForTest, "正文区域点击不应折叠。");
         });
     }
-}
-
-/// <summary>headless 测试用的最小 Avalonia 应用。</summary>
-public class HeadlessTestApp : Application
-{
-    /// <summary>菜单的模板由主题提供:缺了它 MenuItem 无模板、无命中区,真实点击测不了。</summary>
-    public override void Initialize() => Styles.Add(new FluentTheme());
-
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<HeadlessTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
 }

--- a/tests/VelaShell.Terminal.Tests/HeadlessTestSession.cs
+++ b/tests/VelaShell.Terminal.Tests/HeadlessTestSession.cs
@@ -1,0 +1,60 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Themes.Fluent;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 全程序集共用的 headless 会话。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>为什么是每程序集一个,而不是每测试类一个。</b>本项目的 12 个 headless UI 测试类原先
+/// 各自 <c>StartNew</c> + <c>Dispose</c> 一个会话。Avalonia 的平台注册与调度器线程是进程级的,
+/// 多个会话的建立/拆除交错进行时,<c>HeadlessUnitTestSession.Dispose()</c> 会在
+/// <c>[ClassCleanup]</c> 里抛 <see cref="NullReferenceException" /> —— 某个会话拆掉了另一个
+/// 还在用的全局状态。表现为"整套跑偶发挂一两条 ClassCleanup,单独跑某个类却永远是绿的",
+/// 三次全量里能中两次。
+/// </para>
+/// <para>
+/// 改成全程序集一个之后,建立与拆除各只发生一次,这条竞争彻底消失;顺带也省掉了 11 次
+/// Avalonia 应用启动。各测试类保留 <c>_session</c> 这个名字(指向本类),故用法不变。
+/// </para>
+/// <para>
+/// 注意:headless UI 测试共用同一条 UI 线程,窗口用完必须关,异步准备要放在 Dispatch 体内
+/// (见各测试类)。这条纪律与本会话是否共享无关,但共享之后一处泄漏会影响全程序集,更要守住。
+/// </para>
+/// </remarks>
+[TestClass]
+public class HeadlessTestSession
+{
+    private static HeadlessUnitTestSession? _shared;
+
+    /// <summary>共用会话;在 <see cref="Init" /> 之后、<see cref="Cleanup" /> 之前有效。</summary>
+    public static HeadlessUnitTestSession Current =>
+        _shared ?? throw new InvalidOperationException(
+            "headless 会话尚未建立 —— [AssemblyInitialize] 没跑到,通常是测试宿主没有加载本程序集的初始化。");
+
+    /// <summary>建立全程序集唯一的 headless 会话。</summary>
+    [AssemblyInitialize]
+    public static void Init(TestContext _) => _shared = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
+
+    /// <summary>拆除会话。</summary>
+    [AssemblyCleanup]
+    public static void Cleanup()
+    {
+        _shared?.Dispose();
+        _shared = null;
+    }
+}
+
+/// <summary>headless 测试宿主应用。</summary>
+public class HeadlessTestApp : Application
+{
+    /// <summary>菜单的模板由主题提供:缺了它 MenuItem 无模板、无命中区,真实点击测不了。</summary>
+    public override void Initialize() => Styles.Add(new FluentTheme());
+
+    /// <summary>供 <see cref="HeadlessUnitTestSession" /> 反射调用。</summary>
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<HeadlessTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
@@ -23,17 +23,11 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("TerminalGrid")]
 public sealed class HostGridReconcileUiTests
 {
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+
     /// <summary>xterm-256color 的 <c>is2</c>:里面的 <c>ESC[?3l</c> 就是 #253 的扳机。</summary>
     private const string XtermInitString = "\x1b[!p\x1b[?3;4l\x1b[4l\x1b>";
-
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
 
     [TestMethod]
     public void XtermInitString_DoesNotShrinkTheSelectableWidth()

--- a/tests/VelaShell.Terminal.Tests/MultiRegionSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/MultiRegionSelectionTests.cs
@@ -17,16 +17,10 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("MultiRegionSelection")]
 public sealed class MultiRegionSelectionTests
 {
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+
     private const string Sample = "abcdefgh\r\nijklmnop\r\nqrstuvwx";
-
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
 
     [TestMethod]
     public void CtrlShiftDrag_AddsASecondRegion_AndCopiesBoth()

--- a/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
@@ -26,13 +26,8 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("PasteShortcutUi")]
 public class PasteShortcutUiTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
@@ -50,19 +50,57 @@ public class ResizePreservationTests
     }
 
     [TestMethod]
+    public void Reflow_WideCharWrapPadding_IsNotCarriedAsContent()
+    {
+        // 双宽字符在行尾只剩一列时放不下,自动换行会在那一列留下一个永远不会被写入的填充格。
+        // 它不是内容,重排时必须丢掉 —— 否则每经一次 reflow 就在断点处凭空多出一个空格。
+        //
+        // 宽度 5:'a','b' 占 0,1;'中' 占 2,3;'文' 需要两列而只剩第 4 列 → 换行,第 4 列成为填充格。
+        var e = New(5, 4);
+        Feed(e, "ab中文");
+
+        TerminalRow wrapped = e.Screen.ViewLine(0);
+        Assert.IsTrue(wrapped.Wrapped, "第 0 行应当是软换行行。");
+        Assert.AreEqual(0, wrapped[4].Rune, "第 4 列应当是没写过的填充格。");
+        Assert.IsFalse(wrapped[4].IsWideTrailing, "填充格不是宽字符尾格 —— 两者都 Rune==0,正是本用例要区分的。");
+        Assert.IsTrue(wrapped[3].IsWideTrailing, "第 3 列应当是 '中' 的尾格。");
+
+        e.Resize(10, 4); // 变宽 → 重排,两段应当无缝接回
+
+        Assert.AreEqual(
+            "ab中文",
+            e.Screen.ViewLine(0).GetText(),
+            "换行填充格被当成内容收进了逻辑行,断点处多出一个空格。");
+    }
+
+    [TestMethod]
+    public void Reflow_WideCharAtLineEnd_KeepsTrailingHalf()
+    {
+        // 反向保险:修填充格时不能顺手把宽字符的尾格也砍了 —— 砍掉的话前导格会被当成
+        // 单宽字符,重排后宽字符只占一列,后面所有内容跟着错位。
+        var e = New(8, 4);
+        Feed(e, "ab中");
+
+        e.Resize(20, 4);
+
+        TerminalRow row = e.Screen.ViewLine(0);
+        Assert.AreEqual("ab中", row.GetText());
+        Assert.AreEqual('中', row[2].Rune);
+        Assert.IsTrue(row[3].IsWideTrailing, "重排后 '中' 必须仍然占两列(尾格还在)。");
+    }
+
+    [TestMethod]
     public void Reflow_RepeatedWidthChanges_PreserveTextExactly()
     {
         // 行回收之后的内容回归:反复改宽再回到原宽,文本必须逐字不变。
-        //
-        // 刻意只用 ASCII:宽字符另有一条与本用例无关的既有行为 —— 双宽字符放不进行尾时
-        // 会在那里留下一个空白格,再变宽重排时该空白被并进逻辑行,于是 "触发" 变成 "触 发"。
-        // 那是 reflow 收集逻辑本身的老问题(在改行回收之前就能复现),不该由这条用例来断言;
-        // 混进来只会让它变成一条测两件事、且长期红着的用例。
+        // 混排宽字符:它们曾经会在每次重排的换行断点处多攒一个空格(见
+        // Reflow_WideCharWrapPadding_IsNotCarriedAsContent),这条用例连带把那个回归也压住。
         var e = New(60, 6);
         string[] written =
         [
             "alpha bravo charlie delta echo foxtrot golf hotel india juliet",
-            "short",
+            "短行",
+            "中文宽字符 mixed with ascii 混排的一行足够长以便触发换行重排",
             "kilo lima mike november oscar papa quebec romeo sierra tango",
             "the quick brown fox jumps over the lazy dog again and again"
         ];

--- a/tests/VelaShell.Terminal.Tests/ShiftExtendSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ShiftExtendSelectionTests.cs
@@ -16,16 +16,10 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("ShiftExtendSelection")]
 public sealed class ShiftExtendSelectionTests
 {
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+
     private const string Sample = "abcdefgh\r\nijklmnop\r\nqrstuvwx";
-
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Initialize(TestContext _) =>
-        _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
 
     [TestMethod]
     public void ShiftClick_ExtendsFromExistingAnchor_InsteadOfDroppingTheSelection()

--- a/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
@@ -20,16 +20,11 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("DevicePixelSnap")]
 public class TerminalSeamSnapUiTests
 {
+    /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
+    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+
     private const double FractionalScale = 1.25;
     private const double Padding = 5;
-
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(HeadlessTestApp));
-
-    [ClassCleanup]
-    public static void Cleanup() => _session.Dispose();
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

新增 VelaShell.Terminal.RenderTests，基于 Skia 进行像素级回归测试，验证 GlyphRun 批处理与资源释放。统一 Dictionary 初始化为 C# 12 集合表达式。TerminalRow/Screen 修正宽字符断点空格问题，完善 ResizePreservationTests 用例。UI 测试类共用 HeadlessTestSession，集中管理 Avalonia 测试会话。新增 Avalonia.Skia 依赖供渲染测试使用。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [x] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
