### PR TITLE
消息中心默认订阅官方源并支持拖拽持久化

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # VelaShell Privacy Policy / 隐私政策
 
-**Last updated / 最后更新:2026-07-26**
+**Last updated / 最后更新:2026-08-31**
 
 [English](#english) · [简体中文](#简体中文)
 
@@ -12,17 +12,25 @@
 
 VelaShell is an open-source SSH and SFTP client that runs entirely on your own computer.
 
-**The developer of VelaShell operates no servers and receives no data from you.** There is no
-account to create, no telemetry, no analytics, no crash reporting, and no advertising. Nothing
-you type, no host you connect to, and no file you transfer is ever sent to us — we have no
-infrastructure that could receive it.
+There is no account to create, no telemetry, no analytics, and no crash reporting. Nothing you
+type, no host you connect to, and no file you transfer is ever sent to us.
+
+The developer does operate **one** server that VelaShell talks to on its own: the news feed
+behind the message centre (`feeds.easilynet.top`), which publishes security advisories and
+product announcements. It is **on by default**, and VelaShell downloads a public JSON file from
+it at startup and every few hours after that. The request carries nothing about you or your
+installation — no account, no identifier, no version, no list of your hosts — so that server
+learns only what any web server learns from a plain download: your IP address and the time.
+Clearing the address in Settings → General → Message centre stops it completely: not "less
+often", but never again.
 
 Every network connection VelaShell makes is listed in full below.
 
 ### Information we collect
 
-**None.** VelaShell has no backend service. We do not collect, store, transmit, sell, or share
-any personal information.
+**None.** We do not collect, store, transmit, sell, or share any personal information. The news
+feed is a one-way download of a file that is identical for everyone: nothing is uploaded to it,
+it has no user accounts, and it cannot tell one VelaShell installation from another.
 
 ### Information stored on your device
 
@@ -64,16 +72,27 @@ VelaShell connects to the network only in these situations:
    stored on your computer; no address is ever sent to a lookup service. The world map is drawn
    from vector data bundled inside the application — no online map tiles are requested.
 
-3. **Update checks — manual only.** When you click "Check for updates" in Settings, VelaShell
-   requests a release manifest from GitHub. GitHub receives your IP address and the request, as
-   with any website visit. VelaShell never checks automatically in the background. **In the
+3. **The news feed — on by default.** VelaShell downloads
+   <https://feeds.easilynet.top/feed.json> (a public file, https only) when it starts and then
+   once every few hours, and shows what it finds — security advisories and announcements — in
+   the message centre. The request is a plain GET: it sends no account, no identifier, and no
+   information about your machine or your connections, so the server sees only your IP address,
+   the same as any website you visit. Which entries apply to your platform, language, and
+   version is decided **on your computer**, after the whole file is downloaded. You can point
+   the address at your own feed, or clear it in Settings → General → Message centre, in which
+   case no request is ever sent.
+
+4. **Update checks.** VelaShell asks GitHub for a release manifest when you click "Check for
+   updates" in Settings, and also once at startup while "Check for updates at startup" is on
+   (Settings → General; on by default) so that a new version can appear in the message centre.
+   GitHub receives your IP address and the request, as with any website visit. **In the
    Microsoft Store version this feature is disabled entirely**, because the Store handles updates.
 
-4. **Contributor avatars.** Opening the About page loads contributor profile pictures from
+5. **Contributor avatars.** Opening the About page loads contributor profile pictures from
    GitHub, which discloses your IP address to GitHub in the same way. If the request fails,
    placeholder initials are shown and nothing else is affected.
 
-5. **Cloud sync — off by default, entirely optional.** If you enable it, VelaShell stores your
+6. **Cloud sync — off by default, entirely optional.** If you enable it, VelaShell stores your
    settings, connection profiles, and snippets in a **secret GitHub Gist in your own GitHub
    account**, using a personal access token that you supply. The data goes to your GitHub
    account, never to us. You may additionally set an end-to-end encryption passphrase, in which
@@ -92,7 +111,7 @@ VelaShell has no third-party SDKs, trackers, or advertising libraries.
 The only third parties that can receive anything are those you direct it to:
 
 - **The SSH/SFTP servers you connect to**, which are yours or your organization's.
-- **GitHub**, for manual update checks, About-page avatars, and optional cloud sync into your
+- **GitHub**, for update checks, About-page avatars, and optional cloud sync into your
   own account. See the [GitHub Privacy Statement](https://docs.github.com/site-policy/privacy-policies/github-privacy-statement).
 - **DB-IP**, only if you choose to download their free offline database, and only through your
   own browser. See the [DB-IP privacy policy](https://db-ip.com/legal/privacy-policy).
@@ -135,15 +154,23 @@ Questions or concerns: <https://github.com/joesdu/VelaShell/issues>
 
 VelaShell 是一款开源的 SSH / SFTP 客户端,完全运行在你自己的计算机上。
 
-**VelaShell 的开发者不运营任何服务器,也不会收到你的任何数据。** 无需注册账号,没有遥测、
-没有数据分析、没有崩溃上报、没有广告。你输入的内容、连接的主机、传输的文件,都不会被发送
-给我们 —— 我们根本没有可以接收这些数据的基础设施。
+无需注册账号,没有遥测、没有数据分析、没有崩溃上报。你输入的内容、连接的主机、传输的文件,
+都不会被发送给我们。
+
+开发者确实运营着**一台** VelaShell 会主动访问的服务器:消息中心背后的资讯源
+(`feeds.easilynet.top`),发布安全资讯与产品公告。它**默认开启** —— 启动时拉一次,
+之后每隔几小时再拉一次,下载的是一个所有人都一样的公开 JSON 文件。请求里不带任何与你、
+与你这台机器有关的东西(没有账号、没有标识符、没有版本号、没有你的主机列表),因此那台
+服务器能知道的,和任何网站从一次普通下载里能知道的一样多:你的 IP 地址与访问时间。
+在「设置 → 常规 → 消息中心」把地址清空即可彻底停止 —— 不是"少发一点",而是一个请求都不再发。
 
 VelaShell 发起的每一个网络连接,都完整列在下方。
 
 ### 我们收集的信息
 
-**没有。** VelaShell 没有后端服务。我们不收集、不存储、不传输、不出售、不共享任何个人信息。
+**没有。** 我们不收集、不存储、不传输、不出售、不共享任何个人信息。资讯源是**单向下载**
+一份对所有人完全相同的文件:没有任何东西被上传给它,它没有用户账号,也分不出两个 VelaShell
+安装之间的区别。
 
 ### 存储在你设备上的信息
 
@@ -180,14 +207,23 @@ VelaShell 仅在以下情形联网:
    **完全离线**,基于保存在你计算机上的数据库文件完成,任何地址都不会被发往查询服务。
    世界地图由应用内置的矢量数据绘制,不请求任何在线地图瓦片。
 
-3. **检查更新 —— 仅手动触发。** 当你在设置中点击"检查更新"时,VelaShell 会向 GitHub 请求
-   发布清单。与访问任何网站一样,GitHub 会收到你的 IP 地址与该请求。VelaShell 从不在后台
-   自动检查。**Microsoft Store 版本完全禁用了该功能**,更新由商店接管。
+3. **资讯源 —— 默认开启。** VelaShell 在启动时以及此后每隔几小时,下载一次
+   <https://feeds.easilynet.top/feed.json>(公开文件,仅 https),把其中的安全资讯与公告
+   显示在消息中心。请求是一次普通的 GET:不带账号、不带标识符,也不带任何关于你这台机器
+   或你的连接的信息,那台服务器看到的只有你的 IP 地址 —— 与你访问任何网站时一样。
+   哪些条目适用于你的平台、语言与版本,是在**你的计算机上**、把整份文件下载完之后才判定的。
+   你可以把地址换成自建资讯源,也可以在「设置 → 常规 → 消息中心」把它清空,清空后一个请求
+   都不会发出。
 
-4. **贡献者头像。** 打开"关于"页面会从 GitHub 加载贡献者头像,同样会向 GitHub 暴露你的
+4. **检查更新。** 你在设置中点击"检查更新"时,以及"启动时检查更新"处于开启状态时
+   (「设置 → 常规」,默认开启)启动时的那一次,VelaShell 会向 GitHub 请求发布清单,
+   以便有新版本时投一条消息到消息中心。与访问任何网站一样,GitHub 会收到你的 IP 地址与
+   该请求。**Microsoft Store 版本完全禁用了该功能**,更新由商店接管。
+
+5. **贡献者头像。** 打开"关于"页面会从 GitHub 加载贡献者头像,同样会向 GitHub 暴露你的
    IP 地址。请求失败时显示首字母占位图,不影响其他功能。
 
-5. **云同步 —— 默认关闭,完全可选。** 若你启用,VelaShell 会使用你自己提供的个人访问令牌,
+6. **云同步 —— 默认关闭,完全可选。** 若你启用,VelaShell 会使用你自己提供的个人访问令牌,
    把设置、连接配置与代码片段保存到**你自己 GitHub 账户下的一个 secret Gist** 中。数据进入
    的是你的 GitHub 账户,而非我们。你还可以额外设置端到端加密口令,此时载荷会在你的设备上
    用 AES-GCM 加密后再上传,GitHub 只能拿到密文。同步范围由你勾选,可随时关闭或删除该 Gist。
@@ -202,7 +238,7 @@ VelaShell 不含任何第三方 SDK、追踪器或广告库。
 唯一可能接收到信息的第三方,都是由你指定的:
 
 - **你连接的 SSH/SFTP 服务器**,它们属于你或你的组织。
-- **GitHub**,用于手动检查更新、"关于"页头像,以及同步到你自己账户的可选云同步。参见
+- **GitHub**,用于检查更新、"关于"页头像,以及同步到你自己账户的可选云同步。参见
   [GitHub 隐私声明](https://docs.github.com/site-policy/privacy-policies/github-privacy-statement)。
 - **DB-IP**,仅当你选择下载其免费离线数据库时,且全程通过你自己的浏览器。参见
   [DB-IP 隐私政策](https://db-ip.com/legal/privacy-policy)。

--- a/plan.md
+++ b/plan.md
@@ -384,6 +384,7 @@ Tmds.Ssh 把 LocalForward / SocksForward 的搬运整个做在内部,**不暴露
 `AnnouncementFeedDocumentTests` 逐条钉住,那份用例同时也是契约的可执行说明。
 **默认不订阅**:`Notifications.FeedUrl` 为空时一个网络请求都不发 ——
 终端客户端默默定期外呼在企业环境里是要被问责的事,得由用户或部署方明确开启。
+(**08-31 改为默认订阅官方源**,见 §22。)
 
 **C. 快捷跳转走 `ICommandRegistry`**:通知带 `commandId` 就执行注册表里的命令,
 带 `url` 就用系统浏览器开(仅 https);**站内优先**,命令没注册(返回 false)时退回外链。
@@ -442,3 +443,70 @@ Tmds.Ssh 把 LocalForward / SocksForward 的搬运整个做在内部,**不暴露
 登记进 `ShortcutCatalog` 的补全分组并同步 `velashell-docs` 的中英快捷键参考(收起建议弹层:
 `Esc` / `Ctrl+C` / 左键)。回归测试 `TerminalInputTrackerTests.CtrlC_OnAlreadyEmptyLine_StillRaisesInputChanged`
 钉住 A;B 是视图层指针接线,本仓暂无宿主视图的 headless 会话,未加用例。
+
+## 22. 2026-08-31 资讯源默认订阅官方源
+
+`velashell-feeds` 上线后,`Notifications.FeedUrl` 的默认值从空串改为
+`NotificationOptions.OfficialFeedUrl`(`https://feeds.easilynet.top/feed.json`)。
+理由是安全资讯的价值在于「用户没去找的时候它自己到」:默认关闭的源几乎没人会去打开,
+CISA KEV 那几条「现在就有人在打这个洞」就等于谁也收不到。
+
+**这是一次「默认行为」变更,不是一个配置项调整**,因此三处必须跟着改,否则文档开始骗人:
+
+- `PRIVACY.md`(中英两份正文):概述里「开发者不运营任何服务器」不再成立 —— 改成如实说明
+  开发者运营**一台**服务器、默认每几小时下载一次公开 JSON、请求里不带任何标识,
+  服务端能拿到的只有 IP 与时间,以及「清空地址即彻底不发」。同时在「网络连接」清单里
+  新增资讯源一条。**顺手修正了上一批留下的失真**:该清单第 3 条仍写着「检查更新 —— 仅手动
+  触发……从不在后台自动检查」,而 08-30 起 `CheckUpdatesOnStartup`(默认开)会在启动时查一次。
+- `velashell-docs` 的消息中心文档(中英):默认值表与「留空即不订阅」段落。
+- 本文件 §20-B 的「默认不订阅」结论。
+
+**存量用户不受影响**:设置整份 JSON 持久化在 `app_config/settings`,老文档里已经存着
+`FeedUrl: ""`,反序列化会把空串照原样带回来 —— 新默认只对全新安装(以及消息中心发布前
+从未存过该字段的配置)生效。消息中心尚未随版本发布,因此实际上没有需要迁移的存量。
+
+## 23. 2026-08-31 消息中心:可拖动、加大字号、动作靠右(用户反馈)
+
+**A. 拖拽逻辑抽成一份共用实现**:消息中心成为第二个可拖动浮层,而拖拽那套东西细到
+「按在标题栏的按钮上不许起拖」「`Bounds` 不含渲染变换所以它就是锚定位置」这一层 ——
+复制第二份必然漂。于是从 `FileTransferView` 原样抽出 `Behaviors/PanelDragHandler`
+(捕获/位移/越界夹紧/松手落盘)与 `ViewModels/IDraggablePanel`(两个偏移量 + 落盘),
+两个视图各一行 `PanelDragHandler.Attach(this, DragHandle)`。持久化载体
+`TransferPanelPosition` 随之更名 `PanelPosition` 并独立成文件:同一个 `ui-layout` 集合里,
+文件传输是 `transfer-panel`、消息中心是 `notification-panel`,类型名不该再绑着其中一个。
+
+**B. 拖拽空间是父容器,所以外层 Panel 必须铺满**:`MainWindow.axaml` 里消息中心原先包在一个
+`HorizontalAlignment=Left/VerticalAlignment=Bottom` 的 `Panel` 里 —— 那个 Panel 紧紧贴着面板本身,
+而 `PanelDragHandler` 的参考坐标系正是父容器,于是可拖范围会是零。改为**外层 Panel 铺满整行、
+对齐与边距落到里面的视图上**(与 `FileTransferView` 的摆法一致)。Panel 不设 `Background`
+即不参与命中测试,铺满也不会挡住底下的操作 —— 这与标题栏手柄必须显式写
+`Background="Transparent"` 是同一条规则的两面。
+
+**C. 字号加大一档**:正文 10→12、标题 11→13、徽标/时间/主机名 9→10、标题栏 11→12,
+全部走 `VelaFontSize*` 令牌(仍跟随「设置 → 外观 → 界面字号」缩放)。行高随之增加,
+列表 `MaxHeight` 380→440,可见条数与改字号前基本持平;每行的删除键 20→22px、图标 10→12px。
+
+**D. 「去处」一行改为两端对齐**(用户反馈两轮):动作原先贴左边缘,而指针本来就多停在右侧
+(每行删除键、滚动条都在那边),一次跳转要横穿整张卡片。第一版直接把整条靠右,用户当场
+反馈「参差不齐」—— 确实:主机名长短不一(站内跳转那行根本没有),整条靠右时动作的左沿
+一行一个位置。最终做成**两端对齐**:主机名钉左、`动作 + ›` 钉右,两条竖直边都是齐的。
+
+**D-1. 但真正让它参差的是另一件事**:`Button` 的默认 `HorizontalAlignment` 是
+**`Left` 而非 `Stretch`**。整行那个透明按钮因此按自己的内容缩成一团(实测三行分别
+295 / 284 / 309px,而它那一列是 318px),里面再怎么"靠右"也只是靠在那团东西的右边。
+只设 `HorizontalContentAlignment="Stretch"` 不够 —— 那管的是内容在按钮里怎么摆,
+管不到按钮自己有多宽。补上 `HorizontalAlignment="Stretch"` 后三行按钮齐齐 318px,
+右沿才真的共线。顺带:这也让内容列的空白处变成可点区域,与「整行可点 = 跳转」的原意一致。
+(同时给列表显式关掉横向滚动:开着的话每行按"不换行的理想宽度"各量各的,行宽本身就不一样。)
+
+**E. 右留白 16,给悬浮滚动条让位**(用户反馈):列表的悬浮滚动条展开后约 12px,
+压在贴着右边缘的每行删除键上。标题栏右内边距与每行删除键的右外边距统一改成 16
+(左仍是 12),滚动条出现时既不遮挡,两处的 x 也仍然对齐。
+
+回归测试:`NotificationPanelViewModelTests` 补三条(落盘到 `ui-layout/notification-panel`、
+构造时恢复、无存储时不炸);`NotificationPanelUiTests.DestinationLine_ActionsShareOneRightEdge`
+在真实 Avalonia 布局里钉住 D/D-1/E —— 用「无主机名 / 短主机名 / 超长主机名」三行,
+断言各行等宽、整行按钮铺满内容列、动作右沿共线、删除键与标题栏关闭键共线。
+这条用例在写下时**是红的**(实测 314 / 303 / 328),D-1 那行 `Stretch` 才让它变绿,
+不是先有结论再补的用例。拖拽手柄本身是指针接线,未加用例 —— 但那份逻辑现在只有一处,
+`FileTransferViewModelTests` 的位置用例仍覆盖着它的另一半。

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -1011,21 +1011,31 @@ public class ProxyOptions : ObservableOptions
 /// <summary>
 /// 消息中心(侧边栏铃铛)的选项。
 /// <para>
-/// 默认不订阅任何资讯源:<see cref="FeedUrl" /> 为空时一个网络请求都不发。
-/// 一个终端客户端默默定期外呼,在企业环境里是要被问责的事,得由用户或部署方明确开启。
+/// 默认订阅官方资讯源(<see cref="OfficialFeedUrl" />):安全资讯的价值在于「用户没去找的时候
+/// 它自己到」,默认关掉等于绝大多数人永远收不到 CISA KEV 那几条「现在就有人在打这个洞」。
+/// 代价必须说清楚,不能藏:每 <see cref="FeedIntervalHours" /> 小时一次的定期外呼是**默认发生**的,
+/// 因而写进了 <c>PRIVACY.md</c> 的「网络连接」清单。**把地址清空,一个网络请求都不会发出** ——
+/// 企业环境里要求客户端零外呼是正当诉求,那个退出口必须一直留着。
 /// </para>
 /// </summary>
 public class NotificationOptions : ObservableOptions
 {
     /// <summary>
-    /// 资讯源地址(**仅 https**)。留空 = 不订阅、不联网。格式见
+    /// 官方资讯源(<see href="https://github.com/joesdu/velashell-feeds">velashell-feeds</see>):
+    /// 聚合 CISA KEV + NVD 的漏洞情报,外加公告投放。<see cref="FeedUrl" /> 的默认值。
+    /// </summary>
+    public const string OfficialFeedUrl = "https://feeds.easilynet.top/feed.json";
+
+    /// <summary>
+    /// 资讯源地址(**仅 https**)。默认为 <see cref="OfficialFeedUrl" />;
+    /// 留空 = 不订阅、不联网。可换成自建源,格式见
     /// <c>Core/Notifications/AnnouncementFeedDocument</c> 的契约说明。
     /// </summary>
     public string FeedUrl
     {
         get;
         set => Set(ref field, value ?? "");
-    } = "";
+    } = OfficialFeedUrl;
 
     /// <summary>拉取间隔(小时);启动时先拉一次,之后按此节奏。下限 1 小时。</summary>
     public int FeedIntervalHours

--- a/src/VelaShell/Behaviors/PanelDragHandler.cs
+++ b/src/VelaShell/Behaviors/PanelDragHandler.cs
@@ -1,0 +1,149 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Behaviors;
+
+/// <summary>
+/// 给非模态浮层装上「拖表头挪位置」:把手柄上的指针位移写进
+/// <see cref="IDraggablePanel" /> 的偏移量,松手时落盘,并在窗口尺寸变化后把浮层夹回可视区。
+/// <para>
+/// 抽出来是因为它有两个用户(文件传输提示、消息中心),而其中的夹紧与捕获逻辑细到
+/// 「按在表头按钮上不许起拖」这一层 —— 复制第二份必然会漂。
+/// </para>
+/// <para>
+/// 用法:<c>PanelDragHandler.Attach(this, DragHandle)</c>,浮层的 DataContext 实现
+/// <see cref="IDraggablePanel" />,XAML 里把 <c>RenderTransform</c> 绑到那两个偏移量上。
+/// </para>
+/// </summary>
+public sealed class PanelDragHandler
+{
+    private readonly Control _handle;
+
+    private readonly Control _panel;
+
+    /// <summary>按下拖拽手柄时的指针位置(父容器坐标),用于计算位移增量。</summary>
+    private Point _dragOrigin;
+
+    /// <summary>按下那一刻的面板偏移,拖拽期间按增量叠加。</summary>
+    private double _dragStartOffsetX;
+
+    private double _dragStartOffsetY;
+
+    private bool _isDragging;
+
+    private PanelDragHandler(Control panel, Control handle)
+    {
+        _panel = panel;
+        _handle = handle;
+    }
+
+    /// <summary>把 <paramref name="handle" /> 接成 <paramref name="panel" /> 的拖拽手柄。</summary>
+    public static PanelDragHandler Attach(Control panel, Control handle)
+    {
+        ArgumentNullException.ThrowIfNull(panel);
+        ArgumentNullException.ThrowIfNull(handle);
+        var dragHandler = new PanelDragHandler(panel, handle);
+        handle.PointerPressed += dragHandler.OnPressed;
+        handle.PointerMoved += dragHandler.OnMoved;
+        handle.PointerReleased += dragHandler.OnReleased;
+
+        // 窗口缩放/最大化后,原先合法的位置可能已经越界 —— 重新夹回可视区,
+        // 否则面板会停在看不见也够不着的地方。
+        panel.LayoutUpdated += (_, _) =>
+        {
+            if (!dragHandler._isDragging)
+            {
+                dragHandler.ClampIntoView();
+            }
+        };
+        return dragHandler;
+    }
+
+    private IDraggablePanel? Target => _panel.DataContext as IDraggablePanel;
+
+    private void OnPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // 表头里还有按钮(关闭、全部已读……)。Avalonia 里 Button 会把 PointerPressed 标记为
+        // 已处理,默认订阅收不到 —— 但不要依赖这个隐式行为:按在按钮上就明确不起拖拽。
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(true) is not null)
+        {
+            return;
+        }
+        if (Target is not { } vm
+            || GetDragSpace() is not { } space
+            || !e.GetCurrentPoint(_panel).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+        _isDragging = true;
+        _dragOrigin = e.GetPosition(space);
+        _dragStartOffsetX = vm.PanelOffsetX;
+        _dragStartOffsetY = vm.PanelOffsetY;
+        e.Pointer.Capture((IInputElement?)sender);
+        e.Handled = true;
+    }
+
+    private void OnMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_isDragging || Target is not { } vm || GetDragSpace() is not { } space)
+        {
+            return;
+        }
+        Point current = e.GetPosition(space);
+        ApplyOffset(vm,
+            _dragStartOffsetX + (current.X - _dragOrigin.X),
+            _dragStartOffsetY + (current.Y - _dragOrigin.Y));
+        e.Handled = true;
+    }
+
+    private void OnReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_isDragging)
+        {
+            return;
+        }
+        _isDragging = false;
+        e.Pointer.Capture(null);
+
+        // 只在松手时落盘,而不是每次移动都写 —— 拖一次会产生上百个移动事件。
+        Target?.PersistPanelPosition();
+        e.Handled = true;
+    }
+
+    /// <summary>拖拽的参考坐标系:浮层所在的父容器。</summary>
+    private Visual? GetDragSpace() => _panel.GetVisualParent();
+
+    /// <summary>把恢复出来的/当前的偏移夹回可视区(窗口尺寸变化后尤其必要)。</summary>
+    private void ClampIntoView()
+    {
+        if (Target is { } vm)
+        {
+            ApplyOffset(vm, vm.PanelOffsetX, vm.PanelOffsetY);
+        }
+    }
+
+    /// <summary>
+    /// 夹紧并写入偏移,保证浮层整体留在父容器内。
+    /// <para>
+    /// <see cref="Visual.Bounds" /> 不含渲染变换,因此它就是"偏移为 0 时的锚定位置",
+    /// 由此推出合法偏移区间 —— 无需把 XAML 里的对齐方式和边距硬编码进来。
+    /// </para>
+    /// </summary>
+    private void ApplyOffset(IDraggablePanel vm, double offsetX, double offsetY)
+    {
+        if (GetDragSpace() is not { } space || _panel.Bounds.Width <= 0 || space.Bounds.Width <= 0)
+        {
+            return;
+        }
+        Rect anchored = _panel.Bounds;
+        vm.PanelOffsetX = Clamp(offsetX, -anchored.X, space.Bounds.Width - anchored.Width - anchored.X);
+        vm.PanelOffsetY = Clamp(offsetY, -anchored.Y, space.Bounds.Height - anchored.Height - anchored.Y);
+    }
+
+    /// <summary>面板比容器还大时下限会超过上限,此时贴左上角而不是抛异常。</summary>
+    private static double Clamp(double value, double min, double max) =>
+        max < min ? min : Math.Clamp(value, min, max);
+}

--- a/src/VelaShell/ViewModels/FileTransferViewModel.cs
+++ b/src/VelaShell/ViewModels/FileTransferViewModel.cs
@@ -14,7 +14,7 @@ namespace VelaShell.ViewModels;
 /// 文件传输面板(toast)的视图模型:聚合活动/历史传输项,驱动准备扫描、
 /// 可取消批量传输、徽标计数与自动隐藏等交互逻辑。
 /// </summary>
-public class FileTransferViewModel : ReactiveObject
+public class FileTransferViewModel : ReactiveObject, IDraggablePanel
 {
     /// <summary>面板位置的存储位置(IAppDataStore 的用途之一即 UI 配置)。</summary>
     private const string LayoutCollection = "ui-layout";
@@ -365,7 +365,7 @@ public class FileTransferViewModel : ReactiveObject
         {
             return;
         }
-        var position = new TransferPanelPosition { OffsetX = PanelOffsetX, OffsetY = PanelOffsetY };
+        var position = new PanelPosition { OffsetX = PanelOffsetX, OffsetY = PanelOffsetY };
         _ = SaveAsync();
 
         async Task SaveAsync()
@@ -394,8 +394,8 @@ public class FileTransferViewModel : ReactiveObject
         {
             try
             {
-                TransferPanelPosition? saved = await _dataStore
-                                                     .GetAsync<TransferPanelPosition>(LayoutCollection, PanelPositionId)
+                PanelPosition? saved = await _dataStore
+                                                     .GetAsync<PanelPosition>(LayoutCollection, PanelPositionId)
                                                      .ConfigureAwait(true);
                 if (saved is null)
                 {
@@ -535,17 +535,4 @@ public class FileTransferViewModel : ReactiveObject
             Transfers.Remove(item);
         }
     }
-}
-
-/// <summary>
-/// 传输面板拖拽位置的持久化载体(IAppDataStore 需要引用类型)。
-/// 存偏移而非绝对坐标,理由见 <see cref="FileTransferViewModel.PanelOffsetX" />。
-/// </summary>
-public sealed class TransferPanelPosition
-{
-    /// <summary>相对默认锚点的水平偏移(像素)。</summary>
-    public double OffsetX { get; set; }
-
-    /// <summary>相对默认锚点的垂直偏移(像素)。</summary>
-    public double OffsetY { get; set; }
 }

--- a/src/VelaShell/ViewModels/IDraggablePanel.cs
+++ b/src/VelaShell/ViewModels/IDraggablePanel.cs
@@ -1,0 +1,21 @@
+namespace VelaShell.ViewModels;
+
+/// <summary>
+/// 可拖动浮层(文件传输提示、消息中心……)的视图模型契约。
+/// <para>
+/// 存的是**相对默认锚点的偏移**而非绝对坐标:窗口缩放/最大化后浮层仍贴着它原来的
+/// 相对位置,不会因为窗口变小而跑到可视区外。越界夹紧由视图负责 ——
+/// 只有视图知道父容器与自身的实际尺寸。
+/// </para>
+/// </summary>
+public interface IDraggablePanel
+{
+    /// <summary>相对默认锚点的水平偏移(像素)。</summary>
+    double PanelOffsetX { get; set; }
+
+    /// <summary>相对默认锚点的垂直偏移(像素)。</summary>
+    double PanelOffsetY { get; set; }
+
+    /// <summary>拖拽结束时由视图调用:把当前位置落盘,供下次打开恢复。失败不该影响使用。</summary>
+    void PersistPanelPosition();
+}

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1376,7 +1376,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             return;
         }
         _notificationCenter = center;
-        var panel = new NotificationPanelViewModel(center, Commands.Execute, OpenExternalUrlAsync);
+        var panel = new NotificationPanelViewModel(center, Commands.Execute, OpenExternalUrlAsync, _appDataStore);
         panel.CloseRequested += (_, _) => IsNotificationPanelOpen = false;
         NotificationPanel = panel;
 

--- a/src/VelaShell/ViewModels/NotificationPanelViewModel.cs
+++ b/src/VelaShell/ViewModels/NotificationPanelViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Threading;
 using ReactiveUI;
 using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Notifications;
 using VelaShell.Core.Resources;
@@ -17,27 +18,41 @@ namespace VelaShell.ViewModels;
 /// 混进来只会把真正要读的东西淹掉。
 /// </para>
 /// </summary>
-public class NotificationPanelViewModel : ReactiveObject, IDisposable
+public class NotificationPanelViewModel : ReactiveObject, IDisposable, IDraggablePanel
 {
+    /// <summary>浮层位置的存放处;与文件传输提示同一个集合,各占一个文档 Id。</summary>
+    private const string LayoutCollection = "ui-layout";
+
+    private const string PanelPositionId = "notification-panel";
+
     private readonly INotificationCenter _center;
 
     /// <summary>执行站内跳转:传命令 id,返回是否跳成功。</summary>
     private readonly Func<string, bool>? _commandInvoker;
+
+    // 可空:无存储的宿主(单元测试)不提供,此时面板位置只在本次运行内保持。
+    private readonly IAppDataStore? _dataStore;
 
     private readonly DispatcherTimer? _relativeTimeTimer;
 
     /// <summary>在浏览器里打开外链。</summary>
     private readonly Func<string, Task>? _urlOpener;
 
-    /// <summary>构造消息中心面板;站内跳转与外链打开均可为空(便于测试)。</summary>
+    /// <summary>
+    /// 构造消息中心面板;站内跳转与外链打开均可为空(便于测试)。
+    /// <paramref name="dataStore" /> 为空时拖拽位置不跨重启保留。
+    /// </summary>
     public NotificationPanelViewModel(
         INotificationCenter center,
         Func<string, bool>? commandInvoker = null,
-        Func<string, Task>? urlOpener = null)
+        Func<string, Task>? urlOpener = null,
+        IAppDataStore? dataStore = null)
     {
         _center = center ?? throw new ArgumentNullException(nameof(center));
         _commandInvoker = commandInvoker;
         _urlOpener = urlOpener;
+        _dataStore = dataStore;
+        RestorePanelPosition();
         Items = [];
         MarkAllReadCommand = ReactiveCommand.CreateFromTask(async () => await _center.MarkAllReadAsync());
         ClearCommand = ReactiveCommand.CreateFromTask(async () => await _center.ClearAsync());
@@ -100,6 +115,75 @@ public class NotificationPanelViewModel : ReactiveObject, IDisposable
 
     /// <summary>收起面板。</summary>
     public ReactiveCommand<RxVoid, RxVoid> CloseCommand { get; }
+
+    // ---- 面板拖拽位置(与文件传输提示同一套:见 IDraggablePanel) ----
+
+    /// <summary>面板相对默认锚点(左下角贴着铃铛)的水平偏移(像素)。</summary>
+    public double PanelOffsetX
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>面板相对默认锚点的垂直偏移(像素,向上为负)。</summary>
+    public double PanelOffsetY
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>拖拽结束时由视图调用:把当前位置落盘,供下次打开恢复。失败不影响使用。</summary>
+    public void PersistPanelPosition()
+    {
+        if (_dataStore is null)
+        {
+            return;
+        }
+        var position = new PanelPosition { OffsetX = PanelOffsetX, OffsetY = PanelOffsetY };
+        _ = SaveAsync();
+
+        async Task SaveAsync()
+        {
+            try
+            {
+                await _dataStore.UpsertAsync(LayoutCollection, PanelPositionId, position).ConfigureAwait(false);
+            }
+            catch
+            {
+                // 位置记不住不该影响消息中心本身;下次拖动会再试一次。
+            }
+        }
+    }
+
+    /// <summary>启动时异步取回上次的位置。取不到就保持默认锚点。</summary>
+    private void RestorePanelPosition()
+    {
+        if (_dataStore is null)
+        {
+            return;
+        }
+        _ = LoadAsync();
+
+        async Task LoadAsync()
+        {
+            try
+            {
+                PanelPosition? saved = await _dataStore
+                                            .GetAsync<PanelPosition>(LayoutCollection, PanelPositionId)
+                                            .ConfigureAwait(true);
+                if (saved is null)
+                {
+                    return;
+                }
+                PanelOffsetX = saved.OffsetX;
+                PanelOffsetY = saved.OffsetY;
+            }
+            catch
+            {
+                // 读不出来就用默认位置,不打扰用户。
+            }
+        }
+    }
 
     /// <summary>释放面板资源:停表并退订消息中心。</summary>
     public void Dispose()

--- a/src/VelaShell/ViewModels/PanelPosition.cs
+++ b/src/VelaShell/ViewModels/PanelPosition.cs
@@ -1,0 +1,15 @@
+namespace VelaShell.ViewModels;
+
+/// <summary>
+/// 可拖动浮层位置的持久化载体(<c>IAppDataStore</c> 需要引用类型)。
+/// 各浮层在 <c>ui-layout</c> 集合里各占一个文档 Id(如 <c>transfer-panel</c>、
+/// <c>notification-panel</c>)。存偏移而非绝对坐标,理由见 <see cref="IDraggablePanel" />。
+/// </summary>
+public sealed class PanelPosition
+{
+    /// <summary>相对默认锚点的水平偏移(像素)。</summary>
+    public double OffsetX { get; set; }
+
+    /// <summary>相对默认锚点的垂直偏移(像素)。</summary>
+    public double OffsetY { get; set; }
+}

--- a/src/VelaShell/Views/FileTransferView.axaml.cs
+++ b/src/VelaShell/Views/FileTransferView.axaml.cs
@@ -1,7 +1,5 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
-using Avalonia.VisualTree;
+using VelaShell.Behaviors;
 using VelaShell.ViewModels;
 
 namespace VelaShell.Views;
@@ -9,16 +7,6 @@ namespace VelaShell.Views;
 /// <summary>文件传输视图,展示传输进度与结果提示;表头可拖动,位置跨会话保留。</summary>
 public partial class FileTransferView : UserControl
 {
-    /// <summary>按下拖拽手柄时的指针位置(父容器坐标),用于计算位移增量。</summary>
-    private Point _dragOrigin;
-
-    /// <summary>按下那一刻的面板偏移,拖拽期间按增量叠加。</summary>
-    private double _dragStartOffsetX;
-
-    private double _dragStartOffsetY;
-
-    private bool _isDragging;
-
     /// <summary>初始化视图,接线指针悬停(暂停自动隐藏)与表头拖拽。</summary>
     public FileTransferView()
     {
@@ -29,104 +17,10 @@ public partial class FileTransferView : UserControl
         PointerEntered += (_, _) => (DataContext as FileTransferViewModel)?.SetPointerOver(true);
         PointerExited += (_, _) => (DataContext as FileTransferViewModel)?.SetPointerOver(false);
 
+        // 拖拽 + 越界夹紧 + 松手落盘,与消息中心共用一份实现。
         if (this.FindControl<Border>("DragHandle") is { } handle)
         {
-            handle.PointerPressed += OnDragHandlePressed;
-            handle.PointerMoved += OnDragHandleMoved;
-            handle.PointerReleased += OnDragHandleReleased;
-        }
-
-        // 窗口缩放/最大化后,原先合法的位置可能已经越界 —— 重新夹回可视区,
-        // 否则面板会停在看不见也够不着的地方。
-        LayoutUpdated += (_, _) =>
-        {
-            if (!_isDragging)
-            {
-                ClampOffsetIntoView();
-            }
-        };
-    }
-
-    private void OnDragHandlePressed(object? sender, PointerPressedEventArgs e)
-    {
-        // 表头里还有"取消"和"关闭"按钮。Avalonia 里 Button 会把 PointerPressed 标记为已处理,
-        // 默认订阅收不到 —— 但不要依赖这个隐式行为:按在按钮上就明确不起拖拽。
-        if (e.Source is Visual source && source.FindAncestorOfType<Button>(true) is not null)
-        {
-            return;
-        }
-        if (DataContext is not FileTransferViewModel vm
-            || GetDragSpace() is not { } space
-            || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
-        {
-            return;
-        }
-        _isDragging = true;
-        _dragOrigin = e.GetPosition(space);
-        _dragStartOffsetX = vm.PanelOffsetX;
-        _dragStartOffsetY = vm.PanelOffsetY;
-        e.Pointer.Capture((IInputElement?)sender);
-        e.Handled = true;
-    }
-
-    private void OnDragHandleMoved(object? sender, PointerEventArgs e)
-    {
-        if (!_isDragging || DataContext is not FileTransferViewModel vm || GetDragSpace() is not { } space)
-        {
-            return;
-        }
-        Point current = e.GetPosition(space);
-        ApplyOffset(vm,
-            _dragStartOffsetX + (current.X - _dragOrigin.X),
-            _dragStartOffsetY + (current.Y - _dragOrigin.Y));
-        e.Handled = true;
-    }
-
-    private void OnDragHandleReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (!_isDragging)
-        {
-            return;
-        }
-        _isDragging = false;
-        e.Pointer.Capture(null);
-
-        // 只在松手时落盘,而不是每次移动都写 —— 拖一次会产生上百个移动事件。
-        (DataContext as FileTransferViewModel)?.PersistPanelPosition();
-        e.Handled = true;
-    }
-
-    /// <summary>拖拽的参考坐标系:面板所在的父容器。</summary>
-    private Visual? GetDragSpace() => this.GetVisualParent();
-
-    /// <summary>把恢复出来的/当前的偏移夹回可视区(窗口尺寸变化后尤其必要)。</summary>
-    private void ClampOffsetIntoView()
-    {
-        if (DataContext is FileTransferViewModel vm)
-        {
-            ApplyOffset(vm, vm.PanelOffsetX, vm.PanelOffsetY);
+            PanelDragHandler.Attach(this, handle);
         }
     }
-
-    /// <summary>
-    /// 夹紧并写入偏移,保证面板整体留在父容器内。
-    /// <para>
-    /// <see cref="Visual.Bounds" /> 不含渲染变换,因此它就是"偏移为 0 时的锚定位置",
-    /// 由此推出合法偏移区间 —— 无需把 XAML 里的对齐方式和边距硬编码进来。
-    /// </para>
-    /// </summary>
-    private void ApplyOffset(FileTransferViewModel vm, double offsetX, double offsetY)
-    {
-        if (GetDragSpace() is not { } space || Bounds.Width <= 0 || space.Bounds.Width <= 0)
-        {
-            return;
-        }
-        Rect anchored = Bounds;
-        vm.PanelOffsetX = Clamp(offsetX, -anchored.X, space.Bounds.Width - anchored.Width - anchored.X);
-        vm.PanelOffsetY = Clamp(offsetY, -anchored.Y, space.Bounds.Height - anchored.Height - anchored.Y);
-    }
-
-    /// <summary>面板比容器还大时下限会超过上限,此时贴左上角而不是抛异常。</summary>
-    private static double Clamp(double value, double min, double max) =>
-        max < min ? min : Math.Clamp(value, min, max);
 }

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -69,12 +69,15 @@
       <views:TunnelPanelView DataContext="{Binding TunnelPanel}" />
     </Panel>
     <!-- 消息中心:非模态,由侧边栏底部铃铛切换。锚在左下贴着铃铛 —— 浮层从哪个按钮
-         开出来就该长在哪个按钮旁边,开在右上会让人一时找不到它和什么有关。 -->
+         开出来就该长在哪个按钮旁边,开在右上会让人一时找不到它和什么有关。
+         外层 Panel **铺满整行**,对齐与边距落在里面那个视图上:面板可拖动,而拖拽的
+         参考坐标系就是它的父容器 —— 父容器若只贴着面板本身,能拖的范围就是零。
+         Panel 不设 Background,不参与命中测试,铺满也不会挡住底下的操作。 -->
     <Panel Grid.Row="1" ZIndex="60"
-           HorizontalAlignment="Left" VerticalAlignment="Bottom"
-           Margin="12,0,0,48"
            IsVisible="{Binding IsNotificationPanelOpen}">
-      <views:NotificationPanelView DataContext="{Binding NotificationPanel}" />
+      <views:NotificationPanelView DataContext="{Binding NotificationPanel}"
+                                   HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                                   Margin="12,0,0,48" />
     </Panel>
     <!-- 自绘标题栏:logo/名称 + 全局功能图标 + 最小化/最大化/关闭 -->
     <views:TitleBarView x:Name="TitleBarHost" Grid.Row="0" DataContext="{Binding}" />

--- a/src/VelaShell/Views/NotificationPanelView.axaml
+++ b/src/VelaShell/Views/NotificationPanelView.axaml
@@ -14,10 +14,17 @@
        bg-surface、圆角 6、1px border-secondary、阴影 blur16 y+4。
        铃铛在侧边栏左下角,所以这张卡片锚在左下(见 MainWindow.axaml)。 -->
 
+  <!-- 拖表头挪位置(与文件传输提示同一套:PanelDragHandler)。位移相对默认锚点
+       (左下角)而非绝对坐标,窗口缩放后面板仍贴着相对位置;越界夹紧在 handler 里
+       (只有它知道父容器与自身的实际尺寸)。 -->
+  <UserControl.RenderTransform>
+    <TranslateTransform X="{Binding PanelOffsetX}" Y="{Binding PanelOffsetY}" />
+  </UserControl.RenderTransform>
+
   <UserControl.Styles>
     <Style Selector="Button.row-action">
-      <Setter Property="Width" Value="20" />
-      <Setter Property="Height" Value="20" />
+      <Setter Property="Width" Value="22" />
+      <Setter Property="Height" Value="22" />
       <Setter Property="Padding" Value="0" />
       <Setter Property="CornerRadius" Value="3" />
       <Setter Property="Background" Value="Transparent" />
@@ -41,6 +48,11 @@
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
       <Setter Property="Padding" Value="0" />
+      <!-- 这两条**都要**:Button 的默认 HorizontalAlignment 是 Left(不是 Stretch),
+           只设 HorizontalContentAlignment 的话按钮自己就先按内容缩成一团 ——
+           里面再怎么"靠右"也只是靠在那团东西的右边,于是每行的动作各停一处。
+           行内右对齐要成立,先得让按钮真的铺满它那一列。 -->
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="Cursor" Value="Hand" />
     </Style>
@@ -68,8 +80,15 @@
           BoxShadow="{DynamicResource VelaShadowWindow}">
     <StackPanel>
 
-      <!-- 标题栏(36px):铃铛 + 消息 + 未读数 | 只看未读 · 全部已读 · 清空 · 关闭 -->
-      <Border Height="36" Padding="12,0"
+      <!-- 标题栏(36px,兼拖拽手柄):铃铛 + 消息 + 未读数 | 只看未读 · 全部已读 · 清空 · 关闭。
+           Background 必须显式给(哪怕是 Transparent):null 背景的 Border 不参与命中测试,
+           拖拽事件根本到不了手柄上。 -->
+      <!-- 右侧内边距 16(左 12):列表的悬浮滚动条展开后约占 12px,压在右边缘的按钮上。
+           标题栏与每行的 x 用同一个右留白,滚动条出现时既不遮挡,两处也仍然对齐。 -->
+      <Border Name="DragHandle"
+              Height="36" Padding="12,0,16,0"
+              Cursor="SizeAll"
+              Background="Transparent"
               BorderBrush="{DynamicResource VelaBorderPrimary}"
               BorderThickness="0,0,0,1">
         <Grid ColumnDefinitions="Auto,*,Auto,2,Auto,2,Auto,2,Auto">
@@ -80,7 +99,7 @@
             <TextBlock Text="{loc:Localize Notify_Title}"
                        Foreground="{DynamicResource VelaTextPrimary}"
                        FontFamily="{DynamicResource VelaUiMonoFont}"
-                       FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium"
+                       FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
                        VerticalAlignment="Center" />
             <Border Background="{DynamicResource VelaAccent}"
                     CornerRadius="8" Padding="6,1" VerticalAlignment="Center"
@@ -88,17 +107,17 @@
               <TextBlock Text="{Binding UnreadCount}"
                          Foreground="{DynamicResource VelaAccentText}"
                          FontFamily="{DynamicResource VelaUiMonoFont}"
-                         FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
+                         FontSize="{DynamicResource VelaFontSize11}" FontWeight="Medium" />
             </Border>
           </StackPanel>
-          <ToggleButton Grid.Column="2" Height="20" Padding="6,0" CornerRadius="3"
+          <ToggleButton Grid.Column="2" Height="22" Padding="6,0" CornerRadius="3"
                         Background="Transparent" BorderThickness="0" Cursor="Hand"
                         VerticalAlignment="Center"
                         IsChecked="{Binding UnreadOnly}"
                         ToolTip.Tip="{loc:Localize Notify_UnreadOnlyTip}">
             <TextBlock Text="{loc:Localize Notify_UnreadOnly}"
                        FontFamily="{DynamicResource VelaUiMonoFont}"
-                       FontSize="{DynamicResource VelaFontSize10}" />
+                       FontSize="{DynamicResource VelaFontSize11}" />
           </ToggleButton>
           <Button Grid.Column="4" Classes="row-action"
                   ToolTip.Tip="{loc:Localize Notify_MarkAllRead}"
@@ -129,12 +148,17 @@
         <TextBlock Text="{Binding EmptyHint}"
                    Foreground="{DynamicResource VelaTextMuted}"
                    FontFamily="{DynamicResource VelaUiMonoFont}"
-                   FontSize="{DynamicResource VelaFontSize10}"
+                   FontSize="{DynamicResource VelaFontSize11}"
                    HorizontalAlignment="Center" />
       </Border>
 
       <!-- 消息列表 -->
-      <ScrollViewer MaxHeight="380" VerticalScrollBarVisibility="Auto">
+      <!-- 字号加大后每行更高,列表上限跟着抬一档,可见条数与改字号前基本持平。
+           横向滚动必须显式关掉:开着的话每行按"不换行的理想宽度"量出各自不同的宽度,
+           行内靠右的元素就会各停在各自的右边缘 —— 一列本该对齐的动作变成参差不齐。 -->
+      <ScrollViewer MaxHeight="440"
+                    VerticalScrollBarVisibility="Auto"
+                    HorizontalScrollBarVisibility="Disabled">
         <ItemsControl ItemsSource="{Binding Items}">
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="vm:NotificationItemViewModel">
@@ -158,7 +182,7 @@
                           <TextBlock Text="{Binding KindBadge}"
                                      Foreground="{DynamicResource VelaAccent}"
                                      FontFamily="{DynamicResource VelaUiMonoFont}"
-                                     FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
+                                     FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
                         </Border>
                         <Border CornerRadius="2" Padding="5,1" VerticalAlignment="Center"
                                 Background="Transparent"
@@ -167,12 +191,12 @@
                           <TextBlock Text="{Binding KindBadge}"
                                      Foreground="{DynamicResource VelaWarning}"
                                      FontFamily="{DynamicResource VelaUiMonoFont}"
-                                     FontSize="{DynamicResource VelaFontSize9}" FontWeight="Medium" />
+                                     FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium" />
                         </Border>
                         <TextBlock Text="{Binding RelativeTime}"
                                    Foreground="{DynamicResource VelaTextMuted}"
                                    FontFamily="{DynamicResource VelaUiMonoFont}"
-                                   FontSize="{DynamicResource VelaFontSize9}"
+                                   FontSize="{DynamicResource VelaFontSize10}"
                                    VerticalAlignment="Center" />
                       </StackPanel>
                       <!-- 已读退到次要色且不加粗,未读保持主文本 + Medium:
@@ -180,42 +204,54 @@
                       <TextBlock Text="{Binding Title}"
                                  Classes="msg-title" Classes.unread="{Binding IsUnread}"
                                  FontFamily="{DynamicResource VelaUiFont}"
-                                 FontSize="{DynamicResource VelaFontSize11}"
+                                 FontSize="{DynamicResource VelaFontSize13}"
                                  TextWrapping="Wrap" />
                       <TextBlock Text="{Binding Body}"
                                  IsVisible="{Binding HasBody}"
                                  Foreground="{DynamicResource VelaTextMuted}"
                                  FontFamily="{DynamicResource VelaUiFont}"
-                                 FontSize="{DynamicResource VelaFontSize10}"
+                                 FontSize="{DynamicResource VelaFontSize12}"
                                  TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis" />
                       <!-- 去处:站内动作只显示文案;外链把主机名摆出来,
-                           让用户在点之前就知道自己会被带去哪个站点。 -->
-                      <StackPanel Orientation="Horizontal" Spacing="4"
-                                  IsVisible="{Binding HasLink}">
-                        <TextBlock Text="{Binding LinkLabel}"
-                                   Foreground="{DynamicResource VelaAccent}"
-                                   FontFamily="{DynamicResource VelaUiFont}"
-                                   FontSize="{DynamicResource VelaFontSize10}" FontWeight="Medium"
-                                   VerticalAlignment="Center" />
-                        <pc:LucideIcon Width="10" Height="10"
-                                       Data="{StaticResource Icon.chevron-right}"
-                                       Foreground="{DynamicResource VelaAccent}"
-                                       VerticalAlignment="Center" />
-                        <TextBlock Text="{Binding LinkHost}"
+                           让用户在点之前就知道自己会被带去哪个站点。
+                           **两端对齐**(主机名钉左、动作钉右)而不是整条靠右:动作贴右边缘,
+                           是因为指针本来就多停在那侧(每行的删除键、滚动条都在那边),
+                           "看到→点到"的路最短;而主机名长短不一,若跟着挤在动作左边,
+                           动作的左沿就会一行一个位置 —— 一列扫下来全是参差。
+                           两端各钉一边,两条竖直边就都是齐的。 -->
+                      <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding HasLink}">
+                        <TextBlock Grid.Column="0"
+                                   Text="{Binding LinkHost}"
                                    IsVisible="{Binding HasLinkHost}"
                                    Foreground="{DynamicResource VelaTextMuted}"
                                    FontFamily="{DynamicResource VelaUiMonoFont}"
-                                   FontSize="{DynamicResource VelaFontSize9}"
+                                   FontSize="{DynamicResource VelaFontSize10}"
+                                   TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center" />
-                      </StackPanel>
+                        <!-- link-action:布局回归测试按这个类找到动作组,断言各行右沿共线。 -->
+                        <StackPanel Grid.Column="1" Classes="link-action"
+                                    Orientation="Horizontal" Spacing="4"
+                                    Margin="8,0,0,0">
+                          <TextBlock Text="{Binding LinkLabel}"
+                                     Foreground="{DynamicResource VelaAccent}"
+                                     FontFamily="{DynamicResource VelaUiFont}"
+                                     FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
+                                     VerticalAlignment="Center" />
+                          <pc:LucideIcon Width="12" Height="12"
+                                         Data="{StaticResource Icon.chevron-right}"
+                                         Foreground="{DynamicResource VelaAccent}"
+                                         VerticalAlignment="Center" />
+                        </StackPanel>
+                      </Grid>
                     </StackPanel>
                   </Button>
-                  <Button Grid.Column="2" Classes="row-action" Margin="0,10,8,0"
+                  <!-- 右留白 16:与标题栏的关闭键同一条竖线,且让开展开后的悬浮滚动条。 -->
+                  <Button Grid.Column="2" Classes="row-action" Margin="0,10,16,0"
                           VerticalAlignment="Top"
                           ToolTip.Tip="{loc:Localize Notify_Remove}"
                           Command="{Binding $parent[ItemsControl].((vm:NotificationPanelViewModel)DataContext).RemoveCommand}"
                           CommandParameter="{Binding Id}">
-                    <pc:LucideIcon Width="10" Height="10"
+                    <pc:LucideIcon Width="12" Height="12"
                                    Data="{StaticResource Icon.x}"
                                    Foreground="{DynamicResource VelaTextTertiary}" />
                   </Button>

--- a/src/VelaShell/Views/NotificationPanelView.axaml.cs
+++ b/src/VelaShell/Views/NotificationPanelView.axaml.cs
@@ -1,10 +1,20 @@
 using Avalonia.Controls;
+using VelaShell.Behaviors;
 
 namespace VelaShell.Views;
 
-/// <summary>消息中心面板视图:侧边栏铃铛切换的非模态浮层。</summary>
+/// <summary>消息中心面板视图:侧边栏铃铛切换的非模态浮层,表头可拖动、位置跨会话保留。</summary>
 public partial class NotificationPanelView : UserControl
 {
-    /// <summary>创建消息中心面板视图并加载其可视组件。</summary>
-    public NotificationPanelView() => InitializeComponent();
+    /// <summary>创建消息中心面板视图并加载其可视组件,接线表头拖拽。</summary>
+    public NotificationPanelView()
+    {
+        InitializeComponent();
+
+        // 拖拽 + 越界夹紧 + 松手落盘,与文件传输提示共用一份实现。
+        if (this.FindControl<Border>("DragHandle") is { } handle)
+        {
+            PanelDragHandler.Attach(this, handle);
+        }
+    }
 }

--- a/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/FileTransferViewModelTests.cs
@@ -461,7 +461,7 @@ public class FileTransferViewModelTests
         store.Received(1).UpsertAsync(
             "ui-layout",
             "transfer-panel",
-            Arg.Is<TransferPanelPosition>(p => p.OffsetX == -320 && p.OffsetY == 180),
+            Arg.Is<PanelPosition>(p => p.OffsetX == -320 && p.OffsetY == 180),
             Arg.Any<CancellationToken>());
     }
 
@@ -470,8 +470,8 @@ public class FileTransferViewModelTests
     public async Task Construction_RestoresPersistedPanelPosition()
     {
         IAppDataStore store = Substitute.For<IAppDataStore>();
-        store.GetAsync<TransferPanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
-             .Returns(new TransferPanelPosition { OffsetX = -240, OffsetY = 96 });
+        store.GetAsync<PanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
+             .Returns(new PanelPosition { OffsetX = -240, OffsetY = 96 });
 
         var vm = new FileTransferViewModel(_transferManager, store);
 
@@ -545,8 +545,8 @@ public class FileTransferViewModelTests
     public async Task Construction_WhenStoreThrows_FallsBackToDefaultPosition()
     {
         IAppDataStore store = Substitute.For<IAppDataStore>();
-        store.GetAsync<TransferPanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
-             .Returns<TransferPanelPosition?>(_ => throw new InvalidOperationException("store offline"));
+        store.GetAsync<PanelPosition>("ui-layout", "transfer-panel", Arg.Any<CancellationToken>())
+             .Returns<PanelPosition?>(_ => throw new InvalidOperationException("store offline"));
 
         var vm = new FileTransferViewModel(_transferManager, store);
         await Task.Delay(50);

--- a/tests/VelaShell.Tests/ViewModels/NotificationPanelViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/NotificationPanelViewModelTests.cs
@@ -1,4 +1,6 @@
+using NSubstitute;
 using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Infrastructure.Notifications;
 using VelaShell.ViewModels;
@@ -177,6 +179,62 @@ public class NotificationPanelViewModelTests
         Assert.IsTrue(external.HasLinkHost);
         Assert.IsNull(inApp.LinkHost, "站内跳转没有外部主机可显示。");
         Assert.IsFalse(inApp.HasLinkHost);
+    }
+
+    /// <summary>
+    /// 拖动后的位置落在 <c>ui-layout/notification-panel</c> —— 与文件传输提示同集合、
+    /// 各占一个文档 Id。两个浮层写进同一个 Id 会互相踩,这条钉住 Id 不被写错。
+    /// </summary>
+    [TestMethod]
+    public async Task PersistPanelPosition_WritesCurrentOffsetToStore()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"));
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        var vm = new NotificationPanelViewModel(center, dataStore: store)
+        {
+            PanelOffsetX = 240,
+            PanelOffsetY = -180
+        };
+
+        vm.PersistPanelPosition();
+
+        // 断言本身返回 Task(方法是 async 的),丢弃它以免 CS4014 —— 调用记录是同步的。
+        _ = store.Received(1).UpsertAsync(
+            "ui-layout",
+            "notification-panel",
+            Arg.Is<PanelPosition>(p => p.OffsetX == 240 && p.OffsetY == -180),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>构造时从存储恢复上次的位置 —— 这就是「再次打开回到原有位置」。</summary>
+    [TestMethod]
+    public async Task Construction_RestoresPersistedPanelPosition()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"));
+        IAppDataStore store = Substitute.For<IAppDataStore>();
+        store.GetAsync<PanelPosition>("ui-layout", "notification-panel", Arg.Any<CancellationToken>())
+             .Returns(new PanelPosition { OffsetX = 120, OffsetY = -64 });
+
+        var vm = new NotificationPanelViewModel(center, dataStore: store);
+
+        // 恢复是异步的,给它一次调度机会。
+        await Task.Yield();
+        await Task.Delay(50);
+
+        Assert.AreEqual(120, vm.PanelOffsetX);
+        Assert.AreEqual(-64, vm.PanelOffsetY);
+    }
+
+    /// <summary>没有存储(单元测试/精简宿主)时不该炸,位置退回默认锚点。</summary>
+    [TestMethod]
+    public async Task WithoutStore_PanelPositionDefaultsToAnchorAndPersistIsHarmless()
+    {
+        NotificationCenter center = await SeededCenterAsync(Item("a"));
+        var vm = new NotificationPanelViewModel(center);
+
+        Assert.AreEqual(0, vm.PanelOffsetX);
+        Assert.AreEqual(0, vm.PanelOffsetY);
+        vm.PersistPanelPosition();
     }
 
     /// <summary>相对时间按量级切换单位;源端时钟偏到未来时一律当作「刚刚」。</summary>

--- a/tests/VelaShell.Tests/Views/NotificationPanelUiTests.cs
+++ b/tests/VelaShell.Tests/Views/NotificationPanelUiTests.cs
@@ -141,6 +141,104 @@ public sealed class NotificationPanelUiTests
         });
     }
 
+    /// <summary>
+    /// 「去处」一行两端对齐:主机名钉左、动作钉右,**动作的右沿逐行共线**。
+    /// <para>
+    /// 用户反馈:动作刚挪到右边时一列扫下来参差不齐。两个成因都在这里钉住 ——
+    /// ① 整条靠右时,主机名长短不一会把动作推到各自不同的位置(站内跳转那行根本没有主机名);
+    /// ② 列表若开着横向滚动,每行按"不换行的理想宽度"各量各的,行宽本身就不一样。
+    /// 因此同时断言:各行等宽,且动作右沿共线。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void DestinationLine_ActionsShareOneRightEdge()
+    {
+        OnUi(() =>
+        {
+            var center = new NotificationCenter();
+            DateTime now = DateTime.UtcNow;
+            center.PublishAsync([
+                // 站内跳转:没有主机名,动作左边空空如也。
+                new NotificationItem
+                {
+                    Id = "in-app",
+                    Kind = NotificationKind.Update,
+                    Title = "VelaShell 1.4.2 已发布",
+                    Body = "当前版本 0.0.1-dev。到「关于」页查看并安装更新。",
+                    PublishedAt = now.AddMinutes(-16),
+                    Link = new() { Label = "前往关于页", CommandId = "app.settings.about" }
+                },
+                // 外链:主机名短。
+                new NotificationItem
+                {
+                    Id = "short-host",
+                    Kind = NotificationKind.Security,
+                    Title = "CVE-2026-82644 (CVSS 7.5)",
+                    Body = "WWBN AVideo contains a brute-force rate limiting bypass in enforceRateLimit().",
+                    PublishedAt = now.AddHours(-3),
+                    Link = new() { Label = "阅读全文", Url = "https://nvd.nist.gov/vuln/detail/CVE-2026-82644" }
+                },
+                // 外链:主机名长得多 —— 若动作跟着主机名走,这一行会被推得最远。
+                new NotificationItem
+                {
+                    Id = "long-host",
+                    Kind = NotificationKind.News,
+                    Title = "八月产品月报",
+                    Body = "SFTP 双栏、资源监控与插件市场的进展。",
+                    PublishedAt = now.AddDays(-2),
+                    Link = new() { Label = "阅读全文", Url = "https://blog.a-very-long-host-name.example.com/2026-08" }
+                }
+            ]).GetAwaiter().GetResult();
+
+            var view = new NotificationPanelView { DataContext = new NotificationPanelViewModel(center) };
+            var window = new Window { Width = 400, Height = 560, Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            List<Border> rows = [.. view.GetVisualDescendants().OfType<Border>()
+                                        .Where(border => border.Classes.Contains("msg-row"))];
+            Assert.HasCount(3, rows);
+
+            double[] widths = [.. rows.Select(row => Math.Round(row.Bounds.Width, 2)).Distinct()];
+            Assert.HasCount(1, widths, "各行必须等宽 —— 宽度不一,行内靠右的元素就不可能对齐。");
+
+            // 行内右对齐的前提:整行按钮真的铺满了它那一列(Button 默认是 Left,不是 Stretch)。
+            foreach (Border row in rows)
+            {
+                Grid outer = row.GetVisualDescendants().OfType<Grid>().First();
+                Button rowButton = row.GetVisualDescendants().OfType<Button>()
+                                      .First(button => button.Classes.Contains("row"));
+                Assert.AreEqual(outer.ColumnDefinitions[1].ActualWidth, rowButton.Bounds.Width, 0.5,
+                                "整行按钮必须铺满内容列,否则里面的右对齐是相对它自己那一团内容。");
+            }
+
+            double[] actionRightEdges = [.. rows.Select(RightEdgeOf("link-action")).Distinct()];
+            Assert.HasCount(1, actionRightEdges,
+                            $"动作的右沿必须逐行共线,实测 {string.Join(" / ", rows.Select(RightEdgeOf("link-action")))}。");
+
+            // 每行的删除键与标题栏的关闭键同一条竖线(右留白 16,给悬浮滚动条让位)。
+            Border header = view.GetVisualDescendants().OfType<Border>().First(b => b.Name == "DragHandle");
+            double headerCloseRight = RightEdgeOf("row-action")(header);
+            Assert.AreEqual(headerCloseRight, RightEdgeOf("row-action")(rows[0]), 0.5,
+                            "行内删除键应与标题栏关闭键右沿对齐。");
+
+            SaveFrame(window, "notification-panel-destination-alignment.png");
+            window.Close();
+
+            // 取容器内**最后一个**带该类的控件(标题栏里有三个 row-action,关闭键在最右),
+            // 换算到窗口坐标后的右沿。
+            Func<Visual, double> RightEdgeOf(string className) => container =>
+            {
+                Visual target = container.GetVisualDescendants()
+                                         .OfType<Control>()
+                                         .Last(control => control.Classes.Contains(className));
+                Point? corner = target.TranslatePoint(new(target.Bounds.Width, 0), window);
+                return Math.Round(corner?.X ?? throw new InvalidOperationException("控件未参与布局。"), 2);
+            };
+        });
+    }
+
     private static void SaveFrame(TopLevel topLevel, string fileName)
     {
         string? directory = Environment.GetEnvironmentVariable("VELASHELL_VISUAL_QA_DIR");


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

- NotificationOptions.FeedUrl 默认改为官方资讯源，PRIVACY.md 说明联网与关闭方式，plan.md 记录变更背景与兼容性。
- 消息中心与文件传输面板支持拖拽，位置持久化，抽象 IDraggablePanel/PanelPosition，统一拖拽逻辑。
- UI 优化：字号加大、消息列表高度提升、对齐与滚动条细节调整，补充 UI 测试断言。
- 结构与测试同步适配新接口，文档与注释完善。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
