### PR TITLE
升级依赖包SDK版本.

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -24,7 +24,9 @@
          PrivateAssets=all + ExcludeAssets=runtime:编译期能看见类型,输出目录里不留 dll ——
          装载时它必须与宿主是同一份程序集,复制过去就成了两份类型。
          版本须与 src/Directory.Packages.props 里宿主引的那一条一致。 -->
-    <PackageReference Include="VelaShell.PluginSdk" Version="1.5.0" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="VelaShell.PluginSdk" Version="1.5.1" PrivateAssets="all" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <!-- 仅编译期引用 Avalonia,运行时由装载方共享同一套(版本须与宿主一致)。 -->
     <PackageReference Include="Avalonia" Version="12.1.1" ExcludeAssets="runtime" />
     <!-- 输入框是 AvaloniaEdit(Markdown 高亮 + @ 引用芯片,纯 TextBox 给不了内联富文本)。

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
          (VelaShellLabs/velashell-plugins)里,版本由那边的中央包管理登记,别再加回来。
          本仓库 plugins/ 下的自建插件(AI)不走中央包版本管理
          (根目录没有 Directory.Packages.props),依赖版本写在各自的 csproj 里。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.0" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.1" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <!-- 插件契约与测试替身,由插件工具链仓库(joesdu/velashell-plugin-toolchain)
          发布到 nuget.org。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.0" />
-    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.5.0" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.1" />
+    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.5.1" />
     <PackageVersion Include="Avalonia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 真实光栅化后端。headless 平台默认 UseHeadlessDrawing=true(绘制是空操作,

--- a/tests/fixtures/VelaShell.TestPlugin.Terminal/VelaShell.TestPlugin.Terminal.csproj
+++ b/tests/fixtures/VelaShell.TestPlugin.Terminal/VelaShell.TestPlugin.Terminal.csproj
@@ -15,7 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="VelaShell.PluginSdk" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="VelaShell.PluginSdk" PrivateAssets="all" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/fixtures/VelaShell.TestPlugin/VelaShell.TestPlugin.csproj
+++ b/tests/fixtures/VelaShell.TestPlugin/VelaShell.TestPlugin.csproj
@@ -29,7 +29,9 @@
   <ItemGroup>
     <!-- 契约由装载方(测试宿主)统一提供,不随夹具输出复制 —— 与真插件同一条规则:
          VelaShell.PluginSdk 必须与装载方是同一份程序集,复制过去就成了两份类型。 -->
-    <PackageReference Include="VelaShell.PluginSdk" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="VelaShell.PluginSdk" PrivateAssets="all" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
