### PR TITLE
修复补全弹层在空行无法关闭的问题

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -420,3 +420,25 @@ Tmds.Ssh 把 LocalForward / SocksForward 的搬运整个做在内部,**不暴露
 优先级高于样式,`:pointerover` 再也盖不过去(Avalonia 的属性优先级,不是选择器不够具体)。
 回归测试 `NotificationPanelUiTests.Row_HoverHighlight_CoversWholeRow` 把指针停在**删除键那一列**
 再断言整行 `IsPointerOver` —— 问题正出在那半边,指在内容区是测不出来的。
+
+## 21. 2026-08-31 补全弹层关不掉(#315)
+
+空行按 `Alt+Enter` 召出「快捷指令 + 最近历史」全量面板后,**Ctrl+C 关不掉、点终端也关不掉**。
+两个触发条件是两处独立的缺口,凑在一起正好把这个面板最常见的召出方式变成了单向门:
+
+**A. Ctrl+C —— 事件在跟踪器里被吞掉**:`TerminalInputTracker` 只在「行的字面内容变了」时发
+`InputChanged`,而 `ResetToKnownEmpty()` 对一个**本来就是确定空行**的行返回 `false`。
+弹层的收口完全挂在 `InputChanged` 上(`TerminalTabView.OnTrackedInputChanged`),于是:
+`Alt+Enter` 的主场景恰恰是空行 → Ctrl+C 发出的 `0x03` 走到跟踪器 → 空行清空空行 → 不算变化 →
+一拍都不发 → 面板留在屏幕上。行里有字时 Ctrl+C 是好的(内容真的变了),所以这个洞只在空行上露出来。
+修法:`0x03`/`0x15` 一律记为变化 —— **「取消当前行」本身就是消费方要感知的事件**,
+不是内容差分的副产品。另加视图侧的 `Key.C when Ctrl` 分支直接收口(不置 `Handled`,按键照常下发):
+开了「有选区时 Ctrl+C 复制」的用户根本没有字节发往 PTY,跟踪器那条路等不到。
+
+**B. 点击终端 —— 没有任何路径能收口**:弹层刻意不开 light-dismiss(那会吞掉关闭它的那一次点击),
+而唯一的指针侧收口是终端的 `LostFocus` —— 点一个**已经聚焦**的终端不产生 `LostFocus`。
+补 `TerminalHost` 上的 `PointerPressed`(Tunnel、不置 `Handled`,选区/光标行为不变)。
+
+登记进 `ShortcutCatalog` 的补全分组并同步 `velashell-docs` 的中英快捷键参考(收起建议弹层:
+`Esc` / `Ctrl+C` / 左键)。回归测试 `TerminalInputTrackerTests.CtrlC_OnAlreadyEmptyLine_StillRaisesInputChanged`
+钉住 A;B 是视图层指针接线,本仓暂无宿主视图的 headless 会话,未加用例。

--- a/src/VelaShell.Terminal/Input/TerminalInputTracker.cs
+++ b/src/VelaShell.Terminal/Input/TerminalInputTracker.cs
@@ -43,7 +43,11 @@ public sealed class TerminalInputTracker
     /// </summary>
     public string TentativeRun => _unknown ? _tentative.ToString() : string.Empty;
 
-    /// <summary>行内容(或未知态/试探段)变化时触发,在输入线程(UI 线程)上同步回调。</summary>
+    /// <summary>
+    /// 行内容(或未知态/试探段)变化时触发,在输入线程(UI 线程)上同步回调。
+    /// Ctrl+C / Ctrl+U 这类「取消当前行」无条件触发,即使行本来就是确定的空行 ——
+    /// 消费方(补全弹层)要靠它收口,只比较字面内容会漏掉空行上的取消。
+    /// </summary>
     public event Action? InputChanged;
 
     /// <summary>
@@ -93,7 +97,12 @@ public sealed class TerminalInputTracker
                     }
                     break;
                 case 0x03 or 0x15: // Ctrl+C / Ctrl+U:shell 把行清掉,回到确定的空行。
-                    changed |= ResetToKnownEmpty();
+                    ResetToKnownEmpty();
+                    // 无条件记为「变化」:行本就是确定的空行时字面内容确实没变,但
+                    // 「取消当前行」是消费方必须收到的一拍 —— 补全弹层靠 InputChanged
+                    // 收口,吞掉这一拍就会出现「空行 Alt+Enter 召出全量面板后 Ctrl+C
+                    // 关不掉」(#315)。
+                    changed = true;
                     break;
                 case 0x1B: // ESC:进入序列吞噬模式,整行不可知。
                     changed |= MarkUnknown();

--- a/src/VelaShell/ViewModels/ShortcutCatalog.cs
+++ b/src/VelaShell/ViewModels/ShortcutCatalog.cs
@@ -130,6 +130,10 @@ public static class ShortcutCatalog
                     Item("Sc_SuggestPrev", ["Up"], "Sc_NoteSuggestOpen"),
                     Item("Sc_SuggestAccept", ["Enter"], "Sc_NoteSuggestOpen"),
                     Item("Sc_SuggestDismiss", ["Esc"], "Sc_NoteSuggestOpen"),
+                    // Ctrl+C(取消当前行)与点击终端正文同样收起弹层:按键/点击照常
+                    // 下发给终端,只是顺手收口面板(#315)。
+                    Item("Sc_SuggestDismiss", [Ctrl, "C"], "Sc_NoteSuggestOpen"),
+                    Item("Sc_SuggestDismiss", [K("Sc_KeyLeftClick")], "Sc_NoteSuggestOpen"),
                     Item("Sc_SuggestNative", ["Tab"]),
                     Item("Sc_GhostAccept", ["Right"]),
                     Item("Sc_GhostAccept", ["End"]),

--- a/src/VelaShell/Views/TerminalTabView.axaml.cs
+++ b/src/VelaShell/Views/TerminalTabView.axaml.cs
@@ -74,6 +74,25 @@ public partial class TerminalTabView : UserControl
         SearchClose.Click += (_, _) => CloseSearch();
         SearchBox.KeyDown += OnSearchBoxKeyDown;
         SuggestList.Tapped += (_, _) => AcceptSuggestion();
+
+        // 点终端正文即收起补全弹层(#315)。弹层刻意不开 light-dismiss(那会吞掉
+        // 关闭它的那一次点击),而点击一个**已经聚焦**的终端不产生 LostFocus,
+        // 于是原先没有任何路径能收口它 —— 面板会一直悬在旧光标处。
+        // Tunnel 抢在终端控件消费指针之前拿到,且不置 Handled:选区/光标行为不变。
+        TerminalHost.AddHandler(
+            PointerPressedEvent,
+            OnTerminalHostPointerPressed,
+            RoutingStrategies.Tunnel
+        );
+    }
+
+    /// <summary>点击终端正文:收起补全弹层与幽灵,按键不消费(终端照常处理选区)。</summary>
+    private void OnTerminalHostPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (SuggestPopup.IsOpen)
+        {
+            DismissSuggestions(suppress: false);
+        }
     }
 
     private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
@@ -648,6 +667,12 @@ public partial class TerminalTabView : UserControl
                 CloseSuggestPopup(suppress: true);
                 e.Handled = true;
                 return true;
+            case Key.C when e.KeyModifiers == Avalonia.Input.KeyModifiers.Control:
+                // Ctrl+C = 取消当前行,面板一并收口(#315)。不置 Handled、返回 false:
+                // 按键必须照常下发(中断前台进程;开了「有选区时 Ctrl+C 复制」则是复制)。
+                // 走 InputChanged 那条路收口在这里不够 —— 复制语义下根本没有字节发往 PTY。
+                DismissSuggestions(suppress: false);
+                return false;
             case Key.Enter when e.KeyModifiers == Avalonia.Input.KeyModifiers.None:
                 // 弹层存在时 Enter 始终输入当前选中项(VS 语义,无需先按方向键;
                 // 不想要建议按 Esc 退出)。唯一例外:选中项与已输入完全相同

--- a/tests/VelaShell.Terminal.Tests/Input/TerminalInputTrackerTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Input/TerminalInputTrackerTests.cs
@@ -59,6 +59,22 @@ public class TerminalInputTrackerTests
     }
 
     [TestMethod]
+    public void CtrlC_OnAlreadyEmptyLine_StillRaisesInputChanged()
+    {
+        // #315:空行上 Alt+Enter 召出全量补全面板后按 Ctrl+C。行内容前后都是空串,
+        // 若只按「字面内容变了才通知」,消费方收不到任何一拍,面板就永远关不掉。
+        var tracker = new TerminalInputTracker();
+        int changes = 0;
+        tracker.InputChanged += () => changes++;
+        tracker.Process([0x03]);
+        Assert.AreEqual(1, changes, "Ctrl+C 取消空行也必须通知消费方");
+        Assert.AreEqual(string.Empty, tracker.CurrentInput);
+
+        tracker.Process([0x15]); // Ctrl+U(kill line)同理。
+        Assert.AreEqual(2, changes);
+    }
+
+    [TestMethod]
     public void ArrowKey_EscSequence_MarksUnknownUntilReset()
     {
         var tracker = new TerminalInputTracker();


### PR DESCRIPTION
修复了补全弹层在空行上无法通过 Ctrl+C 或点击终端正文关闭的问题。TerminalInputTracker 现无论当前行内容是否变化，Ctrl+C/Ctrl+U 都会触发 InputChanged，确保消费方能收到取消通知。TerminalTabView 增加了对 Ctrl+C 的专门处理和正文点击监听，保证弹层收口且不影响终端原有行为。ShortcutCatalog 同步登记了相关快捷键。新增测试用例验证空行场景。同步更新了代码注释和文档。

<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #315

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
