### PR TITLE
优化代码风格与一致性提升可读性和规范性

### DIFF
--- a/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Protocols/PluginProtocolRegistry.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using VelaShell.PluginSdk.Protocols;
 using VelaShell.PluginSdk.Workspaces;
 

--- a/src/VelaShell.Infrastructure/Ssh/MeteredPortForwardHandle.cs
+++ b/src/VelaShell.Infrastructure/Ssh/MeteredPortForwardHandle.cs
@@ -110,41 +110,41 @@ internal sealed class MeteredPortForwardHandle : IPortForwardHandle
         switch (request.Kind)
         {
             case PortForwardKind.Local:
-            {
-                string targetHost = request.TargetHost!;
-                var targetPort = (int)request.TargetPort!;
-                TcpListener listener = Listen(request.BoundHost, (int)request.BoundPort);
-                return new(listener,
-                    async (_, ct) => await client.OpenTcpConnectionAsync(targetHost, targetPort, ct).ConfigureAwait(false));
-            }
+                {
+                    string targetHost = request.TargetHost!;
+                    int targetPort = (int)request.TargetPort!;
+                    TcpListener listener = Listen(request.BoundHost, (int)request.BoundPort);
+                    return new(listener,
+                        async (_, ct) => await client.OpenTcpConnectionAsync(targetHost, targetPort, ct).ConfigureAwait(false));
+                }
             case PortForwardKind.Dynamic:
-            {
-                TcpListener listener = Listen(request.BoundHost, (int)request.BoundPort);
-                return new(listener, (inbound, ct) => OpenSocksTargetAsync(client, inbound, ct));
-            }
+                {
+                    TcpListener listener = Listen(request.BoundHost, (int)request.BoundPort);
+                    return new(listener, (inbound, ct) => OpenSocksTargetAsync(client, inbound, ct));
+                }
             case PortForwardKind.Remote:
-            {
-                // 服务器侧的监听只有库能开,所以让它把流量交到本机的一个临时端口上,
-                // 由本类接力到真正的目标 —— 这样远程转发也走同一条计量路径。
-                IPEndPoint target = ResolveOutboundEndPoint(request.TargetHost!, (int)request.TargetPort!);
-                TcpListener meter = Listen("127.0.0.1", 0);
-                var meterPort = ((IPEndPoint)meter.LocalEndpoint).Port;
-                try
                 {
-                    RemoteForward forward = await client.StartRemoteForwardAsync(
-                        new RemoteIPListenEndPoint(request.BoundHost, (int)request.BoundPort),
-                        new IPEndPoint(IPAddress.Loopback, meterPort),
-                        cancellationToken).ConfigureAwait(false);
-                    return new(meter,
-                        async (_, ct) => await ConnectLocalAsync(target, ct).ConfigureAwait(false),
-                        forward, forward.ThrowIfStopped, forward.Stopped);
+                    // 服务器侧的监听只有库能开,所以让它把流量交到本机的一个临时端口上,
+                    // 由本类接力到真正的目标 —— 这样远程转发也走同一条计量路径。
+                    IPEndPoint target = ResolveOutboundEndPoint(request.TargetHost!, (int)request.TargetPort!);
+                    TcpListener meter = Listen("127.0.0.1", 0);
+                    int meterPort = ((IPEndPoint)meter.LocalEndpoint).Port;
+                    try
+                    {
+                        RemoteForward forward = await client.StartRemoteForwardAsync(
+                            new RemoteIPListenEndPoint(request.BoundHost, (int)request.BoundPort),
+                            new IPEndPoint(IPAddress.Loopback, meterPort),
+                            cancellationToken).ConfigureAwait(false);
+                        return new(meter,
+                            async (_, ct) => await ConnectLocalAsync(target, ct).ConfigureAwait(false),
+                            forward, forward.ThrowIfStopped, forward.Stopped);
+                    }
+                    catch
+                    {
+                        try { meter.Stop(); } catch { }
+                        throw;
+                    }
                 }
-                catch
-                {
-                    try { meter.Stop(); } catch { }
-                    throw;
-                }
-            }
             default:
                 throw new ArgumentOutOfRangeException(nameof(request), request.Kind, @"Unknown port forward kind.");
         }

--- a/src/VelaShell.Terminal/FileTransfer/TransferCommandParser.cs
+++ b/src/VelaShell.Terminal/FileTransfer/TransferCommandParser.cs
@@ -36,7 +36,7 @@ public static class TransferCommandParser
             return null;
         }
         string[] tokens = commandLine.Split(
-            (char[])[' ', '\t'],
+            [' ', '\t'],
             StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         int i = SkipPrefixTokens(tokens);

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -2745,7 +2745,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
                 }
                 else
                 {
-                   _ = CopyAsync();
+                    _ = CopyAsync();
                 }
                 return;
 

--- a/tests/VelaShell.Core.Tests/Tunnels/TunnelServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Tunnels/TunnelServiceTests.cs
@@ -258,7 +258,7 @@ public class TunnelServiceTests
     [TestMethod]
     public async Task RefreshStatistics_CopiesCountersFromHandle()
     {
-        var handle = Substitute.For<IPortForwardHandle>();
+        IPortForwardHandle handle = Substitute.For<IPortForwardHandle>();
         handle.BytesTransferred.Returns(4096L);
         handle.TotalConnections.Returns(3);
         handle.ActiveConnections.Returns(1);
@@ -280,7 +280,7 @@ public class TunnelServiceTests
     [TestMethod]
     public async Task StopTunnelAsync_KeepsFinalCounters_AndClearsActive()
     {
-        var handle = Substitute.For<IPortForwardHandle>();
+        IPortForwardHandle handle = Substitute.For<IPortForwardHandle>();
         handle.BytesTransferred.Returns(8192L);
         handle.TotalConnections.Returns(5);
         handle.ActiveConnections.Returns(2);

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
@@ -222,7 +222,7 @@ public class FtpFileServiceIntegrationTests
         Directory.CreateDirectory(outDir);
         try
         {
-            var faulted = false;
+            bool faulted = false;
             _service.SessionStateChanged += (_, change) => faulted |= change.State == FtpSessionState.Faulted;
 
             byte[] payload = Enumerable.Range(0, 4096).Select(static i => (byte)(i % 251)).ToArray();

--- a/tests/VelaShell.Infrastructure.Tests/Ssh/MeteredPortForwardTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ssh/MeteredPortForwardTests.cs
@@ -21,7 +21,7 @@ public class MeteredPortForwardTests
     public async Task Relay_CountsBothDirections()
     {
         using CancellationTokenSource deadline = Deadline();
-        await using EchoServer echo = EchoServer.Start();
+        await using var echo = EchoServer.Start();
         using MeteredPortForwardHandle relay = StartRelay(echo, out int relayPort);
 
         byte[] payload = Encoding.ASCII.GetBytes("the quick brown fox");
@@ -46,11 +46,11 @@ public class MeteredPortForwardTests
     public async Task Relay_AggregatesAcrossConnections()
     {
         using CancellationTokenSource deadline = Deadline();
-        await using EchoServer echo = EchoServer.Start();
+        await using var echo = EchoServer.Start();
         using MeteredPortForwardHandle relay = StartRelay(echo, out int relayPort);
 
         byte[] payload = "0123456789"u8.ToArray();
-        for (var i = 0; i < 3; i++)
+        for (int i = 0; i < 3; i++)
         {
             using var client = new TcpClient();
             await client.ConnectAsync(IPAddress.Loopback, relayPort, deadline.Token);
@@ -99,7 +99,7 @@ public class MeteredPortForwardTests
     public async Task Stop_ReleasesListeningPort()
     {
         using CancellationTokenSource deadline = Deadline();
-        await using EchoServer echo = EchoServer.Start();
+        await using var echo = EchoServer.Start();
         MeteredPortForwardHandle relay = StartRelay(echo, out int relayPort);
         Assert.IsTrue(relay.IsStarted);
 
@@ -131,8 +131,8 @@ public class MeteredPortForwardTests
         var reported = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
-        var relayPort = ((IPEndPoint)listener.LocalEndpoint).Port;
-        using MeteredPortForwardHandle relay = MeteredPortForwardHandle.CreateRelay(listener, (_, _) =>
+        int relayPort = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var relay = MeteredPortForwardHandle.CreateRelay(listener, (_, _) =>
         {
             throw new SocketException((int)SocketError.ConnectionRefused);
         });

--- a/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
+++ b/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
@@ -5,7 +5,6 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using VelaShell.Terminal.Rendering;

--- a/tests/VelaShell.Terminal.Tests/BroadcastInputEncodingTests.cs
+++ b/tests/VelaShell.Terminal.Tests/BroadcastInputEncodingTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Avalonia.Headless;
 using Avalonia.Input;
 using VelaShell.Terminal.Rendering;
 

--- a/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/TerminalCellMemoryTests.cs
@@ -48,26 +48,26 @@ public class TerminalCellMemoryTests
         // 各 Kind 下未使用的位必须恒为 0,否则"比较 packed"就不再等价于逐字段比较。
         Assert.IsTrue(TerminalColor.Default.IsDefault);
         Assert.AreEqual(TerminalColorKind.Default, TerminalColor.Default.Kind);
-        Assert.AreEqual(0, (int)TerminalColor.Default.Index);
+        Assert.AreEqual(0, TerminalColor.Default.Index);
 
         var indexed = TerminalColor.FromIndex(196);
         Assert.AreEqual(TerminalColorKind.Indexed, indexed.Kind);
-        Assert.AreEqual(196, (int)indexed.Index);
-        Assert.AreEqual(0, (int)indexed.R, "Indexed 色的 RGB 通道必须读作 0(与打包前语义一致)。");
-        Assert.AreEqual(0, (int)indexed.G);
-        Assert.AreEqual(0, (int)indexed.B);
+        Assert.AreEqual(196, indexed.Index);
+        Assert.AreEqual(0, indexed.R, "Indexed 色的 RGB 通道必须读作 0(与打包前语义一致)。");
+        Assert.AreEqual(0, indexed.G);
+        Assert.AreEqual(0, indexed.B);
         Assert.IsFalse(indexed.IsDefault);
 
         var rgb = TerminalColor.FromRgb(0x12, 0x34, 0x56);
         Assert.AreEqual(TerminalColorKind.Rgb, rgb.Kind);
-        Assert.AreEqual(0x12, (int)rgb.R);
-        Assert.AreEqual(0x34, (int)rgb.G);
-        Assert.AreEqual(0x56, (int)rgb.B);
-        Assert.AreEqual(0, (int)rgb.Index, "Rgb 色的调色板索引必须读作 0。");
+        Assert.AreEqual(0x12, rgb.R);
+        Assert.AreEqual(0x34, rgb.G);
+        Assert.AreEqual(0x56, rgb.B);
+        Assert.AreEqual(0, rgb.Index, "Rgb 色的调色板索引必须读作 0。");
 
         // 索引钳制。
-        Assert.AreEqual(255, (int)TerminalColor.FromIndex(999).Index);
-        Assert.AreEqual(0, (int)TerminalColor.FromIndex(-5).Index);
+        Assert.AreEqual(255, TerminalColor.FromIndex(999).Index);
+        Assert.AreEqual(0, TerminalColor.FromIndex(-5).Index);
 
         // 跨 Kind 绝不相等,即使低位数值相同(Indexed 5 vs Rgb 0,0,5)。
         Assert.AreNotEqual(TerminalColor.FromIndex(5), TerminalColor.FromRgb(0, 0, 5));
@@ -98,7 +98,7 @@ public class TerminalCellMemoryTests
 
         cell.Combining = null;
         Assert.IsNull(cell.Combining);
-        Assert.AreEqual(0, (int)cell.CombiningIndex);
+        Assert.AreEqual(0, cell.CombiningIndex);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GhostTextRemainderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Avalonia.Headless;
 using VelaShell.Terminal.Rendering;
 
 namespace VelaShell.Terminal.Tests;

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -3,7 +3,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
-using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using VelaShell.Terminal.Rendering;
 

--- a/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/PasteShortcutUiTests.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Avalonia.Controls;
-using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;

--- a/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ResizePreservationTests.cs
@@ -27,7 +27,7 @@ public class ResizePreservationTests
         // reflow 会把旧行对象回收复用(避免每次重排为整个缓冲区重新分配上万个单元格数组)。
         // 这类复用出错的典型症状就是"同一个行对象被塞进缓冲区两处":一处改写会连带另一处
         // 一起变,画面上表现为某一行的内容莫名其妙复制到别处。这里直接按引用identity 查重。
-        var e = New(40, 8);
+        TerminalEmulator e = New(40, 8);
         for (int i = 0; i < 40; i++)
         {
             Feed(e, $"line-{i} with enough text to wrap when the terminal gets narrow\r\n");
@@ -56,7 +56,7 @@ public class ResizePreservationTests
         // 它不是内容,重排时必须丢掉 —— 否则每经一次 reflow 就在断点处凭空多出一个空格。
         //
         // 宽度 5:'a','b' 占 0,1;'中' 占 2,3;'文' 需要两列而只剩第 4 列 → 换行,第 4 列成为填充格。
-        var e = New(5, 4);
+        TerminalEmulator e = New(5, 4);
         Feed(e, "ab中文");
 
         TerminalRow wrapped = e.Screen.ViewLine(0);
@@ -78,7 +78,7 @@ public class ResizePreservationTests
     {
         // 反向保险:修填充格时不能顺手把宽字符的尾格也砍了 —— 砍掉的话前导格会被当成
         // 单宽字符,重排后宽字符只占一列,后面所有内容跟着错位。
-        var e = New(8, 4);
+        TerminalEmulator e = New(8, 4);
         Feed(e, "ab中");
 
         e.Resize(20, 4);
@@ -95,7 +95,7 @@ public class ResizePreservationTests
         // 行回收之后的内容回归:反复改宽再回到原宽,文本必须逐字不变。
         // 混排宽字符:它们曾经会在每次重排的换行断点处多攒一个空格(见
         // Reflow_WideCharWrapPadding_IsNotCarriedAsContent),这条用例连带把那个回归也压住。
-        var e = New(60, 6);
+        TerminalEmulator e = New(60, 6);
         string[] written =
         [
             "alpha bravo charlie delta echo foxtrot golf hotel india juliet",

--- a/tests/VelaShell.Tests/ViewModels/TunnelPanelViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TunnelPanelViewModelTests.cs
@@ -42,8 +42,8 @@ public class TunnelPanelViewModelTests
     [TestCategory("TunnelUI")]
     public async Task RefreshLiveState_SessionDropped_RebuildsAutoReconnectTunnel()
     {
-        var alive = true;
-        Guid reconnectedSession = Guid.NewGuid();
+        bool alive = true;
+        var reconnectedSession = Guid.NewGuid();
         TunnelPanelViewModel vm = CreateVm(() => alive, _ => Task.FromResult(reconnectedSession));
         await SeedTunnelAsync(vm, autoReconnect: true);
 
@@ -65,7 +65,7 @@ public class TunnelPanelViewModelTests
     [TestCategory("TunnelUI")]
     public async Task RefreshLiveState_SessionDropped_LeavesManualTunnelStopped()
     {
-        var alive = true;
+        bool alive = true;
         TunnelPanelViewModel vm = CreateVm(() => alive, _ => Task.FromResult(Guid.NewGuid()));
         await SeedTunnelAsync(vm, autoReconnect: false);
         _workflowService.ClearReceivedCalls();
@@ -87,9 +87,9 @@ public class TunnelPanelViewModelTests
     [TestCategory("TunnelUI")]
     public async Task RefreshLiveState_ReconnectFailure_BacksOffBeforeRetrying()
     {
-        var alive = true;
-        var serverIsDown = false;
-        var attempts = 0;
+        bool alive = true;
+        bool serverIsDown = false;
+        int attempts = 0;
         TunnelPanelViewModel vm = CreateVm(() => alive, _ =>
         {
             if (!serverIsDown)
@@ -123,7 +123,7 @@ public class TunnelPanelViewModelTests
     [TestCategory("TunnelUI")]
     public async Task RefreshLiveState_DoesNotRebuild_TunnelTheUserStopped()
     {
-        var alive = true;
+        bool alive = true;
         TunnelPanelViewModel vm = CreateVm(() => alive, _ => Task.FromResult(_sessionId));
         await SeedTunnelAsync(vm, autoReconnect: true);
         await vm.StopTunnelCommand.Execute(vm.Tunnels[0].Id).FirstAsync();


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次提交包括：
- 局部变量由 var 改为显式类型，增强类型安全
- 修正数组初始化方式，语法更规范
- 统一异步资源释放写法，采用 await using var
- 优化 switch 结构和缩进，提升可维护性
- 移除无用 using 引用
- 单元测试类型声明和命名更规范
- TerminalColor 测试断言去除多余类型转换
- 变量初始化、异常处理等细节微调

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
