### PR TITLE
引入具名主题与终端配色联动机制

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,9 +20,63 @@ VelaShell is a keyboard-first, high-density SSH/SFTP terminal client for ops and
 
 All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds via `{DynamicResource VelaXxx}`. Never use hex literals.
 
+### 2.0 Named themes
+
+VelaShell ships **nine named themes**. A theme is not a variant switch — it is a full palette
+that replaces every `Vela*` token at runtime.
+
+Themes carry the name of the palette they come from — only the two house themes are Vela-branded.
+
+| Theme | Base | Paired terminal scheme |
+|---|---|---|
+| `VelaDark` (id `dark`, factory default; Dracula) | dark | `Dracula` |
+| `Tokyo Night` (`tokyo-night`) | dark | `Tokyo Night` |
+| `Nord` (`nord`) | dark | `Nord` |
+| `Everforest` (`everforest`) | dark | `Everforest Dark` |
+| `Obsidian` (`obsidian`; neutral near-black, OLED) | dark | `Obsidian` |
+| `Gruvbox` (`gruvbox`) | dark | `Gruvbox Bright` |
+| `VelaLight` (`light`; Alucard) | light | `Alucard` |
+| `Rosé Pine Dawn` (`rose-pine-dawn`) | light | `Rosé Pine Dawn` |
+| `GitHub Light` (`github-light`) | light | `GitHub Light` |
+
+Plus the pseudo-theme `system`, which resolves to `VelaDark` / `VelaLight` by OS appearance.
+
+**Following vs. pinning.** `AppearanceOptions.TerminalColorsFollowTheme` is the *explicit* record of
+which one the user chose; the terminal color-scheme dropdown's first entry is "follow theme", the
+rest pin a scheme. Never re-derive "following" by comparing colors against a scheme — that is what
+made picking `Dracula` under a non-Dracula theme a no-op (the comparison could not tell "picked
+Dracula" from "following"). `null` on that field means a pre-1.5 config that predates it; it is
+resolved once, by the old rule, in `TerminalColorScheme.FollowsTheme`.
+
+**Where the values live.** Each theme is a ~25-colour **seed palette**
+(`UiThemePalette` in `src/VelaShell.Core/Models/UiTheme.cs`); the sixty-odd `Vela*` tokens below
+are *derived* from that seed by `ThemeTokenApplier` (`src/VelaShell/Services/`), which writes them
+into `Application.Resources` — top-level entries shadow the `ThemeDictionaries` in
+`VelaTokens.axaml` / `VelaShellTokens.axaml` / `DarkTheme.axaml` / `LightTheme.axaml`, so every
+`{DynamicResource}` follows the switch with no restart. Those axaml files remain the compile-time
+defaults for `VelaDark` / `VelaLight` (designer, headless tests, the instant before the applier
+runs) and are pinned equal to the applier's output by `ThemeTokenApplierTests`.
+
+Adding a theme therefore means adding one seed palette — never sixty hand-copied literals.
+`UiThemeCatalog` and `ThemeTokenApplier` are the **only** places colour literals belong in C#.
+
+Derivation rules worth knowing (the rest are 1:1):
+
+- `VelaAccentDim` / `VelaBgActive`(light) / `VelaShell*Dim` / `VelaHeat*` = a seed colour at a fixed alpha.
+  Alpha is `#AARRGGBB`; writing it last silently yields a different colour (issue #246), so these
+  are derived rather than typed.
+- `VelaGaugeCpu` = `Info`, `VelaGaugeMemory` = `Accent`, `VelaGaugeTrack` = `BorderSecondary`.
+- `VelaTraceLineDim` = `Info` blended 50% into `BgPage`.
+- Heat grid ladder = `TextTertiary → Info → Accent → Yellow → Error` (idle → full).
+- `VelaShadowWindow` has exactly two forms, keyed on the theme's base (see §4.5).
+
+Every theme is held to WCAG AA for body text on every surface, and 3:1 for status glyphs, by
+`UiThemeCatalogTests`. The paired terminal scheme's background **must equal** `VelaBgTerminal` —
+the terminal canvas and the UI around it are one plane; a mismatch shows up as a visible seam.
+
 ### 2.1 Backgrounds (`VelaShellTokens.axaml`)
 
-| Token | Dark (Dracula) | Light (Alucard) | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaBgPage` | `#191A21` | `#F2EDDA` | Window base layer |
 | `VelaBgSidebar` | `#252734` | `#F8F4E4` | Sidebar, status bar |
@@ -36,7 +90,7 @@ All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds vi
 
 ### 2.2 Text & Icon (`VelaTokens.axaml`)
 
-| Token | Dark | Light | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaTextPrimary` | `#F8F8F2` | `#1F1F1F` | Primary text |
 | `VelaTextSecondary` | `#B0B8D6` | `#4A4636` | Secondary text, session names |
@@ -45,14 +99,14 @@ All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds vi
 
 ### 2.3 Borders (`VelaTokens.axaml`)
 
-| Token | Dark | Light | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaBorderPrimary` | `#3B3E51` | `#E3DCBF` | Standard dividers, row bottom borders |
 | `VelaBorderSecondary` | `#44475A` | `#D3CBA9` | Float/tooltip borders |
 
 ### 2.4 Accent (`VelaTokens.axaml`)
 
-| Token | Dark | Light | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaAccent` | `#BD93F9` | `#644AC9` | Primary brand color (Dracula purple) |
 | `VelaAccentDim` | `#BD93F930` | `#644AC91A` | Accent at low opacity (badge/tag backgrounds) |
@@ -61,7 +115,7 @@ All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds vi
 
 ### 2.5 Semantic Status (`DarkTheme.axaml` / `LightTheme.axaml`)
 
-| Token | Dark | Light | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaStatusConnected` | `#50FA7B` | `#14710A` | Connected state dot |
 | `VelaStatusConnecting` | `#F1FA8C` | `#846E15` | Connecting state dot |
@@ -72,14 +126,19 @@ All colors are `SolidColorBrush` resources keyed by semantic name. XAML binds vi
 
 ### 2.6 File Browser Specific (`VelaTokens.axaml`)
 
-| Token | Dark | Light | Usage |
+| Token | VelaDark | VelaLight | Usage |
 |---|---|---|---|
 | `VelaFileFolderIcon` | `#FFB86C` | `#9E841A` | Folder icon fill |
 | `VelaFileDirName` | `#8BE9FD` | `#036A96` | Directory name text |
 
 ### 2.7 Terminal ANSI Palette (`DarkTheme.axaml`)
 
-| Token | Dark | Usage |
+These are **UI-side** markers (charts, badges, gutter glyphs) that borrow the terminal hues — they
+are derived from the same seed as everything else. The terminal canvas itself does not read them:
+it gets the theme's paired `TerminalColorScheme`, pushed down as `VelaTerminalControl.ThemePalette`
+with the user's per-colour overrides layered on top.
+
+| Token | VelaDark | Usage |
 |---|---|---|
 | `VelaShellWhite` | `#F8F8F2` | Default foreground |
 | `VelaShellGreen` | `#50FA7B` | ANSI green |

--- a/plan.md
+++ b/plan.md
@@ -566,3 +566,155 @@ CISA KEV 那几条「现在就有人在打这个洞」就等于谁也收不到�
 **留了一处没动**:SFTP / FTP / 插件协议 / 工作台文档也往同一个节点写状态(`SetTreeSessionStatus`),
 它们与终端标签之间仍是「后写的赢」。本次只把终端标签这一侧收成合并语义 —— 与既有行为等价,不是新洞,
 但要彻底,得把这些来源一起纳入同一个合并器。
+
+## 25. 2026-08-31 具名主题:九套配色 + 终端配色配对
+
+此前"主题"只有三个值:`dark` / `light` / `system`,颜色写死在两份 axaml 的 ThemeDictionaries 里;
+终端那边同样只认明暗两套(暗 Dracula / 亮 Solarized Light,硬编码在 `VelaTerminalControl`)。
+本批把它改成**具名主题目录**:六套暗色 + 三套亮色,各自带一套配套的终端配色。
+
+**改名**:原亮色 → **VelaLight**,原暗色 → **VelaDark**。持久化的 Id 仍是 `light` / `dark`
+—— 老配置一行不用迁,`ThemeServiceSwitchTests` / `HeadlessUiTests` 也不用改。
+
+**新增七套**(名字取自"Vela=船帆座"的星空与自然一系,各有明确的使用场景,不是换个色相凑数):
+
+| 主题 | 基底 | 血统 | 配套终端方案 |
+| --- | --- | --- | --- |
+| Tokyo Night | 暗 | Tokyo Night | Tokyo Night |
+| Nord | 暗 | Nord | Nord |
+| Everforest | 暗 | Everforest | Everforest Dark |
+| Obsidian | 暗 | 中性近黑(OLED) | Obsidian |
+| Gruvbox | 暗 | Gruvbox | Gruvbox Bright |
+| Rosé Pine Dawn | 亮 | Rosé Pine Dawn | Rosé Pine Dawn |
+| GitHub Light | 亮 | GitHub Light | GitHub Light |
+
+### 一、六十多个令牌,只写二十几个种子色
+
+`UiThemePalette`(Core)是一套主题需要人来定的全部内容 —— 底色阶梯、四档文字、两档描边、
+强调色与语义色,二十五个。其余令牌(`*Dim`、`VelaHeat1-5`、`VelaGauge*`、`VelaTrace*`、
+`VelaShell*` 等)由 `ThemeTokenApplier`(宿主侧)按固定规则派生。
+
+理由是**手抄会错,而且错了看不出来**:`#644AC922` 这种把透明度写在末尾的错拼,编译期无感、
+运行期是一片绿(issue #246 的原始症状)。派生出来的令牌天生自洽,加一套主题只需要填种子色。
+
+**运行时怎么生效**:Avalonia 的资源查找先看字典自身的条目,再看 ThemeDictionaries 与合并字典 ——
+所以写进 `Application.Resources` 顶层的键会**遮蔽** axaml 里同名的主题条目,全部
+`DynamicResource` 立刻跟着变(强调色覆盖 #3 一直就是这么做的,这次把它推广到整套令牌)。
+axaml 那两套保留为 VelaDark / VelaLight 的编译期缺省,`ThemeTokenApplierTests` 钉住两边逐值一致。
+这条遮蔽假设本身也有用例:`ThemeTokenShadowingUiTests` 在真 Avalonia 资源栈上验证"贴上去盖得住、
+摘下来落得回"。
+
+**踩到的一个坑**:清空自定义强调色的老实现是把 `VelaAccent` 三件套从资源里**删掉**,让它落回
+axaml 缺省。在只有明暗两套时这是对的;有了具名主题就成了错的 —— Tokyo Night 的蓝会变成VelaDark 的紫。改为 `ThemeTokenApplier.ResetAccent` 写回**当前主题自己**的强调色。
+
+### 二、终端配色跟着主题走
+
+`VelaTerminalControl` 原来只听 `ActualThemeVariant`。具名主题里有六套暗色,VelaDark 换到
+Tokyo Night 时变体压根没变 —— 光听变体,终端画面会原地不动,和换过颜色的界面拼在一起。
+
+改为三层叠加:**控件自带的明暗缺省 → 宿主下发的整套主题配色(新增的 `ThemePalette`)→
+用户改过的单色(原有的稀疏 `PaletteOverrides`)**。宿主在 `ApplyLiveTerminalSettings` 里按当前
+主题下发,并订阅 `IThemeService.ThemeChanged` 与 `Application.ActualThemeVariantChanged`
+(后者是"跟随系统"下系统明暗翻转的那条路)。
+
+配对的硬约束:**方案背景色必须等于该主题的 `VelaBgTerminal`**。亮色主题此前配 Solarized Light
+(终端底 #FDF6E3)而界面底是 #FFFBEB,终端边缘一直挂着一道看得见的拼缝 —— 这次 VelaLight 改配
+**Alucard**(Dracula 官方亮色),缝消失了。`UiThemeCatalogTests` 逐主题钉住这一条。
+
+新增五套终端方案:Alucard、Everforest Dark、Obsidian、Rosé Pine Dawn、GitHub Light,外加 Gruvbox Bright
+—— 最后这套是因为原版 Gruvbox 的 normal 红(#CC241D)压在 #282828 上只有 2.7:1,报错信息比正文
+还难读;Gruvbox Bright 的常规八色取官方 bright 一档,原汁原味的 "Gruvbox Dark" 仍留在列表里。
+
+### 三、配色不是"看着顺眼"就算数
+
+`UiThemeCatalogTests` 对**每一套**主题跑:正文两档压在七种底色(含半透明选中底压在浮层上的
+观感色)上 ≥ 4.5:1;按钮文字压在强调色上 ≥ 4.5:1;状态点与语义色 ≥ 3:1;强调色淡底的 RGB 必须
+等于强调色本身;配套终端方案的前景 ≥ 4.5:1、ANSI 1–6 ≥ 3:1。
+
+这把尺子真的拦下了东西:Nord 原色红压在面板上只有 2.5:1(提亮到 #D4757F)、Rosé Pine 的
+iris 压白底只有 3.7:1(压深到 #7C5F9F)、Tokyo Night 的选中底让次要文字掉到 4.3:1(压暗一档)、
+Everforest 的选中底同样偏亮。Rosé Pine 原版**没有绿**,补了一支同调森林绿 —— 没有绿,
+`ls` 的目录与可执行位就分不开。
+
+### 四、顺手修掉的一个静默 bug
+
+`TerminalPaletteOverrides.IsEmpty` 写的是 `Ansi.Length == 0`,而数组恒为 16 个槽位 ——
+于是它**恒为 false**,"一色未改"也被当成有覆盖。叠加一份全 null 的覆盖不改变画面,所以从没露头;
+但它让"跟随主题"与"钉死配色"这两种状态在外部无从区分。改为逐槽位判空。
+
+### 五、界面与插件侧
+
+设置 → 外观 → 主题模式的下拉从写死的三个 `ComboBoxItem` 改为绑定 `AvailableThemeNames`
+(主题目录 + 末项"跟随系统"),`SetAppear_ThemeDark` / `SetAppear_ThemeLight` 两个 resx 键随之
+从五份资源里删除,说明文案改写。终端配色方案下拉的"(默认)"后缀现在跟着**当前主题的配套方案**走。
+
+插件契约里的 `IHostInfo.Theme` 与 `HostEvents.ThemeChanged` 仍然只给 `dark` / `light` / `system`
+—— 具名主题不外泄(`UiThemeCatalog.VariantName`)。插件拿到一个没见过的字符串,多半会落到自己的
+兜底分支上;而插件真正需要的信息只有明暗。隔离插件的令牌快照走 `PluginThemeTokens`,读的就是
+应用资源,自动拿到新主题的颜色,无需改动。
+
+启动读配置时先验 Id 再 `SetTheme`:用新版选过 Tokyo Night 再退回旧版,老版本不认识这个 Id,
+`SetTheme` 会抛 —— 验一下就退回默认主题,启动照常。
+
+## 26. 2026-08-31 主题命名收敛 + 「跟随主题」不再是隐式状态(用户反馈)
+
+两处,都是上一节留下的账。
+
+### 一、主题名改回各自调色板本来的名字
+
+上一批给每套主题都套了 `Vela` 前缀(VelaMidnight / VelaGlacier / …),用户反馈**没必要**:
+一套源自 Tokyo Night 的配色就叫 Tokyo Night,认得出的名字比统一的品牌前缀有用。现在只有两套
+自家配色保留品牌名 —— **VelaDark**(Dracula)与 **VelaLight**(Alucard),其余一律用血统名:
+
+| 主题(Id) | 基底 | 配套终端方案 |
+| --- | --- | --- |
+| VelaDark(`dark`,出厂默认) | 暗 | Dracula |
+| Tokyo Night(`tokyo-night`) | 暗 | Tokyo Night |
+| Nord(`nord`) | 暗 | Nord |
+| Everforest(`everforest`) | 暗 | Everforest Dark |
+| Obsidian(`obsidian`) | 暗 | Obsidian |
+| Gruvbox(`gruvbox`) | 暗 | Gruvbox Bright |
+| VelaLight(`light`) | 亮 | Alucard |
+| Rosé Pine Dawn(`rose-pine-dawn`) | 亮 | Rosé Pine Dawn |
+| GitHub Light(`github-light`) | 亮 | GitHub Light |
+
+Id 一并对齐到名字(`midnight` → `tokyo-night` 等);`dark` / `light` 仍是历史值不动。
+调过的那套 Gruvbox 终端方案改名 **Gruvbox Bright** —— 它与原版的差别就是常规八色取了官方的
+bright 一档,名字直接把这件事说出来,原版 "Gruvbox Dark" 仍在列表里。
+
+### 二、选 Dracula 没反应:「跟随主题」不能再是隐式状态
+
+用户报的:在配套方案不是 Dracula 的主题(Nord、VelaLight…)下,配色方案下拉里选 **Dracula
+毫无反应**,终端仍是主题自带的那套,选中项还会自己跳回去。
+
+根因是一处**语义重载**。老实现把「跟随主题」隐式编码成「设置里的颜色 == 出厂默认」,
+而出厂默认的色值就是 Dracula:
+
+- `ColorSchemeIndex` 的 setter 里,选中当前主题的配套方案 = 写回出厂值(= Dracula 色值);
+- `BuildPaletteOverrides` 与出厂值逐色做差,全同 ⇒ 无覆盖 ⇒ 跟随主题;
+- 于是**「用户明确选了 Dracula」与「跟随主题」写出来的设置一模一样**,分不开。
+
+在 VelaDark 上这个洞看不见(它的配套方案本来就是 Dracula,两种解释同色);具名主题一上来,
+除 VelaDark 之外的每一套都会踩到。
+
+改法是把跟随与否变成**显式**的一项:
+
+- `AppearanceOptions.TerminalColorsFollowTheme`(`bool?`)。**不给初值**:`null` 表示配置里
+  没有这一项(1.4.x 及更早),由 `TerminalColorScheme.FollowsTheme` 按老口径推断
+  (颜色 == 出厂 Dracula ⇒ 跟随)。给了初值 `true`,老用户自定义过的配色会被当成跟随态丢掉。
+- `BuildPaletteOverrides`:跟随 → 返回 null(一个槽位都不覆盖);不跟随 → **整套**下发,
+  不再与出厂值做差。用户在设置页上看到的那套颜色,就是终端要用的那套。
+- 下拉首项独立为 **「跟随主题(配套方案名)」**(`SetVm_FollowThemeScheme`,五份 resx 齐),
+  其后是全部内置方案,配套的那个仍带「(默认)」后缀标明出处。选首项 = 跟随,
+  并把配套方案的色值写进去 —— 下面那几个色块显示的就是屏幕上真正在用的颜色。
+- 跟随态下手改前景/背景/光标/选区任一色 = 用户要自己定配色,就此脱离跟随。
+  **判定不能反过来问 `FollowsTheme`**:PropertyChanged 到达时新色值已经写进去了,
+  而老配置的跟随与否恰恰是按色值推断的 —— 一改就自己翻成「不跟随」,永远看不到
+  「改之前在跟随」这个事实。直接置标志,幂等。(这一版第一次写就踩了,用例是红的。)
+- 换主题时若处于跟随态,顺带把色块重灌成新主题配套方案的颜色(载入阶段 `_suppressPreview`
+  为真,不会改动刚读进来的设置)。
+
+回归用例 `TerminalColorSchemeSelectionTests` 五条:非 Dracula 主题下选 Dracula 真的生效且不跳回、
+配套方案本身也能被钉住、选回「跟随主题」清空覆盖并显示配套色、跟随态下改单色即脱离跟随、
+老配置(无标志)按老口径判定 —— 最后一条同时钉住「没改过的老用户仍跟随」与
+「改过配色的老用户覆盖不丢」。

--- a/src/VelaShell.Controls/Themes/VelaTokens.axaml
+++ b/src/VelaShell.Controls/Themes/VelaTokens.axaml
@@ -67,12 +67,12 @@
       <SolidColorBrush x:Key="VelaGaugeTrack" Color="#44475A" />
       <!-- 链路追踪地图:路径用青色(和紫色强调、红色告警都拉得开),已到达段更亮。 -->
       <SolidColorBrush x:Key="VelaTraceLine" Color="#8BE9FD" />
-      <SolidColorBrush x:Key="VelaTraceLineDim" Color="#4A7C8C" />
+      <SolidColorBrush x:Key="VelaTraceLineDim" Color="#52828F" />
       <SolidColorBrush x:Key="VelaTraceLand" Color="#333850" />
       <!-- 国境线要比陆地填充明显亮一档,否则整块大陆看不出内部分界。 -->
       <SolidColorBrush x:Key="VelaTraceBorder" Color="#5C6488" />
       <!-- 标注底片:压在陆地上也要读得清,故用半透明深色垫底。 -->
-      <SolidColorBrush x:Key="VelaTraceLabelBg" Color="#D2151A28" />
+      <SolidColorBrush x:Key="VelaTraceLabelBg" Color="#D2191A21" />
     </ResourceDictionary>
     <!-- Alucard 亮色:accent=紫 #644AC9,弱文字取 Alucard comment #6C664B。 -->
     <ResourceDictionary x:Key="Light">
@@ -97,10 +97,10 @@
       <SolidColorBrush x:Key="VelaGaugeMemory" Color="#644AC9" />
       <SolidColorBrush x:Key="VelaGaugeWarn" Color="#846E15" />
       <SolidColorBrush x:Key="VelaGaugeCritical" Color="#CB3A2A" />
-      <SolidColorBrush x:Key="VelaGaugeTrack" Color="#E3DCBF" />
+      <SolidColorBrush x:Key="VelaGaugeTrack" Color="#D3CBA9" />
       <!-- 链路追踪地图:亮色主题下取同色相的深青。 -->
       <SolidColorBrush x:Key="VelaTraceLine" Color="#036A96" />
-      <SolidColorBrush x:Key="VelaTraceLineDim" Color="#7FA8BC" />
+      <SolidColorBrush x:Key="VelaTraceLineDim" Color="#7AACB8" />
       <SolidColorBrush x:Key="VelaTraceLand" Color="#EFE9D2" />
       <SolidColorBrush x:Key="VelaTraceBorder" Color="#BDB392" />
       <SolidColorBrush x:Key="VelaTraceLabelBg" Color="#E6FFFBEB" />

--- a/src/VelaShell.Core/Models/AppSettings.cs
+++ b/src/VelaShell.Core/Models/AppSettings.cs
@@ -408,6 +408,24 @@ public class AppearanceOptions : ObservableOptions
         set => Set(ref field, value);
     }
 
+    /// <summary>
+    /// 终端配色是否跟随当前界面主题(即用主题配套的那套终端方案)。
+    /// <para>
+    /// <c>null</c> = 配置里没有这一项(1.4.x 及更早):按老口径推断 —— 那时"跟随"是**隐式**
+    /// 编码为「颜色与出厂 Dracula 完全一致」。判定见 <see cref="TerminalColorScheme.FollowsTheme" />。
+    /// 因此这里**不能**给初值:给了 true,老用户自定义过的配色会被当成跟随态一并丢掉。
+    /// </para>
+    /// <para>
+    /// 这一项之所以必须显式存在:老口径下「用户明确选了 Dracula」与「跟随主题」写出来的设置
+    /// 一模一样,于是在配套方案不是 Dracula 的主题(VelaLight、Nord…)上选 Dracula 会毫无反应。
+    /// </para>
+    /// </summary>
+    public bool? TerminalColorsFollowTheme
+    {
+        get;
+        set => Set(ref field, value);
+    }
+
     // 终端颜色(默认 = Dracula 官方 Windows Terminal 方案)
     /// <summary>终端前景(文本)颜色(十六进制)。</summary>
     public string TerminalForeground

--- a/src/VelaShell.Core/Models/TerminalColorScheme.cs
+++ b/src/VelaShell.Core/Models/TerminalColorScheme.cs
@@ -22,13 +22,67 @@ public sealed record TerminalColorScheme(
     string[] AnsiNormal,
     string[] AnsiBright)
 {
-    /// <summary>内置方案;首项 Dracula 色值等同出厂默认(不产生覆盖、跟随主题)。</summary>
+    /// <summary>
+    /// 内置方案;首项 Dracula 色值等同出厂默认(不产生覆盖、跟随主题)。
+    /// <para>
+    /// 前九项与九套界面主题一一配对(见 <see cref="UiTheme.TerminalSchemeName" />):
+    /// 每一项的背景色都等于对应主题的 <c>VelaBgTerminal</c> —— 终端画面和它周围的界面
+    /// 是同一个平面,背景差一档就会在终端边缘看出一道拼缝。其余几项是无配对的经典方案,
+    /// 供用户单独挑选。
+    /// </para>
+    /// </summary>
     public static readonly TerminalColorScheme[] BuiltIn =
     [
         new("Dracula",
             "#F8F8F2", "#282A36", "#F8F8F2", "#44475A",
             ["#21222C", "#FF5555", "#50FA7B", "#F1FA8C", "#BD93F9", "#FF79C6", "#8BE9FD", "#F8F8F2"],
             ["#6272A4", "#FF6E6E", "#69FF94", "#FFFFA5", "#D6ACFF", "#FF92DF", "#A4FFFF", "#FFFFFF"]),
+        // Alucard = Dracula 官方亮色。配 VelaLight:此前亮色主题配的是 Solarized Light,
+        // 终端底 #FDF6E3 与界面底 #FFFBEB 差一档,终端边缘一直挂着一道看得见的拼缝。
+        new("Alucard",
+            "#1F1F1F", "#FFFBEB", "#644AC9", "#CFCFDE",
+            ["#1F1F1F", "#CB3A2A", "#14710A", "#846E15", "#644AC9", "#A3144D", "#036A96", "#CFCFDE"],
+            ["#6C664B", "#E35A48", "#1E8E10", "#A38A1B", "#7A5CE0", "#C21A5E", "#0784B5", "#FFFBEB"]),
+        new("Tokyo Night",
+            "#C0CAF5", "#1A1B26", "#C0CAF5", "#33467C",
+            ["#15161E", "#F7768E", "#9ECE6A", "#E0AF68", "#7AA2F7", "#BB9AF7", "#7DCFFF", "#A9B1D6"],
+            ["#414868", "#F7768E", "#9ECE6A", "#E0AF68", "#7AA2F7", "#BB9AF7", "#7DCFFF", "#C0CAF5"]),
+        new("Nord",
+            "#D8DEE9", "#2E3440", "#D8DEE9", "#434C5E",
+            ["#3B4252", "#BF616A", "#A3BE8C", "#EBCB8B", "#81A1C1", "#B48EAD", "#88C0D0", "#E5E9F0"],
+            ["#4C566A", "#D4757F", "#B5CE9F", "#F0D8A4", "#95B4CE", "#C4A0BD", "#8FBCBB", "#ECEFF4"]),
+        new("Everforest Dark",
+            "#D3C6AA", "#2D353B", "#D3C6AA", "#475258",
+            ["#343F44", "#E67E80", "#A7C080", "#DBBC7F", "#7FBBB3", "#D699B6", "#83C092", "#D3C6AA"],
+            ["#859289", "#EC9A9C", "#B9CE97", "#E5CB95", "#96C8C1", "#E0AEC6", "#97CFA5", "#FFFFFF"]),
+        // Obsidian:中性近黑底 + 高饱和 ANSI。底色不带色相,色块看上去比在任何
+        // 有色底上都干净一档。
+        new("Obsidian",
+            "#E7E7EA", "#131316", "#22D3EE", "#2E2E38",
+            ["#131316", "#F87171", "#4ADE80", "#FACC15", "#38BDF8", "#E879F9", "#22D3EE", "#D4D4D8"],
+            ["#6A6A76", "#FCA5A5", "#86EFAC", "#FDE047", "#7DD3FC", "#F0ABFC", "#67E8F9", "#FAFAFA"]),
+        new("Gruvbox Dark",
+            "#EBDBB2", "#282828", "#EBDBB2", "#504945",
+            ["#282828", "#CC241D", "#98971A", "#D79921", "#458588", "#B16286", "#689D6A", "#A89984"],
+            ["#928374", "#FB4934", "#B8BB26", "#FABD2F", "#83A598", "#D3869B", "#8EC07C", "#EBDBB2"]),
+        // Gruvbox Bright:同样的暖色底,但常规八色取 gruvbox 官方的 bright 一档 ——
+        // 原版的 normal 红(#CC241D)压在 #282828 上只有 2.7:1,而报错信息是终端里最该一眼
+        // 看见的东西,不能让它比正文还难读。要原汁原味的那套,上面的 "Gruvbox Dark" 还在。
+        new("Gruvbox Bright",
+            "#EBDBB2", "#282828", "#FE8019", "#504945",
+            ["#32302F", "#FB4934", "#B8BB26", "#FABD2F", "#83A598", "#D3869B", "#8EC07C", "#D5C4A1"],
+            ["#928374", "#FE8082", "#D3D75B", "#FFD866", "#A8C4BC", "#E2A9BE", "#A9D9AB", "#FBF1C7"]),
+        // Rosé Pine Dawn:Rosé Pine Dawn 的色感,但补齐了原版没有的绿,并把几支色压深到
+        // 白底上读得出的程度 —— 亮色方案照抄暗色方案的饱和度,结果就是一屏看不清的彩字。
+        new("Rosé Pine Dawn",
+            "#575279", "#FFFAF3", "#7C5F9F", "#EADDD3",
+            ["#575279", "#A5445F", "#3E7A54", "#9A6A12", "#286983", "#7C5F9F", "#2E7A85", "#DFD8D0"],
+            ["#797593", "#B85C74", "#4E8F64", "#B07415", "#34798F", "#8A6FAF", "#3D93A0", "#FFFAF3"]),
+        // GitHub Light:纯白纸面上的中性 ANSI(GitHub Light 口径),白天强光下最好读。
+        new("GitHub Light",
+            "#1F2328", "#FFFFFF", "#0969DA", "#CFE4FB",
+            ["#24292F", "#CF222E", "#1A7F37", "#9A6700", "#0969DA", "#8250DF", "#1B7C83", "#6E7781"],
+            ["#57606A", "#A40E26", "#116329", "#7D4E00", "#0550AE", "#6639BA", "#136061", "#8C959F"]),
         new("Solarized Dark",
             "#839496", "#002B36", "#839496", "#073642",
             ["#073642", "#DC322F", "#859900", "#B58900", "#268BD2", "#D33682", "#2AA198", "#EEE8D5"],
@@ -37,14 +91,6 @@ public sealed record TerminalColorScheme(
             "#657B83", "#FDF6E3", "#657B83", "#EEE8D5",
             ["#073642", "#DC322F", "#859900", "#B58900", "#268BD2", "#D33682", "#2AA198", "#EEE8D5"],
             ["#586E75", "#CB4B16", "#859900", "#B58900", "#268BD2", "#6C71C4", "#93A1A1", "#FDF6E3"]),
-        new("Nord",
-            "#D8DEE9", "#2E3440", "#D8DEE9", "#434C5E",
-            ["#3B4252", "#BF616A", "#A3BE8C", "#EBCB8B", "#81A1C1", "#B48EAD", "#88C0D0", "#E5E9F0"],
-            ["#4C566A", "#BF616A", "#A3BE8C", "#EBCB8B", "#81A1C1", "#B48EAD", "#8FBCBB", "#ECEFF4"]),
-        new("Gruvbox Dark",
-            "#EBDBB2", "#282828", "#EBDBB2", "#504945",
-            ["#282828", "#CC241D", "#98971A", "#D79921", "#458588", "#B16286", "#689D6A", "#A89984"],
-            ["#928374", "#FB4934", "#B8BB26", "#FABD2F", "#83A598", "#D3869B", "#8EC07C", "#EBDBB2"]),
         new("One Dark",
             "#ABB2BF", "#282C34", "#ABB2BF", "#3E4451",
             ["#282C34", "#E06C75", "#98C379", "#E5C07B", "#61AFEF", "#C678DD", "#56B6C2", "#ABB2BF"],
@@ -52,12 +98,23 @@ public sealed record TerminalColorScheme(
         new("Monokai",
             "#F8F8F2", "#272822", "#F8F8F2", "#49483E",
             ["#272822", "#F92672", "#A6E22E", "#F4BF75", "#66D9EF", "#AE81FF", "#A1EFE4", "#F8F8F2"],
-            ["#75715E", "#F92672", "#A6E22E", "#F4BF75", "#66D9EF", "#AE81FF", "#A1EFE4", "#F9F8F5"]),
-        new("Tokyo Night",
-            "#C0CAF5", "#1A1B26", "#C0CAF5", "#33467C",
-            ["#15161E", "#F7768E", "#9ECE6A", "#E0AF68", "#7AA2F7", "#BB9AF7", "#7DCFFF", "#A9B1D6"],
-            ["#414868", "#F7768E", "#9ECE6A", "#E0AF68", "#7AA2F7", "#BB9AF7", "#7DCFFF", "#C0CAF5"])
+            ["#75715E", "#F92672", "#A6E22E", "#F4BF75", "#66D9EF", "#AE81FF", "#A1EFE4", "#F9F8F5"])
     ];
+
+    /// <summary>
+    /// 终端配色当前是否处于「跟随主题」状态 —— 跟随即不产生任何颜色覆盖,
+    /// 终端用当前界面主题配套的那套方案。
+    /// <para>
+    /// <see cref="AppearanceOptions.TerminalColorsFollowTheme" /> 为 null(老配置没有这一项)
+    /// 时按老口径推断:颜色与出厂默认(<c>BuiltIn[0]</c> = Dracula)完全一致即视为跟随。
+    /// 这正是老版本的判定方式,因此老配置的行为一字不差地保留下来。
+    /// </para>
+    /// </summary>
+    public static bool FollowsTheme(AppearanceOptions appearance)
+    {
+        ArgumentNullException.ThrowIfNull(appearance);
+        return appearance.TerminalColorsFollowTheme ?? BuiltIn[0].Matches(appearance);
+    }
 
     /// <summary>把本方案的整套颜色(前景/背景/光标/选区 + ANSI 16 色)写入给定外观选项。</summary>
     public void ApplyTo(AppearanceOptions appearance)

--- a/src/VelaShell.Core/Models/UiTheme.cs
+++ b/src/VelaShell.Core/Models/UiTheme.cs
@@ -1,0 +1,285 @@
+namespace VelaShell.Core.Models;
+
+/// <summary>
+/// 一套界面配色的**种子色**(24 个)。界面上真正用到的 <c>Vela*</c> 令牌有六十多个,
+/// 但其中绝大多数是从这几个种子色派生出来的(同色不同透明度、同一语义色换个用途),
+/// 派生规则见宿主侧的 <c>ThemeTokenApplier</c>。
+/// <para>
+/// 之所以不把六十多个令牌逐主题手写一遍:那样每加一个主题就要抄六十多个色值,
+/// 抄错一个既不会编译失败也不会有人发现 —— 而"强调色的淡底"与"强调色"色相不一致
+/// 这类错误,历史上已经真的发生过(见 <c>ThemeTokenContrastTests</c> 的通道顺序一条)。
+/// 派生出来的令牌天然一致。
+/// </para>
+/// <para>色值一律 <c>#RRGGBB</c>;<see cref="BgActive" /> 允许 <c>#AARRGGBB</c>(亮色主题用强调色淡底)。</para>
+/// </summary>
+public sealed record UiThemePalette
+{
+    /// <summary>强调色:按钮、选中态、进度、链接。</summary>
+    public required string Accent { get; init; }
+
+    /// <summary>压在强调色实底上的文字/图标色(与 <see cref="Accent" /> 至少 4.5:1)。</summary>
+    public required string AccentForeground { get; init; }
+
+    /// <summary>窗口铬色(最外层:标题栏、标签栏底)。</summary>
+    public required string BgPage { get; init; }
+
+    /// <summary>侧边栏底。</summary>
+    public required string BgSidebar { get; init; }
+
+    /// <summary>终端平面底;同时是 SFTP 面板、停靠文档区与活动标签的底色。</summary>
+    public required string BgTerminal { get; init; }
+
+    /// <summary>浮层/对话框/菜单底;同时是内容区表头底色。</summary>
+    public required string BgSurface { get; init; }
+
+    /// <summary>选中行底色。亮色主题用强调色淡底(<c>#AARRGGBB</c>),暗色用中性提亮色。</summary>
+    public required string BgActive { get; init; }
+
+    /// <summary>悬停行底色。</summary>
+    public required string BgHover { get; init; }
+
+    /// <summary>输入框底色。</summary>
+    public required string BgInput { get; init; }
+
+    /// <summary>非活动标签底色。</summary>
+    public required string BgTabInactive { get; init; }
+
+    /// <summary>正文一档:标题与主要内容。</summary>
+    public required string TextPrimary { get; init; }
+
+    /// <summary>正文二档:次要说明。仍须满足 AA(4.5:1)。</summary>
+    public required string TextSecondary { get; init; }
+
+    /// <summary>装饰档:占位符、弱化标签。不承载正文。</summary>
+    public required string TextTertiary { get; init; }
+
+    /// <summary>最弱一档:禁用态、水印。</summary>
+    public required string TextMuted { get; init; }
+
+    /// <summary>分隔线/描边(弱)。</summary>
+    public required string BorderPrimary { get; init; }
+
+    /// <summary>分隔线/描边(强),兼作占用条轨道底。</summary>
+    public required string BorderSecondary { get; init; }
+
+    /// <summary>成功/已连接(绿)。</summary>
+    public required string Success { get; init; }
+
+    /// <summary>警告(暖色,通常偏橙);语义标记 <c>VelaWarning</c>。</summary>
+    public required string Warning { get; init; }
+
+    /// <summary>黄:连接中状态、占用条警戒段、终端黄。与 <see cref="Warning" /> 分开是因为
+    /// 暗色主题里橙(警告)与黄(进行中)是两种语义,亮色主题下二者可以取同一个值。</summary>
+    public required string Yellow { get; init; }
+
+    /// <summary>错误/离线(红)。</summary>
+    public required string Error { get; init; }
+
+    /// <summary>信息(青/蓝):目录名、CPU 占用条、链路追踪线。</summary>
+    public required string Info { get; init; }
+
+    /// <summary>品红/粉:图表第六色与终端 magenta。</summary>
+    public required string Magenta { get; init; }
+
+    /// <summary>文件浏览器的文件夹图标色。</summary>
+    public required string FolderIcon { get; init; }
+
+    /// <summary>链路追踪地图的陆地填充。</summary>
+    public required string TraceLand { get; init; }
+
+    /// <summary>链路追踪地图的国境线(必须比陆地明显亮/暗一档,否则看不出分界)。</summary>
+    public required string TraceBorder { get; init; }
+}
+
+/// <summary>
+/// 一套完整的界面主题:配色种子 + 明暗基底 + 配套的终端配色方案。
+/// </summary>
+/// <param name="Id">持久化标识,写进 <c>AppSettings.Theme</c>。<c>dark</c> / <c>light</c>
+/// 两个 Id 沿用历史值,老配置无需迁移。</param>
+/// <param name="Name">显示名(品牌名,不本地化)。</param>
+/// <param name="IsDark">基底明暗。决定 Avalonia 的 <c>ThemeVariant</c>,Fluent 控件与投影浓度跟着它走。</param>
+/// <param name="TerminalSchemeName">配套终端配色方案名,须存在于 <see cref="TerminalColorScheme.BuiltIn" />;
+/// 其背景色必须等于 <see cref="UiThemePalette.BgTerminal" /> —— 终端画面与界面是同一个平面,
+/// 差一档就会看出一道拼缝。</param>
+/// <param name="Palette">配色种子。</param>
+public sealed record UiTheme(
+    string Id,
+    string Name,
+    bool IsDark,
+    string TerminalSchemeName,
+    UiThemePalette Palette)
+{
+    /// <summary>配套的终端配色方案(按 <see cref="TerminalSchemeName" /> 从内置表取)。</summary>
+    public TerminalColorScheme Terminal =>
+        Array.Find(TerminalColorScheme.BuiltIn, scheme => scheme.Name == TerminalSchemeName)
+        ?? TerminalColorScheme.BuiltIn[0];
+}
+
+/// <summary>
+/// 内置界面主题目录。<c>AppSettings.Theme</c> 存的是这里的 <see cref="UiTheme.Id" />,
+/// 外加一个不在目录里的特殊值 <see cref="SystemThemeId" />(跟随系统明暗)。
+/// </summary>
+public static class UiThemeCatalog
+{
+    /// <summary>“跟随系统”的伪主题 Id:按操作系统明暗落到 <see cref="DefaultDark" /> / <see cref="DefaultLight" />。</summary>
+    public const string SystemThemeId = "system";
+
+    /// <summary>全部内置主题,顺序即设置页下拉的顺序(暗色在前、亮色在后)。</summary>
+    public static readonly UiTheme[] All =
+    [
+        // ——— 暗色 ———————————————————————————————————————————————————————
+        new("dark", "VelaDark", true, "Dracula", new UiThemePalette
+        {
+            // Dracula 正典:出厂默认,色值与 1.x 起的历史版本逐一致。
+            Accent = "#BD93F9", AccentForeground = "#0A0E14",
+            BgPage = "#191A21", BgSidebar = "#252734", BgTerminal = "#282A36", BgSurface = "#343746",
+            BgActive = "#44475A", BgHover = "#363948", BgInput = "#282A36", BgTabInactive = "#191A21",
+            TextPrimary = "#F8F8F2", TextSecondary = "#B0B8D6", TextTertiary = "#6272A4", TextMuted = "#545B76",
+            BorderPrimary = "#3B3E51", BorderSecondary = "#44475A",
+            Success = "#50FA7B", Warning = "#FFB86C", Yellow = "#F1FA8C", Error = "#FF5555",
+            Info = "#8BE9FD", Magenta = "#FF79C6", FolderIcon = "#FFB86C",
+            TraceLand = "#333850", TraceBorder = "#5C6488",
+        }),
+        new("tokyo-night", "Tokyo Night", true, "Tokyo Night", new UiThemePalette
+        {
+            // Tokyo Night 血统:深蓝夜景,强调色是蓝而不是紫,长时间盯屏最不刺眼的一档。
+            Accent = "#7AA2F7", AccentForeground = "#0B0E16",
+            BgPage = "#15161E", BgSidebar = "#1A1B26", BgTerminal = "#1A1B26", BgSurface = "#24283B",
+            BgActive = "#2C3A63", BgHover = "#2A2E45", BgInput = "#1F2335", BgTabInactive = "#15161E",
+            TextPrimary = "#C0CAF5", TextSecondary = "#A9B1D6", TextTertiary = "#7A84B0", TextMuted = "#565F89",
+            BorderPrimary = "#2A2F45", BorderSecondary = "#3B4261",
+            Success = "#9ECE6A", Warning = "#FF9E64", Yellow = "#E0AF68", Error = "#F7768E",
+            Info = "#7DCFFF", Magenta = "#BB9AF7", FolderIcon = "#FF9E64",
+            TraceLand = "#2A2F4A", TraceBorder = "#4A5480",
+        }),
+        new("nord", "Nord", true, "Nord", new UiThemePalette
+        {
+            // Nord 血统:低饱和的极地蓝灰,冷静、对比温和。红色按 Nord 原色(#BF616A)压在
+            // 面板底上只有 2.5:1,状态标签会读不出来,故提亮到 #D4757F。
+            Accent = "#88C0D0", AccentForeground = "#1F242E",
+            BgPage = "#242933", BgSidebar = "#2B313C", BgTerminal = "#2E3440", BgSurface = "#3B4252",
+            BgActive = "#4C566A", BgHover = "#3E4658", BgInput = "#2E3440", BgTabInactive = "#242933",
+            TextPrimary = "#ECEFF4", TextSecondary = "#D8DEE9", TextTertiary = "#A3ACBD", TextMuted = "#7B8494",
+            BorderPrimary = "#434B5C", BorderSecondary = "#4C566A",
+            Success = "#A3BE8C", Warning = "#D08770", Yellow = "#EBCB8B", Error = "#D4757F",
+            Info = "#81A1C1", Magenta = "#B48EAD", FolderIcon = "#D08770",
+            TraceLand = "#3B4252", TraceBorder = "#5A657B",
+        }),
+        new("everforest", "Everforest", true, "Everforest Dark", new UiThemePalette
+        {
+            // Everforest 血统:低对比的墨绿与暖灰,强调色取绿、成功色取青绿,
+            // 两者分开才不会让"已连接"的圆点与强调色糊成一个颜色。
+            Accent = "#A7C080", AccentForeground = "#1E2529",
+            BgPage = "#232A2E", BgSidebar = "#2A3238", BgTerminal = "#2D353B", BgSurface = "#343F44",
+            BgActive = "#414D52", BgHover = "#3A464B", BgInput = "#2D353B", BgTabInactive = "#232A2E",
+            TextPrimary = "#D3C6AA", TextSecondary = "#B9C0AB", TextTertiary = "#9DA9A0", TextMuted = "#7A8478",
+            BorderPrimary = "#3D484D", BorderSecondary = "#4F585E",
+            Success = "#83C092", Warning = "#E69875", Yellow = "#DBBC7F", Error = "#E67E80",
+            Info = "#7FBBB3", Magenta = "#D699B6", FolderIcon = "#E69875",
+            TraceLand = "#3D484D", TraceBorder = "#62706F",
+        }),
+        new("obsidian", "Obsidian", true, "Obsidian", new UiThemePalette
+        {
+            // 中性近黑 + 高饱和青:OLED 屏省电、暗房里最不发光的一档,
+            // 也是唯一一套底色不带色相的暗色主题(其余几套的底都偏蓝/绿/棕)。
+            Accent = "#22D3EE", AccentForeground = "#071013",
+            BgPage = "#0A0A0C", BgSidebar = "#111114", BgTerminal = "#131316", BgSurface = "#1B1B20",
+            BgActive = "#2E2E38", BgHover = "#212128", BgInput = "#131316", BgTabInactive = "#0A0A0C",
+            TextPrimary = "#E7E7EA", TextSecondary = "#C2C2CB", TextTertiary = "#8A8A96", TextMuted = "#6A6A76",
+            BorderPrimary = "#26262E", BorderSecondary = "#34343F",
+            Success = "#4ADE80", Warning = "#FB923C", Yellow = "#FACC15", Error = "#F87171",
+            Info = "#38BDF8", Magenta = "#E879F9", FolderIcon = "#FB923C",
+            TraceLand = "#1F1F26", TraceBorder = "#3C3C48",
+        }),
+        new("gruvbox", "Gruvbox", true, "Gruvbox Bright", new UiThemePalette
+        {
+            // Gruvbox 血统:暖棕底 + 琥珀强调,是唯一一套暖色暗色主题;
+            // 夜间与暖色屏幕滤镜(Night Shift / 护眼模式)叠加时不会发脏。
+            Accent = "#FE8019", AccentForeground = "#1D2021",
+            BgPage = "#1D2021", BgSidebar = "#252424", BgTerminal = "#282828", BgSurface = "#32302F",
+            BgActive = "#504945", BgHover = "#3A3735", BgInput = "#282828", BgTabInactive = "#1D2021",
+            TextPrimary = "#EBDBB2", TextSecondary = "#D5C4A1", TextTertiary = "#A89984", TextMuted = "#7C6F64",
+            BorderPrimary = "#3C3836", BorderSecondary = "#504945",
+            Success = "#B8BB26", Warning = "#FE8019", Yellow = "#FABD2F", Error = "#FB4934",
+            Info = "#83A598", Magenta = "#D3869B", FolderIcon = "#FABD2F",
+            TraceLand = "#3C3836", TraceBorder = "#665C54",
+        }),
+        // ——— 亮色 ———————————————————————————————————————————————————————
+        new("light", "VelaLight", false, "Alucard", new UiThemePalette
+        {
+            // Alucard(Dracula 官方亮色)正典:奶油底,与 VelaDark 同源,切明暗不换性格。
+            Accent = "#644AC9", AccentForeground = "#FFFBEB",
+            BgPage = "#F2EDDA", BgSidebar = "#F8F4E4", BgTerminal = "#FFFBEB", BgSurface = "#FFFBEB",
+            BgActive = "#22644AC9", BgHover = "#EDE7D0", BgInput = "#F7F2DF", BgTabInactive = "#EBE5CC",
+            TextPrimary = "#1F1F1F", TextSecondary = "#4A4636", TextTertiary = "#6C664B", TextMuted = "#9A9377",
+            BorderPrimary = "#E3DCBF", BorderSecondary = "#D3CBA9",
+            Success = "#14710A", Warning = "#846E15", Yellow = "#846E15", Error = "#CB3A2A",
+            Info = "#036A96", Magenta = "#A3144D", FolderIcon = "#9E841A",
+            TraceLand = "#EFE9D2", TraceBorder = "#BDB392",
+        }),
+        new("rose-pine-dawn", "Rosé Pine Dawn", false, "Rosé Pine Dawn", new UiThemePalette
+        {
+            // Rosé Pine Dawn 血统:玫瑰灰暖底、鸢尾紫强调。原版 iris(#907AA9)压白底只有
+            // 3.7:1,按钮上的文字读不出来,故压深到 #7C5F9F;绿色是原版没有的,补一支
+            // 与之同调的森林绿 —— 没有绿,ls 的目录/可执行位就分不开。
+            Accent = "#7C5F9F", AccentForeground = "#FFFAF3",
+            BgPage = "#F2E9E1", BgSidebar = "#FAF4ED", BgTerminal = "#FFFAF3", BgSurface = "#FFFAF3",
+            BgActive = "#247C5F9F", BgHover = "#F2E9E1", BgInput = "#FDF8F1", BgTabInactive = "#E9DED5",
+            TextPrimary = "#575279", TextSecondary = "#635D82", TextTertiary = "#797593", TextMuted = "#9893A5",
+            BorderPrimary = "#E6DCD4", BorderSecondary = "#D6C9C0",
+            Success = "#3E7A54", Warning = "#9A6A12", Yellow = "#9A6A12", Error = "#A5445F",
+            Info = "#286983", Magenta = "#8A4E76", FolderIcon = "#B07415",
+            TraceLand = "#F0E7DF", TraceBorder = "#C9BBB2",
+        }),
+        new("github-light", "GitHub Light", false, "GitHub Light", new UiThemePalette
+        {
+            // 中性冷白:纯白纸面 + 克制的蓝强调,是唯一一套底色不带暖调的亮色主题,
+            // 白天强光下最好读,截图贴进文档里也不会跟文档底色打架。
+            Accent = "#0969DA", AccentForeground = "#FFFFFF",
+            BgPage = "#EEF1F4", BgSidebar = "#F6F8FA", BgTerminal = "#FFFFFF", BgSurface = "#FFFFFF",
+            BgActive = "#1A0969DA", BgHover = "#EEF1F4", BgInput = "#FBFCFD", BgTabInactive = "#E6EAEF",
+            TextPrimary = "#1F2328", TextSecondary = "#424A53", TextTertiary = "#656D76", TextMuted = "#8C959F",
+            BorderPrimary = "#D8DEE4", BorderSecondary = "#C4CCD4",
+            Success = "#1A7F37", Warning = "#9A6700", Yellow = "#9A6700", Error = "#CF222E",
+            Info = "#1B7C83", Magenta = "#8250DF", FolderIcon = "#9A6700",
+            TraceLand = "#EAEEF2", TraceBorder = "#C4CDD5",
+        }),
+    ];
+
+    /// <summary>跟随系统时的暗色落点。</summary>
+    public static UiTheme DefaultDark => Get("dark");
+
+    /// <summary>跟随系统时的亮色落点。</summary>
+    public static UiTheme DefaultLight => Get("light");
+
+    /// <summary>设置页主题下拉的可选值:全部主题 Id + <see cref="SystemThemeId" />(置末)。</summary>
+    public static string[] SelectableIds { get; } = [.. All.Select(theme => theme.Id), SystemThemeId];
+
+    /// <summary><paramref name="id" /> 是否为可持久化的主题值(含“跟随系统”)。</summary>
+    public static bool IsValidId(string? id) =>
+        !string.IsNullOrWhiteSpace(id)
+        && SelectableIds.Contains(id.Trim(), StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>按 Id 取主题;不存在时返回 <see cref="DefaultDark" />。</summary>
+    public static UiTheme Get(string? id) => Find(id) ?? All[0];
+
+    /// <summary>按 Id 取主题;不存在(含“跟随系统”)时返回 null。</summary>
+    public static UiTheme? Find(string? id) =>
+        string.IsNullOrWhiteSpace(id)
+            ? null
+            : Array.Find(All, theme => string.Equals(theme.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// 把持久化的主题值解析为一套实际生效的配色:“跟随系统”按
+    /// <paramref name="systemPrefersDark" /> 落到默认暗/亮主题,未知值一律落到默认暗色。
+    /// </summary>
+    public static UiTheme Resolve(string? id, bool systemPrefersDark) =>
+        Find(id) ?? (systemPrefersDark ? DefaultDark : DefaultLight);
+
+    /// <summary>
+    /// 主题值对外的明暗名("dark" / "light" / "system")。插件契约里的
+    /// <c>IHostInfo.Theme</c> 只认这三个值,新增的具名主题不能直接漏给插件。
+    /// </summary>
+    public static string VariantName(string? id) =>
+        Find(id) is { } theme ? (theme.IsDark ? "dark" : "light") : SystemThemeId;
+}

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -1764,17 +1764,11 @@
   <data name="SetAppear_TerminalColorsSection" xml:space="preserve">
     <value>ターミナルの配色</value>
   </data>
-  <data name="SetAppear_ThemeDark" xml:space="preserve">
-    <value>ダークモード</value>
-  </data>
-  <data name="SetAppear_ThemeLight" xml:space="preserve">
-    <value>ライトモード</value>
-  </data>
   <data name="SetAppear_ThemeMode" xml:space="preserve">
     <value>テーマモード</value>
   </data>
   <data name="SetAppear_ThemeModeDesc" xml:space="preserve">
-    <value>// ライト、ダーク、またはシステムに従うを選択</value>
+    <value>// 名前付きテーマを選ぶか、システムに従います</value>
   </data>
   <data name="SetAppear_ThemeSystem" xml:space="preserve">
     <value>システムに従う</value>
@@ -2597,6 +2591,9 @@
   </data>
   <data name="SetTransfer_ZeroUnlimited" xml:space="preserve">
     <value>// 0 は無制限</value>
+  </data>
+  <data name="SetVm_FollowThemeScheme" xml:space="preserve">
+    <value>テーマに従う({0})</value>
   </data>
   <data name="SetVm_DefaultSuffix" xml:space="preserve">
     <value>(デフォルト)</value>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -1764,17 +1764,11 @@
   <data name="SetAppear_TerminalColorsSection" xml:space="preserve">
     <value>터미널 색상</value>
   </data>
-  <data name="SetAppear_ThemeDark" xml:space="preserve">
-    <value>다크 모드</value>
-  </data>
-  <data name="SetAppear_ThemeLight" xml:space="preserve">
-    <value>라이트 모드</value>
-  </data>
   <data name="SetAppear_ThemeMode" xml:space="preserve">
     <value>테마 모드</value>
   </data>
   <data name="SetAppear_ThemeModeDesc" xml:space="preserve">
-    <value>// 라이트, 다크 또는 시스템 따르기 선택</value>
+    <value>// 이름이 있는 테마를 선택하거나 시스템을 따릅니다</value>
   </data>
   <data name="SetAppear_ThemeSystem" xml:space="preserve">
     <value>시스템 따르기</value>
@@ -2597,6 +2591,9 @@
   </data>
   <data name="SetTransfer_ZeroUnlimited" xml:space="preserve">
     <value>// 0은 무제한</value>
+  </data>
+  <data name="SetVm_FollowThemeScheme" xml:space="preserve">
+    <value>테마 따르기({0})</value>
   </data>
   <data name="SetVm_DefaultSuffix" xml:space="preserve">
     <value>(기본값)</value>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1867,17 +1867,11 @@ Paste anyway?</value>
   <data name="SetAppear_TerminalColorsSection" xml:space="preserve">
     <value>Terminal Colors</value>
   </data>
-  <data name="SetAppear_ThemeDark" xml:space="preserve">
-    <value>Dark</value>
-  </data>
-  <data name="SetAppear_ThemeLight" xml:space="preserve">
-    <value>Light</value>
-  </data>
   <data name="SetAppear_ThemeMode" xml:space="preserve">
     <value>Theme mode</value>
   </data>
   <data name="SetAppear_ThemeModeDesc" xml:space="preserve">
-    <value>// Choose light, dark, or follow system</value>
+    <value>// Pick a named theme, or follow the system</value>
   </data>
   <data name="SetAppear_ThemeSystem" xml:space="preserve">
     <value>Follow system</value>
@@ -2697,6 +2691,9 @@ Paste anyway?</value>
   </data>
   <data name="SetTransfer_ZeroUnlimited" xml:space="preserve">
     <value>// 0 means unlimited</value>
+  </data>
+  <data name="SetVm_FollowThemeScheme" xml:space="preserve">
+    <value>Follow theme ({0})</value>
   </data>
   <data name="SetVm_DefaultSuffix" xml:space="preserve">
     <value>(default)</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1978,17 +1978,11 @@
   <data name="SetAppear_TerminalColorsSection" xml:space="preserve">
     <value>终端颜色</value>
   </data>
-  <data name="SetAppear_ThemeDark" xml:space="preserve">
-    <value>暗色模式</value>
-  </data>
-  <data name="SetAppear_ThemeLight" xml:space="preserve">
-    <value>亮色模式</value>
-  </data>
   <data name="SetAppear_ThemeMode" xml:space="preserve">
     <value>主题模式</value>
   </data>
   <data name="SetAppear_ThemeModeDesc" xml:space="preserve">
-    <value>// 选择亮色、暗色或跟随系统</value>
+    <value>// 选择一套具名主题,或跟随系统明暗</value>
   </data>
   <data name="SetAppear_ThemeSystem" xml:space="preserve">
     <value>跟随系统</value>
@@ -2808,6 +2802,9 @@
   </data>
   <data name="SetTransfer_ZeroUnlimited" xml:space="preserve">
     <value>// 0 表示不限制</value>
+  </data>
+  <data name="SetVm_FollowThemeScheme" xml:space="preserve">
+    <value>跟随主题({0})</value>
   </data>
   <data name="SetVm_DefaultSuffix" xml:space="preserve">
     <value>(默认)</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1978,17 +1978,11 @@
   <data name="SetAppear_TerminalColorsSection" xml:space="preserve">
     <value>終端機色彩</value>
   </data>
-  <data name="SetAppear_ThemeDark" xml:space="preserve">
-    <value>暗色模式</value>
-  </data>
-  <data name="SetAppear_ThemeLight" xml:space="preserve">
-    <value>亮色模式</value>
-  </data>
   <data name="SetAppear_ThemeMode" xml:space="preserve">
     <value>主題模式</value>
   </data>
   <data name="SetAppear_ThemeModeDesc" xml:space="preserve">
-    <value>// 選擇亮色、暗色或跟隨系統</value>
+    <value>// 選擇一套具名主題,或跟隨系統明暗</value>
   </data>
   <data name="SetAppear_ThemeSystem" xml:space="preserve">
     <value>跟隨系統</value>
@@ -2808,6 +2802,9 @@
   </data>
   <data name="SetTransfer_ZeroUnlimited" xml:space="preserve">
     <value>// 0 表示不限制</value>
+  </data>
+  <data name="SetVm_FollowThemeScheme" xml:space="preserve">
+    <value>跟隨主題({0})</value>
   </data>
   <data name="SetVm_DefaultSuffix" xml:space="preserve">
     <value>(預設)</value>

--- a/src/VelaShell.Core/Services/ThemeService.cs
+++ b/src/VelaShell.Core/Services/ThemeService.cs
@@ -1,17 +1,21 @@
+using VelaShell.Core.Models;
+
 namespace VelaShell.Core.Services;
 
 /// <summary>
-/// <see cref="IThemeService"/> 的默认实现,跟踪当前活动主题("dark"、"light" 或 "system")
-/// 与可选的强调色,任一方更新时抛出变更事件。
+/// <see cref="IThemeService"/> 的默认实现,跟踪当前活动主题(<see cref="UiThemeCatalog" />
+/// 里的主题 Id,或 "system" = 跟随系统)与可选的强调色,任一方更新时抛出变更事件。
 /// </summary>
 public class ThemeService(string initialTheme = "dark", string? initialAccent = null) : IThemeService
 {
-    private static readonly HashSet<string> ValidThemes = [with(StringComparer.OrdinalIgnoreCase), "dark", "light", "system"];
-
     /// <summary>
-    /// 当前活动的主题名称("dark"、"light" 或 "system")。
+    /// 当前活动的主题 Id("dark"、"light"、"tokyo-night"…,或 "system")。
+    /// <para>
+    /// "dark" / "light" 是 VelaDark / VelaLight 的 Id —— 历史值,老配置直接沿用,不做迁移。
+    /// </para>
     /// </summary>
-    public string CurrentTheme { get; private set; } = ValidThemes.Contains(initialTheme) ? initialTheme.ToLowerInvariant() : "dark";
+    public string CurrentTheme { get; private set; } =
+        UiThemeCatalog.IsValidId(initialTheme) ? initialTheme.ToLowerInvariant() : "dark";
 
     /// <summary>
     /// 活动主题变更时触发,携带新的主题名称。
@@ -50,9 +54,11 @@ public class ThemeService(string initialTheme = "dark", string? initialAccent = 
     public void SetTheme(string themeName)
     {
         string normalized = themeName.ToLowerInvariant();
-        if (!ValidThemes.Contains(normalized))
+        if (!UiThemeCatalog.IsValidId(normalized))
         {
-            throw new ArgumentException($@"Invalid theme: '{themeName}'. Valid themes: dark, light, system.", nameof(themeName));
+            throw new ArgumentException(
+                $@"Invalid theme: '{themeName}'. Valid themes: {string.Join(", ", UiThemeCatalog.SelectableIds)}.",
+                nameof(themeName));
         }
         if (CurrentTheme == normalized)
         {

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/HostInfoCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/HostInfoCapability.cs
@@ -14,5 +14,6 @@ internal sealed class HostInfoCapability(string appVersion, IThemeService? theme
 
     public string Locale => localization?.CurrentLanguage ?? "en";
 
-    public string Theme => theme?.CurrentTheme ?? "system";
+    // 具名主题不外泄:插件只认 dark / light / system(见 PluginEventHub 的同一处处理)。
+    public string Theme => VelaShell.Core.Models.UiThemeCatalog.VariantName(theme?.CurrentTheme);
 }

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/PluginEventHub.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/PluginEventHub.cs
@@ -39,7 +39,9 @@ internal sealed class PluginEventHub : IHostEvents, IDisposable
         _localization = localization;
         _onConnected = session => Forward(SessionConnected, SessionsCapability.Map(session));
         _onDisconnected = session => Forward(SessionDisconnected, SessionsCapability.Map(session));
-        _onThemeChanged = themeName => Forward(ThemeChanged, themeName);
+        // 插件契约里的主题只有 dark / light / system 三个值:具名主题(Tokyo Night…)
+        // 不能直接漏给插件 —— 插件拿到一个没见过的字符串,多半会落到自己的兜底分支上。
+        _onThemeChanged = themeName => Forward(ThemeChanged, Core.Models.UiThemeCatalog.VariantName(themeName));
         _onLanguageChanged = language => Forward(LocaleChanged, language);
         if (_connections is not null)
         {

--- a/src/VelaShell.Terminal/Rendering/TerminalPaletteOverrides.cs
+++ b/src/VelaShell.Terminal/Rendering/TerminalPaletteOverrides.cs
@@ -36,7 +36,10 @@ public sealed class TerminalPaletteOverrides
             {
                 return false;
             }
-            return Ansi.Length == 0;
+            // 曾经写的是 Ansi.Length == 0 —— 数组恒为 16 个槽位,于是 IsEmpty 恒为 false,
+            // "一色未改"也会被当成有覆盖。叠加一份全 null 的覆盖不改变画面,所以从没露头;
+            // 但它使"跟随主题"与"钉死配色"这两种状态在外部看来无从区分。
+            return Array.TrueForAll(Ansi, color => color is null);
         }
     }
 }

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -467,6 +467,24 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     }
 
     /// <summary>
+    /// 当前界面主题配套的**整套**终端配色(前景/背景/光标/选区 + ANSI 16 色),由宿主随
+    /// 主题切换下发。null = 用控件自带的明暗缺省。
+    /// <para>
+    /// 为什么不能只看 <see cref="Avalonia.Styling.ThemeVariant" />:具名主题里有五套暗色、
+    /// 四套亮色,VelaDark 换到 Tokyo Night 时变体根本没变,控件无从得知该换配色。
+    /// </para>
+    /// </summary>
+    public TerminalPaletteOverrides? ThemePalette
+    {
+        get;
+        set
+        {
+            field = value;
+            ApplyThemePalette();
+        }
+    }
+
+    /// <summary>
     /// 用户自定义终端配色(设置 → 外观 → 终端颜色/ANSI 调色板):只包含用户实际
     /// 改过的颜色,叠加在主题调色板之上;null 或空对象 = 完全跟随主题。
     /// </summary>
@@ -728,14 +746,19 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
 
     private void ApplyThemePalette()
     {
+        // 三层叠加,后者盖前者:
+        //   ① 控件自带的明暗缺省(宿主没下发主题配色时的兜底,也是 headless 测试看到的那套)
+        //   ② 当前界面主题配套的整套终端配色(宿主按具名主题下发)
+        //   ③ 用户在设置里改过的单色(稀疏覆盖)
         ApplyDesignPalette(Emulator.Palette, ActualThemeVariant == ThemeVariant.Light);
-        ApplyPaletteOverrides(Emulator.Palette);
+        ApplyPaletteOverrides(Emulator.Palette, ThemePalette);
+        ApplyPaletteOverrides(Emulator.Palette, PaletteOverrides);
         InvalidateTerminal();
     }
 
-    private void ApplyPaletteOverrides(TerminalPalette palette)
+    private static void ApplyPaletteOverrides(TerminalPalette palette, TerminalPaletteOverrides? overrides)
     {
-        if (PaletteOverrides is not { } o)
+        if (overrides is not { } o)
         {
             return;
         }
@@ -872,6 +895,9 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     }
 
     /// <summary>本控件正文(不含叠加层)的累计渲染次数,仅供 headless 测试断言重绘范围。</summary>
+    /// <summary>当前生效的调色板(主题底 + 用户覆盖叠加后的结果),供叠加顺序的用例断言。</summary>
+    internal TerminalPalette PaletteForTest => Emulator.Palette;
+
     internal int BodyRenderCountForTest { get; private set; }
 
     /// <summary>光标/幽灵叠加层的累计渲染次数,仅供 headless 测试断言重绘范围。</summary>

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -133,6 +133,15 @@ public class App : Application
             });
         _themeService.ThemeChanged += OnThemeChanged;
         _themeService.AccentChanged += ApplyAccent;
+        // 「跟随系统」下系统明暗翻转时,基底变体由 Avalonia 自己换,但令牌得我们重贴 ——
+        // 不贴的话界面会停在上一套配色上,只有 Fluent 控件跟着变,看上去像半边换了主题。
+        ActualThemeVariantChanged += (_, _) =>
+        {
+            if (UiThemeCatalog.Find(_themeService?.CurrentTheme) is null)
+            {
+                ApplyThemeTokens();
+            }
+        };
         ApplyThemeVariant(_themeService.CurrentTheme);
         ApplyAccent(_themeService.AccentColor);
     }
@@ -431,7 +440,10 @@ public class App : Application
             _serviceProvider
                 .GetRequiredService<ILocalizationService>()
                 .SetLanguage(settings.Language);
-            if (!string.IsNullOrWhiteSpace(settings.Theme))
+            // 先验再设:配置里存着一个本版本不认识的主题 Id 时(用新版选过 Tokyo Night
+            // 再退回旧版就是这个情形),SetTheme 会抛,连带把后面的强调色一起跳过。
+            // 认不出来就退回默认主题,启动照常。
+            if (UiThemeCatalog.IsValidId(settings.Theme))
             {
                 _themeService?.SetTheme(settings.Theme);
             }
@@ -480,14 +492,34 @@ public class App : Application
         ApplyThemeVariant(themeName);
     }
 
+    /// <summary>
+    /// 应用一套具名主题:先定明暗基底(Fluent 控件与 axaml 里的 ThemeDictionaries 跟着它走),
+    /// 再把该主题的整套 <c>Vela*</c> 令牌写到应用级资源上遮蔽掉基底的缺省值。
+    /// <para>
+    /// "system" 不是一套配色,而是"按系统明暗落到 VelaDark / VelaLight":
+    /// 此时基底交给 <see cref="ThemeVariant.Default" />,令牌按解析结果贴。
+    /// </para>
+    /// </summary>
     private void ApplyThemeVariant(string themeName)
     {
-        RequestedThemeVariant = themeName.ToLowerInvariant() switch
-        {
-            "light" => ThemeVariant.Light,
-            "system" => ThemeVariant.Default,
-            _ => ThemeVariant.Dark,
-        };
+        UiTheme? selected = UiThemeCatalog.Find(themeName);
+        RequestedThemeVariant = selected is null
+            ? ThemeVariant.Default
+            : selected.IsDark
+                ? ThemeVariant.Dark
+                : ThemeVariant.Light;
+        ApplyThemeTokens();
+    }
+
+    /// <summary>当前实际生效的主题:“跟随系统”按应用的实际变体落到 VelaDark / VelaLight。</summary>
+    private UiTheme CurrentUiTheme =>
+        UiThemeCatalog.Resolve(_themeService?.CurrentTheme, ActualThemeVariant != ThemeVariant.Light);
+
+    /// <summary>把当前主题的令牌贴到应用资源;强调色覆盖必须随后重贴,否则被主题的 accent 盖掉。</summary>
+    private void ApplyThemeTokens()
+    {
+        ThemeTokenApplier.Apply(Resources, CurrentUiTheme);
+        ApplyAccent(_themeService?.AccentColor);
     }
 
     /// <summary>
@@ -499,9 +531,10 @@ public class App : Application
     {
         if (string.IsNullOrWhiteSpace(hex))
         {
-            Resources.Remove("VelaAccent");
-            Resources.Remove("VelaAccentDim");
-            Resources.Remove("VelaAccentForeground");
+            // 回到当前主题自己的强调色。**不能删键** —— 删了会掉到 axaml 的编译期缺省
+            // (VelaDark / VelaLight 的紫),Tokyo Night 之类的主题就会顶着一个不属于
+            // 自己的强调色跑。
+            ThemeTokenApplier.ResetAccent(Resources, CurrentUiTheme);
             return;
         }
         if (!Color.TryParse(hex, out Color color))

--- a/src/VelaShell/Services/TerminalAppearanceMapper.cs
+++ b/src/VelaShell/Services/TerminalAppearanceMapper.cs
@@ -6,55 +6,82 @@ using VelaShell.Terminal.Rendering;
 namespace VelaShell.Services;
 
 /// <summary>
-/// 把设置 → 外观 的终端配色映射成渲染层的稀疏覆盖集:只有与出厂默认(Dracula)不同的
-/// 颜色才会生效覆盖,未改过的槽位保持 null,让终端继续跟随应用主题
-/// (暗 = Dracula / 亮 = Solarized Light)。
+/// 把设置 → 外观 的终端配色映射成渲染层的调色板。两层:
+/// <list type="number">
+/// <item>主题给的底 —— 当前具名主题配套的那套终端方案(<see cref="UiTheme.TerminalSchemeName" />),
+/// 由 <see cref="BuildThemePalette" /> 摊成整套下发。</item>
+/// <item>用户的配色 —— 由 <see cref="BuildPaletteOverrides" /> 叠在底上。
+/// 处于「跟随主题」时返回 null(一个槽位都不覆盖);用户选了具体方案就整套覆盖。</item>
+/// </list>
 /// </summary>
 public static class TerminalAppearanceMapper
 {
-    private static readonly AppearanceOptions Defaults = new();
+    /// <summary>
+    /// 把一套终端配色方案摊成**整套**(每个槽位都有值)的调色板,供宿主随主题下发到终端控件。
+    /// </summary>
+    public static TerminalPaletteOverrides BuildThemePalette(TerminalColorScheme scheme)
+    {
+        ArgumentNullException.ThrowIfNull(scheme);
+        return BuildPalette(
+            scheme.Foreground, scheme.Background, scheme.Cursor, scheme.Selection,
+            scheme.AnsiNormal, scheme.AnsiBright);
+    }
 
-    /// <summary>把外观配色映射为渲染层的稀疏覆盖集;全部与默认一致时返回 null。</summary>
+    /// <summary>
+    /// 把用户设置里的终端配色映射为叠在主题配色之上的覆盖集;跟随主题时返回 null。
+    /// <para>
+    /// <b>为什么是整套覆盖、而不是与出厂默认逐色做差</b>:做差的老实现把「跟随主题」隐式编码成
+    /// 「颜色与出厂 Dracula 一致」,于是用户明确选中 Dracula 时算出来的覆盖是空的 ——
+    /// 在配套方案不是 Dracula 的主题上,选 Dracula 毫无反应,终端仍是主题自带的那套。
+    /// 跟随与否现在由 <see cref="AppearanceOptions.TerminalColorsFollowTheme" /> 明确表态,
+    /// 一旦不跟随,用户在设置页上看到的那套颜色就是终端要用的那套,原样下发。
+    /// </para>
+    /// </summary>
     public static TerminalPaletteOverrides? BuildPaletteOverrides(AppearanceOptions appearance)
     {
-        var overrides = new TerminalPaletteOverrides
-        {
-            Foreground = DiffColor(appearance.TerminalForeground, Defaults.TerminalForeground),
-            Background = DiffColor(appearance.TerminalBackground, Defaults.TerminalBackground),
-            Cursor = DiffColor(appearance.CursorColor, Defaults.CursorColor),
-            Selection = DiffColor(appearance.SelectionColor, Defaults.SelectionColor)
-        };
-        FillAnsi(overrides, appearance.AnsiNormal, Defaults.AnsiNormal, 0);
-        FillAnsi(overrides, appearance.AnsiBright, Defaults.AnsiBright, 8);
-        return overrides.IsEmpty ? null : overrides;
-    }
-
-    private static void FillAnsi(TerminalPaletteOverrides overrides,
-        List<string>? values,
-        List<string> defaults,
-        int offset)
-    {
-        if (values is null)
-        {
-            return;
-        }
-        for (int i = 0; i < 8 && i < values.Count; i++)
-        {
-            string def = i < defaults.Count ? defaults[i] : string.Empty;
-            overrides.Ansi[offset + i] = DiffColor(values[i], def);
-        }
-    }
-
-    /// <summary>与默认一致(忽略大小写/空白)→ null;否则解析成 Rgba,解析失败也返回 null。</summary>
-    private static Rgba? DiffColor(string? value, string defaultValue)
-    {
-        string? trimmed = value?.Trim();
-        if (string.IsNullOrEmpty(trimmed) || string.Equals(trimmed, defaultValue, StringComparison.OrdinalIgnoreCase))
+        ArgumentNullException.ThrowIfNull(appearance);
+        if (TerminalColorScheme.FollowsTheme(appearance))
         {
             return null;
         }
-        return TryParseHex(trimmed, out Rgba color) ? color : null;
+        TerminalPaletteOverrides overrides = BuildPalette(
+            appearance.TerminalForeground, appearance.TerminalBackground,
+            appearance.CursorColor, appearance.SelectionColor,
+            appearance.AnsiNormal, appearance.AnsiBright);
+        // 全空只可能出现在配色被写坏(色值全部解析失败)的配置上:那种情况下退回跟随主题,
+        // 总比让终端顶着一屏解析失败的空槽位强。
+        return overrides.IsEmpty ? null : overrides;
     }
+
+    private static TerminalPaletteOverrides BuildPalette(
+        string? foreground,
+        string? background,
+        string? cursor,
+        string? selection,
+        IReadOnlyList<string>? ansiNormal,
+        IReadOnlyList<string>? ansiBright)
+    {
+        var palette = new TerminalPaletteOverrides
+        {
+            Foreground = ParseOrNull(foreground),
+            Background = ParseOrNull(background),
+            Cursor = ParseOrNull(cursor),
+            Selection = ParseOrNull(selection)
+        };
+        for (int i = 0; i < 8; i++)
+        {
+            palette.Ansi[i] = ParseOrNull(ElementOrNull(ansiNormal, i));
+            palette.Ansi[8 + i] = ParseOrNull(ElementOrNull(ansiBright, i));
+        }
+        return palette;
+    }
+
+    private static string? ElementOrNull(IReadOnlyList<string>? values, int index) =>
+        values is not null && index < values.Count ? values[index] : null;
+
+    /// <summary>解析 <c>#RRGGBB</c>;空值或解析失败返回 null(该槽位继续跟随下层)。</summary>
+    private static Rgba? ParseOrNull(string? hex) =>
+        !string.IsNullOrWhiteSpace(hex) && TryParseHex(hex.Trim(), out Rgba color) ? color : null;
 
     private static bool TryParseHex(string hex, out Rgba color)
     {

--- a/src/VelaShell/Services/ThemeTokenApplier.cs
+++ b/src/VelaShell/Services/ThemeTokenApplier.cs
@@ -1,0 +1,193 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Services;
+
+/// <summary>
+/// 把一套界面主题(<see cref="UiTheme" />)展开成全部 <c>Vela*</c> 令牌,写进应用级资源字典。
+/// <para>
+/// <b>为什么是运行时写资源、而不是每个主题一份 axaml</b>:令牌有六十多个,但真正需要
+/// 逐主题决定的只有 <see cref="UiThemePalette" /> 里那二十几个种子色 —— 其余全是派生
+/// (同色换透明度、同一语义色换用途)。每套主题手抄六十多行,抄错了既不会编译失败也没人
+/// 看得出来;派生出来的令牌天然自洽,新增主题也只需要填种子色。
+/// </para>
+/// <para>
+/// <b>为什么能盖住 axaml 里的值</b>:Avalonia 的资源查找先看字典自身的条目,再看它的
+/// ThemeDictionaries 与合并字典。写进 <c>Application.Resources</c> 顶层的键因此会遮蔽
+/// <c>VelaTokens.axaml</c> / <c>VelaShellTokens.axaml</c> 里同名的主题条目,
+/// 所有 <c>DynamicResource</c> 立刻跟着变 —— 强调色覆盖(#3)一直就是这么做的。
+/// axaml 里的两套仍然保留:它们是 VelaDark / VelaLight 的编译期缺省,
+/// 设计器、headless 测试与本类跑起来之前的那一瞬间靠它们。
+/// </para>
+/// </summary>
+internal static class ThemeTokenApplier
+{
+    /// <summary>本类会写入的全部令牌键(切主题时整套重写,不会留下上一套的残值)。</summary>
+    internal static IReadOnlyList<string> TokenKeys { get; } = [.. BuildTokens(UiThemeCatalog.DefaultDark).Keys];
+
+    /// <summary>把主题的整套令牌写入资源字典;随后调用方需要重新贴一次强调色覆盖。</summary>
+    public static void Apply(IResourceDictionary resources, UiTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+        ArgumentNullException.ThrowIfNull(theme);
+        foreach ((string key, Color color) in BuildTokens(theme))
+        {
+            resources[key] = new SolidColorBrush(color);
+        }
+        // 自绘窗体/浮层的投影:几何两套主题一致,只有不透明度分明暗 —— 同一个 50% 纯黑
+        // 压在亮色卡片下面会糊成一块发脏的矩形(见 DarkTheme.axaml 的说明)。
+        resources["VelaShadowWindow"] = BoxShadows.Parse(
+            theme.IsDark
+                ? "0 1 3 0 #40000000, 0 4 12 0 #66000000"
+                : "0 1 3 0 #1A000000, 0 4 12 0 #33000000");
+    }
+
+    /// <summary>用户自定义强调色会遮蔽的三个令牌(见 <see cref="ResetAccent" />)。</summary>
+    private static readonly string[] AccentKeys =
+        ["VelaAccent", "VelaAccentDim", "VelaAccentForeground"];
+
+    /// <summary>
+    /// 把强调色三件套写回**当前主题自己**的值。用户清空自定义强调色时调用。
+    /// <para>
+    /// 不能改成从资源里把这几个键删掉:删掉会掉到 axaml 的编译期缺省(VelaDark / VelaLight
+    /// 的紫),于是除这两套之外的每一套主题,强调色都会变成不属于它的那个紫。
+    /// </para>
+    /// </summary>
+    public static void ResetAccent(IResourceDictionary resources, UiTheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+        ArgumentNullException.ThrowIfNull(theme);
+        Dictionary<string, Color> tokens = BuildTokens(theme);
+        foreach (string key in AccentKeys)
+        {
+            resources[key] = new SolidColorBrush(tokens[key]);
+        }
+    }
+
+    /// <summary>展开种子色为「令牌键 → 颜色」。派生规则集中在这一处。</summary>
+    private static Dictionary<string, Color> BuildTokens(UiTheme theme)
+    {
+        UiThemePalette p = theme.Palette;
+        bool dark = theme.IsDark;
+
+        Color accent = Parse(p.Accent);
+        Color info = Parse(p.Info);
+        Color success = Parse(p.Success);
+        Color warning = Parse(p.Warning);
+        Color yellow = Parse(p.Yellow);
+        Color error = Parse(p.Error);
+        Color magenta = Parse(p.Magenta);
+        Color textPrimary = Parse(p.TextPrimary);
+        Color textTertiary = Parse(p.TextTertiary);
+        Color bgPage = Parse(p.BgPage);
+        Color bgTerminal = Parse(p.BgTerminal);
+
+        // 图表面积填充的不透明度:亮底上要更淡一档,否则几条曲线糊成一片。
+        byte dim = dark ? (byte)0x38 : (byte)0x28;
+        byte subtleDim = dark ? (byte)0x28 : (byte)0x20;
+
+        return new Dictionary<string, Color>(StringComparer.Ordinal)
+        {
+            // ——— 强调色与文字(VelaTokens.axaml) ———
+            ["VelaAccent"] = accent,
+            ["VelaAccentDim"] = WithAlpha(accent, dark ? (byte)0x30 : (byte)0x1A),
+            ["VelaAccentForeground"] = Parse(p.AccentForeground),
+            ["VelaAccentText"] = accent,
+            ["VelaTextPrimary"] = textPrimary,
+            ["VelaTextSecondary"] = Parse(p.TextSecondary),
+            ["VelaTextTertiary"] = textTertiary,
+            ["VelaTextMuted"] = Parse(p.TextMuted),
+            ["VelaBorderPrimary"] = Parse(p.BorderPrimary),
+            ["VelaBorderSecondary"] = Parse(p.BorderSecondary),
+
+            // ——— 状态与语义 ———
+            ["VelaStatusConnected"] = success,
+            ["VelaStatusConnecting"] = yellow,
+            ["VelaStatusDisconnected"] = error,
+            ["VelaWarning"] = warning,
+            ["VelaError"] = error,
+            ["VelaInfo"] = info,
+
+            // ——— 文件浏览器行(设计 dyuii) ———
+            ["VelaFileFolderIcon"] = Parse(p.FolderIcon),
+            ["VelaFileDirName"] = info,
+
+            // ——— 资源占用条:CPU 与内存用不同色相区分,越界统一转黄/红 ———
+            ["VelaGaugeCpu"] = info,
+            ["VelaGaugeMemory"] = accent,
+            ["VelaGaugeWarn"] = yellow,
+            ["VelaGaugeCritical"] = error,
+            // 轨道必须比它所在的卡片底明显差一档,否则未填充段看不见,
+            // 占用条会变成一颗孤零零的胶囊,读不出"占了多少"。
+            ["VelaGaugeTrack"] = Parse(p.BorderSecondary),
+
+            // ——— 链路追踪地图 ———
+            ["VelaTraceLine"] = info,
+            // 未到达段:把线色按一半掺进窗口底色,压暗但不改色相。
+            ["VelaTraceLineDim"] = Blend(info, bgPage, 0.5),
+            ["VelaTraceLand"] = Parse(p.TraceLand),
+            ["VelaTraceBorder"] = Parse(p.TraceBorder),
+            // 标注底片:压在陆地上也要读得清,取色阶最极端的一端(暗色最深、亮色最浅)。
+            ["VelaTraceLabelBg"] = WithAlpha(dark ? bgPage : bgTerminal, dark ? (byte)0xD2 : (byte)0xE6),
+
+            // ——— 平面底色(VelaShellTokens.axaml) ———
+            ["VelaBgPage"] = bgPage,
+            ["VelaBgSidebar"] = Parse(p.BgSidebar),
+            ["VelaBgTerminal"] = bgTerminal,
+            // SFTP 面板与停靠文档区默认同终端色;单列出来是为了背景图功能可与终端分开调不透明度。
+            ["VelaBgSftpPanel"] = bgTerminal,
+            ["VelaBgDockDocument"] = bgTerminal,
+            ["VelaBgSurface"] = Parse(p.BgSurface),
+            ["VelaBgContentHeader"] = Parse(p.BgSurface),
+            ["VelaBgActive"] = Parse(p.BgActive),
+            ["VelaBgHover"] = Parse(p.BgHover),
+            ["VelaBgInput"] = Parse(p.BgInput),
+            ["VelaTabActiveBg"] = bgTerminal,
+            ["VelaTabInactiveBg"] = Parse(p.BgTabInactive),
+
+            // ——— 终端色标记:图表、徽标等界面元素借用同一套色相 ———
+            ["VelaShellWhite"] = textPrimary,
+            ["VelaShellGreen"] = success,
+            ["VelaShellCyan"] = info,
+            ["VelaShellBlue"] = accent,
+            ["VelaShellYellow"] = yellow,
+            ["VelaShellRed"] = error,
+            ["VelaShellMagenta"] = magenta,
+            ["VelaShellSubtle"] = textTertiary,
+            ["VelaShellGreenDim"] = WithAlpha(success, dim),
+            ["VelaShellCyanDim"] = WithAlpha(info, dim),
+            ["VelaShellBlueDim"] = WithAlpha(accent, dim),
+            ["VelaShellYellowDim"] = WithAlpha(yellow, dim),
+            ["VelaShellRedDim"] = WithAlpha(error, dim),
+            ["VelaShellMagentaDim"] = WithAlpha(magenta, dim),
+            ["VelaShellSubtleDim"] = WithAlpha(textTertiary, subtleDim),
+            // 图表刻度文字的底片:曲线面积铺满时,直接写字会糊进填充里。
+            ["VelaChartLabelBg"] = WithAlpha(bgTerminal, dark ? (byte)0xC0 : (byte)0xD0),
+
+            // ——— 逻辑处理器热力网格:空闲 → 低 → 中 → 高 → 满 ———
+            // 五级必须是能一眼排出先后的色序(灰 → 青 → 强调 → 黄 → 红),
+            // 而不是同一个色相加不同透明度 —— 后者在小方块上根本分不出档位。
+            ["VelaHeat1"] = WithAlpha(textTertiary, dark ? (byte)0x50 : (byte)0x28),
+            ["VelaHeat2"] = WithAlpha(info, dark ? (byte)0x55 : (byte)0x33),
+            ["VelaHeat3"] = WithAlpha(accent, dark ? (byte)0x55 : (byte)0x44),
+            ["VelaHeat4"] = WithAlpha(yellow, dark ? (byte)0x55 : (byte)0x44),
+            ["VelaHeat5"] = WithAlpha(error, dark ? (byte)0x66 : (byte)0x55),
+        };
+    }
+
+    /// <summary>解析 <c>#RRGGBB</c> / <c>#AARRGGBB</c>;种子色都是常量,解析失败即是写错了色值。</summary>
+    private static Color Parse(string hex) =>
+        Color.TryParse(hex, out Color color)
+            ? color
+            : throw new ArgumentException($@"Invalid theme color literal: '{hex}'.", nameof(hex));
+
+    private static Color WithAlpha(Color color, byte alpha) => new(alpha, color.R, color.G, color.B);
+
+    private static Color Blend(Color top, Color bottom, double ratio) =>
+        new(
+            0xFF,
+            (byte)Math.Round((top.R * ratio) + (bottom.R * (1 - ratio))),
+            (byte)Math.Round((top.G * ratio) + (bottom.G * (1 - ratio))),
+            (byte)Math.Round((top.B * ratio) + (bottom.B * (1 - ratio))));
+}

--- a/src/VelaShell/Themes/DarkTheme.axaml
+++ b/src/VelaShell/Themes/DarkTheme.axaml
@@ -47,8 +47,8 @@
     <SolidColorBrush x:Key="VelaChartLabelBg" Color="#C0282A36" />
 
     <!-- 逻辑处理器热力网格的五级色阶:空闲 → 低 → 中 → 高 → 满。 -->
-    <SolidColorBrush x:Key="VelaHeat1" Color="#6644475A" />
-    <SolidColorBrush x:Key="VelaHeat2" Color="#666272A4" />
+    <SolidColorBrush x:Key="VelaHeat1" Color="#506272A4" />
+    <SolidColorBrush x:Key="VelaHeat2" Color="#558BE9FD" />
     <SolidColorBrush x:Key="VelaHeat3" Color="#55BD93F9" />
     <SolidColorBrush x:Key="VelaHeat4" Color="#55F1FA8C" />
     <SolidColorBrush x:Key="VelaHeat5" Color="#66FF5555" />

--- a/src/VelaShell/Themes/LightTheme.axaml
+++ b/src/VelaShell/Themes/LightTheme.axaml
@@ -35,10 +35,10 @@
     <SolidColorBrush x:Key="VelaShellSubtleDim"  Color="#206C664B" />
 
     <!-- 图表刻度文字的底片:曲线面积铺满时,直接写字会糊进填充里。 -->
-    <SolidColorBrush x:Key="VelaChartLabelBg" Color="#D0F8F5F0" />
+    <SolidColorBrush x:Key="VelaChartLabelBg" Color="#D0FFFBEB" />
 
     <!-- 逻辑处理器热力网格的五级色阶。 -->
-    <SolidColorBrush x:Key="VelaHeat1" Color="#22644AC9" />
+    <SolidColorBrush x:Key="VelaHeat1" Color="#286C664B" />
     <SolidColorBrush x:Key="VelaHeat2" Color="#33036A96" />
     <SolidColorBrush x:Key="VelaHeat3" Color="#44644AC9" />
     <SolidColorBrush x:Key="VelaHeat4" Color="#44846E15" />

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -114,6 +114,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>工作台会话 id → 为它建的隧道 id(文档关闭时要拆掉,否则本地端口一直占着)。</summary>
     private readonly ConcurrentDictionary<Guid, Guid> _workspaceTunnels = new();
     private readonly ISshConnectionService? _sshConnectionService;
+
+    /// <summary>当前界面主题(具名主题目录),用于给终端下发配套的终端配色。</summary>
+    private readonly IThemeService? _themeService;
     private readonly Func<ITerminalEmulator> _terminalEmulatorFactory;
     private readonly ITunnelService? _tunnelService;
     private readonly ITunnelWorkflowService? _tunnelWorkflowService;
@@ -207,7 +210,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         IBackgroundActivityService? backgroundActivity = null,
         INotificationCenter? notificationCenter = null,
         IAnnouncementFeed? announcementFeed = null,
-        IUpdateService? updateService = null
+        IUpdateService? updateService = null,
+        IThemeService? themeService = null
     )
     {
         // 注册表可注入(DI 里与插件命令桥共享同一单例);无 UI 单测传 null 时自建。
@@ -229,6 +233,20 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         _suggestionProvider = new(CommandHistory, quickCommandRepository);
         _connectionWorkflowService = connectionWorkflowService;
         _sshConnectionService = sshConnectionService;
+        _themeService = themeService;
+        // 切主题 → 终端画面跟着换整套配色。不能只靠控件自己听 ThemeVariant:
+        // 具名主题里有多套暗色,VelaDark 换到 Tokyo Night 时变体压根没变(#主题目录)。
+        if (themeService is not null)
+        {
+            themeService.ThemeChanged += _ => RefreshTerminalThemePalette();
+            // 「跟随系统」下系统明暗翻转:主题服务不动,只有实际变体变了,同样要重下发。
+            // 只在有主题服务时才挂:没有它的那些单测会造出成百个视图模型,
+            // 每个都往共用的 Application 上挂一个再也不会摘掉的处理器。
+            if (Avalonia.Application.Current is { } themeHost)
+            {
+                themeHost.ActualThemeVariantChanged += (_, _) => RefreshTerminalThemePalette();
+            }
+        }
         _settingsService = settingsService;
         _sessionRepository = sessionRepository;
         _sftpService = sftpService;
@@ -4037,11 +4055,31 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         // (主机显式 CSI 12 l 要求终端回显时仍然生效,不受本项影响。)
         control.PeerEchoesInput = true;
 
-        // 用户自定义的终端配色(仅覆盖改过的颜色,其余跟随主题)。
+        // 当前具名主题配套的整套终端配色(VelaDark→Dracula、Nord→Nord…),
+        // 再叠上用户自定义的那几个单色(没改过的颜色一律跟随主题)。
+        control.ThemePalette = TerminalAppearanceMapper.BuildThemePalette(ActiveUiTheme.Terminal);
         control.PaletteOverrides = TerminalAppearanceMapper.BuildPaletteOverrides(
             settings.Appearance
         );
     }
+
+    /// <summary>
+    /// 当前实际生效的界面主题:「跟随系统」按应用的实际变体落到 VelaDark / VelaLight。
+    /// 没有主题服务(单测)时同样按变体兜底。
+    /// </summary>
+    private static UiTheme ActiveUiThemeFor(IThemeService? themeService) =>
+        UiThemeCatalog.Resolve(
+            themeService?.CurrentTheme,
+            Avalonia.Application.Current?.ActualThemeVariant != Avalonia.Styling.ThemeVariant.Light
+        );
+
+    private UiTheme ActiveUiTheme => ActiveUiThemeFor(_themeService);
+
+    /// <summary>主题变了 → 把新主题的终端配色下发到所有已打开的终端标签。</summary>
+    private void RefreshTerminalThemePalette() =>
+        RxSchedulers.MainThreadScheduler.Schedule(() =>
+            ApplyLiveSettingsToOpenTabs(_latestSettings ?? new AppSettings())
+        );
 
     /// <summary>
     /// 把终端默认背景不透明度实时应用到所有已打开的终端标签(背景图即时预览用:拖动滑杆时视图层直接调,

--- a/src/VelaShell/ViewModels/SettingsViewModel.cs
+++ b/src/VelaShell/ViewModels/SettingsViewModel.cs
@@ -166,6 +166,9 @@ public class SettingsViewModel : ReactiveObject
                 PreviewThemeLive();
                 if (!_suppressPreview)
                 {
+                    // 跟随态:色块跟着新主题的配套方案走(载入阶段 _suppressPreview 为真,
+                    // 不会在这里改动刚读进来的设置)。
+                    SyncFollowedSchemeColors();
                     RefreshColorSchemeDisplay();
                 }
             });
@@ -530,8 +533,18 @@ public class SettingsViewModel : ReactiveObject
     /// <summary>支持的界面语言(顺序即语言下拉的条目顺序)。</summary>
     public string[] AvailableLanguages { get; } = ["zh-CN", "en", "zh-TW", "ja", "ko"];
 
-    /// <summary>主题下拉可选值。</summary>
-    public string[] AvailableThemes { get; } = ["dark", "light", "system"];
+    /// <summary>主题下拉可选值(具名主题的 Id,末项为“跟随系统”)。</summary>
+    public string[] AvailableThemes { get; } = UiThemeCatalog.SelectableIds;
+
+    /// <summary>
+    /// 主题下拉显示的名称,与 <see cref="AvailableThemes" /> 一一对应。
+    /// 主题名是品牌名(VelaDark / Tokyo Night…),不本地化;只有末项“跟随系统”跟随语言。
+    /// </summary>
+    public string[] AvailableThemeNames { get; } =
+        [
+            .. UiThemeCatalog.All.Select(theme => theme.Name),
+            Strings.Get("SetAppear_ThemeSystem"),
+        ];
 
     // xterm-256color 是首选/推荐配置,排在最前。
     /// <summary>终端类型下拉可选值(推荐项 xterm-256color 置首)。</summary>
@@ -801,48 +814,48 @@ public class SettingsViewModel : ReactiveObject
     // ———— 终端配色方案预设(§12.5) ————
 
     /// <summary>
-    /// 方案名列表,当前主题的默认方案带“(默认)”后缀
-    /// (暗 = Dracula,亮 = Solarized Light),随主题切换动态刷新。
+    /// 方案下拉的条目:**首项是「跟随主题(配套方案名)」**,其后是全部内置方案,
+    /// 当前主题的配套方案带“(默认)”后缀。随主题切换动态刷新。
+    /// <para>
+    /// 「跟随」必须是它自己的一项。老实现把它藏在带“(默认)”后缀的那个方案上 ——
+    /// 于是「选中 Dracula」与「跟随主题」是同一个动作,在配套方案不是 Dracula 的主题上
+    /// 选 Dracula 就毫无反应,选完还会跳回配套方案那一项。
+    /// </para>
     /// </summary>
     public string[] AvailableColorSchemes
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
-    } = BuildSchemeNames(0);
+    } = BuildSchemeNames(UiThemeCatalog.All[0]);
+
+    /// <summary>下拉里「跟随主题」那一项的下标(恒为 0,其后才是内置方案)。</summary>
+    private const int FollowThemeSchemeIndex = 0;
 
     /// <summary>程序化刷新选中项(主题切换/载入)时抑制“套用方案”写回,防止把跟随态钉死。</summary>
     private bool _suppressSchemeApply;
 
-    /// <summary>当前主题下的默认方案下标:暗 = Dracula(0),亮 = Solarized Light。</summary>
-    private int ThemeDefaultSchemeIndex =>
-        IsLightThemeActive
-            ? Math.Max(
-                0,
-                Array.FindIndex(TerminalColorScheme.BuiltIn, s => s.Name == "Solarized Light")
-            )
-            : 0;
-
-    /// <summary>“跟随系统”时以应用实际生效的主题变体判定亮/暗。</summary>
-    private bool IsLightThemeActive =>
-        Theme == "light"
-        || (
-            Theme == "system"
-            && Avalonia.Application.Current?.ActualThemeVariant
-                == Avalonia.Styling.ThemeVariant.Light
+    /// <summary>“跟随系统”时以应用实际生效的主题变体解析,其余按选中的具名主题。</summary>
+    private UiTheme ActiveUiTheme =>
+        UiThemeCatalog.Resolve(
+            Theme,
+            Avalonia.Application.Current?.ActualThemeVariant
+                != Avalonia.Styling.ThemeVariant.Light
         );
 
-    private static string[] BuildSchemeNames(int defaultIndex) =>
+    private static string[] BuildSchemeNames(UiTheme theme) =>
         [
-            .. TerminalColorScheme.BuiltIn.Select(
-                (s, i) =>
-                    i == defaultIndex ? $"{s.Name}{Strings.Get("SetVm_DefaultSuffix")}" : s.Name
+            Strings.Format("SetVm_FollowThemeScheme", theme.TerminalSchemeName),
+            .. TerminalColorScheme.BuiltIn.Select(scheme =>
+                scheme.Name == theme.TerminalSchemeName
+                    ? $"{scheme.Name}{Strings.Get("SetVm_DefaultSuffix")}"
+                    : scheme.Name
             ),
         ];
 
     /// <summary>
-    /// 选择预设即把整套颜色写入 Appearance(保存后生效);-1 = 未选择(改过单色)。
-    /// 选择带“(默认)”的方案 = 恢复出厂值、终端跟随主题;跟随态下选中项随主题
-    /// 自动落在对应主题的默认方案上(暗 Dracula / 亮 Solarized Light)。
+    /// 选择条目即写回 Appearance(保存后生效):首项 = 跟随主题(不产生任何覆盖),
+    /// 其余 = 明确选定该方案(整套颜色写入,主题切换不再改变终端配色);
+    /// -1 = 未选择(用户改过单色,与任何方案都不一致)。
     /// </summary>
     public int ColorSchemeIndex
     {
@@ -850,7 +863,7 @@ public class SettingsViewModel : ReactiveObject
         set
         {
             this.RaiseAndSetIfChanged(ref _colorSchemeIndex, value);
-            if (_suppressSchemeApply || value < 0 || value >= TerminalColorScheme.BuiltIn.Length)
+            if (_suppressSchemeApply || value < 0 || value > TerminalColorScheme.BuiltIn.Length)
             {
                 return;
             }
@@ -859,34 +872,50 @@ public class SettingsViewModel : ReactiveObject
                 JsonSerializer.Deserialize<AppearanceOptions>(JsonSerializer.Serialize(Appearance))
                 ?? new AppearanceOptions();
 
-            // 选中当前主题的默认方案 = 回到出厂值(Dracula 色值,零覆盖,跟随主题);
-            // 其余方案按其色值写入(与出厂差异成为覆盖,主题切换不再改变终端配色)。
-            TerminalColorScheme
-                .BuiltIn[value == ThemeDefaultSchemeIndex ? 0 : value]
-                .ApplyTo(updated);
+            bool follow = value == FollowThemeSchemeIndex;
+            updated.TerminalColorsFollowTheme = follow;
+            // 跟随:把配套方案的色值一并写进去 —— 下面那几个色块与输入框显示的,
+            // 就是屏幕上真正在用的颜色(它们不参与判定,判定只看上面那个标志)。
+            (follow ? ActiveUiTheme.Terminal : TerminalColorScheme.BuiltIn[value - 1]).ApplyTo(updated);
             Appearance = updated;
 
-            // 写回后重算显示:出厂值命中会折射到当前主题的默认方案位。
             RefreshColorSchemeDisplay();
         }
     }
 
+    /// <summary>跟随态下随主题切换重灌色块:切到 Nord,下面显示的就该是 Nord 的颜色。</summary>
+    private void SyncFollowedSchemeColors()
+    {
+        if (!TerminalColorScheme.FollowsTheme(Appearance))
+        {
+            return;
+        }
+        AppearanceOptions updated =
+            JsonSerializer.Deserialize<AppearanceOptions>(JsonSerializer.Serialize(Appearance))
+            ?? new AppearanceOptions();
+        updated.TerminalColorsFollowTheme = true;
+        ActiveUiTheme.Terminal.ApplyTo(updated);
+        Appearance = updated;
+    }
+
     /// <summary>
-    /// 重算方案下拉的条目后缀与选中项:出厂值(跟随主题)显示为当前主题默认方案,
-    /// 显式方案按整套颜色反向匹配,改过单色则显示“未选择”(-1)。
+    /// 重算方案下拉的条目与选中项:跟随态选中首项,显式方案按整套颜色反向匹配,
+    /// 改过单色则显示“未选择”(-1)。
     /// </summary>
     private void RefreshColorSchemeDisplay()
     {
-        int defaultIndex = ThemeDefaultSchemeIndex;
-        bool following = TerminalColorScheme.BuiltIn[0].Matches(Appearance); // 出厂值 = Dracula 色值
-        int desired = following
-            ? defaultIndex
-            : Array.FindIndex(TerminalColorScheme.BuiltIn, s => s.Matches(Appearance));
+        UiTheme theme = ActiveUiTheme;
+        int matched = Array.FindIndex(TerminalColorScheme.BuiltIn, s => s.Matches(Appearance));
+        int desired = TerminalColorScheme.FollowsTheme(Appearance)
+            ? FollowThemeSchemeIndex
+            : matched < 0
+                ? -1
+                : matched + 1;
         _suppressSchemeApply = true;
         try
         {
             // 先换条目再定选中:ItemsSource 替换会让 ComboBox 短暂把 -1 写回来,抑制期内无害。
-            AvailableColorSchemes = BuildSchemeNames(defaultIndex);
+            AvailableColorSchemes = BuildSchemeNames(theme);
             _colorSchemeIndex = desired;
             this.RaisePropertyChanged(nameof(ColorSchemeIndex));
         }
@@ -1001,24 +1030,15 @@ public class SettingsViewModel : ReactiveObject
 
     // ———— 下拉的索引映射(POCO 字符串 ↔ ComboBox SelectedIndex) ————
 
-    /// <summary>主题下拉选中项与 <see cref="Theme" /> 字符串之间的索引映射。</summary>
+    /// <summary>主题下拉选中项与 <see cref="Theme" /> 字符串(主题 Id)之间的索引映射。</summary>
     public int ThemeIndex
     {
-        get =>
-            Theme switch
-            {
-                "light" => 1,
-                "system" => 2,
-                _ => 0,
-            };
+        get => Math.Max(0, Array.IndexOf(AvailableThemes, Theme));
         set
         {
-            Theme = value switch
-            {
-                1 => "light",
-                2 => "system",
-                _ => "dark",
-            };
+            Theme = value >= 0 && value < AvailableThemes.Length
+                ? AvailableThemes[value]
+                : UiThemeCatalog.All[0].Id;
             this.RaisePropertyChanged();
         }
     }
@@ -1412,8 +1432,30 @@ public class SettingsViewModel : ReactiveObject
 
     private Avalonia.Threading.DispatcherTimer? _previewDebounce;
 
+    /// <summary>用户能逐色改的四项(ANSI 16 色在设置页上是只读色块)。</summary>
+    private static readonly string[] TerminalColorProperties =
+    [
+        nameof(AppearanceOptions.TerminalForeground),
+        nameof(AppearanceOptions.TerminalBackground),
+        nameof(AppearanceOptions.CursorColor),
+        nameof(AppearanceOptions.SelectionColor),
+    ];
+
     private void OnAppearanceItemChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // 在跟随态下手改某一个颜色 = 用户要自己定配色了:就此脱离跟随,否则这次修改
+        // 不会产生任何覆盖,输入框里改完了终端却一动不动。
+        // (套用方案走的是"克隆 → 改 → 整体替换"那条路,改的是尚未挂钩的新对象,不会走到这里。)
+        // 判定不能反过来问 FollowsTheme:事件到达时新色值**已经**写进去了,
+        // 而老配置(标志为 null)的跟随与否恰恰是按色值推断的 —— 一改就自己翻成了"不跟随",
+        // 于是这里永远看不到"改之前在跟随"这个事实。直接置标志,幂等。
+        if (!_suppressPreview
+            && e.PropertyName is { } changed
+            && Array.IndexOf(TerminalColorProperties, changed) >= 0)
+        {
+            Appearance.TerminalColorsFollowTheme = false;
+            RefreshColorSchemeDisplay();
+        }
         if (e.PropertyName == nameof(AppearanceOptions.WindowOpacityPercent))
         {
             if (_suppressPreview || _previewService is null)

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml
@@ -19,11 +19,11 @@
         <TextBlock Classes="row-label" Text="{loc:Localize SetAppear_ThemeMode}" />
         <TextBlock Classes="row-desc" Text="{loc:Localize SetAppear_ThemeModeDesc}" />
       </StackPanel>
-      <ComboBox Grid.Column="1" Width="140" SelectedIndex="{Binding ThemeIndex}" VerticalAlignment="Center">
-        <ComboBoxItem Content="{loc:Localize SetAppear_ThemeDark}" />
-        <ComboBoxItem Content="{loc:Localize SetAppear_ThemeLight}" />
-        <ComboBoxItem Content="{loc:Localize SetAppear_ThemeSystem}" />
-      </ComboBox>
+      <!-- 条目来自主题目录(UiThemeCatalog),末项是「跟随系统」。写死三个 ComboBoxItem
+           的老写法在具名主题上线后就成了瓶颈:每加一套主题都要同时改这里与索引映射。 -->
+      <ComboBox Grid.Column="1" Width="140" VerticalAlignment="Center"
+                ItemsSource="{Binding AvailableThemeNames}"
+                SelectedIndex="{Binding ThemeIndex}" />
     </Grid>
     <Grid ColumnDefinitions="*,Auto">
       <StackPanel Spacing="2">

--- a/tests/VelaShell.Core.Tests/Models/UiThemeCatalogTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/UiThemeCatalogTests.cs
@@ -1,0 +1,256 @@
+using System.Globalization;
+using VelaShell.Core.Models;
+
+namespace VelaShell.Core.Tests.Models;
+
+/// <summary>
+/// 主题目录的硬约束。九套主题各二十几个种子色,靠眼睛看不出哪一套的次要文字掉到了
+/// 3:1 —— 这些用例就是那把尺子,新增一套主题时它们必须仍然是绿的。
+/// <para>
+/// 约束与宿主侧 <c>ThemeTokenContrastTests</c>(读 axaml 校验 VelaDark / VelaLight)同源,
+/// 只是把量程扩到了全部具名主题。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("ThemeTokens")]
+public sealed class UiThemeCatalogTests
+{
+    /// <summary>WCAG AA 对正文(小字号)的最低对比度。</summary>
+    private const double MinimumBodyContrast = 4.5;
+
+    /// <summary>状态色/图标这类"能认出来就行"的非正文元素,按 AA 的图形与界面组件档(3:1)。</summary>
+    private const double MinimumGlyphContrast = 3.0;
+
+    [TestMethod]
+    public void Catalog_HasUniqueIdsAndNames()
+    {
+        Assert.AreEqual(
+            UiThemeCatalog.All.Length,
+            UiThemeCatalog.All.Select(theme => theme.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+            "主题 Id 会被写进配置文件,重复即意味着有一套主题永远选不中。");
+        Assert.AreEqual(
+            UiThemeCatalog.All.Length,
+            UiThemeCatalog.All.Select(theme => theme.Name).Distinct(StringComparer.Ordinal).Count(),
+            "下拉里出现两个同名主题,用户无从分辨。");
+    }
+
+    /// <summary>历史配置里存的是 "dark" / "light",这两个 Id 不能改名 —— 改了等于把老用户的主题重置。</summary>
+    [TestMethod]
+    public void LegacyIds_StillResolveToTheDefaultThemes()
+    {
+        Assert.AreEqual("VelaDark", UiThemeCatalog.Get("dark").Name);
+        Assert.AreEqual("VelaLight", UiThemeCatalog.Get("light").Name);
+        Assert.IsTrue(UiThemeCatalog.IsValidId("system"));
+        Assert.IsFalse(UiThemeCatalog.IsValidId("ocean"), "未知主题必须被拒,否则会静默落到暗色。");
+    }
+
+    /// <summary>“跟随系统”不是一套配色:解析时按系统明暗落到默认暗/亮主题。</summary>
+    [TestMethod]
+    public void Resolve_FollowSystem_LandsOnDefaultThemeByVariant()
+    {
+        Assert.AreEqual("dark", UiThemeCatalog.Resolve("system", systemPrefersDark: true).Id);
+        Assert.AreEqual("light", UiThemeCatalog.Resolve("system", systemPrefersDark: false).Id);
+        Assert.AreEqual("tokyo-night", UiThemeCatalog.Resolve("tokyo-night", systemPrefersDark: false).Id,
+            "选了具名主题就该按它来,系统明暗不参与。");
+    }
+
+    /// <summary>插件契约只认 dark / light / system,具名主题不能原样漏出去。</summary>
+    [TestMethod]
+    public void VariantName_NeverLeaksNamedThemesToPlugins()
+    {
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            string variant = UiThemeCatalog.VariantName(theme.Id);
+            Assert.AreEqual(theme.IsDark ? "dark" : "light", variant, $"{theme.Name} 的对外明暗名不对。");
+        }
+        Assert.AreEqual("system", UiThemeCatalog.VariantName("system"));
+        Assert.AreEqual("system", UiThemeCatalog.VariantName(null));
+    }
+
+    /// <summary>正文两档文字压在任何一层底色上都必须达到 AA(4.5:1)。</summary>
+    [TestMethod]
+    public void BodyText_MeetsWcagAaOnEverySurface()
+    {
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            UiThemePalette p = theme.Palette;
+            (string Name, string Value)[] surfaces =
+            [
+                ("BgSurface", p.BgSurface),
+                ("BgInput", p.BgInput),
+                ("BgHover", p.BgHover),
+                ("BgTerminal", p.BgTerminal),
+                ("BgSidebar", p.BgSidebar),
+                ("BgPage", p.BgPage),
+                // 选中行底可能是半透明的强调色淡底,取它压在浮层底上的观感色。
+                ("BgActive", Composite(p.BgActive, p.BgSurface)),
+            ];
+            foreach ((string surfaceName, string surface) in surfaces)
+            {
+                foreach ((string textName, string text) in new[]
+                         {
+                             ("TextPrimary", p.TextPrimary), ("TextSecondary", p.TextSecondary),
+                         })
+                {
+                    double ratio = Contrast(text, surface);
+                    if (ratio < MinimumBodyContrast)
+                    {
+                        failures.Add(
+                            $"{theme.Name}: {textName}({text}) 压在 {surfaceName}({surface}) 上只有 {ratio:F2}:1");
+                    }
+                }
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>按钮上的文字压在强调色实底上同样是正文,必须达到 AA。</summary>
+    [TestMethod]
+    public void AccentForeground_MeetsWcagAaOnAccent()
+    {
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            double ratio = Contrast(theme.Palette.AccentForeground, theme.Palette.Accent);
+            if (ratio < MinimumBodyContrast)
+            {
+                failures.Add($"{theme.Name}: AccentForeground 压在 Accent 上只有 {ratio:F2}:1");
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>状态点与语义色要在浮层底上认得出来(AA 的图形档 3:1)。</summary>
+    [TestMethod]
+    public void SemanticColors_AreDistinguishableOnSurface()
+    {
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            UiThemePalette p = theme.Palette;
+            foreach ((string name, string value) in new[]
+                     {
+                         ("Accent", p.Accent), ("Success", p.Success), ("Warning", p.Warning),
+                         ("Yellow", p.Yellow), ("Error", p.Error), ("Info", p.Info),
+                         ("Magenta", p.Magenta), ("FolderIcon", p.FolderIcon),
+                     })
+            {
+                double ratio = Contrast(value, p.BgSurface);
+                if (ratio < MinimumGlyphContrast)
+                {
+                    failures.Add($"{theme.Name}: {name}({value}) 压在 BgSurface 上只有 {ratio:F2}:1");
+                }
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>
+    /// 强调色淡底只能改透明度、不能改色相 —— Avalonia 的颜色字面量是 <c>#AARRGGBB</c>,
+    /// 把透明度写在末尾(<c>#644AC922</c>)不报错,而是悄悄变成另一个颜色(issue #246)。
+    /// </summary>
+    [TestMethod]
+    public void TranslucentBgActive_KeepsTheAccentHue()
+    {
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            (byte alpha, byte r, byte g, byte b) = Parse(theme.Palette.BgActive);
+            if (alpha == 0xFF)
+            {
+                continue; // 不透明变体(暗色主题用中性提亮色)不受此约束。
+            }
+            (byte _, byte ar, byte ag, byte ab) = Parse(theme.Palette.Accent);
+            Assert.AreEqual((ar, ag, ab), (r, g, b),
+                $"{theme.Name}: BgActive={theme.Palette.BgActive} 的 RGB 与 Accent 不符 —— "
+                + "多半是把透明度写在了末尾。");
+        }
+    }
+
+    /// <summary>
+    /// 每套主题都要有配套的终端方案,且它的背景色必须等于界面的终端平面底色。
+    /// 差一档就会在终端边缘留下一道看得见的拼缝 —— 亮色主题此前配 Solarized Light
+    /// (#FDF6E3)而界面底是 #FFFBEB,那道缝存在了很久。
+    /// </summary>
+    [TestMethod]
+    public void EveryTheme_PairsWithATerminalSchemeOfTheSameBackground()
+    {
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            TerminalColorScheme? scheme = Array.Find(
+                TerminalColorScheme.BuiltIn, s => s.Name == theme.TerminalSchemeName);
+            Assert.IsNotNull(scheme, $"{theme.Name} 配套的终端方案「{theme.TerminalSchemeName}」不在内置表里。");
+            Assert.AreEqual(
+                theme.Palette.BgTerminal.ToUpperInvariant(),
+                scheme.Background.ToUpperInvariant(),
+                $"{theme.Name}:终端方案「{scheme.Name}」的背景与界面的 BgTerminal 不一致。");
+        }
+    }
+
+    /// <summary>终端方案自身的可读性:正文与 ANSI 前六色压在方案背景上要认得出。</summary>
+    [TestMethod]
+    public void PairedTerminalSchemes_AreReadableOnTheirOwnBackground()
+    {
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            TerminalColorScheme scheme = theme.Terminal;
+            double fg = Contrast(scheme.Foreground, scheme.Background);
+            if (fg < MinimumBodyContrast)
+            {
+                failures.Add($"{scheme.Name}: 前景压在背景上只有 {fg:F2}:1");
+            }
+            // 索引 0 是 black、7 是 white,两者本就贴着底色的两端,不参与此项。
+            for (int i = 1; i <= 6; i++)
+            {
+                double ratio = Contrast(scheme.AnsiNormal[i], scheme.Background);
+                if (ratio < MinimumGlyphContrast)
+                {
+                    failures.Add($"{scheme.Name}: ANSI {i}({scheme.AnsiNormal[i]}) 只有 {ratio:F2}:1");
+                }
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    // ———— 颜色计算(与 ThemeTokenContrastTests 同一套口径) ————
+
+    private static (byte A, byte R, byte G, byte B) Parse(string literal)
+    {
+        string hex = literal.TrimStart('#');
+        Assert.IsTrue(hex.Length is 6 or 8, $"只支持 #RRGGBB / #AARRGGBB,收到 {literal}。");
+        uint packed = uint.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        return hex.Length == 6
+            ? ((byte)0xFF, (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed)
+            : ((byte)(packed >> 24), (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed);
+    }
+
+    /// <summary>半透明色压在基底上的观感色。</summary>
+    private static string Composite(string top, string under)
+    {
+        (byte ta, byte tr, byte tg, byte tb) = Parse(top);
+        (byte _, byte ur, byte ug, byte ub) = Parse(under);
+        double a = ta / 255.0;
+        return $"#{(byte)Math.Round((a * tr) + ((1 - a) * ur)):X2}"
+               + $"{(byte)Math.Round((a * tg) + ((1 - a) * ug)):X2}"
+               + $"{(byte)Math.Round((a * tb) + ((1 - a) * ub)):X2}";
+    }
+
+    private static double Luminance(string literal)
+    {
+        (byte _, byte r, byte g, byte b) = Parse(literal);
+        static double Channel(byte v)
+        {
+            double s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+        return (0.2126 * Channel(r)) + (0.7152 * Channel(g)) + (0.0722 * Channel(b));
+    }
+
+    private static double Contrast(string a, string b)
+    {
+        double la = Luminance(a);
+        double lb = Luminance(b);
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+}

--- a/tests/VelaShell.Terminal.Tests/ThemePaletteLayeringTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ThemePaletteLayeringTests.cs
@@ -1,0 +1,116 @@
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 终端配色的三层叠加(具名主题上线后新增中间一层):
+/// 控件自带的明暗缺省 → 宿主下发的主题配色(整套)→ 用户改过的单色(稀疏)。
+/// <para>
+/// 中间这层是必须的:具名主题里有六套暗色,VelaDark 换到 Tokyo Night 时
+/// <c>ThemeVariant</c> 根本没变,控件光靠听变体事件无从得知该换哪套色。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("TerminalPalette")]
+public class ThemePaletteLayeringTests
+{
+    private static Avalonia.Headless.HeadlessUnitTestSession Session => HeadlessTestSession.Current;
+
+    private static void OnUi(Action body) =>
+        Session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [TestMethod]
+    public void ThemePalette_ReplacesTheBuiltInDefaults()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl();
+            Rgba builtIn = control.PaletteForTest.DefaultBackground;
+
+            control.ThemePalette = Full(background: Rgba.FromRgb(0x2E, 0x34, 0x40));
+
+            Assert.AreNotEqual(builtIn, control.PaletteForTest.DefaultBackground);
+            Assert.AreEqual(Rgba.FromRgb(0x2E, 0x34, 0x40), control.PaletteForTest.DefaultBackground);
+            Assert.AreEqual(Rgba.FromRgb(0x88, 0xC0, 0xD0), control.PaletteForTest[4], "主题配色要连 ANSI 一起换。");
+        });
+    }
+
+    [TestMethod]
+    public void UserOverrides_WinOverTheThemePalette()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl
+            {
+                ThemePalette = Full(background: Rgba.FromRgb(0x2E, 0x34, 0x40)),
+            };
+
+            // 用户只改了背景一色:其余槽位仍然跟随主题。
+            var user = new TerminalPaletteOverrides { Background = Rgba.FromRgb(0x10, 0x10, 0x10) };
+            control.PaletteOverrides = user;
+
+            Assert.AreEqual(Rgba.FromRgb(0x10, 0x10, 0x10), control.PaletteForTest.DefaultBackground);
+            Assert.AreEqual(Rgba.FromRgb(0x88, 0xC0, 0xD0), control.PaletteForTest[4],
+                "用户没改过的颜色必须继续跟随主题,而不是退回控件缺省。");
+        });
+    }
+
+    /// <summary>换主题(重设整套)后,上一套主题的颜色一个都不能留下。</summary>
+    [TestMethod]
+    public void SwitchingThemePalette_LeavesNoStaleColors()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl
+            {
+                ThemePalette = Full(background: Rgba.FromRgb(0x2E, 0x34, 0x40)),
+            };
+
+            control.ThemePalette = Full(
+                background: Rgba.FromRgb(0x1A, 0x1B, 0x26),
+                blue: Rgba.FromRgb(0x7A, 0xA2, 0xF7));
+
+            Assert.AreEqual(Rgba.FromRgb(0x1A, 0x1B, 0x26), control.PaletteForTest.DefaultBackground);
+            Assert.AreEqual(Rgba.FromRgb(0x7A, 0xA2, 0xF7), control.PaletteForTest[4]);
+        });
+    }
+
+    /// <summary>清掉主题配色即回到控件自带的明暗缺省(宿主不在场时的兜底)。</summary>
+    [TestMethod]
+    public void ClearingThemePalette_FallsBackToBuiltInDefaults()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl();
+            Rgba builtIn = control.PaletteForTest.DefaultBackground;
+
+            control.ThemePalette = Full(background: Rgba.FromRgb(0x2E, 0x34, 0x40));
+            control.ThemePalette = null;
+
+            Assert.AreEqual(builtIn, control.PaletteForTest.DefaultBackground);
+        });
+    }
+
+    /// <summary>一套"整套都有值"的主题配色(宿主下发的形态)。</summary>
+    private static TerminalPaletteOverrides Full(Rgba background, Rgba? blue = null)
+    {
+        var palette = new TerminalPaletteOverrides
+        {
+            Foreground = Rgba.FromRgb(0xD8, 0xDE, 0xE9),
+            Background = background,
+            Cursor = Rgba.FromRgb(0xD8, 0xDE, 0xE9),
+            Selection = Rgba.FromRgb(0x43, 0x4C, 0x5E),
+        };
+        for (int i = 0; i < TerminalPaletteOverrides.AnsiCount; i++)
+        {
+            palette.Ansi[i] = Rgba.FromRgb(0x20, 0x20, 0x20);
+        }
+        palette.Ansi[4] = blue ?? Rgba.FromRgb(0x88, 0xC0, 0xD0);
+        return palette;
+    }
+}

--- a/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
@@ -1,0 +1,182 @@
+using System.Xml.Linq;
+using Avalonia.Controls;
+using Avalonia.Media;
+using VelaShell.Core.Models;
+using VelaShell.Services;
+
+namespace VelaShell.Tests.Services;
+
+/// <summary>
+/// 主题令牌展开器的两条硬约束:
+/// <para>
+/// 1. <b>覆盖面</b>:每套主题都要把**同一组**令牌键写全。少写一个,切主题时那个键就会
+///    留着上一套主题的值 —— 界面上是一小块颜色对不上,而且只在特定的切换顺序下出现。
+/// </para>
+/// <para>
+/// 2. <b>与 axaml 缺省一致</b>:VelaDark / VelaLight 展开出来的值必须逐一等于
+///    <c>VelaTokens.axaml</c> / <c>VelaShellTokens.axaml</c> / <c>DarkTheme.axaml</c> /
+///    <c>LightTheme.axaml</c> 里的同名令牌。那两份是贴主题之前的编译期缺省(设计器、
+///    headless 测试、启动的头一瞬间看到的就是它们),两边漂了就会闪一下色。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("ThemeTokens")]
+public sealed class ThemeTokenApplierTests
+{
+    [TestMethod]
+    public void EveryTheme_WritesTheSameTokenKeySet()
+    {
+        string[] expected = [.. ThemeTokenApplier.TokenKeys.Order(StringComparer.Ordinal)];
+        Assert.IsNotEmpty(expected);
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            var resources = new ResourceDictionary();
+            ThemeTokenApplier.Apply(resources, theme);
+            string[] actual =
+            [
+                .. resources.Keys.OfType<string>()
+                    .Where(key => key != "VelaShadowWindow")
+                    .Order(StringComparer.Ordinal),
+            ];
+            CollectionAssert.AreEqual(expected, actual, $"{theme.Name} 写出的令牌集合与其它主题不一致。");
+            Assert.IsTrue(resources.ContainsKey("VelaShadowWindow"), $"{theme.Name} 少了浮层投影令牌。");
+        }
+    }
+
+    /// <summary>切主题是整套重写:上一套的值一个都不能留下。</summary>
+    [TestMethod]
+    public void SwitchingThemes_LeavesNoStaleValues()
+    {
+        var resources = new ResourceDictionary();
+        ThemeTokenApplier.Apply(resources, UiThemeCatalog.Get("dark"));
+        ThemeTokenApplier.Apply(resources, UiThemeCatalog.Get("github-light"));
+
+        var expected = new ResourceDictionary();
+        ThemeTokenApplier.Apply(expected, UiThemeCatalog.Get("github-light"));
+        foreach (string key in ThemeTokenApplier.TokenKeys)
+        {
+            Assert.AreEqual(
+                ColorOf(expected, key),
+                ColorOf(resources, key),
+                $"令牌 {key} 在换主题后仍留着上一套的值。");
+        }
+    }
+
+    /// <summary>
+    /// 清空自定义强调色时,要落回**当前主题**的强调色。
+    /// <para>
+    /// 老实现是把三个键从资源里删掉,让它们掉回 axaml 的缺省 —— 那在只有明暗两套时是对的,
+    /// 到了具名主题上就成了错的:Tokyo Night 的蓝会变成 VelaDark 的紫。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void ResetAccent_RestoresTheThemesOwnAccent_NotTheDefaultOne()
+    {
+        UiTheme midnight = UiThemeCatalog.Get("tokyo-night");
+        var resources = new ResourceDictionary();
+        ThemeTokenApplier.Apply(resources, midnight);
+
+        // 用户挑了个自定义强调色,随后又清空。
+        resources["VelaAccent"] = new SolidColorBrush(Colors.Red);
+        ThemeTokenApplier.ResetAccent(resources, midnight);
+
+        Assert.AreEqual(Color.Parse(midnight.Palette.Accent), ColorOf(resources, "VelaAccent"));
+        Assert.AreEqual(
+            Color.Parse(midnight.Palette.AccentForeground),
+            ColorOf(resources, "VelaAccentForeground"));
+        Color dim = ColorOf(resources, "VelaAccentDim")!.Value;
+        Color accent = Color.Parse(midnight.Palette.Accent);
+        Assert.AreEqual((accent.R, accent.G, accent.B), (dim.R, dim.G, dim.B),
+            "淡底只能改透明度,不能改色相。");
+        Assert.AreNotEqual(0xFF, dim.A, "淡底必须是半透明的。");
+    }
+
+    [TestMethod]
+    public void VelaDark_MatchesTheCompiledDefaults() => AssertMatchesAxaml("dark", "Dark", "DarkTheme.axaml");
+
+    [TestMethod]
+    public void VelaLight_MatchesTheCompiledDefaults() => AssertMatchesAxaml("light", "Light", "LightTheme.axaml");
+
+    private static void AssertMatchesAxaml(string themeId, string variant, string variantFile)
+    {
+        Dictionary<string, string> axaml = LoadVariantTokens(variant);
+        foreach (KeyValuePair<string, string> entry in LoadFlatTokens(variantFile))
+        {
+            axaml[entry.Key] = entry.Value;
+        }
+        Assert.IsNotEmpty(axaml, "令牌 axaml 没被复制到测试输出目录。");
+
+        var applied = new ResourceDictionary();
+        ThemeTokenApplier.Apply(applied, UiThemeCatalog.Get(themeId));
+
+        var failures = new List<string>();
+        foreach ((string key, string literal) in axaml)
+        {
+            if (ColorOf(applied, key) is not { } color)
+            {
+                failures.Add($"{key}:axaml 里有,展开器没写");
+                continue;
+            }
+            Color expected = Color.Parse(literal);
+            if (color != expected)
+            {
+                failures.Add($"{key}:axaml={literal} 展开器={color}");
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    private static Color? ColorOf(ResourceDictionary resources, string key) =>
+        resources.TryGetResource(key, null, out object? value) && value is ISolidColorBrush brush
+            ? brush.Color
+            : null;
+
+    /// <summary>读 ThemeDictionaries 形态的令牌文件(VelaTokens / VelaShellTokens)。</summary>
+    private static Dictionary<string, string> LoadVariantTokens(string variant)
+    {
+        var tokens = new Dictionary<string, string>(StringComparer.Ordinal);
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+        foreach (string file in new[] { "VelaTokens.axaml", "VelaShellTokens.axaml" })
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "Themes", file);
+            Assert.IsTrue(File.Exists(path), $"令牌文件未复制到输出目录:{path}");
+            foreach (XElement dictionary in XDocument.Load(path).Descendants())
+            {
+                if (dictionary.Name.LocalName != "ResourceDictionary"
+                    || dictionary.Attribute(x + "Key")?.Value != variant)
+                {
+                    continue;
+                }
+                foreach (XElement brush in dictionary.Elements())
+                {
+                    if (brush.Name.LocalName == "SolidColorBrush"
+                        && brush.Attribute(x + "Key")?.Value is { } key
+                        && brush.Attribute("Color")?.Value is { } color)
+                    {
+                        tokens[key] = color;
+                    }
+                }
+            }
+        }
+        return tokens;
+    }
+
+    /// <summary>读平铺形态的令牌文件(DarkTheme / LightTheme,按变体各一份)。</summary>
+    private static Dictionary<string, string> LoadFlatTokens(string file)
+    {
+        var tokens = new Dictionary<string, string>(StringComparer.Ordinal);
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+        string path = Path.Combine(AppContext.BaseDirectory, "Themes", file);
+        Assert.IsTrue(File.Exists(path), $"令牌文件未复制到输出目录:{path}");
+        foreach (XElement brush in XDocument.Load(path).Root!.Elements())
+        {
+            if (brush.Name.LocalName == "SolidColorBrush"
+                && brush.Attribute(x + "Key")?.Value is { } key
+                && brush.Attribute("Color")?.Value is { } color)
+            {
+                tokens[key] = color;
+            }
+        }
+        return tokens;
+    }
+}

--- a/tests/VelaShell.Tests/VelaShell.Tests.csproj
+++ b/tests/VelaShell.Tests/VelaShell.Tests.csproj
@@ -28,6 +28,20 @@
              Link="Ftp\LoopbackFtpServer.cs" />
   </ItemGroup>
 
+  <!-- 令牌 axaml 以纯文本读入:ThemeTokenApplier 展开出来的 VelaDark / VelaLight
+       必须与这两份编译期缺省逐值一致(见 ThemeTokenApplierTests),否则贴主题之前
+       那一瞬间的界面与贴完之后是两套颜色。 -->
+  <ItemGroup>
+    <Content Include="..\..\src\VelaShell.Controls\Themes\VelaTokens.axaml"
+             Link="Themes\VelaTokens.axaml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\src\VelaShell.Controls\Themes\VelaShellTokens.axaml"
+             Link="Themes\VelaShellTokens.axaml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\src\VelaShell\Themes\DarkTheme.axaml"
+             Link="Themes\DarkTheme.axaml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\src\VelaShell\Themes\LightTheme.axaml"
+             Link="Themes\LightTheme.axaml" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\VelaShell\VelaShell.csproj" />
     <ProjectReference Include="..\..\src\VelaShell.Infrastructure\VelaShell.Infrastructure.csproj" />

--- a/tests/VelaShell.Tests/ViewModels/TerminalColorSchemeSelectionTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalColorSchemeSelectionTests.cs
@@ -1,0 +1,142 @@
+using Avalonia.Headless;
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.Services;
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 终端配色方案下拉的选中语义。
+/// <para>
+/// 用户报的缺陷:在 Nord / VelaLight 这类**配套方案不是 Dracula** 的主题下,
+/// 下拉里选「Dracula」毫无反应,终端仍然是主题自带的那套,选中项还会自己跳回去。
+/// 根因是老实现把「跟随主题」隐式编码成「颜色与出厂默认(= Dracula)一致」——
+/// 于是「明确选了 Dracula」与「跟随主题」在设置里写出来的东西一模一样,分不开。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("ThemeTokens")]
+public sealed class TerminalColorSchemeSelectionTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    /// <summary>下拉首项是「跟随主题」,其后才是内置方案表。</summary>
+    private const int FollowItem = 0;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(TerminalColorSchemeSelectionTests).Assembly);
+
+    [TestMethod]
+    public async Task PickingDracula_UnderANonDraculaTheme_ActuallyAppliesDracula() =>
+        await _session.Dispatch(async () =>
+        {
+            SettingsViewModel vm = await CreateViewModelAsync("nord");
+            Assert.AreEqual(FollowItem, vm.ColorSchemeIndex, "起点应是跟随态。");
+
+            vm.ColorSchemeIndex = IndexOf("Dracula");
+
+            Assert.AreEqual(IndexOf("Dracula"), vm.ColorSchemeIndex,
+                "选中 Dracula 后不能自己跳回「跟随主题」。");
+            Assert.IsFalse(TerminalColorScheme.FollowsTheme(vm.Appearance),
+                "明确选了方案就不再是跟随态。");
+            Assert.AreEqual("#282A36", vm.Appearance.TerminalBackground);
+
+            TerminalPaletteOverrides? overrides =
+                TerminalAppearanceMapper.BuildPaletteOverrides(vm.Appearance);
+            Assert.IsNotNull(overrides, "选定的方案必须产生覆盖,否则终端仍是主题自带的那套。");
+            Assert.AreEqual(Rgba.FromRgb(0x28, 0x2A, 0x36), overrides.Background);
+            Assert.AreEqual(Rgba.FromRgb(0xBD, 0x93, 0xF9), overrides.Ansi[4], "整套下发,不只是背景。");
+            return true;
+        }, CancellationToken.None);
+
+    /// <summary>配套方案本身也要能被「明确选中」—— 选它和跟随是两回事,只是眼下颜色相同。</summary>
+    [TestMethod]
+    public async Task PickingThePairedScheme_PinsItInsteadOfFollowing() =>
+        await _session.Dispatch(async () =>
+        {
+            SettingsViewModel vm = await CreateViewModelAsync("nord");
+
+            vm.ColorSchemeIndex = IndexOf("Nord");
+
+            Assert.IsFalse(TerminalColorScheme.FollowsTheme(vm.Appearance));
+            Assert.IsNotNull(TerminalAppearanceMapper.BuildPaletteOverrides(vm.Appearance),
+                "钉住方案后换主题终端不该再跟着变,因此必须有覆盖。");
+            return true;
+        }, CancellationToken.None);
+
+    [TestMethod]
+    public async Task PickingFollowTheme_ClearsOverridesAndShowsThePairedColors() =>
+        await _session.Dispatch(async () =>
+        {
+            SettingsViewModel vm = await CreateViewModelAsync("nord");
+            vm.ColorSchemeIndex = IndexOf("Monokai");
+            Assert.IsNotNull(TerminalAppearanceMapper.BuildPaletteOverrides(vm.Appearance));
+
+            vm.ColorSchemeIndex = FollowItem;
+
+            Assert.AreEqual(FollowItem, vm.ColorSchemeIndex);
+            Assert.IsNull(TerminalAppearanceMapper.BuildPaletteOverrides(vm.Appearance),
+                "跟随态一个槽位都不覆盖。");
+            Assert.AreEqual("#2E3440", vm.Appearance.TerminalBackground,
+                "回到跟随后,色块显示的应是配套方案(Nord)的颜色,而不是上一次选的 Monokai。");
+            return true;
+        }, CancellationToken.None);
+
+    /// <summary>跟随态下手改单色 = 用户要自己定配色:必须就此脱离跟随,否则改了等于没改。</summary>
+    [TestMethod]
+    public async Task EditingASingleColorWhileFollowing_LeavesTheFollowingState() =>
+        await _session.Dispatch(async () =>
+        {
+            SettingsViewModel vm = await CreateViewModelAsync("nord");
+            Assert.IsTrue(TerminalColorScheme.FollowsTheme(vm.Appearance));
+
+            vm.Appearance.TerminalBackground = "#101010";
+
+            Assert.IsFalse(TerminalColorScheme.FollowsTheme(vm.Appearance));
+            Assert.AreEqual(-1, vm.ColorSchemeIndex, "与任何方案都不一致 → 未选择。");
+            TerminalPaletteOverrides? overrides =
+                TerminalAppearanceMapper.BuildPaletteOverrides(vm.Appearance);
+            Assert.IsNotNull(overrides);
+            Assert.AreEqual(Rgba.FromRgb(0x10, 0x10, 0x10), overrides.Background);
+            return true;
+        }, CancellationToken.None);
+
+    /// <summary>老配置(没有跟随标志、颜色恰为出厂 Dracula)必须仍被判为跟随态。</summary>
+    [TestMethod]
+    public void LegacySettingsWithoutTheFlag_AreStillTreatedAsFollowing()
+    {
+        var untouched = new AppearanceOptions();
+        Assert.IsNull(untouched.TerminalColorsFollowTheme);
+        Assert.IsTrue(TerminalColorScheme.FollowsTheme(untouched));
+        Assert.IsNull(TerminalAppearanceMapper.BuildPaletteOverrides(untouched));
+
+        // 老配置里改过配色的:同样没有标志,但颜色与出厂不一致 → 不跟随,覆盖照旧生效。
+        var customized = new AppearanceOptions { TerminalBackground = "#123456" };
+        Assert.IsFalse(TerminalColorScheme.FollowsTheme(customized));
+        Assert.AreEqual(
+            Rgba.FromRgb(0x12, 0x34, 0x56),
+            TerminalAppearanceMapper.BuildPaletteOverrides(customized)?.Background);
+    }
+
+    private static int IndexOf(string schemeName) =>
+        Array.FindIndex(TerminalColorScheme.BuiltIn, s => s.Name == schemeName) + 1;
+
+    private static async Task<SettingsViewModel> CreateViewModelAsync(string themeId)
+    {
+        ISettingsService settings = Substitute.For<ISettingsService>();
+        settings.GetSettingsAsync().Returns(_ => Task.FromResult(new AppSettings { Theme = themeId }));
+        var vm = new SettingsViewModel(
+            settingsService: settings,
+            themeService: new ThemeService(themeId));
+        await vm.LoadCommand.Execute().FirstAsync();
+        Assert.AreEqual(themeId, vm.Theme, "载入后主题应为用例指定的那套。");
+        return vm;
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/TerminalThemePairingTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalThemePairingTests.cs
@@ -1,0 +1,85 @@
+using Avalonia.Headless;
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 具名主题 → 终端配色的下发链路:宿主按当前主题把**配套**的整套终端配色推给终端控件。
+/// <para>
+/// 这条链路是新加的:此前终端只认明暗两套(Dracula / Solarized Light),
+/// 而具名主题里有六套暗色 —— VelaDark 换到 Tokyo Night 时明暗变体没变,
+/// 没有这次下发,终端画面会原地不动,和换过颜色的界面拼在一起。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("ThemeTokens")]
+public sealed class TerminalThemePairingTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(TerminalThemePairingTests).Assembly);
+
+    [TestMethod]
+    public async Task ActiveTheme_PushesItsPairedTerminalScheme() =>
+        await _session.Dispatch(() =>
+        {
+            foreach (UiTheme theme in UiThemeCatalog.All)
+            {
+                var control = new VelaTerminalControl();
+                var vm = new MainWindowViewModel(themeService: new ThemeService(theme.Id));
+
+                vm.ApplyTerminalAppearanceToPluginView(control);
+
+                TerminalPaletteOverrides? pushed = control.ThemePalette;
+                Assert.IsNotNull(pushed, $"{theme.Name}:没有给终端下发主题配色。");
+                Assert.AreEqual(
+                    ParseHex(theme.Terminal.Background),
+                    pushed.Background,
+                    $"{theme.Name}:终端背景与配套方案「{theme.TerminalSchemeName}」不符。");
+                Assert.AreEqual(
+                    ParseHex(theme.Terminal.AnsiNormal[4]),
+                    pushed.Ansi[4],
+                    $"{theme.Name}:ANSI 蓝与配套方案不符 —— 下发的多半不是整套。");
+                Assert.AreEqual(
+                    ParseHex(theme.Terminal.AnsiBright[7]),
+                    pushed.Ansi[15],
+                    $"{theme.Name}:高亮八色没有下发到 8–15 槽位。");
+            }
+            return Task.FromResult(true);
+        }, CancellationToken.None);
+
+    /// <summary>
+    /// 没改过任何颜色时用户覆盖必须为空 —— 覆盖非空会把终端钉死在出厂色上,
+    /// 换主题再也不跟随(这正是"跟随主题"与"选了具体方案"的分界)。
+    /// </summary>
+    [TestMethod]
+    public async Task UntouchedAppearance_ProducesNoUserOverrides() =>
+        await _session.Dispatch(() =>
+        {
+            var control = new VelaTerminalControl();
+            var vm = new MainWindowViewModel(themeService: new ThemeService("nord"));
+
+            vm.ApplyTerminalAppearanceToPluginView(control);
+
+            Assert.IsNull(control.PaletteOverrides, "出厂配色不该产生任何用户覆盖。");
+            // 覆盖为空 ⇒ 终端实际用的就是这里下发的主题配色(叠加顺序见
+            // VelaShell.Terminal.Tests 的 ThemePaletteLayeringTests)。
+            Assert.AreEqual(
+                ParseHex(UiThemeCatalog.Get("nord").Terminal.Background),
+                control.ThemePalette?.Background,
+                "跟随态下终端背景就是主题配套方案的背景。");
+            return Task.FromResult(true);
+        }, CancellationToken.None);
+
+    private static Rgba ParseHex(string hex)
+    {
+        uint rgb = Convert.ToUInt32(hex.TrimStart('#'), 16);
+        return Rgba.FromRgb((byte)(rgb >> 16), (byte)(rgb >> 8), (byte)rgb);
+    }
+}

--- a/tests/VelaShell.Tests/Views/ThemeTokenShadowingUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ThemeTokenShadowingUiTests.cs
@@ -1,0 +1,80 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using VelaShell.Core.Models;
+using VelaShell.Services;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 具名主题赖以成立的那条机制:写进 <c>Application.Resources</c> 顶层的令牌,
+/// 必须盖得住 <c>VelaTokens.axaml</c> / <c>VelaShellTokens.axaml</c> 的 ThemeDictionaries
+/// 与 App.axaml 挂上去的 DarkTheme/LightTheme。
+/// <para>
+/// 盖不住的话,九套主题里有六套(暗色那几套共用 Dark 变体)会全部退化成 VelaDark ——
+/// 而且不会有任何报错,只是颜色不对。这条用例就是那道保险。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("ThemeTokens")]
+public sealed class ThemeTokenShadowingUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(ThemeTokenShadowingUiTests).Assembly);
+
+    [TestMethod]
+    public async Task AppliedTokens_ShadowTheCompiledThemeDictionaries() =>
+        await _session.Dispatch(() =>
+        {
+            Application app = Application.Current!;
+            // 贴之前:解析到的是 axaml 里 Dark 变体的值(headless 宿主与 App.axaml 同一套资源栈)。
+            Assert.AreEqual(
+                Color.Parse(UiThemeCatalog.Get("dark").Palette.BgPage),
+                Resolve(app, "VelaBgPage"),
+                "起点不是 VelaDark 的话,后面的断言就说明不了问题。");
+
+            try
+            {
+                foreach (string themeId in new[] { "tokyo-night", "everforest", "github-light" })
+                {
+                    UiTheme theme = UiThemeCatalog.Get(themeId);
+                    ThemeTokenApplier.Apply(app.Resources, theme);
+
+                    // 三类令牌各取一个:平面底色、文字、强调色派生的半透明底。
+                    Assert.AreEqual(Color.Parse(theme.Palette.BgPage), Resolve(app, "VelaBgPage"),
+                        $"{theme.Name}:平面底色没盖住 axaml 的缺省。");
+                    Assert.AreEqual(Color.Parse(theme.Palette.TextPrimary), Resolve(app, "VelaTextPrimary"),
+                        $"{theme.Name}:正文色没盖住 axaml 的缺省。");
+                    Assert.AreEqual(Color.Parse(theme.Palette.Accent), Resolve(app, "VelaAccent"),
+                        $"{theme.Name}:强调色没盖住 axaml 的缺省。");
+                    Assert.AreEqual(Color.Parse(theme.Palette.Error), Resolve(app, "VelaError"),
+                        $"{theme.Name}:语义色(App.axaml 的 ThemeDictionaries 那一层)没盖住。");
+                }
+            }
+            finally
+            {
+                // 会话是全程序集共用的:改完必须还原,否则后面的 UI 用例对着别人的颜色跑。
+                foreach (string key in ThemeTokenApplier.TokenKeys)
+                {
+                    app.Resources.Remove(key);
+                }
+                app.Resources.Remove("VelaShadowWindow");
+            }
+
+            Assert.AreEqual(
+                Color.Parse(UiThemeCatalog.Get("dark").Palette.BgPage),
+                Resolve(app, "VelaBgPage"),
+                "移除顶层令牌后必须落回 axaml 的缺省 —— 说明刚才确实是遮蔽,不是把缺省改掉了。");
+            return Task.FromResult(true);
+        }, CancellationToken.None);
+
+    private static Color Resolve(Application app, string key)
+    {
+        Assert.IsTrue(app.TryGetResource(key, app.ActualThemeVariant, out object? value), $"令牌 {key} 解析不到。");
+        Assert.IsInstanceOfType<ISolidColorBrush>(value, $"令牌 {key} 不是画刷。");
+        return ((ISolidColorBrush)value!).Color;
+    }
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次提交实现 VelaShell 具名主题系统，支持九套独立配色（六暗三亮），主题切换时动态派生颜色令牌并即时换肤。终端配色与主题一一对应，支持用户自定义叠加，配色“跟随主题”状态显式记录，解决语义混淆。设置页主题/配色下拉项动态绑定，支持“跟随系统”与所有具名主题。所有主题通过 WCAG AA/3:1 对比度测试，终端与界面底色一致。插件仅暴露 dark/light/system。同步完善相关测试、文档与资源，提升主题机制正确性与可维护性。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [x] 其他:新增主题

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
