### PR TITLE
优化性能与接口一致性，统一代码风格

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,3 +124,63 @@ dotnet_naming_style.pascal_case.required_prefix =
 dotnet_naming_style.pascal_case.required_suffix = 
 dotnet_naming_style.pascal_case.word_separator = 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# ============================================================================
+# 性能分析器(CA1xxx)
+#
+# 这些规则默认是"隐藏"或"建议"级,不会出现在构建输出里 —— 等于白装。这里按仓库实际
+# 情况分成三档:开成警告(有价值且已清零)、显式关闭(对本仓库是噪声或会引入 bug)、
+# 以及未列出的(保持默认)。
+#
+# 复现完整清单:
+#   dotnet build VelaShell.slnx -t:Rebuild -p:AnalysisModePerformance=All
+# ============================================================================
+
+# ---- 开成警告:已全部清零,新增即失败 ----------------------------------------
+
+# 私有/内部成员的返回类型用具体类型,省掉接口派发。
+dotnet_diagnostic.CA1859.severity = warning
+# 常量数组作实参会每次调用重新分配一个数组,应提为 static readonly。
+dotnet_diagnostic.CA1861.severity = warning
+# 未使用的私有字段 —— 死代码,顺带白占对象大小。
+dotnet_diagnostic.CA1823.severity = warning
+# StringBuilder.Append 单字符用 char 重载,不走字符串路径。
+dotnet_diagnostic.CA1834.severity = warning
+# 可索引集合上别用 LINQ(First/Last/Count),索引器不建枚举器。
+dotnet_diagnostic.CA1826.severity = warning
+# static readonly 能写成 const 的就写 const。
+dotnet_diagnostic.CA1802.severity = warning
+# 密封内部类型,便于 JIT 去虚化。
+dotnet_diagnostic.CA1852.severity = warning
+# 不访问实例数据的成员标 static。
+# 注:对隐式接口实现会误报(见 NullUiApi.NoopPanel.PlacementRatio,改了编译不过),
+# 遇到时按现场判断,不要照搬。
+dotnet_diagnostic.CA1822.severity = warning
+
+# ---- 显式关闭:对本仓库不适用 ------------------------------------------------
+
+# CA2007「考虑调用 ConfigureAwait」—— 5400+ 条。本仓库是 GUI 应用:UI 层的 await
+# 恰恰需要回到 UI 线程,加 ConfigureAwait(false) 是错的;库层(Core/Infrastructure)
+# 已经在该加的地方逐处加了。全局开启只会淹没真正的信号。
+dotnet_diagnostic.CA2007.severity = none
+
+# CA2000「离开作用域前释放对象」—— 400+ 条,几乎全是误报:Avalonia 控件的生命周期
+# 归可视树管,DI 容器注册的实例归容器管,分析器都看不出来。
+dotnet_diagnostic.CA2000.severity = none
+
+# CA1863「缓存 CompositeFormat」—— 本仓库的格式串来自 ResourceManager,每次按
+# CurrentUICulture 现取(见 Core/Resources/Strings)。缓存进静态字段会把语言冻结在
+# 首次使用那一刻,运行时切语言直接失效 —— 这条建议在这里是 bug 而不是优化。
+dotnet_diagnostic.CA1863.severity = none
+
+# CA1819「属性不应返回数组」—— 是 API 设计规则而非性能规则,而本仓库多处刻意返回
+# 数组/Span 以避免拷贝(终端网格、协议缓冲)。
+dotnet_diagnostic.CA1819.severity = none
+
+# ---- 测试项目的放宽 --------------------------------------------------------
+
+[tests/**.cs]
+# CA1861「常量数组作实参应提为 static readonly」在断言里是负优化:
+# Assert.AreSequenceEqual(new[] { "a", "b" }, actual) 就该这么写 —— 把期望值搬到类字段上,
+# 读的人要来回跳才能知道这条断言在比什么,而"重复调用重复分配"在只跑一次的用例里不存在。
+dotnet_diagnostic.CA1861.severity = none

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Microsoft.Extensions.AI;
 
@@ -49,6 +50,10 @@ public partial class ChatPanelView
     }
 
     /// <summary>删除这条用户消息及其之后的一切。</summary>
+    [SuppressMessage("Performance", "CA1859:使用具体类型以提高性能",
+        Justification = "把 Task<bool> 当 Task 返回本就是零成本的引用向上转换,没有装箱也没有包装;" +
+                        "而改成 Task<bool> 等于对外声明一个没有任何调用方在意的返回值。" +
+                        "本方法是点击处理器,一次交互调一次。")]
     private Task DeleteFromAsync(Control bubble) => TruncateAtAsync(bubble);
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.HistoryTools.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.HistoryTools.cs
@@ -153,7 +153,7 @@ public partial class ChatPanelView
             {
                 if (meta.Model.Length > 0)
                 {
-                    md.Append("`").Append(meta.Model).Append('`');
+                    md.Append('`').Append(meta.Model).Append('`');
                     if (meta.ElapsedMs > 0)
                     {
                         md.Append(" · ").Append(FormatDuration(TimeSpan.FromMilliseconds(meta.ElapsedMs)));

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -1352,7 +1352,7 @@ public partial class ChatPanelView : UserControl
     }
 
     /// <summary>非空行拆成数组;全空返回 null(<c>ChatOptions</c> 上 null 才表示"不发这个参数")。</summary>
-    private static IList<string>? SplitLines(string? text)
+    private static string[]? SplitLines(string? text)
     {
         if (string.IsNullOrWhiteSpace(text))
         {
@@ -1819,7 +1819,7 @@ public partial class ChatPanelView : UserControl
     }
 
     /// <summary>一枚文件引用芯片(与输入框里那段彩色引用同色同名,悬停给全路径)。</summary>
-    private Border BuildReferenceChip(string path)
+    private static Border BuildReferenceChip(string path)
     {
         var row = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 4 };
         row.Children.Add(MakeIcon("Icon.file", "VelaAccent", 10));
@@ -1875,7 +1875,7 @@ public partial class ChatPanelView : UserControl
     /// ② 一次性取值扛不住主题切换 —— 绑上去才会跟着 Dark/Light 变。
     /// 同一条经验在 <see cref="ToolPickerView" /> 里也写着,这里是它的统一版本。
     /// </remarks>
-    private Viewbox MakeIcon(string geometryKey, string brushKey, double size)
+    private static Viewbox MakeIcon(string geometryKey, string brushKey, double size)
     {
         var path = new Avalonia.Controls.Shapes.Path
         {
@@ -2152,7 +2152,7 @@ public partial class ChatPanelView : UserControl
                 Spacing = 2,
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
             };
-            var copyIcon = new Decorator { Child = _owner.MakeIcon("Icon.copy", "VelaTextMuted", 12) };
+            var copyIcon = new Decorator { Child = ChatPanelView.MakeIcon("Icon.copy", "VelaTextMuted", 12) };
             var copy = new Button { Content = copyIcon };
             _owner.ApplyThemeResource(copy, "AiGhostIconButtonTheme");
             ToolTip.SetTip(copy, _owner._loc["CopyReply"]);
@@ -2300,7 +2300,7 @@ public partial class ChatPanelView : UserControl
             {
                 var iconBox = new Decorator
                 {
-                    Child = owner.MakeIcon(iconKey, iconBrushKey ?? "VelaTextMuted", 11),
+                    Child = ChatPanelView.MakeIcon(iconKey, iconBrushKey ?? "VelaTextMuted", 11),
                     Margin = new Thickness(0, 0, 5, 0),
                     VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
                 };
@@ -2314,7 +2314,7 @@ public partial class ChatPanelView : UserControl
             {
                 var trailing = new Decorator
                 {
-                    Child = owner.MakeIcon(trailingIconKey, "VelaTextMuted", 11),
+                    Child = ChatPanelView.MakeIcon(trailingIconKey, "VelaTextMuted", 11),
                     VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
                 };
                 Grid.SetColumn(trailing, 3);
@@ -2415,7 +2415,7 @@ public partial class ChatPanelView : UserControl
             };
             _statusIconHost = new Decorator
             {
-                Child = owner.MakeIcon("Icon.ellipsis", "VelaAccent", 11),
+                Child = ChatPanelView.MakeIcon("Icon.ellipsis", "VelaAccent", 11),
                 Margin = new Thickness(0, 0, 6, 0),
                 VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
             };
@@ -2474,7 +2474,7 @@ public partial class ChatPanelView : UserControl
         public void Complete(string result)
         {
             _result = result;
-            _statusIconHost.Child = _owner.MakeIcon("Icon.circle-check", "VelaStatusConnected", 11);
+            _statusIconHost.Child = ChatPanelView.MakeIcon("Icon.circle-check", "VelaStatusConnected", 11);
             ToolTip.SetTip(_statusIconHost, _owner._loc["ToolDone"]);
         }
 

--- a/plugins/VelaShell.Plugin.Ai/Ui/ToolPickerView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ToolPickerView.axaml.cs
@@ -157,7 +157,7 @@ public sealed class ToolPickerView : UserControl
     }
 
     /// <summary>描边小按钮(图标 + 文字),供左栏的「新增服务器」与组里的「更新工具库」共用。</summary>
-    private Button OutlineButton(string icon, string text, Action onClick)
+    private static Button OutlineButton(string icon, string text, Action onClick)
     {
         var content = new StackPanel
         {

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/NullUiApi.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/NullUiApi.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using VelaShell.PluginSdk.Logging;
 using VelaShell.PluginSdk.Ui;
 
@@ -20,6 +21,9 @@ internal sealed class NullUiApi(IPluginLogger log) : IUiApi
         public string PanelId { get; } = Guid.NewGuid().ToString("N");
         public bool IsOpen => false;
         public event Action? Closed { add { } remove { } }
+        [SuppressMessage("Performance", "CA1822:将成员标记为 static",
+            Justification = "IPluginPanel 的接口成员,改成 static 就不再实现该接口(编译失败)。" +
+                            "CA1822 通常会跳过接口实现,这里是误报。")]
         public double PlacementRatio => double.NaN;
         public event Action<double>? PlacementRatioChanged { add { } remove { } }
         public Task ActivateAsync() => Task.CompletedTask;

--- a/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
 using VelaShell.PluginSdk.Protocols;
 using VelaShell.PluginSdk.Workspaces;
@@ -304,6 +305,10 @@ public sealed class PluginProtocolRegistry
         return Register(pluginId, descriptor, fileSystem: null, terminal);
     }
 
+    [SuppressMessage("Performance", "CA1859:使用具体类型以提高性能",
+        Justification = "返回 IDisposable 是注册句柄的契约:公开重载把它原样透给插件,注销方式" +
+                        "只能是 Dispose。换成具体的 Unregister 会把实现类型泄进 API 面," +
+                        "省下的那一次接口派发远不值这个代价。")]
     private IDisposable Register(
         string pluginId,
         ProtocolDescriptor descriptor,
@@ -516,7 +521,7 @@ public sealed class PluginProtocolRegistry
         }
     }
 
-    private void Detach(Entry entry)
+    private static void Detach(Entry entry)
     {
         if (entry.Registration.FileSystem is not { } fileSystem)
         {
@@ -597,7 +602,7 @@ public sealed class PluginProtocolRegistry
             }
             if (removed)
             {
-                owner.Detach(entry); // 锁外拆订阅,理由同 RemovePlugin
+                PluginProtocolRegistry.Detach(entry); // 锁外拆订阅,理由同 RemovePlugin
                 owner.RaiseUnregistered(id);
                 owner.RaiseChanged();
             }

--- a/src/VelaShell.Infrastructure/Ssh/SshAlgorithmProbe.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshAlgorithmProbe.cs
@@ -194,6 +194,6 @@ public static class SshAlgorithmProbe
         return true;
     }
 
-    private static IReadOnlyList<string> Split(string nameList) =>
+    private static string[] Split(string nameList) =>
         nameList.Length == 0 ? [] : nameList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/src/VelaShell.Infrastructure/Startup/VelaShellStartupArguments.cs
+++ b/src/VelaShell.Infrastructure/Startup/VelaShellStartupArguments.cs
@@ -111,6 +111,6 @@ public sealed class VelaShellStartupArguments
                      .Where(v => v.Length > 0);
 
     /// <summary>把一条 <c>--wait-debugger</c> 值切成插件 id 集合(逗号/分号分隔)。</summary>
-    private static IEnumerable<string> SplitIds(string? value) =>
+    private static string[] SplitIds(string? value) =>
         (value ?? "").Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
+++ b/src/VelaShell.Infrastructure/Sync/GistSyncService.cs
@@ -36,8 +36,6 @@ public sealed class GistSyncService(
         WriteIndented = true,
     };
 
-    private readonly GistApiClient _api = new();
-
     /// <summary>同步操作串行化:防止自动推送与手动同步并发互踩。</summary>
     private readonly SemaphoreSlim _gate = new(1, 1);
 

--- a/src/VelaShell/Docking/PluginWorkspaceDocument.cs
+++ b/src/VelaShell/Docking/PluginWorkspaceDocument.cs
@@ -23,8 +23,6 @@ namespace VelaShell.Docking;
 /// </summary>
 public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
 {
-    private readonly IWorkspaceDocument _workspace;
-    private readonly string _typeName;
     private int _closed;
 
     /// <summary>从插件交出的文档初始化停靠标签页。</summary>
@@ -35,19 +33,19 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
     public PluginWorkspaceDocument(SessionProfile profile, Guid sessionId, string typeName, IWorkspaceDocument workspace)
     {
         Profile = profile ?? throw new ArgumentNullException(nameof(profile));
-        _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
-        _typeName = typeName;
+        Workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        TypeName = typeName;
         SessionId = sessionId;
         Id = sessionId.ToString("N");
         Title = string.IsNullOrWhiteSpace(profile.Name) ? profile.Host : profile.Name;
         Status = Map(SafeState());
         // 标签上的状态圆点跟着插件报的状态走。插件在**任意线程**触发这个事件,
         // 而属性通知会直接驱动绑定 —— 不封送回 UI 线程就是一次跨线程改可视树。
-        _workspace.StatusChanged += OnWorkspaceStatus;
+        Workspace.StatusChanged += OnWorkspaceStatus;
     }
 
     /// <summary>连接类型的展示名(如 <c>Redis</c>),标签与提示文本用。</summary>
-    public string TypeName => _typeName;
+    public string TypeName { get; }
 
     /// <summary>
     /// 标签上的状态。刻意映射成宿主的 <see cref="SessionStatus" /> 而不是直接暴露
@@ -74,7 +72,7 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
     {
         try
         {
-            return _workspace.Status.State;
+            return Workspace.Status.State;
         }
         catch
         {
@@ -90,13 +88,13 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
     public Guid SessionId { get; }
 
     /// <summary>插件交出的文档(状态与重连由它提供)。</summary>
-    public IWorkspaceDocument Workspace => _workspace;
+    public IWorkspaceDocument Workspace { get; }
 
     /// <summary>从连接配置派生的强调色画刷,用于视觉标识(与终端/SFTP 标签同一套)。</summary>
     public IBrush ConnectionAccentBrush => ConnectionAccent.BrushFor(Profile.Id);
 
     /// <summary>显示连接详情的提示文本。</summary>
-    public string ConnectionTooltip => $"{Title} · {_typeName} · {Profile.Host}:{Profile.Port}";
+    public string ConnectionTooltip => $"{Title} · {TypeName} · {Profile.Host}:{Profile.Port}";
 
     /// <summary>
     /// 创建停靠内容:向插件索取控件。
@@ -110,16 +108,16 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
     {
         try
         {
-            object view = _workspace.CreateView();
+            object view = Workspace.CreateView();
             if (view is Control control)
             {
                 return control;
             }
-            Trace.WriteLine($"[PluginWorkspace] '{_typeName}' returned {view?.GetType().FullName ?? "null"}, which is not an Avalonia Control.");
+            Trace.WriteLine($"[PluginWorkspace] '{TypeName}' returned {view?.GetType().FullName ?? "null"}, which is not an Avalonia Control.");
         }
         catch (Exception ex)
         {
-            Trace.WriteLine($"[PluginWorkspace] '{_typeName}' threw while creating its view: {ex}");
+            Trace.WriteLine($"[PluginWorkspace] '{TypeName}' threw while creating its view: {ex}");
         }
         return BrokenView();
     }
@@ -134,16 +132,16 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
         {
             return;
         }
-        _workspace.StatusChanged -= OnWorkspaceStatus;
+        Workspace.StatusChanged -= OnWorkspaceStatus;
         try
         {
-            await _workspace.DisposeAsync().ConfigureAwait(false);
+            await Workspace.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             // 关闭路径不许抛:标签页已经从界面上消失了,再冒一个异常出去只会变成
             // 一次没人处理的 UnobservedTaskException。
-            Trace.WriteLine($"[PluginWorkspace] Disposing '{_typeName}' session failed: {ex.Message}");
+            Trace.WriteLine($"[PluginWorkspace] Disposing '{TypeName}' session failed: {ex.Message}");
         }
     }
 
@@ -154,7 +152,7 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
         {
             try
             {
-                return _workspace.Status.State;
+                return Workspace.Status.State;
             }
             catch
             {
@@ -163,8 +161,8 @@ public sealed class PluginWorkspaceDocument : DockDocument, IDockViewProvider
         }
     }
 
-    private static Control BrokenView() =>
-        new TextBlock
+    private static TextBlock BrokenView() =>
+        new()
         {
             Text = Strings.Get("Plugin_ProtocolUnavailable"),
             HorizontalAlignment = HorizontalAlignment.Center,

--- a/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
@@ -766,7 +766,7 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
     /// SSH 配置候选。表单可能在候选加载完之前就渲染(协议激活与仓储读取是两条独立的异步链),
     /// 那时至少要给出"不经跳板机"这一项 —— 一个空下拉会让用户以为功能坏了。
     /// </summary>
-    private IReadOnlyList<PluginSessionChoice> EnsureSshSessionChoices()
+    private List<PluginSessionChoice> EnsureSshSessionChoices()
     {
         if (_sshSessionChoices.Count == 0)
         {

--- a/src/VelaShell/ViewModels/PluginProtocolFieldViewModel.cs
+++ b/src/VelaShell/ViewModels/PluginProtocolFieldViewModel.cs
@@ -244,7 +244,10 @@ public sealed class PluginProtocolFieldViewModel : ReactiveObject
     /// </summary>
     public PluginSessionChoice? SelectedSshSession
     {
-        get => SshSessions.FirstOrDefault(choice => choice.Id == _text) ?? SshSessions.FirstOrDefault();
+        // 兜底项走索引器而非 FirstOrDefault():本 getter 挂在绑定上,每次刷新都会跑,
+        // 而 SshSessions 是可索引集合 —— LINQ 那条要建一个枚举器。
+        get => SshSessions.FirstOrDefault(choice => choice.Id == _text)
+               ?? (SshSessions.Count > 0 ? SshSessions[0] : null);
         set
         {
             if (value is not null)

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -791,7 +791,7 @@ public class SftpServiceTests
         };
     }
 
-    private class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
     {
         public void Report(T value) => handler(value);
     }

--- a/tests/VelaShell.Infrastructure.Tests/PluginTimeSeriesTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/PluginTimeSeriesTests.cs
@@ -52,7 +52,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task WriteAndQuery_RoundTripsAllValueKinds_AndFiltersByTag()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         ITimeSeries series = await api.OpenAsync(ChatDefinition);
         var clock = new TimeSeriesClock();
         await series.WriteManyAsync(
@@ -82,7 +82,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task Query_HonoursDescendingLimitAndTimeRange()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         ITimeSeries series = await api.OpenAsync(ChatDefinition);
         DateTimeOffset start = DateTimeOffset.UtcNow;
         for (int i = 0; i < 5; i++)
@@ -108,7 +108,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task SameTimestampInSameSeries_Overwrites_ClockAvoidsIt()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         ITimeSeries series = await api.OpenAsync(ChatDefinition);
         DateTimeOffset at = DateTimeOffset.UtcNow;
         await series.WriteAsync(Message(at, "c1", 0, "user", "first"));
@@ -128,7 +128,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task CountDistinctAndDelete_WorkPerConversation()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         ITimeSeries series = await api.OpenAsync(ChatDefinition);
         var clock = new TimeSeriesClock();
         await series.WriteManyAsync(
@@ -153,8 +153,8 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task Plugins_CannotSeeEachOthersSeries()
     {
-        ITimeSeriesApi ai = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
-        ITimeSeriesApi other = new SonnetDbPluginTimeSeries(_engine, "velashell.other");
+        var ai = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var other = new SonnetDbPluginTimeSeries(_engine, "velashell.other");
         ITimeSeries aiSeries = await ai.OpenAsync(ChatDefinition);
         ITimeSeries otherSeries = await other.OpenAsync(ChatDefinition);
         await aiSeries.WriteAsync(Message(DateTimeOffset.UtcNow, "c1", 0, "user", "secret"));
@@ -181,7 +181,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task Open_RejectsBadNamesAndEnforcesQuota()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await api.OpenAsync(new("Bad Name", [TimeSeriesColumn.Field("v", TimeSeriesValueKind.Integer)])));
         await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
@@ -198,7 +198,7 @@ public sealed class PluginTimeSeriesTests : IDisposable
     [TestMethod]
     public async Task Drop_RemovesSeriesAndItsMarker()
     {
-        ITimeSeriesApi api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
+        var api = new SonnetDbPluginTimeSeries(_engine, "velashell.ai");
         await api.OpenAsync(ChatDefinition);
         Assert.IsTrue(await api.DropAsync("chat_messages"));
         Assert.IsEmpty(await api.ListAsync());

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/RemoteTunnelCapabilityTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using NSubstitute;
 using VelaShell.Core.Ssh;
 using VelaShell.Infrastructure.Plugins.Capabilities;
@@ -26,6 +27,10 @@ public class RemoteTunnelCapabilityTests
         return (new(connections), client, sessionId.ToString());
     }
 
+    // 返回类型必须是 Stream:它要喂给 NSubstitute 的 Returns(async call => ... NewStream()),
+    // 那些 lambda 的目标委托是 Task<Stream>。CA1859 建议改成 MemoryStream,改了推断不出委托类型。
+    [SuppressMessage("Performance", "CA1859:使用具体类型以提高性能",
+        Justification = "返回类型由 ISshClientWrapper.OpenUnixConnectionAsync 的 Task<Stream> 签名决定。")]
     private static Stream NewStream() => new MemoryStream();
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/EchoSuppressorTests.cs
+++ b/tests/VelaShell.Terminal.Tests/EchoSuppressorTests.cs
@@ -6,7 +6,7 @@ namespace VelaShell.Terminal.Tests;
 [TestClass]
 public class EchoSuppressorTests
 {
-    private static readonly string Payload = "prompt_nl() { local c; ((c>1)) && echo; }; PROMPT_COMMAND=prompt_nl";
+    private const string Payload = "prompt_nl() { local c; ((c>1)) && echo; }; PROMPT_COMMAND=prompt_nl";
 
     private static byte[] Needle => Encoding.UTF8.GetBytes(Payload + "\r\n");
 

--- a/tests/VelaShell.Terminal.Tests/ManualTransferRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ManualTransferRouterTests.cs
@@ -18,7 +18,6 @@ public class ManualTransferRouterTests
 {
     private const byte SOH = 0x01;
     private const byte EOT = 0x04;
-    private const byte ACK = 0x06;
     private const byte C = 0x43;
     private const byte SUB = 0x1A;
 

--- a/tests/VelaShell.Terminal.Tests/SemanticMatcherTests.cs
+++ b/tests/VelaShell.Terminal.Tests/SemanticMatcherTests.cs
@@ -6,8 +6,6 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Semantics")]
 public class SemanticMatcherTests
 {
-    private readonly SemanticMatcher _matcher = new();
-
     [TestMethod]
     public void Match_FindsUrl_WithCorrectOffsets()
     {


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次变更包括：
- 优化 .editorconfig，细化性能分析器（CA1xxx）规则，测试项目特殊放宽。
- 多处将接口返回类型改为具体类型，提升性能与类型推断，必要处添加 SuppressMessage 注解。
- 私有/静态方法调整为 static，提升可读性与性能。
- 优化 LINQ 用法，避免在可索引集合上使用 FirstOrDefault。
- 字段、属性、方法命名与实现方式统一，提升一致性。
- 测试代码类型声明由接口改为具体实现，便于测试。
- 增加性能分析器 SuppressMessage 注解并详细说明原因。
- 其他细节优化如常量声明、参数顺序、注释补充等。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
