### PR TITLE
修复文件浏览器目录跟随及远端 shell 探测

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -299,7 +299,7 @@ Core 的中立抽象证明有效——**迁移一行 Core 代码都没改**,改�
 
 **E. 远端任务管理器(07-25)**:SSH 进程管理(`IRemoteProcessService`/`RemoteProcessService`),入口:标题栏"进程管理器"图标。
 
-**F. 文件浏览器跟随终端目录(07-24,08-20 修复)**:SFTP 上传按钮右侧 map-pin 开关(`FileBrowserViewModel.FollowTerminal`);终端 cwd 由对端 shell 的提示符发 OSC 7,`TerminalEmulator` 解析(`ParseOsc7Path`)→去重→浏览器同步。SSH bash 会话会静默安装一个仅负责 OSC 7 上报的 `PROMPT_COMMAND` 钩子(不再包含已撤除的提示符补行/光标查询逻辑);其他 shell 可在远端 rc 中按各自机制上报 OSC 7。
+**F. 文件浏览器跟随终端目录(07-24,08-20、08-29 修复)**:SFTP 上传按钮右侧 map-pin 开关(`FileBrowserViewModel.FollowTerminal`);终端 cwd 由对端 shell 的提示符发 OSC 7,`TerminalEmulator` 解析(`ParseOsc7Path`)→去重→浏览器同步。SSH bash 会话会静默安装一个仅负责 OSC 7 上报的 `PROMPT_COMMAND` 钩子(不再包含已撤除的提示符补行/光标查询逻辑);其他 shell 可在远端 rc 中按各自机制上报 OSC 7。注入前先由 `RemoteShellProbe` 走一条独立 exec 通道确认对端认 sh 语法(考验 `printf` 与 `$((...))` 算术展开,结果按主机缓存),Windows OpenSSH(默认 shell 为 cmd.exe/PowerShell)一律不注入 —— 否则整行会被当命令执行,屏幕上留下 `'test' 不是内部或外部命令`(#305)。
 
 **G. SFTP 传输面板增强(07-27 ~ 07-29)**:框选、批量操作、文件+文件夹混选上传、冲突与历史交互优化;文件传输 toast 面板(`FileTransferView`,浮动活动/历史项,不跨重启持久化)。
 

--- a/src/VelaShell.Core/Ssh/RemoteShellProbe.cs
+++ b/src/VelaShell.Core/Ssh/RemoteShellProbe.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+
+namespace VelaShell.Core.Ssh;
+
+/// <summary>
+/// 远端默认 shell 的 POSIX 探针:回答"能不能往这台机器的交互式 shell 里喂一段 sh 代码"。
+/// <para>
+/// 目录上报钩子(OSC 7,见 MainWindowViewModel.WorkingDirectoryReportHook)是给 Linux/类 Unix
+/// 用的 —— 文件浏览器「跟随终端目录」靠它拿 cwd。可它是**盲注**的:连上就写进去,
+/// 对端是什么 shell 无所谓。Windows OpenSSH 的默认 shell 是 cmd.exe,那一整行于是被当成
+/// 一条命令执行,屏幕上留下 <c>'test' 不是内部或外部命令</c>(#305);PowerShell 作默认 shell
+/// 同理。钩子里那个 <c>test -n "$BASH_VERSION"</c> 守卫只挡得住 fish/csh 这类**POSIX 世界内部**
+/// 的差异,挡不住根本不认 sh 语法的 shell。
+/// </para>
+/// <para>
+/// 所以先问一句再注入。探针走**独立的 exec 通道**,不碰用户的交互式 shell,终端里一个字符都看不见;
+/// 用完即关,排在开交互 shell 之前,连 <c>MaxSessions 1</c> 的服务端也只需要一个通道名额。
+/// 代价是每台主机的**首次**连接多一次往返 —— 结论按主机缓存,重连与新标签直接取用。
+/// </para>
+/// </summary>
+public static class RemoteShellProbe
+{
+    /// <summary>
+    /// 探针命令。要求三件只有 POSIX shell 才同时做得到的事:有 <c>printf</c>、
+    /// 会做 <c>$((...))</c> 算术展开、认 <c>${var:-默认值}</c> 的默认值展开。
+    /// 三样凑齐才拼得出 <see cref="PosixMarker" />(实测 bash/zsh/dash/sh 均通过):
+    /// <list type="bullet">
+    /// <item>cmd.exe:<c>'printf' 不是内部或外部命令</c>,退出码非 0。</item>
+    /// <item>PowerShell:找不到 printf 命令,退出码非 0。</item>
+    /// <item>cmd.exe 而 PATH 上恰好有 MSYS/Git 的 printf.exe(常见于装了 Git for Windows 的机器):
+    /// 命令跑通了,但 cmd 两种展开都不做,打出的是字面量 —— 标记对不上,仍判为非 POSIX。</item>
+    /// <item>PowerShell 而 PATH 上有 printf.exe:PowerShell 的 <c>$(...)</c> 子表达式**会**把
+    /// <c>$((6*7))</c> 算成 42,但 <c>${vela_probe_ok:-ok}</c> 被它当成驱动器限定的变量名而展开为空 ——
+    /// 少了后半截,标记同样对不上。两种展开缺一不可,正是为了堵住这一条。</item>
+    /// <item>fish/csh 不支持这两种展开,一并落在"非 POSIX"这边;它们本就不吃 bash 钩子,不吃亏。</item>
+    /// </list>
+    /// </summary>
+    public const string ProbeCommand =
+        """
+        printf 'vela-posix-%s%s\n' "$((6*7))" "${vela_probe_ok:-ok}"
+        """;
+
+    /// <summary>探针输出里必须原样出现的标记(两种展开都做对了才拼得出来)。</summary>
+    public const string PosixMarker = "vela-posix-42ok";
+
+    /// <summary>
+    /// 探针超时。给足一次 exec 通道往返即可;超时按"探不到"处理 —— 宁可丢掉目录跟随,
+    /// 也不能把 sh 代码糊到一个不认它的 shell 上。
+    /// </summary>
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(3);
+
+    /// <summary>主机 → 探测结论。同一台机器只问一次,重连与新标签直接取缓存。</summary>
+    private static readonly ConcurrentDictionary<string, bool> Results = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>缓存键:同一主机换了用户可能换了默认 shell,故用户名也进键。</summary>
+    public static string CacheKey(string? host, int port, string? user) =>
+        $"{user ?? string.Empty}@{host ?? string.Empty}:{port}";
+
+    /// <summary>
+    /// 判定一次探针执行的结果。退出码必须为 0 <b>且</b>标准输出里出现标记 ——
+    /// 只看其一都不够:ForceCommand 会让退出码为 0 但输出的是别的东西,
+    /// 而 cmd.exe 把命令原样回显时标记也对不上。
+    /// </summary>
+    public static bool IsPosixShell(RemoteCommandResult? result) =>
+        result is { IsSuccess: true } && result.StandardOutput.Contains(PosixMarker, StringComparison.Ordinal);
+
+    /// <summary>
+    /// 探测(带缓存)。任何失败 —— exec 被禁、通道开不出来、超时、连接已断 —— 一律返回 false
+    /// 且**不进缓存**:那些是环境噪声,不是"这台机器不是 POSIX"的结论,下次连接值得再问一次。
+    /// </summary>
+    /// <param name="client">已连接的 SSH 客户端。</param>
+    /// <param name="cacheKey">见 <see cref="CacheKey" />;空串表示不缓存。</param>
+    /// <param name="cancellationToken">取消令牌(连接被取消时一并放弃探测)。</param>
+    public static async Task<bool> IsPosixShellAsync(
+        ISshClientWrapper client,
+        string cacheKey,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (cacheKey.Length > 0 && Results.TryGetValue(cacheKey, out bool cached))
+        {
+            return cached;
+        }
+        bool isPosix;
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(ProbeTimeout);
+            isPosix = IsPosixShell(await client
+                .RunCommandDetailedAsync(ProbeCommand, timeout.Token)
+                .ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.WriteLine($"[VelaShell] POSIX shell probe failed: {ex.Message}");
+            return false;
+        }
+        if (cacheKey.Length > 0)
+        {
+            Results[cacheKey] = isPosix;
+        }
+        return isPosix;
+    }
+
+    /// <summary>清空缓存(单元测试用;主机换了默认 shell 时重启应用即可)。</summary>
+    public static void ClearCache() => Results.Clear();
+}

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -57,6 +57,12 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// bash 代码放在单引号包裹的 eval 参数里,避免 fish 等 shell 预解析函数体时报错;
     /// 外层守卫让非 bash shell 不执行。只追加 PROMPT_COMMAND,不覆盖用户已有的
     /// starship/direnv/atuin 等钩子,并在重连时按函数名去重。
+    /// <para>
+    /// 这道守卫只在 POSIX 世界内部有效:它挡得住 fish/csh,挡不住 cmd.exe ——
+    /// Windows OpenSSH 的默认 shell 把整行当命令执行,屏幕上就是
+    /// <c>'test' 不是内部或外部命令</c>(#305)。所以注入前必须先用
+    /// <see cref="RemoteShellProbe" /> 确认对端认 sh 语法,守卫是第二道闸不是第一道。
+    /// </para>
     /// </remarks>
     private const string WorkingDirectoryReportHook =
         """
@@ -2029,6 +2035,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         ISshClientWrapper client =
             _sshConnectionService!.GetClient(session.SessionId)
             ?? throw new InvalidOperationException("SSH client was not created for the session.");
+        // 先问一句对端是不是 POSIX shell,再决定要不要注入目录上报钩子(#305)。
+        // 独立 exec 通道,用完即关;每台主机只探一次,之后走缓存。
+        bool isPosixShell = await ProbePosixShellAsync(client, profile, settings, cancellationToken);
         // 通道打开是网络往返(pty-req + shell,2~3 个 RTT);真异步 API,UI 线程零阻塞。
         IShellStreamWrapper shellStream = await client.CreateShellStreamAsync(
             terminalType.ToTermName(), 120, 32, 0, 0, 4096,
@@ -2040,7 +2049,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         terminalTab.ConnectionStatus = SessionStatus.Connected;
         await FeedJumpChainNoticeAsync(terminalTab, profile);
         StartSessionLogging(terminalTab, settings);
-        SendStartupCommand(terminalTab, settings);
+        SendStartupCommand(terminalTab, settings, isPosixShell);
 
         // 会话 Id 从现在起才存在(握手完成后)——活动标签订阅在它被赋值前已触发,
         // 因此在这里绑定 SFTP 浏览器(并展示+加载),否则它将一直指向空占位,永远加载不到列表(#22)。
@@ -2120,6 +2129,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 ?? throw new InvalidOperationException(
                     "SSH client was not created for the session."
                 );
+            // 同 RunHandshakeAsync:注入前先确认对端是 POSIX shell(#305)。首连已探过的主机命中缓存,不再发探针。
+            bool isPosixShell = await ProbePosixShellAsync(client, tab.Profile, settings, cancellationToken);
             // 同 RunHandshakeAsync:通道打开走真异步 API,UI 线程零阻塞。
             IShellStreamWrapper shellStream = await client.CreateShellStreamAsync(
                 terminalType.ToTermName(), 120, 32, 0, 0, 4096,
@@ -2135,7 +2146,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             await FeedJumpChainNoticeAsync(tab, tab.Profile);
             tab.ResetReconnectAttempts();
             StartSessionLogging(tab, settings);
-            SendStartupCommand(tab, settings);
+            SendStartupCommand(tab, settings, isPosixShell);
             if (_metricsService is not null)
             {
                 tab.ResourceMonitor = new(_metricsService, session.SessionId, tab.Title);
@@ -2362,19 +2373,50 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     }
 
     /// <summary>
+    /// 探一句对端是不是 POSIX shell(#305):只有它认 sh 语法,才敢注入目录上报钩子。
+    /// 「上报终端工作目录」关着时直接返回 false —— 连探针那条 exec 通道都不开,守住
+    /// "关掉就一个字节都不发"的承诺(#286)。结果按主机缓存,只有每台机器的首次连接付这次往返。
+    /// </summary>
+    /// <remarks>
+    /// 刻意排在开 shell 通道**之前**、而不是与之并行:一是探针用完即关,不与 shell 通道并存,
+    /// 对 <c>MaxSessions 1</c> 的严苛服务端也只占一个通道名额;二是结论在注入前就已就绪,
+    /// 注入仍然赶在 shell 画出提示符之前,钩子末尾那记清行(见
+    /// <see cref="WorkingDirectoryReportHook" />)才落在该落的地方。
+    /// </remarks>
+    private static Task<bool> ProbePosixShellAsync(
+        ISshClientWrapper client,
+        SessionProfile? profile,
+        AppSettings settings,
+        CancellationToken cancellationToken
+    ) =>
+        settings.TerminalBehavior.ReportWorkingDirectory
+            ? RemoteShellProbe.IsPosixShellAsync(
+                client,
+                RemoteShellProbe.CacheKey(profile?.Host, profile?.Port ?? 22, profile?.Username),
+                cancellationToken
+            )
+            : Task.FromResult(false);
+
+    /// <summary>
     /// 连接成功后按设置注入目录上报钩子,并追加用户配置的"连接后执行命令"
     /// (设置 → 终端 → 会话)。PTY 输入由内核缓冲,shell 就绪后才会读取,
     /// 无需等待提示符。
     /// </summary>
-    private static void SendStartupCommand(TerminalTabViewModel tab, AppSettings settings)
-    {
+    /// <param name="tab">已挂上传输的终端标签。</param>
+    /// <param name="settings">当前设置。</param>
+    /// <param name="isPosixShell">
+    /// <see cref="ProbePosixShellAsync" /> 的结论;false 时不注入钩子。
+    /// 用户自己配的"连接后执行命令"不受它影响 —— 那是用户明确要求执行的东西,
+    /// 对端是什么 shell 由用户自己负责。
+    /// </param>
+    private static void SendStartupCommand(
+        TerminalTabViewModel tab,
+        AppSettings settings,
+        bool isPosixShell
+    ) =>
         tab.SendSilentCommand(
-            BuildStartupCommand(
-                settings.TerminalBehavior.StartupCommand,
-                settings.TerminalBehavior.ReportWorkingDirectory
-            )
+            BuildStartupCommand(settings.TerminalBehavior.StartupCommand, isPosixShell)
         );
-    }
 
     /// <summary>
     /// 组合内置目录上报钩子与用户启动命令;保持一次注入以共用同一个回显抑制窗口。

--- a/tests/VelaShell.Core.Tests/Ssh/RemoteShellProbeTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/RemoteShellProbeTests.cs
@@ -1,0 +1,136 @@
+using NSubstitute;
+using VelaShell.Core.Ssh;
+
+namespace VelaShell.Core.Tests.Ssh;
+
+/// <summary>
+/// 注入目录上报钩子(OSC 7)之前的 POSIX shell 探测。
+/// </summary>
+/// <remarks>
+/// 用户报的现象:连 Windows 的 OpenSSH,一登录就在 cmd.exe 里看到
+/// <c>'test' 不是内部或外部命令</c> —— 那串给 bash 准备的钩子被 cmd 当命令执行了(#305)。
+/// 这里的断言全部围绕"什么样的回答才算 POSIX",样例取自各 shell 对探针命令的真实反应。
+/// </remarks>
+[TestClass]
+[TestCategory("Ssh")]
+public class RemoteShellProbeTests
+{
+    [TestInitialize]
+    public void ResetCache() => RemoteShellProbe.ClearCache();
+
+    /// <summary>
+    /// 探针必须三样一起考:printf、<c>$((...))</c> 算术展开、<c>${var:-默认值}</c> 默认值展开。
+    /// 少一样就会被 cmd.exe(有 printf.exe 时)或 PowerShell(它自己会算 <c>$(...)</c>)蒙混过去。
+    /// </summary>
+    [TestMethod]
+    public void ProbeCommand_ExercisesPrintfAndBothExpansions()
+    {
+        Assert.Contains("printf", RemoteShellProbe.ProbeCommand);
+        Assert.Contains("$((6*7))", RemoteShellProbe.ProbeCommand);
+        Assert.Contains("${vela_probe_ok:-ok}", RemoteShellProbe.ProbeCommand);
+    }
+
+    /// <summary>bash/zsh/dash/sh:两种展开都做对,退出码 0。</summary>
+    [TestMethod]
+    public void IsPosixShell_WithExpandedMarker_IsTrue() =>
+        Assert.IsTrue(RemoteShellProbe.IsPosixShell(new("vela-posix-42ok\n", "", 0)));
+
+    /// <summary>cmd.exe:没有 printf 这个命令。</summary>
+    [TestMethod]
+    public void IsPosixShell_WhenCommandNotFound_IsFalse() =>
+        Assert.IsFalse(RemoteShellProbe.IsPosixShell(
+            new("", "'printf' 不是内部或外部命令,也不是可运行的程序\n", 1)));
+
+    /// <summary>
+    /// cmd.exe 而 PATH 上恰好有 MSYS/Git 的 printf.exe:命令跑通了(退出码 0),
+    /// 但 cmd 两种展开都不做,打出来的是字面量 —— 只看退出码就会误判成 POSIX。
+    /// </summary>
+    [TestMethod]
+    public void IsPosixShell_WhenNothingExpanded_IsFalse() =>
+        Assert.IsFalse(RemoteShellProbe.IsPosixShell(
+            new("vela-posix-$((6*7))${vela_probe_ok:-ok}\n", "", 0)));
+
+    /// <summary>
+    /// PowerShell 作默认 shell 且 PATH 上有 printf.exe:它自己会把 <c>$((6*7))</c> 算成 42
+    /// (实测 <c>"vela-$((6*7))-${vela_probe:-ok}"</c> → <c>vela-42--</c>),但认不得
+    /// <c>${var:-默认值}</c>,展开成空。只考算术就会在这里翻车 —— 后半截 ok 就是为它准备的。
+    /// </summary>
+    [TestMethod]
+    public void IsPosixShell_WhenOnlyArithmeticExpanded_IsFalse() =>
+        Assert.IsFalse(RemoteShellProbe.IsPosixShell(new("vela-posix-42\n", "", 0)));
+
+    /// <summary>ForceCommand 之类:退出码 0,但回来的是别的东西。</summary>
+    [TestMethod]
+    public void IsPosixShell_WhenOutputIsUnrelated_IsFalse() =>
+        Assert.IsFalse(RemoteShellProbe.IsPosixShell(new("Welcome to the gateway\n", "", 0)));
+
+    /// <summary>底层根本没给结果(通道开不出来的替身默认值)。</summary>
+    [TestMethod]
+    public void IsPosixShell_WithNullResult_IsFalse() => Assert.IsFalse(RemoteShellProbe.IsPosixShell(null));
+
+    /// <summary>同一台主机只探一次:重连、开新标签都吃缓存,不该反复占对端的 exec 通道。</summary>
+    [TestMethod]
+    public async Task IsPosixShellAsync_CachesResultPerHost()
+    {
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult("vela-posix-42ok\n", "", 0)));
+        string key = RemoteShellProbe.CacheKey("cache.example", 22, "root");
+
+        Assert.IsTrue(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+        Assert.IsTrue(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+
+        await client.Received(1).RunCommandDetailedAsync(
+            RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>非 POSIX 的结论同样进缓存:Windows 主机不该每次连接都再问一遍。</summary>
+    [TestMethod]
+    public async Task IsPosixShellAsync_CachesNegativeResult()
+    {
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult("", "'printf' 不是内部或外部命令", 1)));
+        string key = RemoteShellProbe.CacheKey("windows.example", 22, "slime");
+
+        Assert.IsFalse(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+        Assert.IsFalse(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+
+        await client.Received(1).RunCommandDetailedAsync(
+            RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// 探测失败(exec 被禁、通道异常)返回 false,但**不进缓存**:那是环境噪声不是结论,
+    /// 下次连接还要再问 —— 否则一次网络抖动就永久关掉了这台主机的目录跟随。
+    /// </summary>
+    [TestMethod]
+    public async Task IsPosixShellAsync_WhenProbeThrows_IsFalseAndNotCached()
+    {
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns<Task<RemoteCommandResult>>(_ => throw new InvalidOperationException("exec disabled"));
+        string key = RemoteShellProbe.CacheKey("flaky.example", 22, "root");
+
+        Assert.IsFalse(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+        Assert.IsFalse(await RemoteShellProbe.IsPosixShellAsync(client, key, TestContext.CancellationToken));
+
+        await client.Received(2).RunCommandDetailedAsync(
+            RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>缓存键要认用户:同一台机器上换个用户就可能换了默认 shell。</summary>
+    [TestMethod]
+    public void CacheKey_DistinguishesUserHostAndPort()
+    {
+        Assert.AreNotEqual(
+            RemoteShellProbe.CacheKey("host", 22, "root"),
+            RemoteShellProbe.CacheKey("host", 22, "slime"));
+        Assert.AreNotEqual(
+            RemoteShellProbe.CacheKey("host", 22, "root"),
+            RemoteShellProbe.CacheKey("host", 2222, "root"));
+    }
+
+    /// <summary>MSTest 注入的测试上下文(取消令牌)。</summary>
+    public TestContext TestContext { get; set; } = null!;
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

为 SSH 会话注入目录上报钩子（OSC 7），新增远端 shell 类型探测逻辑，避免在 Windows OpenSSH（如 cmd.exe、PowerShell）等非 POSIX shell 环境下注入 sh 代码，解决 #305 报错问题。实现 `RemoteShellProbe` 类，精准区分 POSIX 与非 POSIX shell，探测结果按主机+端口+用户名缓存，提升效率。仅在 POSIX shell 环境下注入钩子，用户自定义“连接后执行命令”不受影响。补充完整单元测试，覆盖多种 shell 环境及异常处理，详细注释设计思路和兼容性。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #305 

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试(或说明为什么不需要)
- [x] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
