### PR TITLE
新增消息中心（侧边栏铃铛）及完整功能支持

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -363,3 +363,60 @@ Tmds.Ssh 把 LocalForward / SocksForward 的搬运整个做在内部,**不暴露
 而界面字号是用户可调的,不给换行的话基准字号一调大这行就被硬裁。
 `TunnelPanelUiTests` 的视觉 QA 样本补上了统计行与「自动」徽标(设 `VELASHELL_VISUAL_QA_DIR` 出图),
 否则截图回归看不到这两处新元素。
+
+## 20. 2026-08-30 消息中心(侧边栏铃铛)
+
+侧边栏底部那枚铃铛此前是**空占位**(`NotificationsCommand = ReactiveCommand.Create(() => { })`,
+点了什么都不发生)。现在把它做成消息中心。设计与资讯源契约见
+[`velashell-docs zh/host/消息中心与资讯源.md`](https://github.com/VelaShellLabs/velashell-docs/blob/main/zh/host/消息中心与资讯源.md),
+这里只记会绊到人的几点。
+
+**A. 边界:装什么、不装什么**。消息中心收的是**要留存、可回看**的东西 —— 有新版本了、
+订阅源发来的公告与安全资讯、将来后台推的运营消息。**不收运行时告警**:主机指纹变了会当场弹窗、
+会话断了会亮标签写状态栏,那些要的是立即打断,已各有归宿;混进列表只会把真正要读的东西淹掉。
+这条边界写在 `Core/Notifications/INotificationCenter` 的类型注释里,加内容源前先读一遍。
+
+**B. 资讯源契约(`Core/Notifications/AnnouncementFeedDocument`)**:这是**后台系统要照着发布的格式**,
+字段发出去就不能改名,加能力只能加可选字段。支持按 语言 / 平台 RID / 版本区间 定向投放,
+带 `expiresAt` 自动消失。几条硬约束:单次最多 100 条、响应体上限 512 KB、
+**外链只放行 https**(内容来自远端,放行 http 等于让投递方把用户导去一条可被中间人改写的链路)、
+**一条坏数据不让整个源哑掉**(缺字段的条目单独跳过)。
+`AnnouncementFeedDocumentTests` 逐条钉住,那份用例同时也是契约的可执行说明。
+**默认不订阅**:`Notifications.FeedUrl` 为空时一个网络请求都不发 ——
+终端客户端默默定期外呼在企业环境里是要被问责的事,得由用户或部署方明确开启。
+
+**C. 快捷跳转走 `ICommandRegistry`**:通知带 `commandId` 就执行注册表里的命令,
+带 `url` 就用系统浏览器开(仅 https);**站内优先**,命令没注册(返回 false)时退回外链。
+「有可用更新」用的是 `app.settings.about` —— 新增命令,打开设置并**直接落到「关于」页**,
+用户就地更新而不是被丢在设置首页自己找。分区定位用新增的 `SettingsSectionKey` 枚举而非下标:
+往分区列表中间插一页而忘了同步枚举,跳转会静默跑到隔壁页 —— 不报错、不崩,只是用户点了
+"去更新"却看到别的东西。`SettingsSectionKeyTests` 就是为了让那种改动**当场失败**。
+
+**D. 顺手修好一个死开关**:`General.CheckUpdatesOnStartup` 默认 true,却**全仓没有任何消费者**
+(设置审计 R-01 判为"更新服务尚未接入"而隐藏)。现在它真正决定启动时查不查新版本,
+因而在常规页恢复展示。同批新增的 `Notifications.FeedIntervalHours` 一开始也差点成为死开关 ——
+补了周期拉取:计时器按固定半小时跳,真正拉不拉由该设置决定,用户改完下一跳就生效。
+
+**E. 持久化与上限**:SonnetDB 文档集合 `notifications` 单份文档,**跨重启留存**
+(与文件传输面板相反 —— 一次传输的进度隔天没有意义,一条公告第二天仍然成立);200 条上限,
+超出丢最旧的。**同 id 重投会被跳过且保住已读状态** —— 每次启动都重投同一条"有新版本",
+覆盖会把读过的又变回未读,铃铛红点就永远消不掉。
+
+**F. 界面**:360px 非模态浮层,**锚在左下贴着铃铛**(浮层从哪个按钮开出来就该长在哪个按钮旁边)。
+未读左侧 2px 强调竖条 + 主文本色标题,已读退成次要色。整行可点 = 跳转并标记已读,
+做成透明按钮而非给 Border 挂手势 —— 键盘 Tab 走得到,焦点框与 hover 跟着按钮语义走。
+**外链条目把主机名摆在动作旁边**:地址是远端源给的,得让用户在点之前就看见自己会被带去哪。
+
+**G. 界面文案**:新增 24 个键(`Notify_*`、`Cmd_OpenAbout`、`SetGeneral_*` 消息中心分节),五份 resx 已齐。
+
+**未做**:插件发通知(SDK 的 `IUiApi` 只有 `ShowPanelAsync`;宿主侧接口形状已按这个用途定好,
+但要开放给插件需改 velashell-plugin-sdk 仓库 + 扩展隔离进程 IPC + 走 SDK 发版流程,是独立一批)、
+系统级通知。
+
+**H. 悬停高亮切成两半(用户反馈,同日修复)**:消息行的悬停高亮原先挂在 `Button.row` 上,
+而那个按钮只占三列布局里的内容列 —— 删除键那一列不跟着变色,整行被切成深浅两块,
+中间那道边界看着就像凭空多了一条竖分割线。改为挂在整行的外层 `Border.msg-row` 上。
+**两个 Background 都必须由样式设**:直接在元素上写 `Background="Transparent"` 是 local value,
+优先级高于样式,`:pointerover` 再也盖不过去(Avalonia 的属性优先级,不是选择器不够具体)。
+回归测试 `NotificationPanelUiTests.Row_HoverHighlight_CoversWholeRow` 把指针停在**删除键那一列**
+再断言整行 `IsPointerOver` —— 问题正出在那半边,指在内容区是测不出来的。

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -66,6 +66,9 @@ public class AppSettings
     /// <summary>「网络代理」页的分组选项。</summary>
     public ProxyOptions Proxy { get; set; } = new();
 
+    /// <summary>消息中心(侧边栏铃铛)的分组选项。</summary>
+    public NotificationOptions Notifications { get; set; } = new();
+
     /// <summary>
     /// 载入后的规整(由设置服务在反序列化后调用):把旧字段迁移到唯一权威字段,
     /// 保证每个行为只有一个数据来源(设置审计 C-01/M-01)。
@@ -999,6 +1002,47 @@ public class ProxyOptions : ObservableOptions
     /// HTTP CONNECT 天然如此),本地不发 DNS 请求;关 = 本地先解析成 IP 再经代理连接。
     /// </summary>
     public bool ProxyDns
+    {
+        get;
+        set => Set(ref field, value);
+    } = true;
+}
+
+/// <summary>
+/// 消息中心(侧边栏铃铛)的选项。
+/// <para>
+/// 默认不订阅任何资讯源:<see cref="FeedUrl" /> 为空时一个网络请求都不发。
+/// 一个终端客户端默默定期外呼,在企业环境里是要被问责的事,得由用户或部署方明确开启。
+/// </para>
+/// </summary>
+public class NotificationOptions : ObservableOptions
+{
+    /// <summary>
+    /// 资讯源地址(**仅 https**)。留空 = 不订阅、不联网。格式见
+    /// <c>Core/Notifications/AnnouncementFeedDocument</c> 的契约说明。
+    /// </summary>
+    public string FeedUrl
+    {
+        get;
+        set => Set(ref field, value ?? "");
+    } = "";
+
+    /// <summary>拉取间隔(小时);启动时先拉一次,之后按此节奏。下限 1 小时。</summary>
+    public int FeedIntervalHours
+    {
+        get;
+        set => Set(ref field, value < 1 ? 1 : value);
+    } = 6;
+
+    /// <summary>是否把「有可用更新」投进消息中心(本地检查,不依赖资讯源)。</summary>
+    public bool NotifyUpdates
+    {
+        get;
+        set => Set(ref field, value);
+    } = true;
+
+    /// <summary>是否接收运营/推广类消息(资讯源里 kind = promotion 的条目)。</summary>
+    public bool AllowPromotions
     {
         get;
         set => Set(ref field, value);

--- a/src/VelaShell.Core/Models/Notification.cs
+++ b/src/VelaShell.Core/Models/Notification.cs
@@ -1,0 +1,98 @@
+namespace VelaShell.Core.Models;
+
+/// <summary>消息的种类,决定列表里的图标与配色。</summary>
+public enum NotificationKind
+{
+    /// <summary>产品公告、版本说明、订阅到的资讯。</summary>
+    News,
+
+    /// <summary>有可用的应用更新。</summary>
+    Update,
+
+    /// <summary>安全资讯(上游组件的漏洞公告一类的**新闻**)。</summary>
+    /// <remarks>
+    /// 与本机的安全事件(主机指纹变更等)不是一回事:那些走
+    /// <see cref="Ssh.ISecurityAlertService" /> 当场弹窗,要的是立即打断,
+    /// 而不是躺在列表里等人来看。
+    /// </remarks>
+    Security,
+
+    /// <summary>运营/推广类消息。</summary>
+    Promotion
+}
+
+/// <summary>消息的轻重,决定列表里的强调程度。</summary>
+public enum NotificationSeverity
+{
+    /// <summary>一般信息。</summary>
+    Info,
+
+    /// <summary>需要留意。</summary>
+    Warning,
+
+    /// <summary>需要尽快处理。</summary>
+    Critical
+}
+
+/// <summary>
+/// 消息中心里的一条消息(侧边栏铃铛)。
+/// <para>
+/// 这里装的是**要留存、可回看**的东西 —— 有新版本了、订阅源发了篇公告。
+/// 转瞬即逝的运行时状态(某个标签断了、某次传输完了)不进这里:它们各有自己的
+/// 当场反馈(状态栏、标签闪烁、传输面板),塞进消息中心只会把真正要读的东西淹掉。
+/// </para>
+/// </summary>
+public sealed class NotificationItem
+{
+    /// <summary>
+    /// 稳定标识。远端资讯用源里给的 id,本地生成的用确定性字符串
+    /// (如 <c>update:1.4.0</c>)—— 每次启动都重新投递同一条时,靠它去重。
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>消息种类。</summary>
+    public required NotificationKind Kind { get; init; }
+
+    /// <summary>消息轻重。</summary>
+    public NotificationSeverity Severity { get; init; } = NotificationSeverity.Info;
+
+    /// <summary>标题(一行,列表里加粗显示)。</summary>
+    public required string Title { get; init; }
+
+    /// <summary>正文(可选,列表里最多显示两行)。</summary>
+    public string? Body { get; init; }
+
+    /// <summary>消息发布时间(UTC)。列表按它倒序,不是按收到的时间。</summary>
+    public required DateTime PublishedAt { get; init; }
+
+    /// <summary>过期时间(UTC);到点后不再展示。null 表示不过期。</summary>
+    public DateTime? ExpiresAt { get; init; }
+
+    /// <summary>是否已读。</summary>
+    public bool IsRead { get; set; }
+
+    /// <summary>点击这条消息去哪;null 表示没有可去的地方(纯告知)。</summary>
+    public NotificationLink? Link { get; init; }
+}
+
+/// <summary>
+/// 一条消息的去处。二选一:应用内跳到某条已注册命令,或在浏览器里打开一个网址。
+/// 两个都给时优先走应用内 —— 站内能办的事不该把人赶去浏览器。
+/// </summary>
+public sealed class NotificationLink
+{
+    /// <summary>动作文案(如「查看更新」「阅读全文」)。</summary>
+    public required string Label { get; init; }
+
+    /// <summary>
+    /// 应用内命令 id(Presentation 层那套命令注册表里的)。走注册表而不是各处硬编码:
+    /// 菜单、命令面板、快捷键本就共享它,消息中心跟着用,跳转目标就不会与其它入口跑偏。
+    /// </summary>
+    public string? CommandId { get; init; }
+
+    /// <summary>
+    /// 外部网址。**只接受 https** —— 这个字段的内容来自远端源,
+    /// 放行 http 等于允许投递方把用户导去一条可被中间人改写的链路。
+    /// </summary>
+    public string? Url { get; init; }
+}

--- a/src/VelaShell.Core/Notifications/AnnouncementFeedDocument.cs
+++ b/src/VelaShell.Core/Notifications/AnnouncementFeedDocument.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using System.Text.Json;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Notifications;
+
+/// <summary>
+/// 资讯源的 JSON 契约与解析。这是**后台系统要照着发布的格式**,所以字段一旦发出去
+/// 就不能随便改名;要加能力就加可选字段,老客户端读不到会自动忽略。
+/// <para>
+/// 格式(<c>schema</c> 目前恒为 1):
+/// </para>
+/// <code>
+/// {
+///   "schema": 1,
+///   "items": [
+///     {
+///       "id":          "2026-08-30-release-1.4",   // 必填,去重与已读状态的键
+///       "kind":        "news",                      // news | update | security | promotion
+///       "severity":    "info",                      // info | warning | critical
+///       "title":       "VelaShell 1.4 已发布",       // 必填
+///       "body":        "隧道流量统计、断线自动恢复…",
+///       "publishedAt": "2026-08-30T02:00:00Z",      // 必填,列表按它倒序
+///       "expiresAt":   "2026-10-01T00:00:00Z",      // 到点自动消失
+///       "linkLabel":   "查看详情",
+///       "url":         "https://velashell.dev/…",   // 只接受 https
+///       "commandId":   "settings.open",             // 站内跳转,优先于 url
+///       "locales":     ["zh-Hans", "zh-Hant"],      // 定向:界面语言
+///       "platforms":   ["win-x64", "osx-arm64"],    // 定向:运行平台
+///       "minVersion":  "1.2.0",                     // 定向:版本区间(含端点)
+///       "maxVersion":  "1.3.9"
+///     }
+///   ]
+/// }
+/// </code>
+/// <para>
+/// 用 <see cref="JsonDocument" /> 手工取值而非反射序列化:字段少,且不给单文件裁剪/AOT
+/// 留隐患(与 <c>UpdateManifest</c> 同一取舍)。
+/// </para>
+/// </summary>
+public static class AnnouncementFeedDocument
+{
+    /// <summary>单次拉取最多接受的条目数,挡住源端(被入侵或写错)一次推来上万条。</summary>
+    public const int MaxItems = 100;
+
+    /// <summary>标题与正文的长度上限,超出截断 —— 列表容不下一篇文章。</summary>
+    private const int MaxTitleLength = 200;
+
+    private const int MaxBodyLength = 1000;
+
+    /// <summary>
+    /// 解析并按 <paramref name="audience" /> 过滤。整体结构不合法时返回空列表;
+    /// **单条不合法只跳过那一条** —— 一条坏数据不该让整个源哑掉。
+    /// </summary>
+    public static IReadOnlyList<NotificationItem> Parse(string json, FeedAudience audience, DateTime utcNow)
+    {
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                !document.RootElement.TryGetProperty("items", out JsonElement items) ||
+                items.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+            List<NotificationItem> result = [];
+            foreach (JsonElement element in items.EnumerateArray())
+            {
+                if (result.Count >= MaxItems)
+                {
+                    break;
+                }
+                NotificationItem? item = ParseItem(element, audience, utcNow);
+                if (item is not null)
+                {
+                    result.Add(item);
+                }
+            }
+            return result;
+        }
+    }
+
+    private static NotificationItem? ParseItem(JsonElement element, FeedAudience audience, DateTime utcNow)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        string? id = ReadString(element, "id");
+        string? title = ReadString(element, "title");
+        if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(title))
+        {
+            return null;
+        }
+        if (ReadDate(element, "publishedAt") is not { } publishedAt)
+        {
+            return null;
+        }
+        DateTime? expiresAt = ReadDate(element, "expiresAt");
+        if (expiresAt is { } expiry && expiry <= utcNow)
+        {
+            return null;
+        }
+        if (!MatchesAudience(element, audience))
+        {
+            return null;
+        }
+        return new()
+        {
+            Id = id,
+            Kind = ParseKind(ReadString(element, "kind")),
+            Severity = ParseSeverity(ReadString(element, "severity")),
+            Title = Truncate(title, MaxTitleLength),
+            Body = ReadString(element, "body") is { Length: > 0 } body ? Truncate(body, MaxBodyLength) : null,
+            PublishedAt = publishedAt,
+            ExpiresAt = expiresAt,
+            Link = ParseLink(element)
+        };
+    }
+
+    /// <summary>
+    /// 解析去处。外链**只放行 https**:内容来自远端源,允许 http 等于让投递方
+    /// 把用户导去一条可被中间人改写的链路。命令 id 与网址都没有时返回 null。
+    /// </summary>
+    private static NotificationLink? ParseLink(JsonElement element)
+    {
+        string? commandId = ReadString(element, "commandId");
+        string? url = ReadString(element, "url");
+        if (url is { Length: > 0 } &&
+            !(Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed) && parsed.Scheme == Uri.UriSchemeHttps))
+        {
+            url = null;
+        }
+        if (string.IsNullOrEmpty(commandId) && string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+        return new()
+        {
+            Label = Truncate(ReadString(element, "linkLabel") ?? string.Empty, 60),
+            CommandId = commandId,
+            Url = url
+        };
+    }
+
+    /// <summary>定向投放:语言 / 平台 / 版本区间。字段缺省即"不限"。</summary>
+    private static bool MatchesAudience(JsonElement element, FeedAudience audience) =>
+        MatchesList(element, "locales", audience.UiCulture) &&
+        MatchesList(element, "platforms", audience.Rid) &&
+        MatchesVersionRange(element, audience.AppVersion);
+
+    private static bool MatchesList(JsonElement element, string property, string? actual)
+    {
+        if (!element.TryGetProperty(property, out JsonElement list) || list.ValueKind != JsonValueKind.Array)
+        {
+            return true;
+        }
+        bool empty = true;
+        foreach (JsonElement entry in list.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+            empty = false;
+            if (string.Equals(entry.GetString(), actual, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        // 给了个空数组等于没给条件,不该把所有人都筛掉。
+        return empty;
+    }
+
+    private static bool MatchesVersionRange(JsonElement element, string? appVersion)
+    {
+        string? min = ReadString(element, "minVersion");
+        string? max = ReadString(element, "maxVersion");
+        if (min is null && max is null)
+        {
+            return true;
+        }
+        if (!TryParseVersion(appVersion, out Version? current))
+        {
+            // 版本读不出来时不做定向过滤:宁可多看一条,也好过因为本机版本号异常而
+            // 把所有定向消息(可能正是"你这个版本有问题,快升级")全部漏掉。
+            return true;
+        }
+        if (TryParseVersion(min, out Version? minimum) && current < minimum)
+        {
+            return false;
+        }
+        return !TryParseVersion(max, out Version? maximum) || current <= maximum;
+    }
+
+    /// <summary>解析版本号,忽略预发布后缀(<c>1.4.0-beta.2</c> → <c>1.4.0</c>)。</summary>
+    private static bool TryParseVersion(string? text, out Version? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+        string trimmed = text.TrimStart('v', 'V');
+        int dash = trimmed.IndexOfAny(['-', '+']);
+        if (dash >= 0)
+        {
+            trimmed = trimmed[..dash];
+        }
+        return Version.TryParse(trimmed, out version);
+    }
+
+    private static NotificationKind ParseKind(string? kind) =>
+        kind?.ToLowerInvariant() switch
+        {
+            "update" => NotificationKind.Update,
+            "security" => NotificationKind.Security,
+            "promotion" or "promo" => NotificationKind.Promotion,
+            _ => NotificationKind.News
+        };
+
+    private static NotificationSeverity ParseSeverity(string? severity) =>
+        severity?.ToLowerInvariant() switch
+        {
+            "warning" or "warn" => NotificationSeverity.Warning,
+            "critical" or "error" => NotificationSeverity.Critical,
+            _ => NotificationSeverity.Info
+        };
+
+    private static string? ReadString(JsonElement element, string property) =>
+        element.TryGetProperty(property, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()?.Trim()
+            : null;
+
+    private static DateTime? ReadDate(JsonElement element, string property) =>
+        ReadString(element, property) is { Length: > 0 } text &&
+        DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out DateTime parsed)
+            ? parsed
+            : null;
+
+    private static string Truncate(string text, int max) => text.Length <= max ? text : text[..max];
+}

--- a/src/VelaShell.Core/Notifications/IAnnouncementFeed.cs
+++ b/src/VelaShell.Core/Notifications/IAnnouncementFeed.cs
@@ -1,0 +1,26 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Notifications;
+
+/// <summary>
+/// 订阅的资讯源:从一个 URL 取回公告/资讯/安全新闻,交给消息中心。
+/// <para>
+/// 源不可达、返回垃圾、字段缺失都只当作"这次没有新消息",绝不抛给调用方 ——
+/// 一个终端客户端不该因为公告服务器抽风而给用户看错误。
+/// </para>
+/// </summary>
+public interface IAnnouncementFeed
+{
+    /// <summary>
+    /// 拉取并按本机情况过滤后的条目。地址为空、拉取失败或内容无法解析时返回空列表。
+    /// </summary>
+    Task<IReadOnlyList<NotificationItem>> FetchAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// 资讯源的投放上下文:决定一条消息该不该给这台机器看。
+/// </summary>
+/// <param name="AppVersion">当前应用版本,用于 <c>minVersion</c>/<c>maxVersion</c> 定向。</param>
+/// <param name="Rid">运行平台标识(如 <c>win-x64</c>),用于 <c>platforms</c> 定向。</param>
+/// <param name="UiCulture">界面语言(如 <c>zh-Hans</c>),用于 <c>locales</c> 定向。</param>
+public sealed record FeedAudience(string? AppVersion, string? Rid, string? UiCulture);

--- a/src/VelaShell.Core/Notifications/INotificationCenter.cs
+++ b/src/VelaShell.Core/Notifications/INotificationCenter.cs
@@ -1,0 +1,44 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Notifications;
+
+/// <summary>
+/// 消息中心(侧边栏铃铛):汇总要留存、可回看的消息 —— 有新版本了、订阅源发了篇公告。
+/// <para>
+/// 与运行时告警的分工是明确的:主机指纹变了、会话断了,那些要的是**当场打断**
+/// (弹窗 / 状态栏 / 标签闪烁),已各有归宿;塞进这里只会把真正要读的东西淹掉。
+/// </para>
+/// </summary>
+public interface INotificationCenter
+{
+    /// <summary>当前消息列表快照,按发布时间倒序;已过期的不在其中。</summary>
+    IReadOnlyList<NotificationItem> Items { get; }
+
+    /// <summary>未读条数(铃铛角标)。</summary>
+    int UnreadCount { get; }
+
+    /// <summary>列表或已读状态变化(任意线程触发,订阅方自行调度到 UI)。</summary>
+    event Action? Changed;
+
+    /// <summary>从存储载入上次运行留下的消息,并顺手清掉过期与超量的部分。</summary>
+    Task LoadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 投递一批消息。<see cref="NotificationItem.Id" /> 已存在的会被跳过,
+    /// **且保留原有的已读状态** —— 每次启动都重新投递同一条"有新版本"时,
+    /// 不该把用户读过的又变回未读。
+    /// </summary>
+    Task PublishAsync(IEnumerable<NotificationItem> items, CancellationToken cancellationToken = default);
+
+    /// <summary>把一条标记为已读。</summary>
+    Task MarkReadAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>全部标记为已读。</summary>
+    Task MarkAllReadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>删除一条。</summary>
+    Task RemoveAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>清空全部消息。</summary>
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3235,6 +3235,114 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Msg_TunnelAutoReconnectFailed" xml:space="preserve">
     <value>自動再接続に失敗しました: {0}</value>
   </data>
+  <data name="Notify_Title" xml:space="preserve">
+    <value>メッセージ</value>
+  </data>
+  <data name="Notify_Empty" xml:space="preserve">
+    <value>メッセージはありません</value>
+  </data>
+  <data name="Notify_EmptyUnread" xml:space="preserve">
+    <value>未読はありません</value>
+  </data>
+  <data name="Notify_UnreadOnly" xml:space="preserve">
+    <value>未読</value>
+  </data>
+  <data name="Notify_UnreadOnlyTip" xml:space="preserve">
+    <value>未読のみ表示</value>
+  </data>
+  <data name="Notify_MarkAllRead" xml:space="preserve">
+    <value>すべて既読にする</value>
+  </data>
+  <data name="Notify_ClearAll" xml:space="preserve">
+    <value>すべてのメッセージを消去</value>
+  </data>
+  <data name="Notify_Close" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="Notify_Remove" xml:space="preserve">
+    <value>このメッセージを削除</value>
+  </data>
+  <data name="Notify_KindNews" xml:space="preserve">
+    <value>お知らせ</value>
+  </data>
+  <data name="Notify_KindUpdate" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Notify_KindSecurity" xml:space="preserve">
+    <value>セキュリティ</value>
+  </data>
+  <data name="Notify_KindPromotion" xml:space="preserve">
+    <value>キャンペーン</value>
+  </data>
+  <data name="Notify_LinkOpen" xml:space="preserve">
+    <value>開く</value>
+  </data>
+  <data name="Notify_LinkExternal" xml:space="preserve">
+    <value>詳細を読む</value>
+  </data>
+  <data name="Notify_TimeJustNow" xml:space="preserve">
+    <value>たった今</value>
+  </data>
+  <data name="Notify_TimeMinutes" xml:space="preserve">
+    <value>{0}分前</value>
+  </data>
+  <data name="Notify_TimeHours" xml:space="preserve">
+    <value>{0}時間前</value>
+  </data>
+  <data name="Notify_TimeDays" xml:space="preserve">
+    <value>{0}日前</value>
+  </data>
+  <data name="Notify_TimeMonths" xml:space="preserve">
+    <value>{0}か月前</value>
+  </data>
+  <data name="Notify_UpdateTitle" xml:space="preserve">
+    <value>VelaShell {0} が利用可能です</value>
+  </data>
+  <data name="Notify_UpdateBody" xml:space="preserve">
+    <value>現在のバージョンは {0} です。「バージョン情報」で更新を確認・適用できます。</value>
+  </data>
+  <data name="Notify_UpdateAction" xml:space="preserve">
+    <value>バージョン情報を開く</value>
+  </data>
+  <data name="Cmd_OpenAbout" xml:space="preserve">
+    <value>バージョン情報を開く</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartup" xml:space="preserve">
+    <value>起動時に更新を確認</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartupDesc" xml:space="preserve">
+    <value>起動時に新しいバージョンを確認します。見つかるとメッセージセンターに表示されます。</value>
+  </data>
+  <data name="SetGeneral_MessagesSection" xml:space="preserve">
+    <value>メッセージセンター</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdates" xml:space="preserve">
+    <value>更新をお知らせする</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdatesDesc" xml:space="preserve">
+    <value>新しいバージョンが見つかったらメッセージを投稿します。クリックで「バージョン情報」が開きます。</value>
+  </data>
+  <data name="SetGeneral_FeedUrl" xml:space="preserve">
+    <value>ニュースフィード</value>
+  </data>
+  <data name="SetGeneral_FeedUrlDesc" xml:space="preserve">
+    <value>お知らせやセキュリティ情報を配信する https アドレス。空欄なら購読せず、通信も一切行いません。</value>
+  </data>
+  <data name="SetGeneral_FeedUrlPlaceholder" xml:space="preserve">
+    <value>https://example.com/velashell/feed.json</value>
+  </data>
+  <data name="SetGeneral_FeedInterval" xml:space="preserve">
+    <value>取得間隔（時間）</value>
+  </data>
+  <data name="SetGeneral_FeedIntervalDesc" xml:space="preserve">
+    <value>フィードを取得する間隔です。起動時にも一度取得します。</value>
+  </data>
+  <data name="SetGeneral_AllowPromotions" xml:space="preserve">
+    <value>キャンペーン情報を受け取る</value>
+  </data>
+  <data name="SetGeneral_AllowPromotionsDesc" xml:space="preserve">
+    <value>オフにするとフィード内のキャンペーン項目を破棄します。お知らせとセキュリティ情報は届きます。</value>
+  </data>
   <data name="Tunnel_HelpButtonTooltip" xml:space="preserve">
     <value>SSHトンネルについて</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3235,6 +3235,114 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Msg_TunnelAutoReconnectFailed" xml:space="preserve">
     <value>자동 재연결 실패: {0}</value>
   </data>
+  <data name="Notify_Title" xml:space="preserve">
+    <value>메시지</value>
+  </data>
+  <data name="Notify_Empty" xml:space="preserve">
+    <value>메시지가 없습니다</value>
+  </data>
+  <data name="Notify_EmptyUnread" xml:space="preserve">
+    <value>읽지 않은 메시지가 없습니다</value>
+  </data>
+  <data name="Notify_UnreadOnly" xml:space="preserve">
+    <value>읽지 않음</value>
+  </data>
+  <data name="Notify_UnreadOnlyTip" xml:space="preserve">
+    <value>읽지 않은 메시지만 보기</value>
+  </data>
+  <data name="Notify_MarkAllRead" xml:space="preserve">
+    <value>모두 읽음으로 표시</value>
+  </data>
+  <data name="Notify_ClearAll" xml:space="preserve">
+    <value>모든 메시지 지우기</value>
+  </data>
+  <data name="Notify_Close" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="Notify_Remove" xml:space="preserve">
+    <value>이 메시지 삭제</value>
+  </data>
+  <data name="Notify_KindNews" xml:space="preserve">
+    <value>소식</value>
+  </data>
+  <data name="Notify_KindUpdate" xml:space="preserve">
+    <value>업데이트</value>
+  </data>
+  <data name="Notify_KindSecurity" xml:space="preserve">
+    <value>보안</value>
+  </data>
+  <data name="Notify_KindPromotion" xml:space="preserve">
+    <value>이벤트</value>
+  </data>
+  <data name="Notify_LinkOpen" xml:space="preserve">
+    <value>열기</value>
+  </data>
+  <data name="Notify_LinkExternal" xml:space="preserve">
+    <value>자세히 보기</value>
+  </data>
+  <data name="Notify_TimeJustNow" xml:space="preserve">
+    <value>방금</value>
+  </data>
+  <data name="Notify_TimeMinutes" xml:space="preserve">
+    <value>{0}분 전</value>
+  </data>
+  <data name="Notify_TimeHours" xml:space="preserve">
+    <value>{0}시간 전</value>
+  </data>
+  <data name="Notify_TimeDays" xml:space="preserve">
+    <value>{0}일 전</value>
+  </data>
+  <data name="Notify_TimeMonths" xml:space="preserve">
+    <value>{0}개월 전</value>
+  </data>
+  <data name="Notify_UpdateTitle" xml:space="preserve">
+    <value>VelaShell {0} 사용 가능</value>
+  </data>
+  <data name="Notify_UpdateBody" xml:space="preserve">
+    <value>현재 버전은 {0}입니다. 정보 페이지에서 업데이트를 확인하고 설치하세요.</value>
+  </data>
+  <data name="Notify_UpdateAction" xml:space="preserve">
+    <value>정보 페이지로 이동</value>
+  </data>
+  <data name="Cmd_OpenAbout" xml:space="preserve">
+    <value>정보 페이지 열기</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartup" xml:space="preserve">
+    <value>시작할 때 업데이트 확인</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartupDesc" xml:space="preserve">
+    <value>시작할 때 새 버전을 확인합니다. 발견되면 메시지 센터에 표시됩니다.</value>
+  </data>
+  <data name="SetGeneral_MessagesSection" xml:space="preserve">
+    <value>메시지 센터</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdates" xml:space="preserve">
+    <value>업데이트 알림</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdatesDesc" xml:space="preserve">
+    <value>새 버전을 찾으면 메시지를 등록합니다. 클릭하면 정보 페이지가 열립니다.</value>
+  </data>
+  <data name="SetGeneral_FeedUrl" xml:space="preserve">
+    <value>뉴스 피드</value>
+  </data>
+  <data name="SetGeneral_FeedUrlDesc" xml:space="preserve">
+    <value>공지와 보안 소식을 게시하는 https 주소입니다. 비워 두면 구독하지 않으며 요청도 전혀 보내지 않습니다.</value>
+  </data>
+  <data name="SetGeneral_FeedUrlPlaceholder" xml:space="preserve">
+    <value>https://example.com/velashell/feed.json</value>
+  </data>
+  <data name="SetGeneral_FeedInterval" xml:space="preserve">
+    <value>가져오기 간격(시간)</value>
+  </data>
+  <data name="SetGeneral_FeedIntervalDesc" xml:space="preserve">
+    <value>피드를 가져오는 주기입니다. 시작할 때도 한 번 가져옵니다.</value>
+  </data>
+  <data name="SetGeneral_AllowPromotions" xml:space="preserve">
+    <value>이벤트 메시지 받기</value>
+  </data>
+  <data name="SetGeneral_AllowPromotionsDesc" xml:space="preserve">
+    <value>끄면 피드의 이벤트 항목을 버립니다. 공지와 보안 소식은 계속 받습니다.</value>
+  </data>
   <data name="Tunnel_HelpButtonTooltip" xml:space="preserve">
     <value>SSH 터널링 정보</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3272,6 +3272,114 @@ Overwrite it?</value>
   <data name="Msg_TunnelAutoReconnectFailed" xml:space="preserve">
     <value>Automatic reconnect failed: {0}</value>
   </data>
+  <data name="Notify_Title" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="Notify_Empty" xml:space="preserve">
+    <value>No messages</value>
+  </data>
+  <data name="Notify_EmptyUnread" xml:space="preserve">
+    <value>Nothing unread</value>
+  </data>
+  <data name="Notify_UnreadOnly" xml:space="preserve">
+    <value>Unread</value>
+  </data>
+  <data name="Notify_UnreadOnlyTip" xml:space="preserve">
+    <value>Show unread messages only</value>
+  </data>
+  <data name="Notify_MarkAllRead" xml:space="preserve">
+    <value>Mark all as read</value>
+  </data>
+  <data name="Notify_ClearAll" xml:space="preserve">
+    <value>Clear all messages</value>
+  </data>
+  <data name="Notify_Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Notify_Remove" xml:space="preserve">
+    <value>Remove this message</value>
+  </data>
+  <data name="Notify_KindNews" xml:space="preserve">
+    <value>NEWS</value>
+  </data>
+  <data name="Notify_KindUpdate" xml:space="preserve">
+    <value>UPDATE</value>
+  </data>
+  <data name="Notify_KindSecurity" xml:space="preserve">
+    <value>SECURITY</value>
+  </data>
+  <data name="Notify_KindPromotion" xml:space="preserve">
+    <value>OFFER</value>
+  </data>
+  <data name="Notify_LinkOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Notify_LinkExternal" xml:space="preserve">
+    <value>Read more</value>
+  </data>
+  <data name="Notify_TimeJustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="Notify_TimeMinutes" xml:space="preserve">
+    <value>{0}m ago</value>
+  </data>
+  <data name="Notify_TimeHours" xml:space="preserve">
+    <value>{0}h ago</value>
+  </data>
+  <data name="Notify_TimeDays" xml:space="preserve">
+    <value>{0}d ago</value>
+  </data>
+  <data name="Notify_TimeMonths" xml:space="preserve">
+    <value>{0}mo ago</value>
+  </data>
+  <data name="Notify_UpdateTitle" xml:space="preserve">
+    <value>VelaShell {0} is available</value>
+  </data>
+  <data name="Notify_UpdateBody" xml:space="preserve">
+    <value>You are on {0}. Open About to review and install the update.</value>
+  </data>
+  <data name="Notify_UpdateAction" xml:space="preserve">
+    <value>Go to About</value>
+  </data>
+  <data name="Cmd_OpenAbout" xml:space="preserve">
+    <value>Open About</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartup" xml:space="preserve">
+    <value>Check for updates on startup</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartupDesc" xml:space="preserve">
+    <value>Look for a newer version at launch. A found update appears in the message center.</value>
+  </data>
+  <data name="SetGeneral_MessagesSection" xml:space="preserve">
+    <value>Message center</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdates" xml:space="preserve">
+    <value>Announce available updates</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdatesDesc" xml:space="preserve">
+    <value>Post a message when a newer version is found. Clicking it opens the About page.</value>
+  </data>
+  <data name="SetGeneral_FeedUrl" xml:space="preserve">
+    <value>News feed</value>
+  </data>
+  <data name="SetGeneral_FeedUrlDesc" xml:space="preserve">
+    <value>An https address publishing announcements and security news. Leave empty to subscribe to nothing — no request is sent at all.</value>
+  </data>
+  <data name="SetGeneral_FeedUrlPlaceholder" xml:space="preserve">
+    <value>https://example.com/velashell/feed.json</value>
+  </data>
+  <data name="SetGeneral_FeedInterval" xml:space="preserve">
+    <value>Fetch interval (hours)</value>
+  </data>
+  <data name="SetGeneral_FeedIntervalDesc" xml:space="preserve">
+    <value>How often the feed is fetched. It is also fetched once at startup.</value>
+  </data>
+  <data name="SetGeneral_AllowPromotions" xml:space="preserve">
+    <value>Receive promotional messages</value>
+  </data>
+  <data name="SetGeneral_AllowPromotionsDesc" xml:space="preserve">
+    <value>Turn off to drop promotional items from the feed. Announcements and security news still arrive.</value>
+  </data>
   <data name="Tunnel_HelpButtonTooltip" xml:space="preserve">
     <value>About SSH Tunneling</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3409,6 +3409,114 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Msg_TunnelAutoReconnectFailed" xml:space="preserve">
     <value>自动重连失败：{0}</value>
   </data>
+  <data name="Notify_Title" xml:space="preserve">
+    <value>消息</value>
+  </data>
+  <data name="Notify_Empty" xml:space="preserve">
+    <value>暂无消息</value>
+  </data>
+  <data name="Notify_EmptyUnread" xml:space="preserve">
+    <value>没有未读消息</value>
+  </data>
+  <data name="Notify_UnreadOnly" xml:space="preserve">
+    <value>未读</value>
+  </data>
+  <data name="Notify_UnreadOnlyTip" xml:space="preserve">
+    <value>只看未读消息</value>
+  </data>
+  <data name="Notify_MarkAllRead" xml:space="preserve">
+    <value>全部标为已读</value>
+  </data>
+  <data name="Notify_ClearAll" xml:space="preserve">
+    <value>清空全部消息</value>
+  </data>
+  <data name="Notify_Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Notify_Remove" xml:space="preserve">
+    <value>删除这条消息</value>
+  </data>
+  <data name="Notify_KindNews" xml:space="preserve">
+    <value>资讯</value>
+  </data>
+  <data name="Notify_KindUpdate" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Notify_KindSecurity" xml:space="preserve">
+    <value>安全</value>
+  </data>
+  <data name="Notify_KindPromotion" xml:space="preserve">
+    <value>活动</value>
+  </data>
+  <data name="Notify_LinkOpen" xml:space="preserve">
+    <value>查看</value>
+  </data>
+  <data name="Notify_LinkExternal" xml:space="preserve">
+    <value>阅读全文</value>
+  </data>
+  <data name="Notify_TimeJustNow" xml:space="preserve">
+    <value>刚刚</value>
+  </data>
+  <data name="Notify_TimeMinutes" xml:space="preserve">
+    <value>{0} 分钟前</value>
+  </data>
+  <data name="Notify_TimeHours" xml:space="preserve">
+    <value>{0} 小时前</value>
+  </data>
+  <data name="Notify_TimeDays" xml:space="preserve">
+    <value>{0} 天前</value>
+  </data>
+  <data name="Notify_TimeMonths" xml:space="preserve">
+    <value>{0} 个月前</value>
+  </data>
+  <data name="Notify_UpdateTitle" xml:space="preserve">
+    <value>VelaShell {0} 已发布</value>
+  </data>
+  <data name="Notify_UpdateBody" xml:space="preserve">
+    <value>当前版本 {0}。到「关于」页查看并安装更新。</value>
+  </data>
+  <data name="Notify_UpdateAction" xml:space="preserve">
+    <value>前往关于页</value>
+  </data>
+  <data name="Cmd_OpenAbout" xml:space="preserve">
+    <value>打开关于页</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartup" xml:space="preserve">
+    <value>启动时检查更新</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartupDesc" xml:space="preserve">
+    <value>启动时查一次有没有新版本；发现新版本会出现在消息中心。</value>
+  </data>
+  <data name="SetGeneral_MessagesSection" xml:space="preserve">
+    <value>消息中心</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdates" xml:space="preserve">
+    <value>提醒可用更新</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdatesDesc" xml:space="preserve">
+    <value>发现新版本时投一条消息；点它直接打开「关于」页。</value>
+  </data>
+  <data name="SetGeneral_FeedUrl" xml:space="preserve">
+    <value>资讯源</value>
+  </data>
+  <data name="SetGeneral_FeedUrlDesc" xml:space="preserve">
+    <value>发布公告与安全资讯的 https 地址。留空即不订阅——一个网络请求都不会发出。</value>
+  </data>
+  <data name="SetGeneral_FeedUrlPlaceholder" xml:space="preserve">
+    <value>https://example.com/velashell/feed.json</value>
+  </data>
+  <data name="SetGeneral_FeedInterval" xml:space="preserve">
+    <value>拉取间隔（小时）</value>
+  </data>
+  <data name="SetGeneral_FeedIntervalDesc" xml:space="preserve">
+    <value>每隔多久拉一次资讯源；启动时另外拉一次。</value>
+  </data>
+  <data name="SetGeneral_AllowPromotions" xml:space="preserve">
+    <value>接收运营消息</value>
+  </data>
+  <data name="SetGeneral_AllowPromotionsDesc" xml:space="preserve">
+    <value>关闭后丢弃资讯源里的运营类条目；公告与安全资讯照常接收。</value>
+  </data>
   <data name="Tunnel_HelpButtonTooltip" xml:space="preserve">
     <value>关于 SSH 隧道</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3409,6 +3409,114 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Msg_TunnelAutoReconnectFailed" xml:space="preserve">
     <value>自動重新連線失敗：{0}</value>
   </data>
+  <data name="Notify_Title" xml:space="preserve">
+    <value>訊息</value>
+  </data>
+  <data name="Notify_Empty" xml:space="preserve">
+    <value>暫無訊息</value>
+  </data>
+  <data name="Notify_EmptyUnread" xml:space="preserve">
+    <value>沒有未讀訊息</value>
+  </data>
+  <data name="Notify_UnreadOnly" xml:space="preserve">
+    <value>未讀</value>
+  </data>
+  <data name="Notify_UnreadOnlyTip" xml:space="preserve">
+    <value>只看未讀訊息</value>
+  </data>
+  <data name="Notify_MarkAllRead" xml:space="preserve">
+    <value>全部標為已讀</value>
+  </data>
+  <data name="Notify_ClearAll" xml:space="preserve">
+    <value>清空全部訊息</value>
+  </data>
+  <data name="Notify_Close" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="Notify_Remove" xml:space="preserve">
+    <value>刪除這則訊息</value>
+  </data>
+  <data name="Notify_KindNews" xml:space="preserve">
+    <value>資訊</value>
+  </data>
+  <data name="Notify_KindUpdate" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Notify_KindSecurity" xml:space="preserve">
+    <value>安全</value>
+  </data>
+  <data name="Notify_KindPromotion" xml:space="preserve">
+    <value>活動</value>
+  </data>
+  <data name="Notify_LinkOpen" xml:space="preserve">
+    <value>查看</value>
+  </data>
+  <data name="Notify_LinkExternal" xml:space="preserve">
+    <value>閱讀全文</value>
+  </data>
+  <data name="Notify_TimeJustNow" xml:space="preserve">
+    <value>剛剛</value>
+  </data>
+  <data name="Notify_TimeMinutes" xml:space="preserve">
+    <value>{0} 分鐘前</value>
+  </data>
+  <data name="Notify_TimeHours" xml:space="preserve">
+    <value>{0} 小時前</value>
+  </data>
+  <data name="Notify_TimeDays" xml:space="preserve">
+    <value>{0} 天前</value>
+  </data>
+  <data name="Notify_TimeMonths" xml:space="preserve">
+    <value>{0} 個月前</value>
+  </data>
+  <data name="Notify_UpdateTitle" xml:space="preserve">
+    <value>VelaShell {0} 已發布</value>
+  </data>
+  <data name="Notify_UpdateBody" xml:space="preserve">
+    <value>目前版本 {0}。到「關於」頁查看並安裝更新。</value>
+  </data>
+  <data name="Notify_UpdateAction" xml:space="preserve">
+    <value>前往關於頁</value>
+  </data>
+  <data name="Cmd_OpenAbout" xml:space="preserve">
+    <value>開啟關於頁</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartup" xml:space="preserve">
+    <value>啟動時檢查更新</value>
+  </data>
+  <data name="SetGeneral_CheckUpdatesOnStartupDesc" xml:space="preserve">
+    <value>啟動時查一次有沒有新版本；發現新版本會出現在訊息中心。</value>
+  </data>
+  <data name="SetGeneral_MessagesSection" xml:space="preserve">
+    <value>訊息中心</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdates" xml:space="preserve">
+    <value>提醒可用更新</value>
+  </data>
+  <data name="SetGeneral_NotifyUpdatesDesc" xml:space="preserve">
+    <value>發現新版本時投一則訊息；點它直接開啟「關於」頁。</value>
+  </data>
+  <data name="SetGeneral_FeedUrl" xml:space="preserve">
+    <value>資訊來源</value>
+  </data>
+  <data name="SetGeneral_FeedUrlDesc" xml:space="preserve">
+    <value>發布公告與安全資訊的 https 位址。留空即不訂閱——一個網路請求都不會送出。</value>
+  </data>
+  <data name="SetGeneral_FeedUrlPlaceholder" xml:space="preserve">
+    <value>https://example.com/velashell/feed.json</value>
+  </data>
+  <data name="SetGeneral_FeedInterval" xml:space="preserve">
+    <value>擷取間隔（小時）</value>
+  </data>
+  <data name="SetGeneral_FeedIntervalDesc" xml:space="preserve">
+    <value>每隔多久擷取一次資訊來源；啟動時另外擷取一次。</value>
+  </data>
+  <data name="SetGeneral_AllowPromotions" xml:space="preserve">
+    <value>接收營運訊息</value>
+  </data>
+  <data name="SetGeneral_AllowPromotionsDesc" xml:space="preserve">
+    <value>關閉後丟棄資訊來源裡的營運類項目；公告與安全資訊照常接收。</value>
+  </data>
   <data name="Tunnel_HelpButtonTooltip" xml:space="preserve">
     <value>關於 SSH 隧道</value>
   </data>

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using VelaShell.Core.Ftp;
 using VelaShell.Core.Import;
 using VelaShell.Core.Models;
 using VelaShell.Core.Net;
+using VelaShell.Core.Notifications;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Protocols;
 using VelaShell.Core.Recording;
@@ -18,6 +19,7 @@ using VelaShell.Core.Tunnels;
 using VelaShell.Infrastructure.Ftp;
 using VelaShell.Infrastructure.Import;
 using VelaShell.Infrastructure.Net;
+using VelaShell.Infrastructure.Notifications;
 using VelaShell.Infrastructure.Persistence;
 using VelaShell.Infrastructure.Plugins.Protocols;
 using VelaShell.Infrastructure.Sftp;
@@ -93,6 +95,17 @@ public static class InfrastructureServiceCollectionExtensions
         // 统一代理解析:全部出站通道(SSH / FTP / HttpClient)共用的唯一代理出口。
         services.AddSingleton<IProxyResolver>(sp =>
             new ProxyResolver(sp.GetRequiredService<ISettingsService>()));
+
+        // 消息中心(侧边栏铃铛)与它订阅的资讯源。
+        services.AddSingleton<INotificationCenter>(sp =>
+            new NotificationCenter(sp.GetRequiredService<IAppDataStore>()));
+        services.AddSingleton<IAnnouncementFeed>(sp =>
+        {
+            ISettingsService settings = sp.GetRequiredService<ISettingsService>();
+            return new HttpAnnouncementFeed(
+                async () => (await settings.GetSettingsAsync().ConfigureAwait(false)).Notifications.FeedUrl,
+                HttpAnnouncementFeed.DescribeAudience);
+        });
 
         // SSH connection service
         services.AddSingleton<ISshConnectionService>(sp =>

--- a/src/VelaShell.Infrastructure/Notifications/HttpAnnouncementFeed.cs
+++ b/src/VelaShell.Infrastructure/Notifications/HttpAnnouncementFeed.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using VelaShell.Core.Models;
+using VelaShell.Core.Notifications;
+
+namespace VelaShell.Infrastructure.Notifications;
+
+/// <summary>
+/// 从一个 https 地址拉取资讯源(见 <see cref="AnnouncementFeedDocument" /> 的格式约定)。
+/// <para>
+/// <b>不配地址就一个字节都不发。</b> 这是个终端工具,不该在用户没要求的情况下
+/// 定期向外汇报"这台机器还活着";地址由用户/部署方在设置里填,留空即彻底关闭。
+/// </para>
+/// <para>
+/// 出站走进程级 <c>HttpClient.DefaultProxy</c>(由 <c>VelaWebProxy</c> 接管),
+/// 因此自动遵守「设置 → 网络代理」,与更新检查、Gist 同步同一条链路。
+/// </para>
+/// </summary>
+/// <param name="feedUrlProvider">取当前配置的资讯源地址;返回空表示不启用。</param>
+/// <param name="audienceProvider">取本机的投放上下文(版本/平台/语言)。</param>
+/// <param name="httpClient">注入以便测试;省略时使用内置的短超时客户端。</param>
+public sealed class HttpAnnouncementFeed(
+    Func<Task<string?>> feedUrlProvider,
+    Func<FeedAudience> audienceProvider,
+    HttpClient? httpClient = null) : IAnnouncementFeed
+{
+    /// <summary>响应体大小上限:公告是文本,超过这个量级只可能是配错了地址或源被做了手脚。</summary>
+    private const int MaxResponseBytes = 512 * 1024;
+
+    private static readonly HttpClient Shared = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+    private readonly HttpClient _http = httpClient ?? Shared;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<NotificationItem>> FetchAsync(CancellationToken cancellationToken = default)
+    {
+        string? url;
+        try
+        {
+            url = await feedUrlProvider().ConfigureAwait(false);
+        }
+        catch
+        {
+            return [];
+        }
+        if (string.IsNullOrWhiteSpace(url) ||
+            !Uri.TryCreate(url, UriKind.Absolute, out Uri? feed) ||
+            feed.Scheme != Uri.UriSchemeHttps)
+        {
+            // 只走 https:明文取回的公告可被中间人替换,而公告里带的是用户会去点的链接。
+            return [];
+        }
+        string json;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, feed);
+            request.Headers.Accept.Add(new("application/json"));
+            using HttpResponseMessage response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return [];
+            }
+            if (response.Content.Headers.ContentLength is > MaxResponseBytes)
+            {
+                return [];
+            }
+            json = await ReadCappedAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException or InvalidOperationException)
+        {
+            // 源不可达是常态(离线、内网、地址写错),当作"这次没有新消息"。
+            return [];
+        }
+        try
+        {
+            return AnnouncementFeedDocument.Parse(json, audienceProvider(), DateTime.UtcNow);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>读取响应体,超过上限即放弃 —— 不声明长度的源不能拿来当无限流读。</summary>
+    private static async Task<string> ReadCappedAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        await using Stream stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        byte[] buffer = new byte[MaxResponseBytes + 1];
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(total), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+            total += read;
+        }
+        return total > MaxResponseBytes ? string.Empty : System.Text.Encoding.UTF8.GetString(buffer, 0, total);
+    }
+
+    /// <summary>
+    /// 按本机情况组装投放上下文:版本取入口程序集,平台按进程架构解析(与更新产物的
+    /// RID 命名一致),语言取当前界面语言。
+    /// </summary>
+    public static FeedAudience DescribeAudience() =>
+        new(EntryVersion(), CurrentRid(), CultureInfo.CurrentUICulture.Name);
+
+    private static string? EntryVersion() =>
+        System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3);
+
+    /// <summary>
+    /// 当前进程的 RID。按**进程**架构而非 OS 架构解析:x64 版本跑在 arm64 Windows
+    /// 的仿真层上时应继续算 x64,与更新产物的选择口径一致。
+    /// </summary>
+    private static string? CurrentRid()
+    {
+        string? os = OperatingSystem.IsWindows() ? "win"
+            : OperatingSystem.IsMacOS() ? "osx"
+            : OperatingSystem.IsLinux() ? "linux"
+            : null;
+        string? arch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
+        {
+            System.Runtime.InteropServices.Architecture.X64 => "x64",
+            System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+            _ => null
+        };
+        return os is not null && arch is not null ? $"{os}-{arch}" : null;
+    }
+}

--- a/src/VelaShell.Infrastructure/Notifications/NotificationCenter.cs
+++ b/src/VelaShell.Infrastructure/Notifications/NotificationCenter.cs
@@ -1,0 +1,202 @@
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Notifications;
+
+namespace VelaShell.Infrastructure.Notifications;
+
+/// <summary>
+/// <see cref="INotificationCenter" /> 的默认实现:内存列表 + SonnetDB 单文档持久化。
+/// <para>
+/// 消息**跨重启留存**(与文件传输面板相反):一条"有新版本"或者一篇公告,
+/// 关掉应用第二天再看仍然成立,而一次传输的进度隔天已经没有意义。
+/// </para>
+/// </summary>
+public sealed class NotificationCenter(IAppDataStore? store = null) : INotificationCenter
+{
+    /// <summary>持久化落点:文档集合 <c>notifications</c> 下的单份文档。</summary>
+    private const string Collection = "notifications";
+
+    private const string DocumentId = "inbox";
+
+    /// <summary>
+    /// 保留上限。资讯源可以一直发,而消息中心不是归档系统 —— 超出的按发布时间丢最旧的。
+    /// </summary>
+    public const int MaxItems = 200;
+
+    private readonly List<NotificationItem> _items = [];
+    private readonly Lock _gate = new();
+
+    /// <inheritdoc />
+    public IReadOnlyList<NotificationItem> Items
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return [.. _items];
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public int UnreadCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _items.Count(item => !item.IsRead);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public event Action? Changed;
+
+    /// <inheritdoc />
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
+    {
+        if (store is null)
+        {
+            return;
+        }
+        List<NotificationItem>? saved;
+        try
+        {
+            saved = await store.GetAsync<List<NotificationItem>>(Collection, DocumentId, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // 存储损坏或旧格式:当作没有历史消息,后续保存会覆盖成新格式。
+            return;
+        }
+        if (saved is not { Count: > 0 })
+        {
+            return;
+        }
+        lock (_gate)
+        {
+            _items.Clear();
+            _items.AddRange(saved);
+            Prune();
+        }
+        Changed?.Invoke();
+        await SaveAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task PublishAsync(IEnumerable<NotificationItem> items, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        bool added = false;
+        lock (_gate)
+        {
+            foreach (NotificationItem item in items)
+            {
+                // 同 id 的已经在了就跳过 —— 每次启动都重投同一条"有新版本"时,
+                // 覆盖会把用户已经读过的又变回未读。
+                if (_items.Exists(existing => existing.Id == item.Id))
+                {
+                    continue;
+                }
+                _items.Add(item);
+                added = true;
+            }
+            if (!added)
+            {
+                return;
+            }
+            Prune();
+        }
+        Changed?.Invoke();
+        await SaveAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task MarkReadAsync(string id, CancellationToken cancellationToken = default) =>
+        MutateAsync(items =>
+        {
+            NotificationItem? target = items.Find(item => item.Id == id);
+            if (target is null || target.IsRead)
+            {
+                return false;
+            }
+            target.IsRead = true;
+            return true;
+        }, cancellationToken);
+
+    /// <inheritdoc />
+    public Task MarkAllReadAsync(CancellationToken cancellationToken = default) =>
+        MutateAsync(items =>
+        {
+            bool changed = false;
+            foreach (NotificationItem item in items.Where(item => !item.IsRead))
+            {
+                item.IsRead = true;
+                changed = true;
+            }
+            return changed;
+        }, cancellationToken);
+
+    /// <inheritdoc />
+    public Task RemoveAsync(string id, CancellationToken cancellationToken = default) =>
+        MutateAsync(items => items.RemoveAll(item => item.Id == id) > 0, cancellationToken);
+
+    /// <inheritdoc />
+    public Task ClearAsync(CancellationToken cancellationToken = default) =>
+        MutateAsync(items =>
+        {
+            if (items.Count == 0)
+            {
+                return false;
+            }
+            items.Clear();
+            return true;
+        }, cancellationToken);
+
+    private async Task MutateAsync(Func<List<NotificationItem>, bool> mutate, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            if (!mutate(_items))
+            {
+                return;
+            }
+        }
+        Changed?.Invoke();
+        await SaveAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>丢掉过期条目,按发布时间倒序,并把超出上限的最旧那些截掉。调用方须持锁。</summary>
+    private void Prune()
+    {
+        DateTime now = DateTime.UtcNow;
+        _items.RemoveAll(item => item.ExpiresAt is { } expiry && expiry <= now);
+        _items.Sort((left, right) => right.PublishedAt.CompareTo(left.PublishedAt));
+        if (_items.Count > MaxItems)
+        {
+            _items.RemoveRange(MaxItems, _items.Count - MaxItems);
+        }
+    }
+
+    private async Task SaveAsync(CancellationToken cancellationToken)
+    {
+        if (store is null)
+        {
+            return;
+        }
+        List<NotificationItem> snapshot;
+        lock (_gate)
+        {
+            snapshot = [.. _items];
+        }
+        try
+        {
+            await store.UpsertAsync(Collection, DocumentId, snapshot, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // 落盘失败不影响本次运行里看到的消息;下次变更会再试。
+        }
+    }
+}

--- a/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
@@ -58,7 +58,28 @@ public sealed class SidebarViewModel(
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
-    /// <summary>打开通知的命令。</summary>
-    public ReactiveCommand<RxVoid, RxVoid> NotificationsCommand { get; } =
-        ReactiveCommand.Create(() => { });
+    /// <summary>
+    /// 消息中心的未读条数(底部栏铃铛角标);0 表示不显示角标。
+    /// 由宿主在 <see cref="Core.Notifications.INotificationCenter" /> 变化时推过来 ——
+    /// 侧边栏只负责显示这个数字,不关心它从哪来。
+    /// </summary>
+    public int NotificationUnreadCount
+    {
+        get;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref field, value);
+            this.RaisePropertyChanged(nameof(HasUnreadNotifications));
+        }
+    }
+
+    /// <summary>是否有未读消息(控制角标显隐)。</summary>
+    public bool HasUnreadNotifications => NotificationUnreadCount > 0;
+
+    /// <summary>用户点击底部栏铃铛,请求打开消息中心。</summary>
+    public event EventHandler? NotificationsRequested;
+
+    /// <summary>打开消息中心的命令(底部栏铃铛)。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> NotificationsCommand =>
+        field ??= ReactiveCommand.Create(() => NotificationsRequested?.Invoke(this, EventArgs.Empty));
 }

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,7 @@ using VelaShell.Core.Diagnostics;
 using VelaShell.Core.FileTransfer.Model;
 using VelaShell.Core.Ftp;
 using VelaShell.Core.Models;
+using VelaShell.Core.Notifications;
 using VelaShell.Core.Processes;
 using VelaShell.Core.Protocols;
 using VelaShell.Core.Recording;
@@ -196,7 +197,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         PluginProtocolRegistry? protocolRegistry = null,
         PluginWorkspaceLauncher? workspaceLauncher = null,
         IGistSyncService? gistSyncService = null,
-        IBackgroundActivityService? backgroundActivity = null
+        IBackgroundActivityService? backgroundActivity = null,
+        INotificationCenter? notificationCenter = null,
+        IAnnouncementFeed? announcementFeed = null,
+        IUpdateService? updateService = null
     )
     {
         // 注册表可注入(DI 里与插件命令桥共享同一单例);无 UI 单测传 null 时自建。
@@ -341,6 +345,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 }
             });
         StartStatusMetricsPolling();
+        SetUpNotificationCenter(notificationCenter, announcementFeed, updateService);
         OpenSettingsCommand = ReactiveCommand.Create(() =>
             SettingsRequested?.Invoke(this, EventArgs.Empty)
         );
@@ -389,6 +394,20 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
     /// <summary>隧道面板当前是否展开显示。</summary>
     public bool IsTunnelPanelOpen
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>消息中心面板(侧边栏铃铛)。</summary>
+    public NotificationPanelViewModel? NotificationPanel
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>消息中心面板当前是否展开显示。</summary>
+    public bool IsNotificationPanelOpen
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
@@ -783,6 +802,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 () => OpenSettingsCommand.Execute().Subscribe(),
                 Shortcut: "Ctrl+,",
                 Icon: "Icon.settings"
+            )
+        );
+        Commands.Register(
+            new(
+                "app.settings.about",
+                Strings.Get("Cmd_OpenAbout"),
+                Strings.Get("CmdCat_Edit"),
+                () => SettingsSectionRequested?.Invoke(this, SettingsSectionKey.About),
+                Icon: "Icon.info"
             )
         );
         Commands.Register(
@@ -1275,6 +1303,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>Ctrl+, / 菜单 / 侧边栏齿轮“打开设置” —— 由窗口打开设置窗口。</summary>
     public event EventHandler? SettingsRequested;
 
+    /// <summary>
+    /// 打开设置并直接落到某一分区 —— 由窗口打开设置窗口后调 <c>SelectSection</c>。
+    /// 消息中心的「有可用更新」就走这条路进「关于」页,用户点完通知即可就地更新,
+    /// 而不是被丢在设置首页自己去找。
+    /// </summary>
+    public event EventHandler<SettingsSectionKey>? SettingsSectionRequested;
+
     /// <summary>工具菜单“连接诊断”(针对当前标签的配置)—— 由窗口打开诊断中心弹窗。</summary>
     public event Action<SessionProfile>? DiagnosticsRequested;
 
@@ -1324,6 +1359,162 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         _ = TunnelPanel.OpenAsync(preselect?.Id ?? ActiveTerminalTab?.Profile?.Id);
         IsTunnelPanelOpen = true;
     }
+
+    // ---- 消息中心(侧边栏铃铛) ----
+
+    private INotificationCenter? _notificationCenter;
+
+    /// <summary>
+    /// 装配消息中心:面板、铃铛角标,以及两个内容来源(本地的更新检查 + 订阅的资讯源)。
+    /// 无消息中心(单元测试)时整块跳过。
+    /// </summary>
+    private void SetUpNotificationCenter(
+        INotificationCenter? center, IAnnouncementFeed? feed, IUpdateService? updateService)
+    {
+        if (center is null)
+        {
+            return;
+        }
+        _notificationCenter = center;
+        var panel = new NotificationPanelViewModel(center, Commands.Execute, OpenExternalUrlAsync);
+        panel.CloseRequested += (_, _) => IsNotificationPanelOpen = false;
+        NotificationPanel = panel;
+
+        // 铃铛角标:未读数由消息中心推给侧边栏,侧边栏不关心它从哪来。
+        center.Changed += () => RxSchedulers.MainThreadScheduler.Schedule(() =>
+            Sidebar.NotificationUnreadCount = center.UnreadCount);
+        Sidebar.NotificationsRequested += (_, _) => IsNotificationPanelOpen = !IsNotificationPanelOpen;
+
+        _ = InitializeNotificationsAsync(center, feed, updateService);
+
+        // 周期拉取。计时器按固定的半小时跳,真正拉不拉由 FeedIntervalHours 决定 ——
+        // 这样用户在设置里改完间隔,下一跳就生效,不用重启也不用去重设计时器。
+        // 无 Avalonia 应用(单元测试)时不起表。
+        if (Application.Current is null || feed is null)
+        {
+            return;
+        }
+        _feedTimer = new()
+        {
+            Interval = TimeSpan.FromMinutes(30)
+        };
+        _feedTimer.Tick += (_, _) =>
+        {
+            AppSettings settings = _latestSettings ?? new();
+            var due = TimeSpan.FromHours(Math.Max(1, settings.Notifications.FeedIntervalHours));
+            if (DateTime.UtcNow - _lastFeedFetch < due)
+            {
+                return;
+            }
+            _lastFeedFetch = DateTime.UtcNow;
+            _ = RefreshNotificationSourcesAsync(center, feed, updateService: null);
+        };
+        _feedTimer.Start();
+    }
+
+    private DispatcherTimer? _feedTimer;
+
+    /// <summary>上次拉取资讯源的时刻,用于按 <c>FeedIntervalHours</c> 判断是否到点。</summary>
+    private DateTime _lastFeedFetch = DateTime.UtcNow;
+
+    /// <summary>
+    /// 载入历史消息,再拉一次内容源。整段吞异常:消息中心是锦上添花的东西,
+    /// 它出问题不该拦住应用启动。
+    /// </summary>
+    private async Task InitializeNotificationsAsync(
+        INotificationCenter center, IAnnouncementFeed? feed, IUpdateService? updateService)
+    {
+        try
+        {
+            await center.LoadAsync().ConfigureAwait(true);
+            Sidebar.NotificationUnreadCount = center.UnreadCount;
+            await RefreshNotificationSourcesAsync(center, feed, updateService).ConfigureAwait(true);
+        }
+        catch
+        {
+            // 载入/拉取失败时铃铛照常可用,只是没有新内容。
+        }
+    }
+
+    /// <summary>把「有可用更新」与订阅资讯源的内容投进消息中心。</summary>
+    private async Task RefreshNotificationSourcesAsync(
+        INotificationCenter center, IAnnouncementFeed? feed, IUpdateService? updateService)
+    {
+        AppSettings settings = _latestSettings ?? new();
+        List<NotificationItem> incoming = [];
+        if (updateService is not null && settings.Notifications.NotifyUpdates && settings.General.CheckUpdatesOnStartup)
+        {
+            if (await BuildUpdateNotificationAsync(updateService).ConfigureAwait(true) is { } update)
+            {
+                incoming.Add(update);
+            }
+        }
+        if (feed is not null)
+        {
+            IReadOnlyList<NotificationItem> fetched = await feed.FetchAsync().ConfigureAwait(true);
+            incoming.AddRange(settings.Notifications.AllowPromotions
+                                  ? fetched
+                                  : fetched.Where(item => item.Kind != NotificationKind.Promotion));
+        }
+        if (incoming.Count > 0)
+        {
+            await center.PublishAsync(incoming).ConfigureAwait(true);
+        }
+    }
+
+    /// <summary>
+    /// 检查更新,有新版本就攒一条消息。
+    /// <para>
+    /// 商店版直接跳过:安装目录只读、更新由 Microsoft Store 接管,推一条"去关于页更新"
+    /// 只会把用户送到一个什么也做不了的页面。
+    /// </para>
+    /// </summary>
+    private static async Task<NotificationItem?> BuildUpdateNotificationAsync(IUpdateService updateService)
+    {
+        if (updateService.IsStoreManaged)
+        {
+            return null;
+        }
+        bool hasUpdate;
+        try
+        {
+            hasUpdate = await updateService.CheckForUpdateAsync().ConfigureAwait(true);
+        }
+        catch
+        {
+            // 离线或更新源不可达是常态。
+            return null;
+        }
+        if (!hasUpdate || updateService.AvailableVersion is not { Length: > 0 } available)
+        {
+            return null;
+        }
+        return new()
+        {
+            // id 里带上版本号:同一个版本每次启动都会重投,靠它去重并保住已读状态;
+            // 真出了新版本则是一条新 id,会重新亮起未读。
+            Id = $"update:{available}",
+            Kind = NotificationKind.Update,
+            Title = Strings.Format("Notify_UpdateTitle", available),
+            Body = Strings.Format("Notify_UpdateBody", updateService.CurrentVersion ?? "?"),
+            PublishedAt = DateTime.UtcNow,
+            Link = new()
+            {
+                Label = Strings.Get("Notify_UpdateAction"),
+                CommandId = "app.settings.about"
+            }
+        };
+    }
+
+    /// <summary>在系统浏览器里打开外链(由消息中心的外链条目调用)。</summary>
+    private Task OpenExternalUrlAsync(string url)
+    {
+        ExternalUrlRequested?.Invoke(this, url);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>请求在系统浏览器中打开一个网址 —— 由窗口层执行(ViewModel 不碰 TopLevel)。</summary>
+    public event EventHandler<string>? ExternalUrlRequested;
 
     /// <summary>为隧道面板后台建立 SSH 连接:不开终端标签,凭据缺失时走登录验证弹窗。</summary>
     private async Task<Guid> ConnectTunnelHostAsync(

--- a/src/VelaShell/ViewModels/NotificationItemViewModel.cs
+++ b/src/VelaShell/ViewModels/NotificationItemViewModel.cs
@@ -1,0 +1,111 @@
+using ReactiveUI;
+using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.ViewModels;
+
+/// <summary>消息列表里的一条:包装共享的 <see cref="NotificationItem" />,向界面暴露展示属性。</summary>
+public class NotificationItemViewModel(NotificationItem item) : ReactiveObject
+{
+    private readonly NotificationItem _item = item ?? throw new ArgumentNullException(nameof(item));
+
+    /// <summary>消息标识(去重与已读状态的键)。</summary>
+    public string Id => _item.Id;
+
+    /// <summary>标题。</summary>
+    public string Title => _item.Title;
+
+    /// <summary>正文;无正文时为空。</summary>
+    public string? Body => _item.Body;
+
+    /// <summary>是否有正文(控制正文行显隐)。</summary>
+    public bool HasBody => !string.IsNullOrWhiteSpace(_item.Body);
+
+    /// <summary>消息种类。</summary>
+    public NotificationKind Kind => _item.Kind;
+
+    /// <summary>是否已读。</summary>
+    public bool IsRead
+    {
+        get => _item.IsRead;
+        set
+        {
+            if (_item.IsRead == value)
+            {
+                return;
+            }
+            _item.IsRead = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(IsUnread));
+        }
+    }
+
+    /// <summary>是否未读(未读行左侧有强调竖条、标题用主文本色)。</summary>
+    public bool IsUnread => !_item.IsRead;
+
+    /// <summary>种类徽标文字(资讯 / 更新 / 安全 / 推广)。</summary>
+    public string KindBadge => Kind switch
+    {
+        NotificationKind.Update => Strings.Get("Notify_KindUpdate"),
+        NotificationKind.Security => Strings.Get("Notify_KindSecurity"),
+        NotificationKind.Promotion => Strings.Get("Notify_KindPromotion"),
+        _ => Strings.Get("Notify_KindNews")
+    };
+
+    /// <summary>是否为需要留意的消息(警告/严重),用于把徽标换成警示色。</summary>
+    public bool IsHighlighted => _item.Severity is NotificationSeverity.Warning or NotificationSeverity.Critical;
+
+    /// <summary>这条消息有没有可去的地方。</summary>
+    public bool HasLink => _item.Link is not null;
+
+    /// <summary>动作文案;源里没给就按去处兜底(站内「查看」/ 站外「打开链接」)。</summary>
+    public string LinkLabel =>
+        _item.Link is not { } link
+            ? string.Empty
+            : !string.IsNullOrWhiteSpace(link.Label)
+                ? link.Label
+                : Strings.Get(link.CommandId is { Length: > 0 } ? "Notify_LinkOpen" : "Notify_LinkExternal");
+
+    /// <summary>
+    /// 外链的主机名,显示在动作旁边。远端源指过来的链接,**要让用户在点之前就看见去哪** ——
+    /// 一个只显示「阅读全文」的按钮,点下去到哪只有投递方知道。
+    /// </summary>
+    public string? LinkHost =>
+        _item.Link?.CommandId is { Length: > 0 }
+            ? null
+            : _item.Link?.Url is { Length: > 0 } url && Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed)
+                ? parsed.Host
+                : null;
+
+    /// <summary>是否显示外链主机名。</summary>
+    public bool HasLinkHost => LinkHost is { Length: > 0 };
+
+    /// <summary>底层的去处(由面板执行跳转)。</summary>
+    public NotificationLink? Link => _item.Link;
+
+    /// <summary>相对时间(刚刚 / 5 分钟前 / 3 小时前 / 2 天前)。</summary>
+    public string RelativeTime => FormatRelative(DateTime.UtcNow - _item.PublishedAt);
+
+    /// <summary>由面板的时钟调用,刷新相对时间。</summary>
+    public void RefreshRelativeTime() => this.RaisePropertyChanged(nameof(RelativeTime));
+
+    /// <summary>把时间差说成人话;未来时间(源端时钟偏了)一律当作「刚刚」。</summary>
+    public static string FormatRelative(TimeSpan age)
+    {
+        if (age < TimeSpan.FromMinutes(1))
+        {
+            return Strings.Get("Notify_TimeJustNow");
+        }
+        if (age < TimeSpan.FromHours(1))
+        {
+            return Strings.Format("Notify_TimeMinutes", (int)age.TotalMinutes);
+        }
+        if (age < TimeSpan.FromDays(1))
+        {
+            return Strings.Format("Notify_TimeHours", (int)age.TotalHours);
+        }
+        return age < TimeSpan.FromDays(30)
+                   ? Strings.Format("Notify_TimeDays", (int)age.TotalDays)
+                   : Strings.Format("Notify_TimeMonths", (int)(age.TotalDays / 30));
+    }
+}

--- a/src/VelaShell/ViewModels/NotificationPanelViewModel.cs
+++ b/src/VelaShell/ViewModels/NotificationPanelViewModel.cs
@@ -1,0 +1,199 @@
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Threading;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Models;
+using VelaShell.Core.Notifications;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.ViewModels;
+
+/// <summary>
+/// 消息中心面板(侧边栏铃铛):列出留存的消息 —— 有新版本了、订阅源发来的公告与安全资讯,
+/// 点一条即跳到它该去的地方。
+/// <para>
+/// 这里刻意**不收**运行时告警(会话断开、指纹变更):那些要的是当场打断,已各有归宿;
+/// 混进来只会把真正要读的东西淹掉。
+/// </para>
+/// </summary>
+public class NotificationPanelViewModel : ReactiveObject, IDisposable
+{
+    private readonly INotificationCenter _center;
+
+    /// <summary>执行站内跳转:传命令 id,返回是否跳成功。</summary>
+    private readonly Func<string, bool>? _commandInvoker;
+
+    private readonly DispatcherTimer? _relativeTimeTimer;
+
+    /// <summary>在浏览器里打开外链。</summary>
+    private readonly Func<string, Task>? _urlOpener;
+
+    /// <summary>构造消息中心面板;站内跳转与外链打开均可为空(便于测试)。</summary>
+    public NotificationPanelViewModel(
+        INotificationCenter center,
+        Func<string, bool>? commandInvoker = null,
+        Func<string, Task>? urlOpener = null)
+    {
+        _center = center ?? throw new ArgumentNullException(nameof(center));
+        _commandInvoker = commandInvoker;
+        _urlOpener = urlOpener;
+        Items = [];
+        MarkAllReadCommand = ReactiveCommand.CreateFromTask(async () => await _center.MarkAllReadAsync());
+        ClearCommand = ReactiveCommand.CreateFromTask(async () => await _center.ClearAsync());
+        RemoveCommand = ReactiveCommand.CreateFromTask<string>(async id => await _center.RemoveAsync(id));
+        ActivateCommand = ReactiveCommand.CreateFromTask<string>(ActivateAsync);
+        CloseCommand = ReactiveCommand.Create(() => CloseRequested?.Invoke(this, EventArgs.Empty));
+        _center.Changed += OnCenterChanged;
+        Reload();
+
+        // 「5 分钟前」会随时间变成「1 小时前」,每分钟刷一次即可;
+        // 无 Avalonia 应用(单元测试)时没有计时器。
+        if (Application.Current is not null)
+        {
+            _relativeTimeTimer = new()
+            {
+                Interval = TimeSpan.FromMinutes(1)
+            };
+            _relativeTimeTimer.Tick += (_, _) => RefreshRelativeTimes();
+            _relativeTimeTimer.Start();
+        }
+    }
+
+    /// <summary>当前展示的消息(按发布时间倒序;未读优先的排序交给源数据,这里不再重排)。</summary>
+    public ObservableCollection<NotificationItemViewModel> Items { get; }
+
+    /// <summary>未读条数。</summary>
+    public int UnreadCount => _center.UnreadCount;
+
+    /// <summary>是否有未读(控制标题栏角标显隐)。</summary>
+    public bool HasUnread => UnreadCount > 0;
+
+    /// <summary>列表是否为空(控制空态提示)。</summary>
+    public bool IsEmpty => Items.Count == 0;
+
+    /// <summary>只看未读。</summary>
+    public bool UnreadOnly
+    {
+        get;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref field, value);
+            Reload();
+        }
+    }
+
+    /// <summary>空态提示文案:全部已读时说"没有未读",本来就没消息时说"暂无消息"。</summary>
+    public string EmptyHint => Strings.Get(UnreadOnly ? "Notify_EmptyUnread" : "Notify_Empty");
+
+    /// <summary>全部标为已读。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> MarkAllReadCommand { get; }
+
+    /// <summary>清空全部消息。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> ClearCommand { get; }
+
+    /// <summary>删除一条消息。</summary>
+    public ReactiveCommand<string, RxVoid> RemoveCommand { get; }
+
+    /// <summary>点开一条消息:标记已读并跳到它的去处。</summary>
+    public ReactiveCommand<string, RxVoid> ActivateCommand { get; }
+
+    /// <summary>收起面板。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> CloseCommand { get; }
+
+    /// <summary>释放面板资源:停表并退订消息中心。</summary>
+    public void Dispose()
+    {
+        _relativeTimeTimer?.Stop();
+        _center.Changed -= OnCenterChanged;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>面板收起请求(右上角关闭 / 跳转后自动收起)。</summary>
+    public event EventHandler? CloseRequested;
+
+    /// <summary>
+    /// 点开一条消息:先标已读,再跳。
+    /// <para>
+    /// 站内命令优先于外链 —— 站内能办的事不该把人赶去浏览器。
+    /// </para>
+    /// </summary>
+    private async Task ActivateAsync(string id)
+    {
+        NotificationItemViewModel? item = Items.FirstOrDefault(entry => entry.Id == id);
+        if (item is null)
+        {
+            return;
+        }
+        await _center.MarkReadAsync(id).ConfigureAwait(true);
+        if (item.Link is not { } link)
+        {
+            return;
+        }
+        if (link.CommandId is { Length: > 0 } commandId && _commandInvoker?.Invoke(commandId) == true)
+        {
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        // 外链只放行 https:内容来自远端源,http 等于让投递方把用户导去一条可被改写的链路。
+        if (link.Url is not { Length: > 0 } url ||
+            !Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed) ||
+            parsed.Scheme != Uri.UriSchemeHttps ||
+            _urlOpener is null)
+        {
+            return;
+        }
+        try
+        {
+            await _urlOpener(url).ConfigureAwait(true);
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+        }
+        catch
+        {
+            // 没有浏览器可用/被系统拒绝时静默:面板本身仍然可用。
+        }
+    }
+
+    /// <summary>
+    /// 消息中心在任意线程触发变更,刷新列表必须回到 UI 线程。
+    /// 无 Avalonia 应用(单元测试)时没有 dispatcher 循环,Post 进去的回调永远不会跑,
+    /// 此时直接同步刷新。
+    /// </summary>
+    private void OnCenterChanged()
+    {
+        if (Application.Current is null)
+        {
+            Reload();
+            return;
+        }
+        Dispatcher.UIThread.Post(Reload);
+    }
+
+    /// <summary>按当前筛选重建列表。</summary>
+    private void Reload()
+    {
+        IEnumerable<NotificationItem> source = _center.Items;
+        if (UnreadOnly)
+        {
+            source = source.Where(item => !item.IsRead);
+        }
+        Items.Clear();
+        foreach (NotificationItem item in source)
+        {
+            Items.Add(new(item));
+        }
+        this.RaisePropertyChanged(nameof(UnreadCount));
+        this.RaisePropertyChanged(nameof(HasUnread));
+        this.RaisePropertyChanged(nameof(IsEmpty));
+        this.RaisePropertyChanged(nameof(EmptyHint));
+    }
+
+    private void RefreshRelativeTimes()
+    {
+        foreach (NotificationItemViewModel item in Items)
+        {
+            item.RefreshRelativeTime();
+        }
+    }
+}

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -21,6 +21,52 @@ namespace VelaShell.ViewModels;
 /// <summary>设置左侧导航项(图标为 PathIcon 几何)。</summary>
 public sealed record SettingsSection(string Name, string Icon);
 
+/// <summary>
+/// 设置页左侧分区的稳定标识,供"直接跳到某一页"的入口(消息中心、命令注册表)使用。
+/// <para>
+/// 用它而不是下标:分区顺序是会调整的,一旦有谁记住了「关于页 = 10」,
+/// 中间插一页就静默跳错地方,而且没有任何东西会报错。
+/// </para>
+/// </summary>
+public enum SettingsSectionKey
+{
+    /// <summary>常规。</summary>
+    General,
+
+    /// <summary>外观。</summary>
+    Appearance,
+
+    /// <summary>终端。</summary>
+    Terminal,
+
+    /// <summary>密钥管理。</summary>
+    Keys,
+
+    /// <summary>快捷键。</summary>
+    Shortcuts,
+
+    /// <summary>文件传输。</summary>
+    Transfer,
+
+    /// <summary>安全审计。</summary>
+    Security,
+
+    /// <summary>网络代理。</summary>
+    Proxy,
+
+    /// <summary>代码片段。</summary>
+    Snippets,
+
+    /// <summary>云同步。</summary>
+    Sync,
+
+    /// <summary>关于(含检查更新)。</summary>
+    About,
+
+    /// <summary>支持与捐赠。</summary>
+    Support
+}
+
 /// <summary>关于页的开源依赖条目(项目主页 + 许可证页面可点击跳转)。</summary>
 public sealed record DependencyInfo(string Name, string License, string Url, string LicenseUrl);
 
@@ -336,6 +382,13 @@ public class SettingsViewModel : ReactiveObject
         private set => this.RaiseAndSetIfChanged(ref field, value);
     } = new();
 
+    /// <summary>消息中心选项(资讯源、更新提醒)。</summary>
+    public NotificationOptions Notifications
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = new();
+
     /// <summary>密钥管理页。</summary>
     public SshKeyManagerViewModel SshKeys { get; }
 
@@ -458,6 +511,20 @@ public class SettingsViewModel : ReactiveObject
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>
+    /// 跳到指定分区。<see cref="SettingsSectionKey" /> 的顺序与 <see cref="BuildSections" />
+    /// 的产出一一对应,由 <c>SettingsSectionKeyTests</c> 钉住 —— 往中间插一页就会有测试失败,
+    /// 而不是让"跳到关于页"悄悄跳去别处。
+    /// </summary>
+    public void SelectSection(SettingsSectionKey key)
+    {
+        int index = (int)key;
+        if (index >= 0 && index < Sections.Length)
+        {
+            SelectedSectionIndex = index;
+        }
     }
 
     /// <summary>支持的界面语言(顺序即语言下拉的条目顺序)。</summary>
@@ -1272,6 +1339,7 @@ public class SettingsViewModel : ReactiveObject
         Security = settings.Security;
         Keys = settings.Keys;
         Proxy = settings.Proxy;
+        Notifications = settings.Notifications;
         RefreshTrustedLaunchTargets();
 
         // 配色方案下拉:重算“(默认)”标注与选中项(出厂值折射到当前主题默认方案;
@@ -1461,6 +1529,7 @@ public class SettingsViewModel : ReactiveObject
         _loaded.Security = Security;
         _loaded.Keys = Keys;
         _loaded.Proxy = Proxy;
+        _loaded.Notifications = Notifications;
         await _settingsService.SaveSettingsAsync(_loaded);
 
         // 即时生效 —— 主题、强调色与语言均无需重启即可应用(#2/#3/#4)。

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -68,6 +68,14 @@
            IsVisible="{Binding IsTunnelPanelOpen}">
       <views:TunnelPanelView DataContext="{Binding TunnelPanel}" />
     </Panel>
+    <!-- 消息中心:非模态,由侧边栏底部铃铛切换。锚在左下贴着铃铛 —— 浮层从哪个按钮
+         开出来就该长在哪个按钮旁边,开在右上会让人一时找不到它和什么有关。 -->
+    <Panel Grid.Row="1" ZIndex="60"
+           HorizontalAlignment="Left" VerticalAlignment="Bottom"
+           Margin="12,0,0,48"
+           IsVisible="{Binding IsNotificationPanelOpen}">
+      <views:NotificationPanelView DataContext="{Binding NotificationPanel}" />
+    </Panel>
     <!-- 自绘标题栏:logo/名称 + 全局功能图标 + 最小化/最大化/关闭 -->
     <views:TitleBarView x:Name="TitleBarHost" Grid.Row="0" DataContext="{Binding}" />
 

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -201,6 +201,8 @@ public partial class MainWindow : Window
             vm.TerminalFocusRequested += (_, _) => FocusActiveTerminal(vm);
             vm.NewConnectionRequested += (_, _) => _ = OpenProfileDialogAsync(null);
             vm.SettingsRequested += (_, _) => _ = OpenSettingsAsync();
+            vm.SettingsSectionRequested += (_, section) => _ = OpenSettingsAsync(section);
+            vm.ExternalUrlRequested += (_, url) => _ = OpenExternalUrlAsync(url);
             vm.InteractiveAuthenticator = PromptCredentialsAsync;
             // FTPS 与插件协议的 TLS 端点共用同一套「先拒绝 → 提示 → 记指纹后重连」的信任流程,
             // 因此也共用同一个对话框;两者的异常类型不同,这里各接一个薄适配。
@@ -1115,13 +1117,42 @@ public partial class MainWindow : Window
     }
 
     /// <summary>打开设置窗口(设计 §14):DI 单例 VM,打开时重新加载持久化设置。</summary>
-    private async Task OpenSettingsAsync()
+    /// <summary>
+    /// 在系统浏览器里打开一个网址(消息中心的外链条目)。
+    /// **只放行 https** —— 网址来自远端资讯源,这是它落地前的最后一道闸。
+    /// </summary>
+    private async Task OpenExternalUrlAsync(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return;
+        }
+        try
+        {
+            if (GetTopLevel(this) is { Launcher: { } launcher })
+            {
+                await launcher.LaunchUriAsync(uri);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or PlatformNotSupportedException)
+        {
+            // 没有可用浏览器/被系统拒绝:面板本身仍然可用,不该因此崩掉窗口。
+        }
+    }
+
+    /// <summary>打开设置窗口;<paramref name="section" /> 非空时直接落到那一分区。</summary>
+    private async Task OpenSettingsAsync(SettingsSectionKey? section = null)
     {
         if (Application.Current is not App app || app.Services?.GetService<SettingsViewModel>() is not { } settingsViewModel)
         {
             return;
         }
         await settingsViewModel.LoadCommand.Execute().FirstAsync();
+        if (section is { } target)
+        {
+            // 在 Load 之后选:Load 会重建 Sections 并顺带复位选中项。
+            settingsViewModel.SelectSection(target);
+        }
         var dialog = new SettingsView { DataContext = settingsViewModel };
         await dialog.ShowDialog(this);
     }

--- a/src/VelaShell/Views/NotificationPanelView.axaml
+++ b/src/VelaShell/Views/NotificationPanelView.axaml
@@ -1,0 +1,231 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:VelaShell.ViewModels"
+             xmlns:pc="using:VelaShell.Controls.Controls"
+             xmlns:loc="using:VelaShell.Localization"
+             mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="480"
+             x:Class="VelaShell.Views.NotificationPanelView"
+             x:DataType="vm:NotificationPanelViewModel"
+             ClipToBounds="False">
+
+  <!-- 消息中心:非模态浮层,由侧边栏底部铃铛切换。版式沿用隧道面板(规范 §10):
+       bg-surface、圆角 6、1px border-secondary、阴影 blur16 y+4。
+       铃铛在侧边栏左下角,所以这张卡片锚在左下(见 MainWindow.axaml)。 -->
+
+  <UserControl.Styles>
+    <Style Selector="Button.row-action">
+      <Setter Property="Width" Value="20" />
+      <Setter Property="Height" Value="20" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <!-- 悬停高亮挂在**整行**的外层容器上,而不是内层那个只占内容列的按钮 ——
+         挂在按钮上时删除键那一列不会跟着变色,整行被切成深浅两块,
+         中间那道边界看着就像凭空多了一条竖分割线。
+         两个 Background 都必须由样式来设:直接在元素上写 Background="Transparent"
+         是 local value,优先级高于样式,:pointerover 就再也盖不过去了。 -->
+    <Style Selector="Border.msg-row">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="Border.msg-row:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <!-- 整行可点 = 跳转。做成透明按钮而不是给 Border 挂手势:这样键盘 Tab 能走到,
+         焦点框与禁用态也都跟着 Avalonia 的按钮语义走。它自己不画背景,
+         悬停高亮由上面那条整行的样式负责。 -->
+    <Style Selector="Button.row">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="Cursor" Value="Hand" />
+    </Style>
+    <Style Selector="Button.row:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <!-- 消息标题的读/未读两态。选择器限定在 .msg-title 上:写成裸的
+         TextBlock:not(.unread) 会把面板里每一个没显式设色的 TextBlock 都扫进来。 -->
+    <Style Selector="TextBlock.msg-title">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    </Style>
+    <Style Selector="TextBlock.msg-title.unread">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+  </UserControl.Styles>
+
+  <!-- ClipToBounds="False":卡片铺满 UserControl,BoxShadow 画在边界外,
+       裁剪会把它切成"四角有黑块"(与隧道面板同一个坑)。 -->
+  <Border Width="360"
+          Background="{DynamicResource VelaBgSurface}"
+          BorderBrush="{DynamicResource VelaBorderSecondary}"
+          BorderThickness="1"
+          CornerRadius="6"
+          BoxShadow="{DynamicResource VelaShadowWindow}">
+    <StackPanel>
+
+      <!-- 标题栏(36px):铃铛 + 消息 + 未读数 | 只看未读 · 全部已读 · 清空 · 关闭 -->
+      <Border Height="36" Padding="12,0"
+              BorderBrush="{DynamicResource VelaBorderPrimary}"
+              BorderThickness="0,0,0,1">
+        <Grid ColumnDefinitions="Auto,*,Auto,2,Auto,2,Auto,2,Auto">
+          <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+            <pc:LucideIcon Width="12" Height="12"
+                           Data="{StaticResource Icon.bell}"
+                           Foreground="{DynamicResource VelaAccent}" />
+            <TextBlock Text="{loc:Localize Notify_Title}"
+                       Foreground="{DynamicResource VelaTextPrimary}"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium"
+                       VerticalAlignment="Center" />
+            <Border Background="{DynamicResource VelaAccent}"
+                    CornerRadius="8" Padding="6,1" VerticalAlignment="Center"
+                    IsVisible="{Binding HasUnread}">
+              <TextBlock Text="{Binding UnreadCount}"
+                         Foreground="{DynamicResource VelaAccentText}"
+                         FontFamily="{DynamicResource VelaUiMonoFont}"
+                         FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
+            </Border>
+          </StackPanel>
+          <ToggleButton Grid.Column="2" Height="20" Padding="6,0" CornerRadius="3"
+                        Background="Transparent" BorderThickness="0" Cursor="Hand"
+                        VerticalAlignment="Center"
+                        IsChecked="{Binding UnreadOnly}"
+                        ToolTip.Tip="{loc:Localize Notify_UnreadOnlyTip}">
+            <TextBlock Text="{loc:Localize Notify_UnreadOnly}"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}" />
+          </ToggleButton>
+          <Button Grid.Column="4" Classes="row-action"
+                  ToolTip.Tip="{loc:Localize Notify_MarkAllRead}"
+                  Command="{Binding MarkAllReadCommand}">
+            <pc:LucideIcon Width="12" Height="12"
+                           Data="{StaticResource Icon.circle-check}"
+                           Foreground="{DynamicResource VelaTextSecondary}" />
+          </Button>
+          <Button Grid.Column="6" Classes="row-action"
+                  ToolTip.Tip="{loc:Localize Notify_ClearAll}"
+                  Command="{Binding ClearCommand}">
+            <pc:LucideIcon Width="12" Height="12"
+                           Data="{StaticResource Icon.trash-2}"
+                           Foreground="{DynamicResource VelaTextTertiary}" />
+          </Button>
+          <Button Grid.Column="8" Classes="row-action"
+                  ToolTip.Tip="{loc:Localize Notify_Close}"
+                  Command="{Binding CloseCommand}">
+            <pc:LucideIcon Width="12" Height="12"
+                           Data="{StaticResource Icon.x}"
+                           Foreground="{DynamicResource VelaTextTertiary}" />
+          </Button>
+        </Grid>
+      </Border>
+
+      <!-- 空态 -->
+      <Border Padding="12,16" IsVisible="{Binding IsEmpty}">
+        <TextBlock Text="{Binding EmptyHint}"
+                   Foreground="{DynamicResource VelaTextMuted}"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize10}"
+                   HorizontalAlignment="Center" />
+      </Border>
+
+      <!-- 消息列表 -->
+      <ScrollViewer MaxHeight="380" VerticalScrollBarVisibility="Auto">
+        <ItemsControl ItemsSource="{Binding Items}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vm:NotificationItemViewModel">
+              <Border Classes="msg-row"
+                      BorderBrush="{DynamicResource VelaBorderPrimary}"
+                      BorderThickness="0,0,0,1">
+                <Grid ColumnDefinitions="2,*,Auto">
+                  <!-- 未读的左侧强调竖条:扫一眼就知道哪些还没读 -->
+                  <Border Grid.Column="0"
+                          Background="{DynamicResource VelaAccent}"
+                          IsVisible="{Binding IsUnread}" />
+                  <Button Grid.Column="1" Classes="row"
+                          Command="{Binding $parent[ItemsControl].((vm:NotificationPanelViewModel)DataContext).ActivateCommand}"
+                          CommandParameter="{Binding Id}">
+                    <StackPanel Margin="10,10,4,10" Spacing="4">
+                      <StackPanel Orientation="Horizontal" Spacing="6">
+                        <!-- 种类徽标:未读用强调色底,已读退成描边 -->
+                        <Border CornerRadius="2" Padding="5,1" VerticalAlignment="Center"
+                                Background="{DynamicResource VelaAccentDim}"
+                                IsVisible="{Binding !IsHighlighted}">
+                          <TextBlock Text="{Binding KindBadge}"
+                                     Foreground="{DynamicResource VelaAccent}"
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
+                        </Border>
+                        <Border CornerRadius="2" Padding="5,1" VerticalAlignment="Center"
+                                Background="Transparent"
+                                BorderBrush="{DynamicResource VelaWarning}" BorderThickness="1"
+                                IsVisible="{Binding IsHighlighted}">
+                          <TextBlock Text="{Binding KindBadge}"
+                                     Foreground="{DynamicResource VelaWarning}"
+                                     FontFamily="{DynamicResource VelaUiMonoFont}"
+                                     FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
+                        </Border>
+                        <TextBlock Text="{Binding RelativeTime}"
+                                   Foreground="{DynamicResource VelaTextMuted}"
+                                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                                   FontSize="{DynamicResource VelaFontSize9}"
+                                   VerticalAlignment="Center" />
+                      </StackPanel>
+                      <!-- 已读退到次要色且不加粗,未读保持主文本 + Medium:
+                           一列消息里,读没读过要能靠余光分出来,而不是逐条去找竖条。 -->
+                      <TextBlock Text="{Binding Title}"
+                                 Classes="msg-title" Classes.unread="{Binding IsUnread}"
+                                 FontFamily="{DynamicResource VelaUiFont}"
+                                 FontSize="{DynamicResource VelaFontSize11}"
+                                 TextWrapping="Wrap" />
+                      <TextBlock Text="{Binding Body}"
+                                 IsVisible="{Binding HasBody}"
+                                 Foreground="{DynamicResource VelaTextMuted}"
+                                 FontFamily="{DynamicResource VelaUiFont}"
+                                 FontSize="{DynamicResource VelaFontSize10}"
+                                 TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis" />
+                      <!-- 去处:站内动作只显示文案;外链把主机名摆出来,
+                           让用户在点之前就知道自己会被带去哪个站点。 -->
+                      <StackPanel Orientation="Horizontal" Spacing="4"
+                                  IsVisible="{Binding HasLink}">
+                        <TextBlock Text="{Binding LinkLabel}"
+                                   Foreground="{DynamicResource VelaAccent}"
+                                   FontFamily="{DynamicResource VelaUiFont}"
+                                   FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
+                                   VerticalAlignment="Center" />
+                        <pc:LucideIcon Width="10" Height="10"
+                                       Data="{StaticResource Icon.chevron-right}"
+                                       Foreground="{DynamicResource VelaAccent}"
+                                       VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding LinkHost}"
+                                   IsVisible="{Binding HasLinkHost}"
+                                   Foreground="{DynamicResource VelaTextMuted}"
+                                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                                   FontSize="{DynamicResource VelaFontSize9}"
+                                   VerticalAlignment="Center" />
+                      </StackPanel>
+                    </StackPanel>
+                  </Button>
+                  <Button Grid.Column="2" Classes="row-action" Margin="0,10,8,0"
+                          VerticalAlignment="Top"
+                          ToolTip.Tip="{loc:Localize Notify_Remove}"
+                          Command="{Binding $parent[ItemsControl].((vm:NotificationPanelViewModel)DataContext).RemoveCommand}"
+                          CommandParameter="{Binding Id}">
+                    <pc:LucideIcon Width="10" Height="10"
+                                   Data="{StaticResource Icon.x}"
+                                   Foreground="{DynamicResource VelaTextTertiary}" />
+                  </Button>
+                </Grid>
+              </Border>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/src/VelaShell/Views/NotificationPanelView.axaml.cs
+++ b/src/VelaShell/Views/NotificationPanelView.axaml.cs
@@ -1,0 +1,10 @@
+using Avalonia.Controls;
+
+namespace VelaShell.Views;
+
+/// <summary>消息中心面板视图:侧边栏铃铛切换的非模态浮层。</summary>
+public partial class NotificationPanelView : UserControl
+{
+    /// <summary>创建消息中心面板视图并加载其可视组件。</summary>
+    public NotificationPanelView() => InitializeComponent();
+}

--- a/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml
@@ -34,8 +34,51 @@
       </StackPanel>
       <ToggleSwitch Grid.Column="1" IsChecked="{Binding General.MinimizeToTray}" VerticalAlignment="Center" />
     </Grid>
-    <!-- 启动时检查更新 / 更新频道 / 自动下载:更新服务尚未接入,暂不展示(设置审计 R-01~R-03);
-         字段仍持久化,功能实现后恢复展示。 -->
+    <!-- 「启动时检查更新」恢复展示:它此前被判为"更新服务尚未接入"而隐藏(设置审计 R-01),
+         但这个开关已经有实际消费者 —— 消息中心据它决定要不要在启动时查一次新版本。
+         更新频道 / 自动下载仍未接线,继续隐藏。 -->
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetGeneral_CheckUpdatesOnStartup}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetGeneral_CheckUpdatesOnStartupDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding General.CheckUpdatesOnStartup}" VerticalAlignment="Center" />
+    </Grid>
+
+    <Border Classes="sep" />
+
+    <!-- 消息中心(侧边栏铃铛) -->
+    <TextBlock Classes="section-title" Text="{loc:Localize SetGeneral_MessagesSection}" />
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetGeneral_NotifyUpdates}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetGeneral_NotifyUpdatesDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding Notifications.NotifyUpdates}" VerticalAlignment="Center" />
+    </Grid>
+    <StackPanel Spacing="4">
+      <TextBlock Classes="row-label" Text="{loc:Localize SetGeneral_FeedUrl}" />
+      <TextBlock Classes="row-desc" Text="{loc:Localize SetGeneral_FeedUrlDesc}" />
+      <TextBox Text="{Binding Notifications.FeedUrl}"
+               PlaceholderText="{loc:Localize SetGeneral_FeedUrlPlaceholder}" />
+    </StackPanel>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetGeneral_FeedInterval}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetGeneral_FeedIntervalDesc}" />
+      </StackPanel>
+      <NumericUpDown Grid.Column="1" Width="110" Minimum="1" Maximum="168" Increment="1"
+                     FormatString="0"
+                     Value="{Binding Notifications.FeedIntervalHours}"
+                     VerticalAlignment="Center" />
+    </Grid>
+    <Grid ColumnDefinitions="*,Auto">
+      <StackPanel Spacing="2">
+        <TextBlock Classes="row-label" Text="{loc:Localize SetGeneral_AllowPromotions}" />
+        <TextBlock Classes="row-desc" Text="{loc:Localize SetGeneral_AllowPromotionsDesc}" />
+      </StackPanel>
+      <ToggleSwitch Grid.Column="1" IsChecked="{Binding Notifications.AllowPromotions}" VerticalAlignment="Center" />
+    </Grid>
 
     <Border Classes="sep" />
 

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -232,11 +232,20 @@
         </StackPanel>
         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"
                     VerticalAlignment="Center">
+          <!-- 消息中心入口。未读角标叠在铃铛右上角:侧边栏底部只有 24px 见方,
+               放不下数字标签,而"有没有新东西"本来也只需要一个点就能说清。 -->
           <Button Width="24" Height="24" Background="Transparent" Padding="0"
                   CornerRadius="3" Command="{Binding NotificationsCommand}"
                   ToolTip.Tip="{x:Static res:Strings.Notifications}" ToolTip.Placement="Right" Cursor="Hand">
-            <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.bell}"
-                           Foreground="{DynamicResource VelaTextTertiary}" />
+            <Panel>
+              <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.bell}"
+                             Foreground="{DynamicResource VelaTextTertiary}" />
+              <Ellipse Width="6" Height="6"
+                       HorizontalAlignment="Right" VerticalAlignment="Top"
+                       Margin="0,-1,-1,0"
+                       Fill="{DynamicResource VelaAccent}"
+                       IsVisible="{Binding HasUnreadNotifications}" />
+            </Panel>
           </Button>
           <Button Width="24" Height="24" Background="Transparent" Padding="0"
                   CornerRadius="3" Click="OpenPlugins_Click"

--- a/tests/VelaShell.Core.Tests/Notifications/AnnouncementFeedDocumentTests.cs
+++ b/tests/VelaShell.Core.Tests/Notifications/AnnouncementFeedDocumentTests.cs
@@ -1,0 +1,252 @@
+using VelaShell.Core.Models;
+using VelaShell.Core.Notifications;
+
+namespace VelaShell.Core.Tests.Notifications;
+
+/// <summary>
+/// 资讯源的 JSON 契约。**这是后台系统要照着发布的格式**,所以这些用例既是回归测试,
+/// 也是那份格式的可执行说明:定向投放怎么算、什么样的条目会被丢掉、外链放行到什么程度。
+/// </summary>
+[TestClass]
+[TestCategory("Notifications")]
+public class AnnouncementFeedDocumentTests
+{
+    private static readonly DateTime Now = new(2026, 8, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    private static readonly FeedAudience Anyone = new("1.3.0", "win-x64", "zh-Hans");
+
+    /// <summary>一条完整的条目应被原样解析出来。</summary>
+    [TestMethod]
+    public void Parse_ReadsFullItem()
+    {
+        const string json = """
+        {
+          "schema": 1,
+          "items": [{
+            "id": "2026-08-30-release",
+            "kind": "update",
+            "severity": "warning",
+            "title": "VelaShell 1.4 已发布",
+            "body": "隧道流量统计、断线自动恢复。",
+            "publishedAt": "2026-08-30T02:00:00Z",
+            "linkLabel": "查看详情",
+            "url": "https://velashell.dev/releases/1.4"
+          }]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(1, items);
+        NotificationItem item = items[0];
+        Assert.AreEqual("2026-08-30-release", item.Id);
+        Assert.AreEqual(NotificationKind.Update, item.Kind);
+        Assert.AreEqual(NotificationSeverity.Warning, item.Severity);
+        Assert.AreEqual("VelaShell 1.4 已发布", item.Title);
+        Assert.AreEqual("隧道流量统计、断线自动恢复。", item.Body);
+        Assert.AreEqual("查看详情", item.Link?.Label);
+        Assert.AreEqual("https://velashell.dev/releases/1.4", item.Link?.Url);
+    }
+
+    /// <summary>缺 id / 标题 / 发布时间的条目直接丢掉,但**不影响同一批里的好条目**。</summary>
+    [TestMethod]
+    public void Parse_SkipsBadItems_ButKeepsGoodOnes()
+    {
+        const string json = """
+        {
+          "items": [
+            { "title": "没有 id", "publishedAt": "2026-08-30T02:00:00Z" },
+            { "id": "no-title", "publishedAt": "2026-08-30T02:00:00Z" },
+            { "id": "no-date", "title": "没有发布时间" },
+            "这一条压根不是对象",
+            { "id": "good", "title": "好的", "publishedAt": "2026-08-30T02:00:00Z" }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(1, items);
+        Assert.AreEqual("good", items[0].Id);
+    }
+
+    /// <summary>整体结构不对(不是 JSON / 没有 items 数组)时返回空,不抛。</summary>
+    [TestMethod]
+    public void Parse_ReturnsEmpty_ForMalformedDocument()
+    {
+        Assert.IsEmpty(AnnouncementFeedDocument.Parse("这不是 JSON", Anyone, Now));
+        Assert.IsEmpty(AnnouncementFeedDocument.Parse("{}", Anyone, Now));
+        Assert.IsEmpty(AnnouncementFeedDocument.Parse("""{"items":"不是数组"}""", Anyone, Now));
+        Assert.IsEmpty(AnnouncementFeedDocument.Parse("[]", Anyone, Now));
+    }
+
+    /// <summary>过了 expiresAt 的条目不再展示 —— 活动结束了就不该还挂在消息列表里。</summary>
+    [TestMethod]
+    public void Parse_DropsExpiredItems()
+    {
+        const string json = """
+        {
+          "items": [
+            { "id": "expired", "title": "已过期", "publishedAt": "2026-08-01T00:00:00Z", "expiresAt": "2026-08-15T00:00:00Z" },
+            { "id": "live",    "title": "仍有效", "publishedAt": "2026-08-01T00:00:00Z", "expiresAt": "2026-09-15T00:00:00Z" }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(1, items);
+        Assert.AreEqual("live", items[0].Id);
+    }
+
+    /// <summary>按界面语言定向:不在 locales 里的收不到。</summary>
+    [TestMethod]
+    public void Parse_FiltersByLocale()
+    {
+        const string json = """
+        {
+          "items": [
+            { "id": "zh", "title": "中文公告", "publishedAt": "2026-08-30T02:00:00Z", "locales": ["zh-Hans", "zh-Hant"] },
+            { "id": "ja", "title": "日本語のお知らせ", "publishedAt": "2026-08-30T02:00:00Z", "locales": ["ja"] }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(1, items);
+        Assert.AreEqual("zh", items[0].Id);
+    }
+
+    /// <summary>按平台定向:只投给指定 RID。</summary>
+    [TestMethod]
+    public void Parse_FiltersByPlatform()
+    {
+        const string json = """
+        {
+          "items": [
+            { "id": "win", "title": "Windows", "publishedAt": "2026-08-30T02:00:00Z", "platforms": ["win-x64"] },
+            { "id": "mac", "title": "macOS",   "publishedAt": "2026-08-30T02:00:00Z", "platforms": ["osx-arm64"] }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(1, items);
+        Assert.AreEqual("win", items[0].Id);
+    }
+
+    /// <summary>按版本区间定向(含端点),预发布后缀不参与比较。</summary>
+    [TestMethod]
+    public void Parse_FiltersByVersionRange()
+    {
+        const string json = """
+        {
+          "items": [
+            { "id": "too-old", "title": "给更新的版本", "publishedAt": "2026-08-30T02:00:00Z", "minVersion": "1.5.0" },
+            { "id": "too-new", "title": "给更旧的版本", "publishedAt": "2026-08-30T02:00:00Z", "maxVersion": "1.2.0" },
+            { "id": "in-range", "title": "正好", "publishedAt": "2026-08-30T02:00:00Z", "minVersion": "1.2.0", "maxVersion": "1.3.0" }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, new("1.3.0-beta.2", "win-x64", "zh-Hans"), Now);
+
+        Assert.HasCount(1, items);
+        Assert.AreEqual("in-range", items[0].Id);
+    }
+
+    /// <summary>
+    /// 本机版本号读不出来时不做版本定向过滤 —— 宁可多看一条,也好过因为版本号异常
+    /// 就把"你这个版本有问题,快升级"这种正是冲着你来的消息漏掉。
+    /// </summary>
+    [TestMethod]
+    public void Parse_KeepsTargetedItems_WhenLocalVersionUnknown()
+    {
+        const string json = """
+        { "items": [{ "id": "targeted", "title": "定向", "publishedAt": "2026-08-30T02:00:00Z", "minVersion": "1.5.0" }] }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, new(null, "win-x64", "zh-Hans"), Now);
+
+        Assert.HasCount(1, items);
+    }
+
+    /// <summary>空的定向数组等于没设条件,不该把所有人筛掉。</summary>
+    [TestMethod]
+    public void Parse_TreatsEmptyTargetingArrayAsUnrestricted()
+    {
+        const string json = """
+        { "items": [{ "id": "all", "title": "给所有人", "publishedAt": "2026-08-30T02:00:00Z", "locales": [], "platforms": [] }] }
+        """;
+
+        Assert.HasCount(1, AnnouncementFeedDocument.Parse(json, Anyone, Now));
+    }
+
+    /// <summary>
+    /// 外链只放行 https:内容来自远端源,放行 http 等于允许投递方把用户导去
+    /// 一条可被中间人改写的链路。非 https 的链接被抹掉,条目本身仍然保留。
+    /// </summary>
+    [TestMethod]
+    public void Parse_RejectsNonHttpsLinks()
+    {
+        const string json = """
+        {
+          "items": [
+            { "id": "http",   "title": "明文", "publishedAt": "2026-08-30T02:00:00Z", "url": "http://example.com" },
+            { "id": "file",   "title": "本地", "publishedAt": "2026-08-30T02:00:00Z", "url": "file:///etc/passwd" },
+            { "id": "https",  "title": "加密", "publishedAt": "2026-08-30T02:00:00Z", "url": "https://example.com" }
+          ]
+        }
+        """;
+
+        IReadOnlyList<NotificationItem> items = AnnouncementFeedDocument.Parse(json, Anyone, Now);
+
+        Assert.HasCount(3, items);
+        Assert.IsNull(items.Single(item => item.Id == "http").Link, "http 链接应被丢弃。");
+        Assert.IsNull(items.Single(item => item.Id == "file").Link, "file 链接应被丢弃。");
+        Assert.AreEqual("https://example.com", items.Single(item => item.Id == "https").Link?.Url);
+    }
+
+    /// <summary>站内命令 id 与外链可以并存,由界面决定优先级(站内优先)。</summary>
+    [TestMethod]
+    public void Parse_KeepsCommandIdAlongsideUrl()
+    {
+        const string json = """
+        { "items": [{ "id": "both", "title": "两个都给", "publishedAt": "2026-08-30T02:00:00Z",
+                      "commandId": "app.settings.about", "url": "https://example.com" }] }
+        """;
+
+        NotificationLink? link = AnnouncementFeedDocument.Parse(json, Anyone, Now)[0].Link;
+
+        Assert.AreEqual("app.settings.about", link?.CommandId);
+        Assert.AreEqual("https://example.com", link?.Url);
+    }
+
+    /// <summary>源端一次推来上万条时只取前 100 条,不让消息列表被一次拉取撑爆。</summary>
+    [TestMethod]
+    public void Parse_CapsItemCount()
+    {
+        IEnumerable<string> entries = Enumerable.Range(0, 250)
+            .Select(i => $$"""{ "id": "n{{i}}", "title": "第 {{i}} 条", "publishedAt": "2026-08-30T02:00:00Z" }""");
+        string json = $$"""{ "items": [{{string.Join(",", entries)}}] }""";
+
+        Assert.HasCount(AnnouncementFeedDocument.MaxItems, AnnouncementFeedDocument.Parse(json, Anyone, Now));
+    }
+
+    /// <summary>未知的 kind / severity 落到最保守的默认值,而不是让整条失效。</summary>
+    [TestMethod]
+    public void Parse_FallsBackForUnknownEnums()
+    {
+        const string json = """
+        { "items": [{ "id": "x", "title": "未知枚举", "publishedAt": "2026-08-30T02:00:00Z",
+                      "kind": "宇宙射线", "severity": "非常严重" }] }
+        """;
+
+        NotificationItem item = AnnouncementFeedDocument.Parse(json, Anyone, Now)[0];
+
+        Assert.AreEqual(NotificationKind.News, item.Kind);
+        Assert.AreEqual(NotificationSeverity.Info, item.Severity);
+    }
+}

--- a/tests/VelaShell.Core.Tests/XYModem/XYModemInteropTests.cs
+++ b/tests/VelaShell.Core.Tests/XYModem/XYModemInteropTests.cs
@@ -61,7 +61,7 @@ public class XYModemInteropTests
     private static async Task<byte> ReadByteAsync(XYModemByteReader reader, CancellationToken ct)
     {
         int b = await reader.ReadByteAsync(ct);
-        Assert.IsTrue(b >= 0, "对端提前关闭了通道");
+        Assert.IsGreaterThanOrEqualTo(0, b, "对端提前关闭了通道");
         return (byte)b;
     }
 
@@ -114,7 +114,7 @@ public class XYModemInteropTests
         FileTransferSession session = await receiving;
 
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        Assert.AreSequenceEqual(new[] { "中文名.txt" }, sink.OfferedNames, "0 号块的 UTF-8 文件名应原样解出");
+        Assert.AreSequenceEqual(["中文名.txt"], sink.OfferedNames, "0 号块的 UTF-8 文件名应原样解出");
         Assert.AreEqual(content.Length, sink.OfferedSizes[0], "0 号块声明的大小应被解析");
         Assert.AreSequenceEqual(content, sink.Completed["中文名.txt"], "末块的 SUB 填充必须按声明大小裁掉");
     }
@@ -150,7 +150,7 @@ public class XYModemInteropTests
         FileTransferSession session = await receiving;
 
         Assert.AreEqual(FileTransferState.Completed, session.Status);
-        Assert.AreSequenceEqual(new[] { "download.bin" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(["download.bin"], sink.OfferedNames);
         Assert.AreSequenceEqual(content, sink.Completed["download.bin"]);
     }
 
@@ -265,7 +265,7 @@ public class XYModemInteropTests
         await receiving;
 
         byte[] landed = sink.Completed["dup.bin"];
-        Assert.AreEqual(256, landed.Length, "重复块被写了两遍就会超过声明的 256 字节");
+        Assert.HasCount(256, landed, "重复块被写了两遍就会超过声明的 256 字节");
         Assert.AreSequenceEqual(first, landed[..4]);
         Assert.AreSequenceEqual(second, landed[128..132]);
     }
@@ -322,7 +322,7 @@ public class XYModemInteropTests
 
         FileTransferSession session = await receiving;
         Assert.AreEqual(FileTransferState.Cancelled, session.Status);
-        Assert.AreEqual(0, sink.Completed.Count);
+        Assert.IsEmpty(sink.Completed);
     }
 
     /// <summary>

--- a/tests/VelaShell.Core.Tests/XYModem/XYModemLoopbackTests.cs
+++ b/tests/VelaShell.Core.Tests/XYModem/XYModemLoopbackTests.cs
@@ -77,12 +77,12 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        Assert.AreSequenceEqual(new[] { "first.bin", "second.bin", "三个.txt" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(["first.bin", "second.bin", "三个.txt"], sink.OfferedNames);
         foreach ((string name, byte[] data) in files)
         {
             Assert.AreSequenceEqual(data, sink.Completed[name], $"{name} 内容不符");
         }
-        Assert.AreEqual(3, send.Items.Count);
+        Assert.HasCount(3, send.Items);
     }
 
     /// <summary>块号跨过 255 回绕后仍要正确对齐(1024 字节块 × 300 块 &gt; 256)。</summary>
@@ -150,7 +150,7 @@ public class XYModemLoopbackTests
             await RoundTripAsync(TerminalTransferProtocol.YModem, [("exact.bin", data)]);
 
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        Assert.AreEqual(data.Length, sink.Completed["exact.bin"].Length);
+        Assert.HasCount(data.Length, sink.Completed["exact.bin"]);
         Assert.AreSequenceEqual(data, sink.Completed["exact.bin"]);
     }
 
@@ -163,7 +163,7 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Completed, send.Status);
         Assert.AreEqual(FileTransferState.Completed, receive.Status);
-        Assert.AreEqual(0, sink.Completed["empty.bin"].Length);
+        Assert.IsEmpty(sink.Completed["empty.bin"]);
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ public class XYModemLoopbackTests
 
         Assert.AreEqual(FileTransferState.Cancelled, receive.Result.Status);
         Assert.AreEqual(FileTransferState.Cancelled, send.Result.Status);
-        Assert.AreEqual(0, sink.Completed.Count);
+        Assert.IsEmpty(sink.Completed);
     }
 
     /// <summary>用户在文件选择框里取消(空清单)时,发送端应干净地记为取消而不是失败。</summary>

--- a/tests/VelaShell.Core.Tests/ZModem/ZModemHardeningTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ZModemHardeningTests.cs
@@ -78,7 +78,7 @@ public class ZModemHardeningTests
             new ZModemSender(a, new InMemoryFileSource([("测试文件.txt", data)])).SendAsync(cts.Token);
         await Task.WhenAll(receive, send);
 
-        Assert.AreSequenceEqual(new[] { "测试文件.txt" }, sink.OfferedNames);
+        Assert.AreSequenceEqual(["测试文件.txt"], sink.OfferedNames);
         Assert.AreSequenceEqual(data, sink.Completed["测试文件.txt"]);
     }
 
@@ -242,7 +242,7 @@ public class ZModemHardeningTests
         FileTransferItem item = send.Result.Items.Single();
         Assert.AreEqual(FileTransferState.Failed, item.Status);
         StringAssert.Contains(item.ErrorMessage ?? string.Empty, "4 GiB");
-        Assert.AreEqual(0, sink.OfferedNames.Count, "超限文件根本不该被提供给对端");
+        Assert.IsEmpty(sink.OfferedNames, "超限文件根本不该被提供给对端");
     }
 
     /// <summary>谎称自己有 5 GiB 的文件来源(不会真的被读取,发送端应在打开前就拦下)。</summary>

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
@@ -225,7 +225,7 @@ public class FtpFileServiceIntegrationTests
             bool faulted = false;
             _service.SessionStateChanged += (_, change) => faulted |= change.State == FtpSessionState.Faulted;
 
-            byte[] payload = Enumerable.Range(0, 4096).Select(static i => (byte)(i % 251)).ToArray();
+            byte[] payload = [.. Enumerable.Range(0, 4096).Select(static i => (byte)(i % 251))];
             var sources = new List<string>();
             for (int i = 0; i < 5; i++)
             {
@@ -248,7 +248,7 @@ public class FtpFileServiceIntegrationTests
             {
                 string landed = Path.Combine(_root, Path.GetFileName(source));
                 Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
-                CollectionAssert.AreEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+                Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
             }
             Assert.IsFalse(faulted, "退化成单连接是正常降级,不该把整条会话标记为离线。");
         }
@@ -270,7 +270,7 @@ public class FtpFileServiceIntegrationTests
         Directory.CreateDirectory(outDir);
         try
         {
-            byte[] payload = Enumerable.Range(0, 8192).Select(static i => (byte)(i % 253)).ToArray();
+            byte[] payload = [.. Enumerable.Range(0, 8192).Select(static i => (byte)(i % 253))];
             var sources = new List<string>();
             for (int i = 0; i < 4; i++)
             {
@@ -292,7 +292,7 @@ public class FtpFileServiceIntegrationTests
             {
                 string landed = Path.Combine(_root, Path.GetFileName(source));
                 Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
-                CollectionAssert.AreEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+                Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
             }
         }
         finally

--- a/tests/VelaShell.Infrastructure.Tests/Notifications/NotificationCenterTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Notifications/NotificationCenterTests.cs
@@ -1,0 +1,256 @@
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Notifications;
+
+namespace VelaShell.Infrastructure.Tests.Notifications;
+
+/// <summary>
+/// 消息中心:去重、已读状态、过期清理、上限与持久化。
+/// 这些行为串起来才成立 —— 尤其"每次启动都重投同一条更新提醒"不能把读过的又点亮。
+/// </summary>
+[TestClass]
+[TestCategory("Notifications")]
+public class NotificationCenterTests
+{
+    private static NotificationItem Item(string id, DateTime? published = null, DateTime? expires = null) =>
+        new()
+        {
+            Id = id,
+            Kind = NotificationKind.News,
+            Title = $"消息 {id}",
+            PublishedAt = published ?? DateTime.UtcNow,
+            ExpiresAt = expires
+        };
+
+    /// <summary>投递后进列表,未读数跟着涨,并触发一次变更通知。</summary>
+    [TestMethod]
+    public async Task Publish_AddsItemsAndRaisesChanged()
+    {
+        var center = new NotificationCenter();
+        int changes = 0;
+        center.Changed += () => Interlocked.Increment(ref changes);
+
+        await center.PublishAsync([Item("a"), Item("b")]);
+
+        Assert.HasCount(2, center.Items);
+        Assert.AreEqual(2, center.UnreadCount);
+        Assert.AreEqual(1, changes, "一批投递只该触发一次变更。");
+    }
+
+    /// <summary>
+    /// **同 id 重复投递会被跳过,而且保住已读状态。** 每次启动都重投一条
+    /// "有新版本"时,覆盖会把用户已经读过的又变回未读 —— 那样铃铛就永远消不掉红点。
+    /// </summary>
+    [TestMethod]
+    public async Task Publish_IsIdempotent_AndPreservesReadState()
+    {
+        var center = new NotificationCenter();
+        await center.PublishAsync([Item("update:1.4.0")]);
+        await center.MarkReadAsync("update:1.4.0");
+        Assert.AreEqual(0, center.UnreadCount);
+
+        await center.PublishAsync([Item("update:1.4.0")]);
+
+        Assert.HasCount(1, center.Items);
+        Assert.AreEqual(0, center.UnreadCount, "重投同一条不该把它变回未读。");
+    }
+
+    /// <summary>列表按发布时间倒序,新的在上面。</summary>
+    [TestMethod]
+    public async Task Publish_SortsNewestFirst()
+    {
+        var center = new NotificationCenter();
+        DateTime now = DateTime.UtcNow;
+
+        await center.PublishAsync([
+            Item("old", now.AddDays(-3)),
+            Item("new", now),
+            Item("mid", now.AddDays(-1))
+        ]);
+
+        Assert.AreSequenceEqual(["new", "mid", "old"], [.. center.Items.Select(item => item.Id)]);
+    }
+
+    /// <summary>过期条目在投递时就被剔除。</summary>
+    [TestMethod]
+    public async Task Publish_DropsExpiredItems()
+    {
+        var center = new NotificationCenter();
+
+        await center.PublishAsync([
+            Item("expired", DateTime.UtcNow.AddDays(-2), DateTime.UtcNow.AddDays(-1)),
+            Item("live", DateTime.UtcNow, DateTime.UtcNow.AddDays(1))
+        ]);
+
+        Assert.HasCount(1, center.Items);
+        Assert.AreEqual("live", center.Items[0].Id);
+    }
+
+    /// <summary>超出上限时丢最旧的 —— 消息中心不是归档系统。</summary>
+    [TestMethod]
+    public async Task Publish_EnforcesCap_DroppingOldest()
+    {
+        var center = new NotificationCenter();
+        DateTime baseline = DateTime.UtcNow.AddDays(-1);
+
+        await center.PublishAsync(Enumerable.Range(0, NotificationCenter.MaxItems + 20)
+            .Select(i => Item($"n{i}", baseline.AddMinutes(i))));
+
+        Assert.HasCount(NotificationCenter.MaxItems, center.Items);
+        Assert.DoesNotContain(item => item.Id == "n0", center.Items, "最旧的那条应被截掉。");
+        Assert.Contains(item => item.Id == $"n{NotificationCenter.MaxItems + 19}", center.Items, "最新的那条应留下。");
+    }
+
+    /// <summary>全部已读把未读清零;删除与清空按预期收缩列表。</summary>
+    [TestMethod]
+    public async Task MarkAllRead_Remove_And_Clear()
+    {
+        var center = new NotificationCenter();
+        await center.PublishAsync([Item("a"), Item("b"), Item("c")]);
+
+        await center.MarkAllReadAsync();
+        Assert.AreEqual(0, center.UnreadCount);
+
+        await center.RemoveAsync("b");
+        Assert.HasCount(2, center.Items);
+        Assert.DoesNotContain(item => item.Id == "b", center.Items);
+
+        await center.ClearAsync();
+        Assert.IsEmpty(center.Items);
+    }
+
+    /// <summary>没有实际变化的操作不触发变更通知(避免界面白刷)。</summary>
+    [TestMethod]
+    public async Task NoOpMutations_DoNotRaiseChanged()
+    {
+        var center = new NotificationCenter();
+        await center.PublishAsync([Item("a")]);
+        await center.MarkReadAsync("a");
+        int changes = 0;
+        center.Changed += () => Interlocked.Increment(ref changes);
+
+        await center.MarkReadAsync("a");            // 已经是已读
+        await center.MarkReadAsync("不存在");        // 没这条
+        await center.RemoveAsync("也不存在");
+        await center.PublishAsync([Item("a")]);     // 重复 id
+
+        Assert.AreEqual(0, changes);
+    }
+
+    /// <summary>消息跨重启留存:一条公告关掉应用第二天再看仍然成立。</summary>
+    [TestMethod]
+    public async Task Load_RestoresPersistedItemsAndReadState()
+    {
+        var store = new InMemoryDataStore();
+        var first = new NotificationCenter(store);
+        await first.PublishAsync([Item("kept"), Item("read-me")]);
+        await first.MarkReadAsync("read-me");
+
+        var second = new NotificationCenter(store);
+        await second.LoadAsync();
+
+        Assert.HasCount(2, second.Items);
+        Assert.AreEqual(1, second.UnreadCount, "已读状态要一起恢复。");
+    }
+
+    /// <summary>载入时顺手清掉上次运行留下、如今已经过期的条目。</summary>
+    [TestMethod]
+    public async Task Load_PrunesExpiredItems()
+    {
+        var store = new InMemoryDataStore();
+        var first = new NotificationCenter(store);
+        await first.PublishAsync([
+            Item("live", DateTime.UtcNow, DateTime.UtcNow.AddDays(1)),
+            Item("soon", DateTime.UtcNow, DateTime.UtcNow.AddMilliseconds(80))
+        ]);
+        await Task.Delay(150);
+
+        var second = new NotificationCenter(store);
+        await second.LoadAsync();
+
+        Assert.HasCount(1, second.Items);
+        Assert.AreEqual("live", second.Items[0].Id);
+    }
+
+    /// <summary>存储读不出来(损坏/旧格式)时当作没有历史消息,不该把应用拖崩。</summary>
+    [TestMethod]
+    public async Task Load_SurvivesBrokenStore()
+    {
+        var center = new NotificationCenter(new ThrowingDataStore());
+
+        await center.LoadAsync();
+
+        Assert.IsEmpty(center.Items);
+    }
+
+    /// <summary>落盘失败不影响本次运行里看到的消息。</summary>
+    [TestMethod]
+    public async Task Publish_SurvivesFailingStore()
+    {
+        var center = new NotificationCenter(new ThrowingDataStore());
+
+        await center.PublishAsync([Item("a")]);
+
+        Assert.HasCount(1, center.Items);
+    }
+
+    /// <summary>把文档留在内存里的最小存储,用来验证"跨进程"的往返。</summary>
+    private sealed class InMemoryDataStore : IAppDataStore
+    {
+        private readonly Dictionary<string, object> _documents = [];
+
+        public Task<T?> GetAsync<T>(string collection, string id, CancellationToken cancellationToken = default) where T : class =>
+            Task.FromResult(_documents.GetValueOrDefault($"{collection}/{id}") as T);
+
+        public Task<List<T>> GetAllAsync<T>(string collection, CancellationToken cancellationToken = default) where T : class =>
+            Task.FromResult(_documents.Where(pair => pair.Key.StartsWith($"{collection}/", StringComparison.Ordinal))
+                                      .Select(pair => pair.Value)
+                                      .OfType<T>()
+                                      .ToList());
+
+        public Task UpsertAsync<T>(string collection, string id, T value, CancellationToken cancellationToken = default) where T : class
+        {
+            // 存快照的副本:真实存储是序列化落盘,拿到的绝不会是同一个对象实例。
+            _documents[$"{collection}/{id}"] = value is List<NotificationItem> items
+                                                   ? items.Select(Clone).ToList()
+                                                   : value;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string collection, string id, CancellationToken cancellationToken = default)
+        {
+            _documents.Remove($"{collection}/{id}");
+            return Task.CompletedTask;
+        }
+
+        private static NotificationItem Clone(NotificationItem item) =>
+            new()
+            {
+                Id = item.Id,
+                Kind = item.Kind,
+                Severity = item.Severity,
+                Title = item.Title,
+                Body = item.Body,
+                PublishedAt = item.PublishedAt,
+                ExpiresAt = item.ExpiresAt,
+                IsRead = item.IsRead,
+                Link = item.Link
+            };
+    }
+
+    /// <summary>读写都抛的存储,验证消息中心不被存储故障带倒。</summary>
+    private sealed class ThrowingDataStore : IAppDataStore
+    {
+        public Task<T?> GetAsync<T>(string collection, string id, CancellationToken cancellationToken = default) where T : class =>
+            throw new InvalidOperationException("store is broken");
+
+        public Task<List<T>> GetAllAsync<T>(string collection, CancellationToken cancellationToken = default) where T : class =>
+            throw new InvalidOperationException("store is broken");
+
+        public Task UpsertAsync<T>(string collection, string id, T value, CancellationToken cancellationToken = default) where T : class =>
+            throw new InvalidOperationException("store is broken");
+
+        public Task DeleteAsync(string collection, string id, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("store is broken");
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
@@ -464,7 +464,7 @@ public sealed class PluginWorkspaceTests
 
         launcher.OnUnregistered(WorkspaceId);
 
-        Assert.AreSequenceEqual(new[] { session.SessionId }, abandoned);
+        Assert.AreSequenceEqual([session.SessionId], abandoned);
         // 已经报过的会话不会再报第二次(界面关闭标签页时也会 Forget)。
         abandoned.Clear();
         launcher.OnUnregistered(WorkspaceId);

--- a/tests/VelaShell.Infrastructure.Tests/Ssh/MeteredPortForwardTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ssh/MeteredPortForwardTests.cs
@@ -32,7 +32,7 @@ public class MeteredPortForwardTests
             await stream.WriteAsync(payload, deadline.Token);
             byte[] echoed = new byte[payload.Length];
             await stream.ReadExactlyAsync(echoed, deadline.Token);
-            CollectionAssert.AreEqual(payload, echoed);
+            Assert.AreSequenceEqual(payload, echoed);
         }
         await WaitForAsync(() => relay.BytesTransferred >= payload.Length * 2, deadline.Token);
 

--- a/tests/VelaShell.Infrastructure.Tests/Ssh/Socks5NegotiationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ssh/Socks5NegotiationTests.cs
@@ -29,7 +29,7 @@ public class Socks5NegotiationTests
 
         Assert.AreEqual("db.internal", host);
         Assert.AreEqual(5432, port);
-        CollectionAssert.AreEqual(new byte[] { 0x05, 0x00 }, stream.ReadOutbound(2), "应先回一条选定 NO-AUTH 的方法应答。");
+        Assert.AreSequenceEqual(new byte[] { 0x05, 0x00 }, stream.ReadOutbound(2), "应先回一条选定 NO-AUTH 的方法应答。");
     }
 
     /// <summary>IPv4 目标解析:地址按四字节网络序还原。</summary>
@@ -58,7 +58,7 @@ public class Socks5NegotiationTests
         await Assert.ThrowsExactlyAsync<Socks5ProtocolException>(
             async () => await Socks5Negotiation.AcceptRequestAsync(stream, deadline.Token));
 
-        CollectionAssert.AreEqual(new byte[] { 0x05, 0xFF }, stream.ReadOutbound(2));
+        Assert.AreSequenceEqual(new byte[] { 0x05, 0xFF }, stream.ReadOutbound(2));
     }
 
     /// <summary>非 CONNECT 命令(BIND / UDP ASSOCIATE)回 0x07,并把请求判死。</summary>
@@ -112,7 +112,7 @@ public class Socks5NegotiationTests
         await Socks5Negotiation.WriteReplyAsync(stream, Socks5Negotiation.ReplySucceeded, deadline.Token);
 
         byte[] reply = stream.ReadOutbound(10);
-        CollectionAssert.AreEqual(new byte[] { 0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0 }, reply);
+        Assert.AreSequenceEqual(new byte[] { 0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0 }, reply);
         Assert.AreEqual(0, BinaryPrimitives.ReadUInt16BigEndian(reply.AsSpan(8)));
     }
 

--- a/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
+++ b/tests/VelaShell.Terminal.Tests/DevicePixelGridTests.cs
@@ -89,7 +89,7 @@ public class DevicePixelGridTests
 
         // 21.25 的行距只能落在 21 或 22 设备像素上;出现第三种值说明吸附把行距算飘了。
         Assert.AreSequenceEqual(
-            new long[] { 21, 22 }, [.. deviceHeights.OrderBy(h => h)], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "行高应只在 21/22 设备像素之间浮动。"
+            [21, 22], [.. deviceHeights.OrderBy(h => h)], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "行高应只在 21/22 设备像素之间浮动。"
         );
     }
 

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -162,7 +162,7 @@ public sealed class ConnectionProfileViewModelTests
             Assert.IsTrue(vm.HostIsEditableChoice, "可手输:枚举不到的设备也必须填得进去。");
             Assert.IsTrue(vm.HostIsDynamicChoice, "动态:USB 转串口是热插拔的,得给刷新按钮。");
             Assert.IsFalse(vm.HostIsText);
-            Assert.AreSequenceEqual(new[] { "COM3", "COM7" }, [.. vm.HostChoices.Select(choice => choice.Value)]);
+            Assert.AreSequenceEqual(["COM3", "COM7"], [.. vm.HostChoices.Select(choice => choice.Value)]);
             Assert.AreEqual("串口设备", vm.HostLabel);
         }
     }
@@ -181,7 +181,7 @@ public sealed class ConnectionProfileViewModelTests
 
             await vm.RefreshHostChoicesCommand.Execute().FirstAsync();
 
-            Assert.AreSequenceEqual(new[] { "COM3", "COM9" }, [.. vm.HostChoices.Select(choice => choice.Value)]);
+            Assert.AreSequenceEqual(["COM3", "COM9"], [.. vm.HostChoices.Select(choice => choice.Value)]);
             Assert.AreEqual(2, terminal.Queries, "刷新必须是真的重取,而不是拿缓存糊弄。");
         }
     }

--- a/tests/VelaShell.Tests/ViewModels/NotificationPanelViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/NotificationPanelViewModelTests.cs
@@ -1,0 +1,193 @@
+using ReactiveUI.Primitives;
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Notifications;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>消息中心面板:跳转优先级、已读联动、筛选与相对时间。</summary>
+[TestClass]
+[TestCategory("Notifications")]
+public class NotificationPanelViewModelTests
+{
+    private static NotificationItem Item(string id, NotificationLink? link = null, bool read = false) =>
+        new()
+        {
+            Id = id,
+            Kind = NotificationKind.News,
+            Title = $"消息 {id}",
+            PublishedAt = DateTime.UtcNow,
+            IsRead = read,
+            Link = link
+        };
+
+    private static async Task<NotificationCenter> SeededCenterAsync(params NotificationItem[] items)
+    {
+        var center = new NotificationCenter();
+        await center.PublishAsync(items);
+        return center;
+    }
+
+    /// <summary>
+    /// 站内命令优先于外链:站内能办的事不该把人赶去浏览器。
+    /// 更新提醒正是这条路径 —— 点一下直接落到设置的关于页,而不是打开下载页。
+    /// </summary>
+    [TestMethod]
+    public async Task Activate_PrefersInAppCommandOverUrl()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("both", new()
+        {
+            Label = "查看",
+            CommandId = "app.settings.about",
+            Url = "https://example.com/release"
+        }));
+        string? invokedCommand = null;
+        var openedUrls = new List<string>();
+        var vm = new NotificationPanelViewModel(center,
+            id => { invokedCommand = id; return true; },
+            url => { openedUrls.Add(url); return Task.CompletedTask; });
+
+        await vm.ActivateCommand.Execute("both").FirstAsync();
+
+        Assert.AreEqual("app.settings.about", invokedCommand);
+        Assert.IsEmpty(openedUrls, "站内跳成功后不该再开浏览器。");
+    }
+
+    /// <summary>命令没注册(返回 false)时退回外链,而不是什么都不做。</summary>
+    [TestMethod]
+    public async Task Activate_FallsBackToUrl_WhenCommandMissing()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("fallback", new()
+        {
+            Label = "查看",
+            CommandId = "plugin.not.installed",
+            Url = "https://example.com/post"
+        }));
+        var openedUrls = new List<string>();
+        var vm = new NotificationPanelViewModel(center, _ => false, url =>
+        {
+            openedUrls.Add(url);
+            return Task.CompletedTask;
+        });
+
+        await vm.ActivateCommand.Execute("fallback").FirstAsync();
+
+        Assert.AreSequenceEqual(["https://example.com/post"], openedUrls);
+    }
+
+    /// <summary>非 https 的外链一律不开 —— 这是远端来的地址落地前的最后一道闸。</summary>
+    [TestMethod]
+    public async Task Activate_RefusesNonHttpsUrl()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("plain", new()
+        {
+            Label = "查看",
+            Url = "http://example.com"
+        }));
+        var openedUrls = new List<string>();
+        var vm = new NotificationPanelViewModel(center, null, url =>
+        {
+            openedUrls.Add(url);
+            return Task.CompletedTask;
+        });
+
+        await vm.ActivateCommand.Execute("plain").FirstAsync();
+
+        Assert.IsEmpty(openedUrls);
+    }
+
+    /// <summary>点开一条就把它标为已读,未读数跟着落。</summary>
+    [TestMethod]
+    public async Task Activate_MarksRead()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"), Item("b"));
+        var vm = new NotificationPanelViewModel(center);
+        Assert.AreEqual(2, vm.UnreadCount);
+
+        await vm.ActivateCommand.Execute("a").FirstAsync();
+
+        Assert.AreEqual(1, vm.UnreadCount);
+        Assert.IsFalse(vm.Items.Single(item => item.Id == "a").IsUnread);
+    }
+
+    /// <summary>没有去处的消息点了也不报错,只是标记已读。</summary>
+    [TestMethod]
+    public async Task Activate_HandlesItemWithoutLink()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("plain"));
+        var vm = new NotificationPanelViewModel(center);
+
+        await vm.ActivateCommand.Execute("plain").FirstAsync();
+
+        Assert.AreEqual(0, vm.UnreadCount);
+    }
+
+    /// <summary>「只看未读」筛掉已读条目,取消勾选后恢复。</summary>
+    [TestMethod]
+    public async Task UnreadOnly_FiltersList()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("unread"), Item("read", read: true));
+        var vm = new NotificationPanelViewModel(center);
+        Assert.HasCount(2, vm.Items);
+
+        vm.UnreadOnly = true;
+        Assert.HasCount(1, vm.Items);
+        Assert.AreEqual("unread", vm.Items[0].Id);
+
+        vm.UnreadOnly = false;
+        Assert.HasCount(2, vm.Items);
+    }
+
+    /// <summary>全部已读后,「只看未读」下列表为空并给出对应的空态文案。</summary>
+    [TestMethod]
+    public async Task MarkAllRead_EmptiesUnreadFilter()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"), Item("b"));
+        var vm = new NotificationPanelViewModel(center) { UnreadOnly = true };
+
+        await vm.MarkAllReadCommand.Execute().FirstAsync();
+
+        Assert.IsTrue(vm.IsEmpty);
+        Assert.AreEqual(Core.Resources.Strings.Get("Notify_EmptyUnread"), vm.EmptyHint);
+    }
+
+    /// <summary>删除与清空要反映到列表上。</summary>
+    [TestMethod]
+    public async Task Remove_And_Clear_UpdateList()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"), Item("b"));
+        var vm = new NotificationPanelViewModel(center);
+
+        await vm.RemoveCommand.Execute("a").FirstAsync();
+        Assert.HasCount(1, vm.Items);
+
+        await vm.ClearCommand.Execute().FirstAsync();
+        Assert.IsTrue(vm.IsEmpty);
+        Assert.AreEqual(Core.Resources.Strings.Get("Notify_Empty"), vm.EmptyHint);
+    }
+
+    /// <summary>外链条目要把主机名摆出来,让用户在点之前就知道会被带去哪个站点。</summary>
+    [TestMethod]
+    public void ItemViewModel_ExposesLinkHost_ForExternalLinksOnly()
+    {
+        var external = new NotificationItemViewModel(Item("ext", new() { Label = "读全文", Url = "https://news.example.com/a" }));
+        var inApp = new NotificationItemViewModel(Item("in", new() { Label = "查看", CommandId = "app.settings.about" }));
+
+        Assert.AreEqual("news.example.com", external.LinkHost);
+        Assert.IsTrue(external.HasLinkHost);
+        Assert.IsNull(inApp.LinkHost, "站内跳转没有外部主机可显示。");
+        Assert.IsFalse(inApp.HasLinkHost);
+    }
+
+    /// <summary>相对时间按量级切换单位;源端时钟偏到未来时一律当作「刚刚」。</summary>
+    [TestMethod]
+    public void ItemViewModel_FormatsRelativeTime()
+    {
+        Assert.AreEqual(Core.Resources.Strings.Get("Notify_TimeJustNow"), NotificationItemViewModel.FormatRelative(TimeSpan.FromSeconds(20)));
+        Assert.AreEqual(Core.Resources.Strings.Get("Notify_TimeJustNow"), NotificationItemViewModel.FormatRelative(TimeSpan.FromMinutes(-5)));
+        Assert.AreEqual(Core.Resources.Strings.Format("Notify_TimeMinutes", 5), NotificationItemViewModel.FormatRelative(TimeSpan.FromMinutes(5)));
+        Assert.AreEqual(Core.Resources.Strings.Format("Notify_TimeHours", 3), NotificationItemViewModel.FormatRelative(TimeSpan.FromHours(3)));
+        Assert.AreEqual(Core.Resources.Strings.Format("Notify_TimeDays", 2), NotificationItemViewModel.FormatRelative(TimeSpan.FromDays(2)));
+        Assert.AreEqual(Core.Resources.Strings.Format("Notify_TimeMonths", 2), NotificationItemViewModel.FormatRelative(TimeSpan.FromDays(70)));
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/SettingsSectionKeyTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsSectionKeyTests.cs
@@ -1,0 +1,76 @@
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Resources;
+using VelaShell.Core.Services;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// <see cref="SettingsSectionKey" /> 与设置页左侧分区必须逐项对齐。
+/// <para>
+/// 消息中心的「有可用更新」靠 <c>SelectSection(SettingsSectionKey.About)</c> 落到关于页。
+/// 往分区列表中间插一页而忘了同步枚举,跳转就会静默跑到隔壁页 —— 不会报错、不会崩,
+/// 只是用户点了"去更新"却看到别的东西。这个测试就是为了让那种改动**当场失败**。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("Notifications")]
+public class SettingsSectionKeyTests
+{
+    /// <summary>枚举成员数与分区数一致,且逐项落在同名分区上。</summary>
+    [TestMethod]
+    public void SectionKeys_MatchBuiltSections()
+    {
+        SettingsViewModel vm = CreateViewModel();
+        string[] expected =
+        [
+            Strings.Get("SetVm_SectionGeneral"),
+            Strings.Get("SetVm_SectionAppearance"),
+            Strings.Get("SetVm_SectionTerminal"),
+            Strings.Get("SetVm_SectionKeys"),
+            Strings.Get("SetVm_SectionShortcuts"),
+            Strings.Get("SetVm_SectionTransfer"),
+            Strings.Get("SetVm_SectionSecurity"),
+            Strings.Get("SetVm_SectionProxy"),
+            Strings.Get("SetVm_SectionSnippets"),
+            Strings.Get("SetVm_SectionSync"),
+            Strings.Get("SetVm_SectionAbout"),
+            Strings.Get("SetVm_SectionSupport")
+        ];
+
+        Assert.HasCount(expected.Length, vm.Sections);
+        Assert.HasCount(expected.Length, Enum.GetValues<SettingsSectionKey>());
+        foreach (SettingsSectionKey key in Enum.GetValues<SettingsSectionKey>())
+        {
+            Assert.AreEqual(expected[(int)key], vm.Sections[(int)key].Name, $"{key} 没落在它该在的分区上。");
+        }
+    }
+
+    /// <summary>跳到关于页会把选中项落在关于分区 —— 更新提醒点进来看到的就是这一页。</summary>
+    [TestMethod]
+    public void SelectSection_LandsOnAbout()
+    {
+        SettingsViewModel vm = CreateViewModel();
+
+        vm.SelectSection(SettingsSectionKey.About);
+
+        Assert.AreEqual(Strings.Get("SetVm_SectionAbout"), vm.Sections[vm.SelectedSectionIndex].Name);
+    }
+
+    /// <summary>只验证分区表本身,依赖全部替身即可。</summary>
+    private static SettingsViewModel CreateViewModel() =>
+        new(Substitute.For<ISettingsService>(), Substitute.For<IThemeService>());
+
+    /// <summary>越界的枚举值不该把选中项设到列表外去。</summary>
+    [TestMethod]
+    public void SelectSection_IgnoresOutOfRangeKey()
+    {
+        SettingsViewModel vm = CreateViewModel();
+        int before = vm.SelectedSectionIndex;
+
+        vm.SelectSection((SettingsSectionKey)999);
+
+        Assert.AreEqual(before, vm.SelectedSectionIndex);
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -497,7 +497,7 @@ public class SettingsViewModelTests
 
         vm.ShortcutFilter = "   ";
 
-        Assert.AreEqual(vm.ShortcutGroups.Length, vm.FilteredShortcutGroups.Length, "只有空白的搜索词等于没搜");
+        Assert.HasCount(vm.ShortcutGroups.Length, vm.FilteredShortcutGroups, "只有空白的搜索词等于没搜");
         Assert.AreEqual(total, vm.FilteredShortcutGroups.Sum(group => group.FilteredItems.Count));
     }
 

--- a/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
+++ b/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
@@ -144,7 +144,7 @@ public sealed class BreadcrumbUnderscoreUiTests
         // 扫描本身得先成立:一个面包屑都没找到时,下面两条断言会空转成永远通过的空壳。
         Assert.IsGreaterThanOrEqualTo(minimumSegments, crumbTexts.Length,
                                       "没找到面包屑分段 —— 扫描八成失效了,别让这条测试变成空壳。");
-        Assert.IsTrue(crumbTexts.Any(t => t.Text == UnderscoreSegment),
+        Assert.Contains(t => t.Text == UnderscoreSegment, crumbTexts,
                       $"面包屑里没有 {UnderscoreSegment},实际渲染:{string.Join(" | ", crumbTexts.Select(t => t.Text))}");
         Assert.IsEmpty(crumbTexts.OfType<AccessText>().Select(t => t.Text).ToArray(),
                        "面包屑走了助记符解析(AccessText),路径里的下划线会被当成访问键吃掉。");

--- a/tests/VelaShell.Tests/Views/NotificationPanelUiTests.cs
+++ b/tests/VelaShell.Tests/Views/NotificationPanelUiTests.cs
@@ -1,0 +1,159 @@
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Notifications;
+using VelaShell.Localization;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>消息中心面板的真实 Avalonia 布局与截图回归。</summary>
+[TestClass]
+[TestCategory("Notifications")]
+public sealed class NotificationPanelUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+    private static LocalizationService _localization = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(NotificationPanelUiTests).Assembly);
+        _localization = new();
+        LocalizedStrings.Instance.Attach(_localization);
+    }
+
+    /// <summary>面板渲染出四类消息:未读/已读、站内跳转/外链、普通/警示。</summary>
+    [TestMethod]
+    public void Panel_RendersMixedMessages()
+    {
+        OnUi(() =>
+        {
+            CultureInfo previous = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("zh-CN");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("zh-CN");
+            _localization.SetLanguage("zh-CN");
+            try
+            {
+                var center = new NotificationCenter();
+                DateTime now = DateTime.UtcNow;
+                center.PublishAsync([
+                    new NotificationItem
+                    {
+                        Id = "update:1.4.0",
+                        Kind = NotificationKind.Update,
+                        Title = "VelaShell 1.4.0 已发布",
+                        Body = "隧道流量统计、断线自动恢复、端口冲突预检。",
+                        PublishedAt = now.AddMinutes(-3),
+                        Link = new() { Label = "前往关于页", CommandId = "app.settings.about" }
+                    },
+                    new NotificationItem
+                    {
+                        Id = "cve-2026-1234",
+                        Kind = NotificationKind.Security,
+                        Severity = NotificationSeverity.Warning,
+                        Title = "OpenSSH 9.9 安全公告",
+                        Body = "受影响版本存在远程可触发的内存越界，建议尽快升级服务端。",
+                        PublishedAt = now.AddHours(-5),
+                        Link = new() { Label = "阅读全文", Url = "https://www.openssh.com/security.html" }
+                    },
+                    new NotificationItem
+                    {
+                        Id = "news-2026-08",
+                        Kind = NotificationKind.News,
+                        Title = "八月产品月报",
+                        Body = "SFTP 双栏、资源监控与插件市场的进展。",
+                        PublishedAt = now.AddDays(-2),
+                        IsRead = true,
+                        Link = new() { Label = "阅读全文", Url = "https://velashell.dev/blog/2026-08" }
+                    }
+                ]).GetAwaiter().GetResult();
+
+                var vm = new NotificationPanelViewModel(center, _ => true, _ => Task.CompletedTask);
+                var view = new NotificationPanelView { DataContext = vm };
+                var window = new Window { Width = 400, Height = 520, Content = view };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+
+                Assert.HasCount(3, vm.Items);
+                Assert.AreEqual(2, vm.UnreadCount);
+                SaveFrame(window, "notification-panel-dark.png");
+                window.Close();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previous;
+                CultureInfo.CurrentUICulture = previous;
+                _localization.SetLanguage(previous.Name);
+            }
+        });
+    }
+
+    /// <summary>
+    /// 悬停高亮必须铺满整行。此前它挂在只占内容列的按钮上,删除键那一列不跟着变色,
+    /// 整行被切成深浅两块 —— 中间那道边界看着就像凭空多了一条竖分割线(用户反馈)。
+    /// </summary>
+    [TestMethod]
+    public void Row_HoverHighlight_CoversWholeRow()
+    {
+        OnUi(() =>
+        {
+            var center = new NotificationCenter();
+            center.PublishAsync([
+                new NotificationItem
+                {
+                    Id = "hover",
+                    Kind = NotificationKind.Update,
+                    Title = "悬停高亮应铺满整行",
+                    Body = "包括右侧的删除按钮那一列。",
+                    PublishedAt = DateTime.UtcNow,
+                    Link = new() { Label = "查看", CommandId = "app.settings.about" }
+                }
+            ]).GetAwaiter().GetResult();
+
+            var view = new NotificationPanelView { DataContext = new NotificationPanelViewModel(center) };
+            var window = new Window { Width = 400, Height = 320, Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            Border row = view.GetVisualDescendants().OfType<Border>()
+                             .Single(border => border.Classes.Contains("msg-row"));
+            Assert.IsFalse(row.IsPointerOver, "初始状态不该是悬停。");
+
+            // 指到行的**最右侧**(删除按钮所在的那一列)——问题正是出在这半边。
+            Point rightEdge = row.TranslatePoint(new(row.Bounds.Width - 6, row.Bounds.Height / 2), window)
+                              ?? throw new InvalidOperationException("行未参与布局。");
+            window.MouseMove(rightEdge);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.IsTrue(row.IsPointerOver, "指针停在删除按钮那一列时,整行仍应处于悬停态。");
+            SaveFrame(window, "notification-panel-hover.png");
+            window.Close();
+        });
+    }
+
+    private static void SaveFrame(TopLevel topLevel, string fileName)
+    {
+        string? directory = Environment.GetEnvironmentVariable("VELASHELL_VISUAL_QA_DIR");
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+        Directory.CreateDirectory(directory);
+        using WriteableBitmap? frame = topLevel.CaptureRenderedFrame();
+        Assert.IsNotNull(frame, "Skia headless renderer should produce a visual-QA frame.");
+        using FileStream output = File.Create(Path.Combine(directory, fileName));
+        frame.Save(output, PngBitmapEncoderOptions.Default);
+    }
+
+    private static void OnUi(Action action) => _session.Dispatch(action, CancellationToken.None).GetAwaiter().GetResult();
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

实现消息中心功能，支持公告/资讯/安全新闻/更新等消息的留存、已读管理、筛选、持久化和界面展示。新增相关数据结构及 JSON 契约，支持定向投放、外链校验、坏数据容错。引入 INotificationCenter/NotificationCenter，支持去重、已读保留、过期清理、SonnetDB 持久化。实现 IAnnouncementFeed/HttpAnnouncementFeed，支持 https 拉取和环境过滤。完善 MainWindowViewModel/SidebarViewModel 的消息中心装配、角标、事件绑定和定时拉取机制。设置页新增消息中心相关选项，恢复“启动时检查更新”开关。引入 SettingsSectionKey 枚举及测试，支持分区跳转。新增 NotificationPanelView/NotificationPanelViewModel 及 UI 展示、筛选、已读联动等。界面增加铃铛按钮及浮层锚点。补充多语言文案。新增大量单元测试和 UI 测试，优化部分断言写法。其余为依赖注入、界面事件、命令注册等配套调整。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
