### PR TITLE
提升FTP/FTPS批量传输兼容性与健壮性

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -291,13 +291,13 @@ Core 的中立抽象证明有效——**迁移一行 Core 代码都没改**,改�
 - **AI 助手插件**(`plugins/VelaShell.Plugin.Ai`):多提供商流式对话(OpenAI Responses / Chat Completions 兼容 / Anthropic Messages,自填 Base URL+Key 走 Secrets 加密);**Agent 模式**(M.E.AI 工具循环,桥接 sessions/terminal/remoteExec/remoteFs,危险操作面板内逐条审批);**自定义 MCP 服务器**(`McpManager` 把用户自配 MCP 工具并入工具箱,非只读工具走同一审批闸);会话持久化到插件私有时序库(历史列表/切换/删除、↑↓ 调取、`@` 远端文件引用)。示例插件 HelloWorld。
 - 文档:`docs/plugins/` 16 篇蓝图 + `STATUS.md` + `dev-guide.md`;英文镜像 `docs-en/`(08-14,31 个文件)。
 
-**B. 系统资源监控窗口(08-01)**:`ResourceMonitorWindow`(+状态栏内嵌弹层 `ResourceMonitorView`),六页 总览/CPU/GPU/内存/磁盘/网络;CPU 页热力图/迷你折线/列表三态,GPU 无卡自动隐藏;自研图表控件 `TimeSeriesChart`/`UsageHeatGrid`/`MeterBar`(`VelaShell.Controls`)。采集为**单条复合 shell 探针**分段解析(`Core/Services/SessionMetrics.cs`,`MetricsScope` 按页按需取 Basic/Detail/Gpu/Processes):CPU 含 user/sys/iowait/steal 与逐核、内存 htop 口径、磁盘逐分区 df + diskstats IO 速率、网络逐网卡 + `ss -ti` 逐连接速率、GPU nvidia-smi、进程 Top。入口:状态栏按钮。
+**B. 系统资源监控窗口(08-01,08-29 修正)**:`ResourceMonitorWindow`(+状态栏内嵌弹层 `ResourceMonitorView`),六页 总览/CPU/GPU/内存/磁盘/网络;CPU 页热力图/迷你折线/列表三态,GPU 无卡自动隐藏;自研图表控件 `TimeSeriesChart`/`UsageHeatGrid`/`MeterBar`(`VelaShell.Controls`)。采集为**单条复合 shell 探针**分段解析(`Core/Services/SessionMetrics.cs`,`MetricsScope` 按页按需取 Basic/Detail/Gpu/Processes):CPU 含 user/sys/iowait/steal 与逐核、内存 htop 口径、磁盘逐分区 df + diskstats IO 速率、网络逐网卡 + `ss -ti` 逐连接速率、GPU nvidia-smi、进程 Top。入口:状态栏按钮。状态栏每秒轮询一次(`SessionMetricsService`),但只对 POSIX 远端发命令:`RemoteShellProbe` 判否即返回"无数据"。此前不拦,Windows 远端上每秒起一个 cmd.exe,而 cmd 把 `echo __P__; nproc; …` 整行原样回显,`Parse`(只在输出为空时返回 null)据此解出一份全 0 的假指标,状态栏一本正经地显示 CPU 0.00%。
 
 **C. 连接诊断中心(07-25 前后)**:`Presentation/Services/ConnectionDiagnosticsService` 四步诊断 **DNS 解析 → TCP 建链 → SSH 握手(读 banner)→ 用户认证**,输出问题标题/描述/修复建议(`DiagnosticReport`);跳板会话前三步针对第一跳、认证走完整链。UI `ConnectionDiagnosticsView` 独立窗口,入口:会话树右键"诊断"。(诊断的裸 TCP/DNS **有意不走全局代理** —— 诊断语义即测直连链路,§12-10。)
 
 **D. 路由/链路追踪 + 离线 IP 归属地(07-25)**:`PingTraceRouteService`(ICMP TTL 递增,免管理员;Linux TTL 不可用时抛可读异常而非假表)+ `MmdbIpGeolocationService`(本地 MMDB 离线库,默认 `~/.velashell/geoip/`,缺库静默降级、面板内引导下载);`TraceRouteWindow` 左侧 `TraceWorldMap` 世界地图落点 + 右侧 mtr 式跃点表(Loss/Sent/Last/Avg/Best/Worst、ECMP 额外地址)。入口:标题栏图标。设计文档 `docs/路由追踪设计.md`。
 
-**E. 远端任务管理器(07-25)**:SSH 进程管理(`IRemoteProcessService`/`RemoteProcessService`),入口:标题栏"进程管理器"图标。
+**E. 远端任务管理器(07-25,08-29 修正)**:SSH 进程管理(`IRemoteProcessService`/`RemoteProcessService`),入口:标题栏"进程管理器"图标。采集前按 `RemoteShellProbe` 判定对端是否 POSIX shell,不是就直接报"不可用"而不发命令 —— cmd.exe 会把整行探测命令原样 echo 回来,`Parse` 只在输出为空时返回 null,于是面板显示的是一张 CPU 0.0%、0 进程的**假空表**而非那句"需要一个已连接的 Linux 会话"。
 
 **F. 文件浏览器跟随终端目录(07-24,08-20、08-29 修复)**:SFTP 上传按钮右侧 map-pin 开关(`FileBrowserViewModel.FollowTerminal`);终端 cwd 由对端 shell 的提示符发 OSC 7,`TerminalEmulator` 解析(`ParseOsc7Path`)→去重→浏览器同步。SSH bash 会话会静默安装一个仅负责 OSC 7 上报的 `PROMPT_COMMAND` 钩子(不再包含已撤除的提示符补行/光标查询逻辑);其他 shell 可在远端 rc 中按各自机制上报 OSC 7。注入前先由 `RemoteShellProbe` 走一条独立 exec 通道确认对端认 sh 语法(考验 `printf` 与 `$((...))` 算术展开,结果按主机缓存),Windows OpenSSH(默认 shell 为 cmd.exe/PowerShell)一律不注入 —— 否则整行会被当命令执行,屏幕上留下 `'test' 不是内部或外部命令`(#305)。
 
@@ -315,6 +315,6 @@ Core 的中立抽象证明有效——**迁移一行 Core 代码都没改**,改�
 
 **M. 小项(08-14)**:会话树拖动分组(`VSESS|` 拖放载荷、空白处放下=移出分组、拖拽幽灵标签)、侧栏最近连接清除按钮(带确认)、关于页显示进程+系统架构(不一致时并列显示,自更新按进程架构选产物)。
 
-**N. FTP / FTPS(08-13,第三方 PR)**:见 §10.B —— `ConnectionType.FTP` + FluentFTP 后端 + 连接池 + `RoutingRemoteFileService` 按会话分派,上层文件浏览器/传输/限速零改动。
+**N. FTP / FTPS(08-13,第三方 PR;08-29 补并发自适应)**:见 §10.B —— `ConnectionType.FTP` + FluentFTP 后端 + 连接池 + `RoutingRemoteFileService` 按会话分派,上层文件浏览器/传输/限速零改动。连接池上限(`FtpSettings.MaxConnections`,默认 4)现在**会自己往下调**:①池里已有活连接却开不出新连接(`421 Too many users` 这类)→ 收到当前连接数并排队复用;②传输被 `450 Transfer busy` / "too many" 之类顶回来 → 收到 1 并重试该传输。两条合起来对付"服务端只支持单线程上传,批量上传只成功第一个"(闸门见 `AdjustableConcurrencyGate`:`SemaphoreSlim` 的许可只增不减,且超发期间只收不发)。回归测试用 `LoopbackFtpServer` 的 `MaxConcurrentSessions` / `MaxConcurrentTransfers` 复刻这两类服务器。
 
 **O. 全局网络代理(08-14)**:见 §12-10。

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1349,6 +1349,9 @@
   <data name="Msg_Uploading" xml:space="preserve">
     <value>アップロード中</value>
   </data>
+  <data name="Msg_Waiting" xml:space="preserve">
+    <value>待機中</value>
+  </data>
   <data name="Msg_UptimeHours" xml:space="preserve">
     <value>稼働 {0}h {1}m</value>
   </data>
@@ -3288,6 +3291,9 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   </data>
   <data name="Sftp_FollowTerminal" xml:space="preserve">
     <value>ターミナルのディレクトリに追従(現在のパスに同期)</value>
+  </data>
+  <data name="Sftp_FollowTerminalNoReport" xml:space="preserve">
+    <value>ターミナルはまだ作業ディレクトリを報告していません。Windows リモート(cmd.exe / PowerShell)は報告できません。他のシェルはプロンプトフックから OSC 7 を送信できます。</value>
   </data>
   <data name="Sftp_EditPath" xml:space="preserve">
     <value>パスを編集 (Ctrl+L)</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1349,6 +1349,9 @@
   <data name="Msg_Uploading" xml:space="preserve">
     <value>업로드 중</value>
   </data>
+  <data name="Msg_Waiting" xml:space="preserve">
+    <value>대기 중</value>
+  </data>
   <data name="Msg_UptimeHours" xml:space="preserve">
     <value>가동 {0}h {1}m</value>
   </data>
@@ -3288,6 +3291,9 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   </data>
   <data name="Sftp_FollowTerminal" xml:space="preserve">
     <value>터미널 디렉터리 따라가기(현재 경로에 동기화)</value>
+  </data>
+  <data name="Sftp_FollowTerminalNoReport" xml:space="preserve">
+    <value>터미널이 아직 작업 디렉터리를 보고하지 않았습니다. Windows 원격(cmd.exe / PowerShell)은 보고할 수 없으며, 다른 셸은 프롬프트 후크에서 OSC 7을 보낼 수 있습니다.</value>
   </data>
   <data name="Sftp_EditPath" xml:space="preserve">
     <value>경로 편집 (Ctrl+L)</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -430,6 +430,9 @@
   <data name="Sftp_FollowTerminal" xml:space="preserve">
     <value>Follow terminal directory (sync to the terminal's current path)</value>
   </data>
+  <data name="Sftp_FollowTerminalNoReport" xml:space="preserve">
+    <value>The terminal hasn't reported its working directory yet. Windows remotes (cmd.exe / PowerShell) cannot report it; other shells can emit OSC 7 from their prompt hook.</value>
+  </data>
   <data name="Sftp_EditPath" xml:space="preserve">
     <value>Edit path (Ctrl+L)</value>
   </data>
@@ -1545,6 +1548,9 @@ Paste anyway?</value>
   </data>
   <data name="Msg_Uploading" xml:space="preserve">
     <value>Uploading</value>
+  </data>
+  <data name="Msg_Waiting" xml:space="preserve">
+    <value>Waiting</value>
   </data>
   <data name="Msg_UptimeHours" xml:space="preserve">
     <value>Up {0}h {1}m</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -531,6 +531,9 @@
   <data name="Sftp_FollowTerminal" xml:space="preserve">
     <value>跟随终端目录(同步到终端当前路径)</value>
   </data>
+  <data name="Sftp_FollowTerminalNoReport" xml:space="preserve">
+    <value>终端还没有上报过工作目录。Windows 远端(cmd.exe / PowerShell)无法上报;其他 shell 可在自己的提示符钩子里发送 OSC 7。</value>
+  </data>
   <data name="Sftp_EditPath" xml:space="preserve">
     <value>编辑路径 (Ctrl+L)</value>
   </data>
@@ -1636,6 +1639,9 @@
   </data>
   <data name="Msg_Uploading" xml:space="preserve">
     <value>上传中</value>
+  </data>
+  <data name="Msg_Waiting" xml:space="preserve">
+    <value>等待中</value>
   </data>
   <data name="Msg_UptimeHours" xml:space="preserve">
     <value>已运行 {0}h {1}m</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1349,6 +1349,9 @@
   <data name="Msg_Uploading" xml:space="preserve">
     <value>上傳中</value>
   </data>
+  <data name="Msg_Waiting" xml:space="preserve">
+    <value>等待中</value>
+  </data>
   <data name="Msg_UptimeHours" xml:space="preserve">
     <value>已執行 {0}h {1}m</value>
   </data>
@@ -3288,6 +3291,9 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   </data>
   <data name="Sftp_FollowTerminal" xml:space="preserve">
     <value>跟隨終端機目錄(同步到終端機目前路徑)</value>
+  </data>
+  <data name="Sftp_FollowTerminalNoReport" xml:space="preserve">
+    <value>終端機還沒有回報過工作目錄。Windows 遠端(cmd.exe / PowerShell)無法回報;其他 shell 可在自己的提示字元掛鉤中送出 OSC 7。</value>
   </data>
   <data name="Sftp_EditPath" xml:space="preserve">
     <value>編輯路徑 (Ctrl+L)</value>

--- a/src/VelaShell.Core/Ssh/RemoteShellProbe.cs
+++ b/src/VelaShell.Core/Ssh/RemoteShellProbe.cs
@@ -52,9 +52,13 @@ public static class RemoteShellProbe
     /// <summary>主机 → 探测结论。同一台机器只问一次,重连与新标签直接取缓存。</summary>
     private static readonly ConcurrentDictionary<string, bool> Results = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>缓存键:同一主机换了用户可能换了默认 shell,故用户名也进键。</summary>
+    /// <summary>
+    /// 缓存键:同一主机换了用户可能换了默认 shell,故用户名也进键。
+    /// 主机名为空(拿不到会话配置)时返回空串 = 本次不缓存,免得几个来路不明的连接
+    /// 共用同一格,互相顶掉对方的结论。
+    /// </summary>
     public static string CacheKey(string? host, int port, string? user) =>
-        $"{user ?? string.Empty}@{host ?? string.Empty}:{port}";
+        string.IsNullOrWhiteSpace(host) ? string.Empty : $"{user ?? string.Empty}@{host}:{port}";
 
     /// <summary>
     /// 判定一次探针执行的结果。退出码必须为 0 <b>且</b>标准输出里出现标记 ——

--- a/src/VelaShell.Infrastructure/Ftp/AdjustableConcurrencyGate.cs
+++ b/src/VelaShell.Infrastructure/Ftp/AdjustableConcurrencyGate.cs
@@ -1,0 +1,138 @@
+namespace VelaShell.Infrastructure.Ftp;
+
+/// <summary>
+/// 一个**上限可以在运行时调小**的并发闸(FIFO 排队,支持取消)。
+/// <para>
+/// 为什么不用 <see cref="SemaphoreSlim" />:它的许可数只增不减 —— <c>Release</c> 能加,
+/// 没有任何 API 能减。而 FTP 池恰恰需要往下调:服务器只允许一条连接时(一次只能传一个文件),
+/// 池必须从"最多 4 条"当场收成"最多 1 条",并让后来的请求老老实实排队复用那一条,
+/// 而不是继续去开注定被拒的第二条连接。
+/// </para>
+/// <para>
+/// 名额在唤醒等待者时**直接移交**(不先减后加),因此收紧上限不会被某个刚好插进来的
+/// 新请求钻空子:排队的人拿到的是上一个人交回来的那一个名额。
+/// </para>
+/// </summary>
+internal sealed class AdjustableConcurrencyGate(int limit)
+{
+    private readonly Lock _sync = new();
+    private readonly Queue<TaskCompletionSource<bool>> _waiters = new();
+    private int _limit = Math.Max(1, limit);
+    private int _inUse;
+
+    /// <summary>当前上限(至少 1)。</summary>
+    public int Limit
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _limit;
+            }
+        }
+    }
+
+    /// <summary>当前已被占用的名额数。</summary>
+    public int InUse
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _inUse;
+            }
+        }
+    }
+
+    /// <summary>取一个名额;没有空位就排队等。</summary>
+    public Task AcquireAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+        TaskCompletionSource<bool> waiter;
+        lock (_sync)
+        {
+            if (_inUse < _limit)
+            {
+                _inUse++;
+                return Task.CompletedTask;
+            }
+            waiter = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _waiters.Enqueue(waiter);
+        }
+        return WaitAsync(waiter, cancellationToken);
+    }
+
+    /// <summary>
+    /// 交回一个名额。队列非空时把名额**直接交给**排在最前的等待者(<see cref="_inUse" /> 不变),
+    /// 否则计数减一。
+    /// <para>
+    /// <b>超发时不移交</b>:上限刚被调小的那一刻,已经发出去的名额可能多于新上限
+    /// (4 个传输在跑,上限却收成了 1)。这时候每回收一个就转手给下一个,占用数永远降不下来,
+    /// 收紧等于没收 —— 服务器那边看到的仍是多个并发传输,照样报忙。
+    /// 所以只有在"没有超发"时才移交,超出的部分收回来就地作废。
+    /// </para>
+    /// </summary>
+    public void Release()
+    {
+        lock (_sync)
+        {
+            if (_inUse <= _limit)
+            {
+                while (_waiters.TryDequeue(out TaskCompletionSource<bool>? next))
+                {
+                    // TrySetResult 为 false = 这个等待者已经取消了,名额继续往下传。
+                    if (next.TrySetResult(true))
+                    {
+                        return;
+                    }
+                }
+            }
+            if (_inUse > 0)
+            {
+                _inUse--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 只把名额还回计数,**不**叫醒排队的人。
+    /// <para>
+    /// 用在"拿了名额却没能拿到资源"的失败路径上:此时并没有资源变空闲,把名额移交给下一个人
+    /// 只会让他重复同一次失败(FTP 池里的表现就是又去开一条注定被 421 顶回来的连接)。
+    /// 叫醒的时机交给真正归还资源的那一方(<see cref="Release" />)。
+    /// </para>
+    /// </summary>
+    public void ReleaseWithoutHandoff()
+    {
+        lock (_sync)
+        {
+            if (_inUse > 0)
+            {
+                _inUse--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 把上限调小到 <paramref name="newLimit" />(只减不增,最低 1),返回生效后的上限。
+    /// 已经租出去的名额不会被强行收回 —— 它们归还时超出新上限的部分自然不再放行。
+    /// </summary>
+    public int LimitTo(int newLimit)
+    {
+        lock (_sync)
+        {
+            _limit = Math.Max(1, Math.Min(_limit, newLimit));
+            return _limit;
+        }
+    }
+
+    private static async Task WaitAsync(TaskCompletionSource<bool> waiter, CancellationToken cancellationToken)
+    {
+        await using CancellationTokenRegistration registration =
+            cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(), waiter);
+        await waiter.Task.ConfigureAwait(false);
+    }
+}

--- a/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FluentFtpInterop.cs
@@ -41,6 +41,54 @@ internal static class FluentFtpInterop
     public static bool IsConnectionLost(Exception ex) => ex is VelaFtpConnectionException;
 
     /// <summary>
+    /// 服务器是不是在说「同一时刻只能有一个(连接/传输)」。
+    /// <para>
+    /// 用于把该会话就地收成单连接后重试一次 —— 用户报的现象是批量上传时
+    /// 第一个文件成功、其余全失败(服务端只支持单线程上传)。
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// 各家服务器的措辞与应答码都不统一,所以两条线一起看:
+    /// 应答码 421(服务不可用/用户数超限)、425(开不了数据连接)、450(文件/传输忙),
+    /// 以及中英文关键词。判错的代价很小:无非是这一项退化成排队重试一次;
+    /// 判漏的代价才大 —— 用户看到的是一批失败的传输。
+    /// </remarks>
+    public static bool IsConcurrencyRejection(Exception? ex)
+    {
+        for (Exception? current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is FtpCommandException { CompletionCode: "421" or "425" or "450" })
+            {
+                return true;
+            }
+            if (current.Message is { Length: > 0 } message && MentionsConcurrencyLimit(message))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static readonly string[] ConcurrencyKeywords =
+    [
+        "too many", "maximum number", "max clients", "connection limit", "already connected",
+        "only one", "one transfer", "simultaneous", "concurrent", "busy", "try again later",
+        "连接数", "同时", "并发", "超过最大", "已达上限",
+    ];
+
+    private static bool MentionsConcurrencyLimit(string message)
+    {
+        foreach (string keyword in ConcurrencyKeywords)
+        {
+            if (message.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
     /// 按 FTP 应答码分类。5xx 里 550 既可能是「不存在」也可能是「没权限」,
     /// 服务器措辞不统一,因此再看一眼文本 —— 分不清时保守地归为一般操作失败。
     /// </summary>

--- a/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpConnectionPool.cs
@@ -13,8 +13,17 @@ namespace VelaShell.Infrastructure.Ftp;
 /// 用户设置的最大并发传输数也会被悄悄压回 1。
 /// </para>
 /// <para>
-/// 池的形状很简单:一个总量信号量 + 一袋空闲连接。租借时优先复用空闲连接,
-/// 发现掉线就地重连;归还时放回袋子。上限取 <see cref="Core.Models.FtpSettings.MaxConnections" />。
+/// 池的形状很简单:一个可收紧的并发闸(<see cref="AdjustableConcurrencyGate" />)+ 一袋空闲连接。
+/// 租借时优先复用空闲连接,发现掉线就地重连;归还时放回袋子。
+/// 初始上限取 <see cref="Core.Models.FtpSettings.MaxConnections" />。
+/// </para>
+/// <para>
+/// **上限会自己往下调**:不少 FTP 服务器(尤其是设了 <c>MaxClientsPerIP=1</c> 或"一次只允许一个传输"
+/// 的那类)只肯给一条连接。这时第一条连接好端端的,第二条却在建立/登录时被拒 ——
+/// 用户看到的就是"批量上传,第一个成功,其余全失败"。既然第一条连接已经证明地址、凭据、TLS 都没问题,
+/// 第二条建不起来就该退化成**排队复用第一条**,而不是把错误甩给用户。
+/// 判据刻意不去猜服务器的措辞(421/530/425 各家都不一样,还分英文中文),
+/// 而是看"池里已经有活连接却开不出新连接"这个事实,这比匹配错误码稳得多。
 /// </para>
 /// </summary>
 internal sealed class FtpConnectionPool(
@@ -24,17 +33,93 @@ internal sealed class FtpConnectionPool(
     private readonly ConcurrentBag<AsyncFtpClient> _idle = [];
     private readonly List<AsyncFtpClient> _all = [];
     private readonly Lock _sync = new();
-    private readonly SemaphoreSlim _slots = new(Math.Max(1, info.Settings.MaxConnections), Math.Max(1, info.Settings.MaxConnections));
+    private readonly AdjustableConcurrencyGate _gate = new(Math.Max(1, info.Settings.MaxConnections));
     private bool _disposed;
+
+    /// <summary>一次租借最多退化重排几次(见 <see cref="RentAsync" />)。</summary>
+    private const int MaxFallbackAttempts = 3;
 
     /// <summary>该会话的连接参数。</summary>
     public FtpConnectionInfo Info { get; } = info;
 
-    /// <summary>租借一条可用连接;释放 <see cref="Lease" /> 即归还。</summary>
+    /// <summary>当前生效的并发连接上限(可能已被自适应下调)。</summary>
+    public int ConnectionLimit => _gate.Limit;
+
+    /// <summary>
+    /// 把并发上限收到 1 并关掉多余的空闲连接:服务器表示"一次只能跑一个传输"时由上层调用
+    /// (数据通道被拒的场景,控制连接本身开得出来,自适应租借那条路看不到)。
+    /// </summary>
+    /// <returns>此调用是否真的改变了上限(已经是 1 则为 false)。</returns>
+    public bool LimitToSingleConnection()
+    {
+        if (_gate.Limit <= 1)
+        {
+            return false;
+        }
+        _gate.LimitTo(1);
+        DropIdleConnections();
+        System.Diagnostics.Trace.WriteLine(
+            $"[VelaShell] FTP {Info.Host}: server rejected a concurrent transfer; falling back to a single connection.");
+        return true;
+    }
+
+    /// <summary>
+    /// 租借一条可用连接;释放 <see cref="Lease" /> 即归还。
+    /// <para>
+    /// 名额的账在本方法里收口:循环顶上取一个,失败路径上无条件交回 ——
+    /// 退化重排也走这条路(交回后重新排队),因此不会出现"多还一个名额"把上限撑破的情况。
+    /// </para>
+    /// </summary>
     public async Task<Lease> RentAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // 退化重排的次数上限。正常只会用掉一次(收紧后就排队等已有连接);留几次余量是防着
+        // "刚被叫醒、那条连接又被别人抢先拿走"这类罕见交错,免得一次抖动就把传输判死。
+        int fallbacksLeft = MaxFallbackAttempts;
+        while (true)
+        {
+            await _gate.AcquireAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await OpenLeaseAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                ReleaseAfterFailure();
+                if (fallbacksLeft > 0 && ShouldQueueOnExistingConnection(ex, cancellationToken))
+                {
+                    fallbacksLeft--;
+                    continue;
+                }
+                throw FluentFtpInterop.Translate(ex, "connect");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 失败路径上交回名额。**不叫醒**排队的人 —— 这次失败并没有让任何一条连接空出来,
+    /// 叫醒下一个只会让他重复同一次失败(再去开一条注定被顶回来的连接)。
+    /// 叫醒交给真正归还连接的 <see cref="Return" />。
+    /// <para>
+    /// 例外:池里已经一条连接都不剩时照常移交 —— 此时没有"归还"这回事了,
+    /// 排队的人必须被叫醒去自己重连(失败了也该由他把错误报出来),否则就是干等。
+    /// </para>
+    /// </summary>
+    private void ReleaseAfterFailure()
+    {
+        if (_idle.IsEmpty && LiveConnectionCount() > 0)
+        {
+            _gate.ReleaseWithoutHandoff();
+        }
+        else
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>持名额取一条连接:优先复用空闲的,没有就新建;掉线的就地重连。</summary>
+    private async Task<Lease> OpenLeaseAsync(CancellationToken cancellationToken)
+    {
         AsyncFtpClient? client = null;
         try
         {
@@ -51,14 +136,59 @@ internal sealed class FtpConnectionPool(
             }
             return new Lease(this, client);
         }
-        catch (Exception ex)
+        catch
         {
             if (client is not null)
             {
                 Forget(client);
             }
-            _slots.Release();
-            throw FluentFtpInterop.Translate(ex, "connect");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// 这次失败该不该退化成"排队复用已有连接"。
+    /// 判据是事实而非措辞:池里**还有活着的连接**,却开不出这一条 —— 第一条能连上就说明
+    /// 地址、凭据、TLS 都没问题,那么开不出第二条基本只有一个解释:服务器的连接数限制。
+    /// 真是网络抖动被误判也不亏:代价只是这一次操作排队等已有连接,而不是直接失败。
+    /// </summary>
+    private bool ShouldQueueOnExistingConnection(Exception ex, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested || _disposed
+            || ex is ObjectDisposedException or OperationCanceledException
+            || LiveConnectionCount() <= 0)
+        {
+            return false;
+        }
+        int limit = _gate.LimitTo(LiveConnectionCount());
+        DropIdleConnections();
+        System.Diagnostics.Trace.WriteLine(
+            $"[VelaShell] FTP {Info.Host}: could not open an extra connection ({ex.GetType().Name}); "
+            + $"queueing on the existing one (limit={limit}).");
+        return true;
+    }
+
+    /// <summary>池中还活着的连接数(含租出去的与空闲的)。</summary>
+    private int LiveConnectionCount()
+    {
+        lock (_sync)
+        {
+            return _all.Count;
+        }
+    }
+
+    /// <summary>关掉暂时用不到的空闲连接:上限收紧后它们只是白占服务器的名额。</summary>
+    private void DropIdleConnections()
+    {
+        while (_idle.TryTake(out AsyncFtpClient? spare))
+        {
+            if (LiveConnectionCount() <= 1)
+            {
+                // 最后一条活连接留着,否则下一次租借还要从头连一遍。
+                _idle.Add(spare);
+                return;
+            }
+            Forget(spare);
         }
     }
 
@@ -94,7 +224,6 @@ internal sealed class FtpConnectionPool(
                 client.Dispose();
             }
         }
-        _slots.Dispose();
     }
 
     private async Task<AsyncFtpClient> CreateAsync(CancellationToken cancellationToken)
@@ -126,7 +255,7 @@ internal sealed class FtpConnectionPool(
         {
             _idle.Add(client);
         }
-        _slots.Release();
+        _gate.Release();
     }
 
     /// <summary>把一条已经不可用的连接从池中剔除(不再归还给 <see cref="_idle" />)。</summary>

--- a/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
+++ b/src/VelaShell.Infrastructure/Ftp/FtpFileService.cs
@@ -99,15 +99,14 @@ public sealed class FtpFileService(IProxyResolver? proxyResolver = null) : ISftp
         long resumeOffset = 0,
         CancellationToken cancellationToken = default)
     {
-        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
         string fileName = Path.GetFileName(localPath);
         long totalBytes = new FileInfo(localPath).Length;
-        try
+        await RunTransferAsync(sessionId, "upload", async client =>
         {
             await using FileStream source = File.OpenRead(localPath);
             // 续传交给 FluentFTP:Resume 模式下它自己 SIZE 远端、再把本地流 Seek 到同一偏移。
             // 不需要 SFTP 那套「回退一个在途写入窗口」—— FTP 单条数据连接顺序写,没有乱序空洞。
-            FtpStatus status = await lease.Client.UploadStream(
+            FtpStatus status = await client.UploadStream(
                 source,
                 NormalizePath(remotePath),
                 resumeOffset > 0 ? FtpRemoteExists.Resume : FtpRemoteExists.Overwrite,
@@ -118,11 +117,7 @@ public sealed class FtpFileService(IProxyResolver? proxyResolver = null) : ISftp
             {
                 throw new VelaFtpOperationException($"FTP upload of {fileName} failed.");
             }
-        }
-        catch (Exception ex)
-        {
-            throw Fault(sessionId, ex, "upload");
-        }
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -133,15 +128,14 @@ public sealed class FtpFileService(IProxyResolver? proxyResolver = null) : ISftp
         long resumeOffset = 0,
         CancellationToken cancellationToken = default)
     {
-        using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
         string fileName = GetRemoteFileName(remotePath);
-        try
+        await RunTransferAsync(sessionId, "download", async client =>
         {
-            long totalBytes = await lease.Client.GetFileSize(NormalizePath(remotePath), -1, cancellationToken).ConfigureAwait(false);
+            long totalBytes = await client.GetFileSize(NormalizePath(remotePath), -1, cancellationToken).ConfigureAwait(false);
             await using FileStream target = resumeOffset > 0
                 ? new FileStream(localPath, FileMode.Append, FileAccess.Write, FileShare.None)
                 : new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
-            bool ok = await lease.Client.DownloadStream(
+            bool ok = await client.DownloadStream(
                 target,
                 NormalizePath(remotePath),
                 resumeOffset,
@@ -151,11 +145,7 @@ public sealed class FtpFileService(IProxyResolver? proxyResolver = null) : ISftp
             {
                 throw new VelaFtpOperationException($"FTP download of {fileName} failed.");
             }
-        }
-        catch (Exception ex)
-        {
-            throw Fault(sessionId, ex, "download");
-        }
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -370,6 +360,66 @@ public sealed class FtpFileService(IProxyResolver? proxyResolver = null) : ISftp
     }
 
     // ---- 内部实现 ---------------------------------------------------------
+
+    /// <summary>
+    /// 跑一次传输。服务器以「忙 / 连接数超限 / 一次只能传一个」拒绝时,把该会话就地收成
+    /// 单连接并**重试一次** —— 这一次会排队等那条唯一的连接空下来,于是批量传输自然变成串行。
+    /// </summary>
+    /// <remarks>
+    /// 收紧是**整条会话**的一次性动作,而重试是**每个传输**各自的:一批并发传输往往同时撞上
+    /// 这个拒绝,只有跑得最快的那个能把上限从 4 收到 1,其余的看到的是"已经是 1 了"——
+    /// 所以重试的条件不能是"我收紧成功了",而是"这次拒绝是并发导致的,且会话还在"。
+    /// 收紧之后重试会在池的闸门上排队,同一时刻只剩一个传输在跑,自然不会再撞。
+    /// <para>
+    /// 与 <see cref="FtpConnectionPool" /> 里那条自适应是两个场景:池管的是"第二条**连接**开不出来",
+    /// 这里管的是"连接开得出来,但服务器不让同时跑第二个**传输**"(数据通道被拒)。
+    /// </para>
+    /// </remarks>
+    private async Task RunTransferAsync(
+        Guid sessionId,
+        string operation,
+        Func<AsyncFtpClient, Task> body,
+        CancellationToken cancellationToken)
+    {
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                using FtpConnectionPool.Lease lease = await RentAsync(sessionId, cancellationToken).ConfigureAwait(false);
+                await body(lease.Client).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (
+                attempt < MaxBusyRetries
+                && !cancellationToken.IsCancellationRequested
+                && FluentFtpInterop.IsConcurrencyRejection(ex)
+                && LimitSessionToSingleConnection(sessionId))
+            {
+                // 落到下一轮循环重试:这一次会排队等那条唯一的连接空下来。
+            }
+            catch (Exception ex)
+            {
+                throw Fault(sessionId, ex, operation);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 单个传输被"忙/超限"顶回来后允许重试的次数。给 2 次是留一手:
+    /// 收紧生效前抢跑的那几个传输可能连着撞两回,再多就该如实报错了。
+    /// </summary>
+    private const int MaxBusyRetries = 2;
+
+    /// <summary>把会话收成单连接;会话还在就返回 true(上限本来就是 1 也算数,见调用点注释)。</summary>
+    private bool LimitSessionToSingleConnection(Guid sessionId)
+    {
+        if (!_sessions.TryGetValue(sessionId, out FtpConnectionPool? pool))
+        {
+            return false;
+        }
+        pool.LimitToSingleConnection();
+        return true;
+    }
 
     private async Task<FtpConnectionPool.Lease> RentAsync(Guid sessionId, CancellationToken cancellationToken)
     {

--- a/src/VelaShell.Infrastructure/Ssh/RemoteProcessService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/RemoteProcessService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using VelaShell.Core.Models;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Ssh;
 
@@ -26,6 +27,16 @@ public sealed class RemoteProcessService(ISshConnectionService connectionService
     )
     {
         if (GetLiveClient(sessionId) is not { } client)
+        {
+            _lastSamples.TryRemove(sessionId, out _);
+            return null;
+        }
+
+        // 非 POSIX 远端(Windows 的 cmd.exe/PowerShell 等)直接判"不可用",一条命令都不发:
+        // 探测命令读的是 /proc 与 ps,cmd 跑不动它却照样有输出(整行被 echo 原样打回),
+        // 而 RemoteProcessProbe.Parse 只在输出为空时才返回 null —— 于是面板显示的不是
+        // "需要一个已连接的 Linux 会话",而是一张 CPU 0.0%、0 个进程的空表(#305 同源)。
+        if (!await IsPosixRemoteAsync(sessionId, client, cancellationToken).ConfigureAwait(false))
         {
             _lastSamples.TryRemove(sessionId, out _);
             return null;
@@ -103,6 +114,21 @@ public sealed class RemoteProcessService(ISshConnectionService connectionService
     {
         ISshClientWrapper? client = _connectionService.GetClient(sessionId);
         return client is { IsConnected: true } ? client : null;
+    }
+
+    /// <summary>
+    /// 对端是不是 POSIX shell(结论由 <see cref="RemoteShellProbe" /> 按主机缓存,
+    /// 除首次外只是一次字典查找)。
+    /// </summary>
+    private async Task<bool> IsPosixRemoteAsync(Guid sessionId, ISshClientWrapper client, CancellationToken cancellationToken)
+    {
+        ConnectionInfo? info = _connectionService.GetSession(sessionId)?.ConnectionInfo;
+        return await RemoteShellProbe
+            .IsPosixShellAsync(
+                client,
+                RemoteShellProbe.CacheKey(info?.Host, info?.Port ?? 22, info?.Username),
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static async Task<string> RunAsync(

--- a/src/VelaShell.Infrastructure/Ssh/SessionMetricsService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SessionMetricsService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using VelaShell.Core.Models;
 using VelaShell.Core.Services;
 using VelaShell.Core.Ssh;
 
@@ -24,7 +25,8 @@ public sealed class SessionMetricsService(ISshConnectionService connectionServic
 
     /// <summary>
     /// 采集指定会话的一次实时指标:在其现有 SSH 连接上跑探测命令,解析后与上一采样做差分
-    /// 得到瞬时 CPU%/网速。连接不存在或已断开、以及探测失败(超时、非 Linux 主机)时返回 <c>null</c>。
+    /// 得到瞬时 CPU%/网速。连接不存在或已断开、对端不是 POSIX shell、以及探测失败(超时、
+    /// 非 Linux 主机)时返回 <c>null</c>。
     /// </summary>
     public async Task<SessionMetrics?> GetMetricsAsync(Guid sessionId, MetricsScope scope, CancellationToken cancellationToken = default)
     {
@@ -36,6 +38,10 @@ public sealed class SessionMetricsService(ISshConnectionService connectionServic
                 _lastSamples.TryRemove((sessionId, stale), out _);
             }
             _staticInfo.TryRemove(sessionId, out _);
+            return null;
+        }
+        if (!await IsPosixRemoteAsync(sessionId, client, cancellationToken).ConfigureAwait(false))
+        {
             return null;
         }
         try
@@ -67,6 +73,10 @@ public sealed class SessionMetricsService(ISshConnectionService connectionServic
         {
             return null;
         }
+        if (!await IsPosixRemoteAsync(sessionId, client, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
         try
         {
             string output = await client.RunCommandAsync(SessionMetrics.StaticCommand, cancellationToken).ConfigureAwait(false);
@@ -78,6 +88,29 @@ public sealed class SessionMetricsService(ISshConnectionService connectionServic
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// 对端是不是 POSIX shell。<b>不是就一条命令都不发</b>:探测命令通篇是 <c>/proc</c>、
+    /// <c>nproc</c>、<c>df</c>,Windows 的 cmd.exe 既跑不动它,又不会安静 ——
+    /// <c>echo __P__; nproc; …</c> 在 cmd 里是**一条** echo,它把整行原样打回来,于是
+    /// <see cref="SessionMetrics.Parse" />(只在输出为空时返回 null)拿着这堆回声解出一份
+    /// 全是 0 的假指标,状态栏一本正经地显示 CPU 0.00% / 内存 0.0%。
+    /// 状态栏每秒轮询一次,不拦下来就是每秒在对端起一个 cmd.exe(#305 同源)。
+    /// </summary>
+    /// <remarks>
+    /// 结论由 <see cref="RemoteShellProbe" /> 按主机缓存,除首次外只是一次字典查找;
+    /// 拿不到会话信息时退回空缓存键(不缓存,但仍然照探)。
+    /// </remarks>
+    private async Task<bool> IsPosixRemoteAsync(Guid sessionId, ISshClientWrapper client, CancellationToken cancellationToken)
+    {
+        ConnectionInfo? info = _connectionService.GetSession(sessionId)?.ConnectionInfo;
+        return await RemoteShellProbe
+            .IsPosixShellAsync(
+                client,
+                RemoteShellProbe.CacheKey(info?.Host, info?.Port ?? 22, info?.Username),
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/VelaShell/ViewModels/FileBrowserViewModel.cs
+++ b/src/VelaShell/ViewModels/FileBrowserViewModel.cs
@@ -311,6 +311,37 @@ public class FileBrowserViewModel : ReactiveObject
             if (value && _pendingTerminalPath is { Length: > 0 } path)
             {
                 SyncToTerminalPath(path); // 开启当下立即同步到终端当前目录
+                return;
+            }
+
+            // 一次上报都没收到过就打开开关 = 点了之后什么都不会发生。必须说清为什么:
+            // Windows 远端(cmd.exe/PowerShell)压根不上报 —— 那串 bash 钩子只对 POSIX shell
+            // 注入(#305),而受限 sshd 上探测不出来时也不注入。判据用"有没有真收到过 OSC 7"
+            // 而不是探测结论:用户自己在 rc 里发 OSC 7 的情形照样算数,不能误伤。
+            if (value)
+            {
+                ErrorMessage = Strings.Get("Sftp_FollowTerminalNoReport");
+                _followHintShown = true;
+            }
+            else if (_followHintShown)
+            {
+                ClearFollowHint();
+            }
+        }
+    }
+
+    /// <summary>上面那句提示当前是否挂在 <see cref="ErrorMessage" /> 上(只由本类挂、本类摘)。</summary>
+    private bool _followHintShown;
+
+    /// <summary>摘掉提示,但不碰别人写进去的错误(导航失败等)。</summary>
+    private void ClearFollowHint()
+    {
+        if (_followHintShown)
+        {
+            _followHintShown = false;
+            if (string.Equals(ErrorMessage, Strings.Get("Sftp_FollowTerminalNoReport"), StringComparison.Ordinal))
+            {
+                ErrorMessage = null;
             }
         }
     }
@@ -324,6 +355,14 @@ public class FileBrowserViewModel : ReactiveObject
             return;
         }
         _pendingTerminalPath = path;
+
+        // 上报来了 = 提示的前提不再成立,自己摘掉,不劳用户去点。
+        // 本方法在终端 feed 线程上被调用(见下面 SyncToTerminalPath 的注释),
+        // ErrorMessage 是绑定到界面的属性,必须回 UI 线程改。
+        if (_followHintShown)
+        {
+            Dispatcher.UIThread.Post(ClearFollowHint);
+        }
         if (FollowTerminal)
         {
             SyncToTerminalPath(path);
@@ -1461,11 +1500,20 @@ public class FileBrowserViewModel : ReactiveObject
             Type = TransferType.Upload,
             LocalPath = localPath,
             RemotePath = remotePath,
-            Status = TransferStatus.InProgress,
+            // 同批量传输:先"等待中",第一个进度回调到达才算真的开跑
+            // (FTP 单连接对端上,这一份保存也可能排在别人后面)。
+            Status = TransferStatus.Queued,
         };
         TransferSink?.AddTransfer(task);
         TransferItemViewModel? item = TransferSink?.FindTransfer(task.Id);
-        var progress = new Progress<TransferProgress>(p => item?.UpdateProgress(p));
+        var progress = new Progress<TransferProgress>(p =>
+        {
+            item?.UpdateProgress(p);
+            if (item?.Status == TransferStatus.Queued)
+            {
+                item.Status = TransferStatus.InProgress;
+            }
+        });
         try
         {
             await _sftpService.UploadFileAsync(_sessionId, localPath, remotePath, progress);
@@ -2367,7 +2415,9 @@ public class FileBrowserViewModel : ReactiveObject
             Type = type,
             LocalPath = localPath,
             RemotePath = remotePath,
-            Status = resumeOffset > 0 ? TransferStatus.Resuming : TransferStatus.InProgress,
+            // 建行即"等待中":这一刻它只是被排进了队,真正开跑要等拿到传输名额
+            // (FTP 单连接对端上可能要等很久)。第一次进度回调到达才算开始。
+            Status = TransferStatus.Queued,
         };
         TransferStatus finalStatus = TransferStatus.Failed;
         TransferSink?.AddTransfer(task);
@@ -2380,11 +2430,14 @@ public class FileBrowserViewModel : ReactiveObject
         var progress = new Progress<TransferProgress>(p =>
         {
             item?.UpdateProgress(p);
-            // Transition from Resuming to InProgress on first progress tick.
-            if (item?.Status == TransferStatus.Resuming)
+            // 第一个进度回调 = 字节真的开始流动了:排队结束。续传的第一拍先亮一下"续传中",
+            // 之后的回调再落到"进行中"(与改动前的观感一致,只是把它前面那段等待如实标出来了)。
+            item?.Status = item.Status switch
             {
-                item.Status = TransferStatus.InProgress;
-            }
+                TransferStatus.Queued when resumeOffset > 0 => TransferStatus.Resuming,
+                TransferStatus.Queued or TransferStatus.Resuming => TransferStatus.InProgress,
+                _ => item.Status,
+            };
         });
         // 目标"同名但内容对不上"时改名重传的落点(仅"重命名"策略):当前这一行按跳过收尾,
         // 改名后的整份重传在本方法收尾之后另起一行,免得一行的标题与它实际写的目标对不上。

--- a/src/VelaShell/ViewModels/TransferItemViewModel.cs
+++ b/src/VelaShell/ViewModels/TransferItemViewModel.cs
@@ -97,6 +97,7 @@ public class TransferItemViewModel : ReactiveObject
             this.RaiseAndSetIfChanged(ref _status, value);
             _task.Status = value;
             this.RaisePropertyChanged(nameof(IsActive));
+            this.RaisePropertyChanged(nameof(IsWaiting));
             this.RaisePropertyChanged(nameof(IsFailed));
             this.RaisePropertyChanged(nameof(IsCompleted));
             this.RaisePropertyChanged(nameof(CanRetry));
@@ -107,6 +108,15 @@ public class TransferItemViewModel : ReactiveObject
 
     /// <summary>指示任务是否处于活动状态(进行中或排队中或续传中)。</summary>
     public bool IsActive => _status is TransferStatus.InProgress or TransferStatus.Queued or TransferStatus.Resuming;
+
+    /// <summary>
+    /// 还没开始传:排在队里等一个传输名额。面板据此把这一行显示成"等待中"而不是 0%。
+    /// <para>
+    /// 这不是稀有状态:FTP 对端只允许一条连接(或一次只让传一个文件)时,整批传输会被
+    /// 连接池排成串行,后面的项要等很久才轮到 —— 那期间它们确实一个字节都没在动。
+    /// </para>
+    /// </summary>
+    public bool IsWaiting => _status == TransferStatus.Queued;
 
     /// <summary>指示任务是否已失败。</summary>
     public bool IsFailed => _status == TransferStatus.Failed;
@@ -128,11 +138,13 @@ public class TransferItemViewModel : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref _transferredBytes, value);
     }
 
-    /// <summary>Right-hand status: "67%" while running, "完成" when done, "失败" on error.</summary>
+    /// <summary>Right-hand status: "等待中" while queued, "67%" while running, "完成" when done, "失败" on error.</summary>
     public string ProgressText => _status switch
     {
         TransferStatus.Completed => Strings.Get("Msg_Done"),
         TransferStatus.Failed => Strings.Get("Msg_Failed"),
+        // 排队中显示"等待中"而不是 0%:0% 看着像卡住,而它其实还没轮到。
+        TransferStatus.Queued => Strings.Get("Msg_Waiting"),
         _ => $"{_progress}%"
     };
 
@@ -141,6 +153,12 @@ public class TransferItemViewModel : ReactiveObject
     {
         get
         {
+            // 还没轮到的项:只说"等待中"。照常拼"0 B / 0 B • 0 B/s • ↑ 上传中"既不真实
+            // (它没在上传),也让人以为传输卡死了。
+            if (_status == TransferStatus.Queued)
+            {
+                return $"{Direction} {Strings.Get("Msg_Waiting")}";
+            }
             string action = _task.Type == TransferType.Upload ? $"↑ {Strings.Get("Msg_Uploading")}" : $"↓ {Strings.Get("Msg_Downloading")}";
             if (_status == TransferStatus.Completed)
             {

--- a/src/VelaShell/Views/FileTransferView.axaml
+++ b/src/VelaShell/Views/FileTransferView.axaml
@@ -142,7 +142,8 @@
                                FontFamily="{DynamicResource VelaUiMonoFont}"
                                FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
                                Classes.done="{Binding IsCompleted}"
-                               Classes.failed="{Binding IsFailed}">
+                               Classes.failed="{Binding IsFailed}"
+                               Classes.waiting="{Binding IsWaiting}">
                       <TextBlock.Styles>
                         <Style Selector="TextBlock">
                           <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
@@ -152,6 +153,10 @@
                         </Style>
                         <Style Selector="TextBlock.failed">
                           <Setter Property="Foreground" Value="{DynamicResource VelaError}" />
+                        </Style>
+                        <!-- 等待中:静默色。用强调色会跟正在跑的那几行抢注意力,而它恰恰是没在动的那些。 -->
+                        <Style Selector="TextBlock.waiting">
+                          <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
                         </Style>
                       </TextBlock.Styles>
                     </TextBlock>

--- a/tests/VelaShell.Core.Tests/Ssh/RemoteShellProbeTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/RemoteShellProbeTests.cs
@@ -131,6 +131,24 @@ public class RemoteShellProbeTests
             RemoteShellProbe.CacheKey("host", 2222, "root"));
     }
 
+    /// <summary>拿不到主机名时返回空键 = 不缓存,免得几个连接共用一格互相顶掉结论。</summary>
+    [TestMethod]
+    public async Task CacheKey_WhenHostMissing_IsEmptyAndDisablesCaching()
+    {
+        Assert.IsEmpty(RemoteShellProbe.CacheKey(null, 22, "root"));
+        Assert.IsEmpty(RemoteShellProbe.CacheKey("   ", 22, "root"));
+
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult("vela-posix-42ok\n", "", 0)));
+
+        await RemoteShellProbe.IsPosixShellAsync(client, string.Empty, TestContext.CancellationToken);
+        await RemoteShellProbe.IsPosixShellAsync(client, string.Empty, TestContext.CancellationToken);
+
+        await client.Received(2).RunCommandDetailedAsync(
+            RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>());
+    }
+
     /// <summary>MSTest 注入的测试上下文(取消令牌)。</summary>
     public TestContext TestContext { get; set; } = null!;
 }

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/AdjustableConcurrencyGateTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/AdjustableConcurrencyGateTests.cs
@@ -1,0 +1,153 @@
+using VelaShell.Infrastructure.Ftp;
+
+namespace VelaShell.Infrastructure.Tests.Ftp;
+
+/// <summary>
+/// 上限可收紧的并发闸(FTP 连接池的名额账本)。
+/// </summary>
+/// <remarks>
+/// 存在的理由是 <see cref="SemaphoreSlim" /> 的许可只增不减:服务器只肯给一条连接时,
+/// 池必须当场从"最多 4 条"收成"最多 1 条",让后来的传输排队复用那一条 —— 这正是
+/// "批量上传只成功第一个"那个问题的修法。
+/// </remarks>
+[TestClass]
+[TestCategory("Ftp")]
+public class AdjustableConcurrencyGateTests
+{
+    [TestMethod]
+    public async Task Acquire_UpToLimit_DoesNotBlock()
+    {
+        var gate = new AdjustableConcurrencyGate(2);
+
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(2, gate.InUse);
+        Assert.IsFalse(gate.AcquireAsync(TestContext.CancellationToken).IsCompleted, "满员后必须排队。");
+    }
+
+    [TestMethod]
+    public async Task Release_HandsThePermitToTheFirstWaiter()
+    {
+        var gate = new AdjustableConcurrencyGate(1);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        Task first = gate.AcquireAsync(TestContext.CancellationToken);
+        Task second = gate.AcquireAsync(TestContext.CancellationToken);
+
+        gate.Release();
+
+        await first.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+        Assert.IsFalse(second.IsCompleted, "名额只有一个,第二个还得等。");
+        Assert.AreEqual(1, gate.InUse, "移交名额不改变占用数。");
+    }
+
+    /// <summary>收紧上限后,归还的名额不再放行 —— 直到占用数降到新上限以下。</summary>
+    [TestMethod]
+    public async Task LimitTo_ShrinksEffectiveConcurrency()
+    {
+        var gate = new AdjustableConcurrencyGate(3);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(1, gate.LimitTo(1));
+
+        gate.ReleaseWithoutHandoff(); // 占用 2 → 1
+        Task queued = gate.AcquireAsync(TestContext.CancellationToken);
+        Assert.IsFalse(queued.IsCompleted, "上限已是 1、且已占 1,新的请求必须排队。");
+
+        gate.Release(); // 最后一个占用者归还,名额移交给排队者
+        await queued.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+    }
+
+    /// <summary>上限只减不增:一次误报不该把并发又放回去。</summary>
+    [TestMethod]
+    public void LimitTo_NeverRaisesTheLimit_AndNeverGoesBelowOne()
+    {
+        var gate = new AdjustableConcurrencyGate(2);
+
+        Assert.AreEqual(1, gate.LimitTo(1));
+        Assert.AreEqual(1, gate.LimitTo(8));
+        Assert.AreEqual(1, gate.LimitTo(0));
+        Assert.AreEqual(1, gate.LimitTo(-5));
+    }
+
+    /// <summary>
+    /// 失败路径上的归还**不叫醒**排队者:那次失败没有让任何连接空出来,
+    /// 叫醒下一个只会让他重复同一次失败(再去开一条注定被服务器顶回来的连接)。
+    /// </summary>
+    [TestMethod]
+    public async Task ReleaseWithoutHandoff_LeavesWaitersQueued()
+    {
+        var gate = new AdjustableConcurrencyGate(2);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        Task queued = gate.AcquireAsync(TestContext.CancellationToken);
+
+        gate.ReleaseWithoutHandoff();
+
+        Assert.IsFalse(queued.IsCompleted, "不移交就不该叫醒排队者。");
+        Assert.AreEqual(1, gate.InUse);
+
+        gate.Release(); // 真正的归还才叫醒
+        await queued.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+    }
+
+    /// <summary>
+    /// 收紧那一刻已经发出去的名额可能多于新上限(4 个传输在跑、上限却收成了 1)。
+    /// 这时候每回收一个就转手给下一个,占用数永远降不下来 —— 服务器看到的仍是多个并发传输,
+    /// 照样报忙。超发期间必须只收不发,直到占用数落回上限。
+    /// </summary>
+    [TestMethod]
+    public async Task Release_WhileOverSubscribed_ShedsPermitsInsteadOfHandingThemOn()
+    {
+        var gate = new AdjustableConcurrencyGate(3);
+        for (int i = 0; i < 3; i++)
+        {
+            await gate.AcquireAsync(TestContext.CancellationToken);
+        }
+        gate.LimitTo(1);
+        Task queued = gate.AcquireAsync(TestContext.CancellationToken);
+
+        gate.Release(); // 占用 3 → 2:超发,不移交
+        Assert.IsFalse(queued.IsCompleted);
+        gate.Release(); // 2 → 1:仍是超发的最后一格,不移交
+        Assert.IsFalse(queued.IsCompleted);
+        Assert.AreEqual(1, gate.InUse);
+
+        gate.Release(); // 占用已回到上限内,这一次才移交
+        await queued.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+        Assert.AreEqual(1, gate.InUse, "移交后占用数仍是 1:排队者接手了那个名额。");
+    }
+
+    /// <summary>取消的等待者不占名额:归还时跳过它,交给下一个真在等的人。</summary>
+    [TestMethod]
+    public async Task CancelledWaiter_DoesNotSwallowThePermit()
+    {
+        var gate = new AdjustableConcurrencyGate(1);
+        await gate.AcquireAsync(TestContext.CancellationToken);
+        using var cts = new CancellationTokenSource();
+        Task cancelled = gate.AcquireAsync(cts.Token);
+        Task waiting = gate.AcquireAsync(TestContext.CancellationToken);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => cancelled);
+
+        gate.Release();
+
+        await waiting.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+    }
+
+    /// <summary>已取消的令牌直接拒绝,不排队。</summary>
+    [TestMethod]
+    public async Task Acquire_WithAlreadyCancelledToken_Throws()
+    {
+        var gate = new AdjustableConcurrencyGate(1);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => gate.AcquireAsync(cts.Token));
+    }
+
+    /// <summary>MSTest 注入的测试上下文(取消令牌)。</summary>
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
@@ -205,6 +205,105 @@ public class FtpFileServiceIntegrationTests
             () => _service.ListDirectoryAsync(sessionId, "/"));
     }
 
+    /// <summary>
+    /// 服务器只肯给一条控制连接(用户报的"仅支持单线程上传"那类)时,批量上传必须**全部成功**。
+    /// </summary>
+    /// <remarks>
+    /// 修之前:第一个文件占住那唯一的连接,后面每个文件都去开第二条,被 421 顶回来 ——
+    /// 用户看到的是"批量上传只成功一个,其余全失败",而且那个 <c>421</c> 被翻译成连接级异常,
+    /// 顺带把整条会话标记成离线(树上的圆点变灰)。
+    /// 修之后:池发现"已有活连接却开不出新连接",就把上限收成 1,后来的传输排队复用那一条。
+    /// </remarks>
+    [TestMethod]
+    public async Task ConcurrentUploads_WhenServerAllowsOneConnection_AllSucceed()
+    {
+        _server.MaxConcurrentSessions = 1;
+        string outDir = Path.Combine(Path.GetTempPath(), $"vela-ftp-src-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            var faulted = false;
+            _service.SessionStateChanged += (_, change) => faulted |= change.State == FtpSessionState.Faulted;
+
+            byte[] payload = Enumerable.Range(0, 4096).Select(static i => (byte)(i % 251)).ToArray();
+            var sources = new List<string>();
+            for (int i = 0; i < 5; i++)
+            {
+                string path = Path.Combine(outDir, $"batch{i}.bin");
+                await File.WriteAllBytesAsync(path, payload, TestContext.CancellationToken);
+                sources.Add(path);
+            }
+            Guid sessionId = await OpenAsync(maxConnections: 4);
+
+            // 界面上的"最大并发传输数"就是这么发起的:所有文件同时开跑。
+            await Task.WhenAll(sources.Select(source => _service.UploadFileAsync(
+                sessionId,
+                source,
+                "/" + Path.GetFileName(source),
+                progress: null,
+                resumeOffset: 0,
+                TestContext.CancellationToken)));
+
+            foreach (string source in sources)
+            {
+                string landed = Path.Combine(_root, Path.GetFileName(source));
+                Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
+                CollectionAssert.AreEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+            }
+            Assert.IsFalse(faulted, "退化成单连接是正常降级,不该把整条会话标记为离线。");
+        }
+        finally
+        {
+            Directory.Delete(outDir, true);
+        }
+    }
+
+    /// <summary>
+    /// 另一类服务器:控制连接随便开,但**一次只让传一个文件**(第二个 STOR 直接 450)。
+    /// 池那条自适应看不到这种拒绝(连接开得出来),得由传输层收紧后重试。
+    /// </summary>
+    [TestMethod]
+    public async Task ConcurrentUploads_WhenServerAllowsOneTransfer_AllSucceed()
+    {
+        _server.MaxConcurrentTransfers = 1;
+        string outDir = Path.Combine(Path.GetTempPath(), $"vela-ftp-src-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            byte[] payload = Enumerable.Range(0, 8192).Select(static i => (byte)(i % 253)).ToArray();
+            var sources = new List<string>();
+            for (int i = 0; i < 4; i++)
+            {
+                string path = Path.Combine(outDir, $"busy{i}.bin");
+                await File.WriteAllBytesAsync(path, payload, TestContext.CancellationToken);
+                sources.Add(path);
+            }
+            Guid sessionId = await OpenAsync(maxConnections: 4);
+
+            await Task.WhenAll(sources.Select(source => _service.UploadFileAsync(
+                sessionId,
+                source,
+                "/" + Path.GetFileName(source),
+                progress: null,
+                resumeOffset: 0,
+                TestContext.CancellationToken)));
+
+            foreach (string source in sources)
+            {
+                string landed = Path.Combine(_root, Path.GetFileName(source));
+                Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
+                CollectionAssert.AreEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+            }
+        }
+        finally
+        {
+            Directory.Delete(outDir, true);
+        }
+    }
+
+    /// <summary>MSTest 注入的测试上下文(取消令牌)。</summary>
+    public TestContext TestContext { get; set; } = null!;
+
     private Task<Guid> OpenAsync(int maxConnections = 2, bool anonymous = false) =>
         _service.OpenSessionAsync(new FtpConnectionInfo
         {

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/LoopbackFtpServer.cs
@@ -50,6 +50,30 @@ internal sealed class LoopbackFtpServer : IDisposable
     /// <summary>已接受的控制连接数(用于断言连接池确实开了多条连接)。</summary>
     public int AcceptedConnections;
 
+    /// <summary>
+    /// 同一时刻允许的控制连接数上限;超出的连接一律以 <c>421</c> 顶回去(连欢迎语都不给)。
+    /// <para>
+    /// 复刻用户报的那类服务器:只支持单线程上传,一次只能传一个文件,批量上传时
+    /// 除第一个以外全部失败。0 = 不限(默认)。
+    /// </para>
+    /// </summary>
+    public int MaxConcurrentSessions { get; set; }
+
+    /// <summary>被 <see cref="MaxConcurrentSessions" /> 顶回去的连接数(用于断言确实撞过限制)。</summary>
+    public int RejectedConnections;
+
+    /// <summary>
+    /// 同一时刻允许的上传数上限;超出的 <c>STOR</c> 以 <c>450 Transfer busy</c> 顶回去。
+    /// 复刻另一类服务器:控制连接随便开,但一次只让传一个文件。0 = 不限(默认)。
+    /// </summary>
+    public int MaxConcurrentTransfers { get; set; }
+
+    /// <summary>被 <see cref="MaxConcurrentTransfers" /> 顶回去的传输数。</summary>
+    public int RejectedTransfers;
+
+    private int _liveSessions;
+    private int _liveTransfers;
+
     public void Dispose()
     {
         _cts.Cancel();
@@ -87,29 +111,52 @@ internal sealed class LoopbackFtpServer : IDisposable
             NetworkStream stream = client.GetStream();
             using var reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
             using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true) { AutoFlush = true, NewLine = "\r\n" };
-            await writer.WriteLineAsync("220 VelaShell loopback FTP").ConfigureAwait(false);
-            while (!_cts.IsCancellationRequested)
+
+            // 连接数超限:按真实服务器的做法,开口就是 421 然后关掉,不给欢迎语。
+            int live = Interlocked.Increment(ref _liveSessions);
+            if (MaxConcurrentSessions > 0 && live > MaxConcurrentSessions)
             {
-                string? line;
-                try
-                {
-                    line = await reader.ReadLineAsync(_cts.Token).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is IOException or OperationCanceledException)
-                {
-                    return;
-                }
-                if (line is null)
-                {
-                    return;
-                }
-                int space = line.IndexOf(' ');
-                string command = (space < 0 ? line : line[..space]).ToUpperInvariant();
-                string argument = space < 0 ? string.Empty : line[(space + 1)..].Trim();
-                if (!await ExecuteAsync(command, argument, state, writer).ConfigureAwait(false))
-                {
-                    return;
-                }
+                Interlocked.Decrement(ref _liveSessions);
+                Interlocked.Increment(ref RejectedConnections);
+                await writer.WriteLineAsync(
+                    "421 Too many users connected, please try again later.").ConfigureAwait(false);
+                return;
+            }
+            try
+            {
+                await ServeAsync(reader, writer, state).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _liveSessions);
+            }
+        }
+    }
+
+    private async Task ServeAsync(StreamReader reader, StreamWriter writer, SessionState state)
+    {
+        await writer.WriteLineAsync("220 VelaShell loopback FTP").ConfigureAwait(false);
+        while (!_cts.IsCancellationRequested)
+        {
+            string? line;
+            try
+            {
+                line = await reader.ReadLineAsync(_cts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or OperationCanceledException)
+            {
+                return;
+            }
+            if (line is null)
+            {
+                return;
+            }
+            int space = line.IndexOf(' ');
+            string command = (space < 0 ? line : line[..space]).ToUpperInvariant();
+            string argument = space < 0 ? string.Empty : line[(space + 1)..].Trim();
+            if (!await ExecuteAsync(command, argument, state, writer).ConfigureAwait(false))
+            {
+                return;
             }
         }
     }
@@ -344,6 +391,28 @@ internal sealed class LoopbackFtpServer : IDisposable
     {
         string path = Local(Normalize(state, argument));
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        // "一次只让传一个文件"的服务器:控制连接开几条都行,但第二个传输直接 450 顶回去。
+        int live = Interlocked.Increment(ref _liveTransfers);
+        if (MaxConcurrentTransfers > 0 && live > MaxConcurrentTransfers)
+        {
+            Interlocked.Decrement(ref _liveTransfers);
+            Interlocked.Increment(ref RejectedTransfers);
+            await writer.WriteLineAsync("450 Transfer busy, only one transfer at a time").ConfigureAwait(false);
+            return;
+        }
+        try
+        {
+            await ReceiveFileCoreAsync(state, path, writer, append).ConfigureAwait(false);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _liveTransfers);
+        }
+    }
+
+    private static async Task ReceiveFileCoreAsync(SessionState state, string path, StreamWriter writer, bool append)
+    {
         await writer.WriteLineAsync("150 Opening data connection").ConfigureAwait(false);
         await using (Stream data = await state.AcceptDataAsync().ConfigureAwait(false))
         await using (FileStream target = append || state.RestartOffset > 0

--- a/tests/VelaShell.Infrastructure.Tests/RemoteProcessServiceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/RemoteProcessServiceTests.cs
@@ -1,0 +1,62 @@
+using NSubstitute;
+using VelaShell.Core.Processes;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Ssh;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>
+/// 远端任务管理器的数据源:采集前先确认对端认 sh 语法。
+/// </summary>
+/// <remarks>
+/// 不拦的后果和状态栏指标同源(#305):进程探测命令读的是 /proc 与 ps,cmd.exe 跑不动它
+/// 却照样有输出(整行被 echo 原样打回),而 <see cref="RemoteProcessProbe.Parse" /> 只在输出为空时
+/// 返回 null —— 面板于是显示一张 "CPU 0.0% / 0 个进程" 的空表,而不是那句现成的
+/// "该视图读取远端的 /proc 与 ps,需要一个已连接的 Linux 会话"。
+/// </remarks>
+[TestClass]
+[TestCategory("Processes")]
+public class RemoteProcessServiceTests
+{
+    [TestMethod]
+    public async Task NonPosixRemote_SendsNoProbeCommand_AndReportsUnavailable()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(true);
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult("", "'printf' 不是内部或外部命令", 1)));
+        client.RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("__N__; nproc ; echo __P__; cat /proc/stat\n");
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        var service = new RemoteProcessService(connections);
+
+        Assert.IsNull(await service.GetSnapshotAsync(sessionId, TestContext.CancellationToken));
+
+        await client.DidNotReceive().RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>反向守卫:Linux 远端不能被这道闸误伤,采集命令照发。</summary>
+    [TestMethod]
+    public async Task PosixRemote_StillRunsTheProbeCommand()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(true);
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult(RemoteShellProbe.PosixMarker + "\n", "", 0)));
+        client.RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("");
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        var service = new RemoteProcessService(connections);
+
+        await service.GetSnapshotAsync(sessionId, TestContext.CancellationToken);
+
+        await client.Received(1).RunCommandAsync(
+            RemoteProcessProbe.ProbeCommand, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>MSTest 注入的测试上下文(取消令牌)。</summary>
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/tests/VelaShell.Infrastructure.Tests/SessionMetricsServiceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/SessionMetricsServiceTests.cs
@@ -9,6 +9,14 @@ namespace VelaShell.Infrastructure.Tests;
 [TestCategory("Metrics")]
 public class SessionMetricsServiceTests
 {
+    /// <summary>
+    /// 让替身像一台 Linux 主机那样回答 POSIX shell 探针。采集前先探一句是 #305 之后的前置动作:
+    /// 不答这一句,服务就认定对端跑不了 /proc 探测,一条命令都不会发。
+    /// </summary>
+    private static void StubPosixShell(ISshClientWrapper client) =>
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult(RemoteShellProbe.PosixMarker + "\n", "", 0)));
+
     private static string Probe(long cpuBusy, long cpuIdle, long rx, long tx) =>
         "__P__\n4\n" +
         "__L__\n0.5 0.4 0.3 1/100 200\n" +
@@ -25,6 +33,7 @@ public class SessionMetricsServiceTests
         var sessionId = Guid.NewGuid();
         ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
         client.IsConnected.Returns(true);
+        StubPosixShell(client);
         ISshConnectionService connections = Substitute.For<ISshConnectionService>();
         connections.GetClient(sessionId).Returns(client);
         var service = new SessionMetricsService(connections);
@@ -60,6 +69,7 @@ public class SessionMetricsServiceTests
         var sessionId = Guid.NewGuid();
         ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
         client.IsConnected.Returns(true);
+        StubPosixShell(client);
         ISshConnectionService connections = Substitute.For<ISshConnectionService>();
         connections.GetClient(sessionId).Returns(client);
         var service = new SessionMetricsService(connections);
@@ -85,6 +95,7 @@ public class SessionMetricsServiceTests
         var sessionId = Guid.NewGuid();
         ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
         client.IsConnected.Returns(true);
+        StubPosixShell(client);
         ISshConnectionService connections = Substitute.For<ISshConnectionService>();
         connections.GetClient(sessionId).Returns(client);
         var service = new SessionMetricsService(connections);
@@ -128,6 +139,7 @@ public class SessionMetricsServiceTests
         var sessionId = Guid.NewGuid();
         ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
         client.IsConnected.Returns(true);
+        StubPosixShell(client);
         ISshConnectionService connections = Substitute.For<ISshConnectionService>();
         connections.GetClient(sessionId).Returns(client);
         var service = new SessionMetricsService(connections);
@@ -147,5 +159,32 @@ public class SessionMetricsServiceTests
 
         Assert.IsNotNull(afterReconnect);
         Assert.IsFalse(afterReconnect.HasNetRates);
+    }
+
+    /// <summary>
+    /// 非 POSIX 远端(Windows 的 cmd.exe)必须**一条采集命令都不发**,并如实报告"无数据"。
+    /// 以前不拦:cmd 把 <c>echo __P__; nproc; …</c> 整行原样回显,Parse 只在输出为空时才返回
+    /// null,于是状态栏拿着这堆回声显示 CPU 0.00% 的假数据,而且每秒重来一次(#305 同源)。
+    /// </summary>
+    [TestMethod]
+    public async Task NonPosixRemote_SendsNoProbeCommand_AndReportsNoData()
+    {
+        var sessionId = Guid.NewGuid();
+        ISshClientWrapper client = Substitute.For<ISshClientWrapper>();
+        client.IsConnected.Returns(true);
+        // cmd.exe 的回答:printf 不是内部或外部命令。
+        client.RunCommandDetailedAsync(RemoteShellProbe.ProbeCommand, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new RemoteCommandResult("", "'printf' 不是内部或外部命令", 1)));
+        // 万一门没关住,让采集命令返回 cmd 那种"整行回声",以便断言能抓到假数据。
+        client.RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("__P__; nproc ; echo __L__; cat /proc/loadavg\n");
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.GetClient(sessionId).Returns(client);
+        var service = new SessionMetricsService(connections);
+
+        Assert.IsNull(await service.GetMetricsAsync(sessionId));
+        Assert.IsNull(await service.GetStaticInfoAsync(sessionId));
+
+        await client.DidNotReceive().RunCommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileBrowserViewModelTests.cs
@@ -1960,4 +1960,40 @@ public class FileBrowserViewModelTests
             .DidNotReceive()
             .ListDirectoryAsync(_sessionId, "/somewhere/else", Arg.Any<CancellationToken>());
     }
+
+    /// <summary>
+    /// 一次 OSC 7 都没收到过就打开「跟随终端目录」= 点了什么都不会发生,必须说清为什么。
+    /// Windows 远端(cmd.exe/PowerShell)就是这种情况:那串钩子只对 POSIX shell 注入(#305)。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public void FollowTerminal_WithoutAnyReport_ExplainsWhyNothingHappens()
+    {
+        _vm.FollowTerminal = true;
+
+        Assert.AreEqual(Strings.Get("Sftp_FollowTerminalNoReport"), _vm.ErrorMessage);
+    }
+
+    /// <summary>关掉开关就把这句提示收回去,别赖在面板顶上。</summary>
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public void FollowTerminal_TurnedOff_RemovesTheHint()
+    {
+        _vm.FollowTerminal = true;
+        _vm.FollowTerminal = false;
+
+        Assert.IsNull(_vm.ErrorMessage);
+    }
+
+    /// <summary>终端有上报的会话不该看到这句提示 —— 它说的是"没收到过上报"。</summary>
+    [TestMethod]
+    [TestCategory("FileBrowser")]
+    public void FollowTerminal_AfterAReport_ShowsNoHint()
+    {
+        _vm.OnTerminalWorkingDirectoryChanged("/srv/app");
+
+        _vm.FollowTerminal = true;
+
+        Assert.IsNull(_vm.ErrorMessage);
+    }
 }

--- a/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
@@ -2,6 +2,7 @@ using NSubstitute;
 using ReactiveUI.Primitives;
 using VelaShell.Core.Data;
 using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
 using VelaShell.Core.Sftp;
 using VelaShell.ViewModels;
 
@@ -491,6 +492,52 @@ public class FileTransferViewModelTests
         Assert.AreEqual(0, vm.PanelOffsetX);
         Assert.AreEqual(0, vm.PanelOffsetY);
         vm.PersistPanelPosition();
+    }
+
+    /// <summary>
+    /// 排队中的行显示"等待中",而不是 0% + "0 B / 0 B • 0 B/s • ↑ 上传中"。
+    /// </summary>
+    /// <remarks>
+    /// FTP 对端只允许一条连接(或一次只让传一个文件)时,整批传输会被连接池排成串行,
+    /// 后面的项要等很久才轮到 —— 那期间它们一个字节都没在动,却写着"上传中 0%",
+    /// 看上去就是卡死了。
+    /// </remarks>
+    [TestMethod]
+    [TestCategory("FileTransfer")]
+    public void QueuedTransfer_ReadsAsWaiting_NotZeroPercent()
+    {
+        _vm.AddTransfer(CreateTask(status: TransferStatus.Queued));
+        TransferItemViewModel item = _vm.Transfers[0];
+
+        Assert.IsTrue(item.IsWaiting);
+        Assert.AreEqual(Strings.Get("Msg_Waiting"), item.ProgressText);
+        Assert.Contains(Strings.Get("Msg_Waiting"), item.InfoLine);
+        Assert.DoesNotContain("0 B/s", item.InfoLine);
+        Assert.DoesNotContain(Strings.Get("Msg_Uploading"), item.InfoLine);
+    }
+
+    /// <summary>轮到它开跑之后,那一行要变回正常的百分比与速度。</summary>
+    [TestMethod]
+    [TestCategory("FileTransfer")]
+    public void QueuedTransfer_OnceStarted_ShowsPercentAgain()
+    {
+        _vm.AddTransfer(CreateTask(status: TransferStatus.Queued));
+        TransferItemViewModel item = _vm.Transfers[0];
+
+        item.Status = TransferStatus.InProgress;
+        item.UpdateProgress(new TransferProgress
+        {
+            FileName = "file.txt",
+            BytesTransferred = 512,
+            TotalBytes = 1024,
+            Percentage = 50,
+            SpeedBytesPerSecond = 128,
+            EstimatedTimeRemaining = TimeSpan.FromSeconds(4),
+        });
+
+        Assert.IsFalse(item.IsWaiting);
+        Assert.AreEqual("50%", item.ProgressText);
+        Assert.Contains(Strings.Get("Msg_Uploading"), item.InfoLine);
     }
 
     /// <summary>存储读取失败不能把界面带崩 —— 位置记不住是小事,启动不了是大事。</summary>


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

- FTP连接池并发自适应，支持动态降级串行，解决“只允许单连接/单传输”服务器批量失败问题，统一异常识别并触发降级
- 文件传输面板新增“等待中”状态，优化排队体验与进度显示
- SFTP终端目录跟随增加无OSC 7提示，自动移除，完善多语言资源
- 系统资源监控/远端任务管理器仅POSIX采集，避免非POSIX误采集与假数据
- 优化RemoteShellProbe缓存逻辑，完善多语言文案，补充相关单元/集成测试

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [x] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`docs/快捷键参考.md` 已同步
- [ ] **改了文档** → `docs/` 与 `docs-en/` 两侧都改了
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `docs/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
