### PR TITLE
重构并增强主题系统，统一主题同步与推送

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,13 @@ dotnet test  VelaShell.slnx
   `HeadlessUnitTestSession` 没有 `Func<Task>` 重载,写成无返回值会拿到一个从未被等待的
   `Task<Task>`,测试跑到第一个 `await` 就"通过",断言失败全部丢失。
 - **插件 SDK 一律走 NuGet 包**,不做工程引用。版本在 `src/Directory.Packages.props`。
+- **不要自己决定 SDK 版本号,也不要造本地包**。宿主的改动需要 SDK 的新契约时,正确做法是:
+  在 velashell-plugin-sdk 里把契约写好(那边**同样**不动版本号),然后**明确交代**
+  「需要发一版 SDK,发完把 `src/Directory.Packages.props` 与 `tests/Directory.Packages.props`
+  抬上去」。在那之前宿主编译不过是**预期内的**,不是要绕过的障碍。
+  绝不要 `dotnet pack` 一个本地包、往 `nuget.config` 塞本地源、或者把包版本指到一个
+  还不存在的号 —— 下一版发什么号是排期决定的,你猜一个就把所有下游都钉死在那个号上了;
+  何况本地包未签名(`VelaShell.snk` 不在仓库里),一编译就是一片 `CS0012` 假错误。
 
 ### 相关仓库
 

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -24,7 +24,7 @@
          PrivateAssets=all + ExcludeAssets=runtime:编译期能看见类型,输出目录里不留 dll ——
          装载时它必须与宿主是同一份程序集,复制过去就成了两份类型。
          版本须与 src/Directory.Packages.props 里宿主引的那一条一致。 -->
-    <PackageReference Include="VelaShell.PluginSdk" Version="1.5.1" PrivateAssets="all" ExcludeAssets="runtime">
+    <PackageReference Include="VelaShell.PluginSdk" Version="2.0.0" PrivateAssets="all" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- 仅编译期引用 Avalonia,运行时由装载方共享同一套(版本须与宿主一致)。 -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
          (VelaShellLabs/velashell-plugins)里,版本由那边的中央包管理登记,别再加回来。
          本仓库 plugins/ 下的自建插件(AI)不走中央包版本管理
          (根目录没有 Directory.Packages.props),依赖版本写在各自的 csproj 里。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.6.0" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
          (VelaShellLabs/velashell-plugins)里,版本由那边的中央包管理登记,别再加回来。
          本仓库 plugins/ 下的自建插件(AI)不走中央包版本管理
          (根目录没有 Directory.Packages.props),依赖版本写在各自的 csproj 里。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.1" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="1.6.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />

--- a/src/VelaShell.Controls/Themes/VelaShellTokens.axaml
+++ b/src/VelaShell.Controls/Themes/VelaShellTokens.axaml
@@ -24,6 +24,10 @@
       <SolidColorBrush x:Key="VelaBgInput" Color="#282A36" />
       <SolidColorBrush x:Key="VelaTabActiveBg" Color="#282A36" />
       <SolidColorBrush x:Key="VelaTabInactiveBg" Color="#191A21" />
+      <!-- 遮罩两档:轻(点空白即关的浮层)与重(模态抽屉/对话框)。窗口铬色掺七成黑,
+           再按档位给不透明度 —— 派生规则在 ThemeTokenApplier,这里是编译期缺省。 -->
+      <SolidColorBrush x:Key="VelaScrim" Color="#9908080A" />
+      <SolidColorBrush x:Key="VelaScrimStrong" Color="#CC08080A" />
     </ResourceDictionary>
     <!-- Alucard 亮色(dracula/foot 官方亮色方案):奶油底 #FFFBEB 家族。 -->
     <ResourceDictionary x:Key="Light">
@@ -41,6 +45,10 @@
       <SolidColorBrush x:Key="VelaBgInput" Color="#F7F2DF" />
       <SolidColorBrush x:Key="VelaTabActiveBg" Color="#FFFBEB" />
       <SolidColorBrush x:Key="VelaTabInactiveBg" Color="#EBE5CC" />
+      <!-- 亮色主题的遮罩同样偏黑:铺一层浅遮罩读不出"下面那层不可点了",
+           而这正是遮罩唯一要传达的事。 -->
+      <SolidColorBrush x:Key="VelaScrim" Color="#99494741" />
+      <SolidColorBrush x:Key="VelaScrimStrong" Color="#CC494741" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/VelaShell.Core/Services/IThemeService.cs
+++ b/src/VelaShell.Core/Services/IThemeService.cs
@@ -1,5 +1,11 @@
 namespace VelaShell.Core.Services;
 
+/// <summary>
+/// 系统是否偏好暗色。由 UI 层实现(Avalonia 的 <c>ActualThemeVariant</c>)——
+/// Core 与 Infrastructure 都不引用 Avalonia,而“跟随系统”落到哪一套主题只有它知道。
+/// </summary>
+public delegate bool SystemDarkModeProbe();
+
 /// <summary>主题服务:管理当前主题(明/暗等)与强调色覆盖,并在变化时通知订阅方。</summary>
 public interface IThemeService
 {
@@ -22,4 +28,23 @@ public interface IThemeService
 
     /// <summary>强调色覆盖变更时触发;参数为十六进制颜色,或为 null 表示默认。</summary>
     event Action<string?>? AccentChanged;
+
+    /// <summary>
+    /// **生效配色**变化时触发 —— 换主题、“跟随系统”下系统明暗翻转、强调色覆盖变化,三者的并集。
+    /// <para>
+    /// 为什么不能用 <see cref="ThemeChanged" /> 代替:它只覆盖第一种,而且它的参数是主题 id,
+    /// 订阅方多半会拿它去判断“变没变” —— 后两种情况下主题 id 根本没动,判断结果是“没变”,
+    /// 而屏幕上整套颜色已经换了。要重取颜色的地方(插件令牌快照、一次性取色的缓存)认这个事件。
+    /// </para>
+    /// <para>触发时机在 <see cref="ThemeChanged" /> / <see cref="AccentChanged" /> **之后**:
+    /// 宿主对那两个事件的处理器会把新令牌贴到应用资源上,先后颠倒的话订阅方取到的还是旧色。</para>
+    /// </summary>
+    event Action? EffectiveThemeChanged;
+
+    /// <summary>
+    /// “跟随系统”下系统明暗翻转时由宿主调用:主题 id 没变,但整套生效配色换了。
+    /// 只触发 <see cref="EffectiveThemeChanged" />,不触发 <see cref="ThemeChanged" />
+    /// (后者的语义是“用户换了主题”,这里没有)。
+    /// </summary>
+    void NotifySystemVariantChanged();
 }

--- a/src/VelaShell.Core/Services/ThemeService.cs
+++ b/src/VelaShell.Core/Services/ThemeService.cs
@@ -32,6 +32,12 @@ public class ThemeService(string initialTheme = "dark", string? initialAccent = 
     /// </summary>
     public event Action<string?>? AccentChanged;
 
+    /// <inheritdoc />
+    public event Action? EffectiveThemeChanged;
+
+    /// <inheritdoc />
+    public void NotifySystemVariantChanged() => EffectiveThemeChanged?.Invoke();
+
     /// <summary>
     /// 根据给定十六进制字符串设置强调色(经过校验与规范化),
     /// 仅当值确实变化时抛出 <see cref="AccentChanged"/>。
@@ -45,6 +51,9 @@ public class ThemeService(string initialTheme = "dark", string? initialAccent = 
         }
         AccentColor = normalized;
         AccentChanged?.Invoke(AccentColor);
+        // 次序要紧:AccentChanged 的处理器(App.ApplyAccent)刚把新强调色贴到应用资源上,
+        // 这一句之后订阅方去取色才取得到新值。
+        EffectiveThemeChanged?.Invoke();
     }
 
     /// <summary>
@@ -66,6 +75,9 @@ public class ThemeService(string initialTheme = "dark", string? initialAccent = 
         }
         CurrentTheme = normalized;
         ThemeChanged?.Invoke(CurrentTheme);
+        // 同 SetAccent:ThemeChanged 的处理器(App.ApplyThemeVariant)已把整套令牌换好,
+        // 这一句之后订阅方取到的才是新主题的颜色。
+        EffectiveThemeChanged?.Invoke();
     }
 
     /// <summary>

--- a/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
@@ -69,6 +69,9 @@ public static class PluginServiceCollectionExtensions
                 CommandsFactory = sp.GetService<Func<string, IPluginLogger, ICommandsApi>>(),
                 UiFactory = sp.GetService<Func<string, IPluginLogger, IUiApi>>(),
                 ThemeTokensProvider = sp.GetService<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(),
+                // "跟随系统"时把系统明暗问出来:插件的 IHostThemeApi.Current 要报一套
+                // **已解析**的主题,不能把 "system" 原样丢给插件(那正是老契约的毛病)。
+                SystemPrefersDark = sp.GetService<SystemDarkModeProbe>(),
                 DataStore = sp.GetService<IPluginDataStore>(),
                 SecretProtector = sp.GetService<Core.Data.ISecretProtector>(),
                 Clipboard = sp.GetService<PluginSdk.Clipboard.IClipboardApi>(),

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/HostThemeCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/HostThemeCapability.cs
@@ -1,0 +1,101 @@
+using VelaShell.PluginSdk.Logging;
+using VelaShell.PluginSdk.Theming;
+
+namespace VelaShell.Infrastructure.Plugins.Capabilities;
+
+/// <summary>
+/// 每插件一个的 <see cref="IHostThemeApi" />:身份与配色直接透传共享的
+/// <see cref="HostThemeSource" />,变更事件逐处理器守卫异常(单个插件的坏处理器只记日志,
+/// 不影响宿主与其它插件)。
+/// <see cref="Dispose" /> 时拆掉对共享源的订阅并清空插件处理器 ——
+/// 与 <see cref="PluginEventHub" /> 同理,悬挂的事件引用会把整个插件程序集钉在内存里,
+/// 可收集 ALC 就回收不掉。
+/// </summary>
+internal sealed class HostThemeCapability : IHostThemeApi, IDisposable
+{
+    private readonly IPluginLogger _log;
+    private readonly HostThemeSource _source;
+    private readonly Action<HostThemeInfo> _onChanged;
+    private bool _disposed;
+
+    public HostThemeCapability(IPluginLogger log, HostThemeSource source)
+    {
+        _log = log;
+        _source = source;
+        _onChanged = info => Forward(Changed, info);
+        _source.Changed += _onChanged;
+    }
+
+    /// <inheritdoc />
+    public HostThemeInfo Current => _source.Current;
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> Colors => _source.Colors;
+
+    /// <inheritdoc />
+    public event Action<HostThemeInfo>? Changed;
+
+    /// <inheritdoc />
+    public string? GetColor(string token) =>
+        token is not null && _source.Colors.TryGetValue(token, out string? value) ? value : null;
+
+    /// <summary>逐处理器转发,插件处理器抛出只记入该插件日志。</summary>
+    private void Forward(Action<HostThemeInfo>? handlers, HostThemeInfo payload)
+    {
+        if (handlers is null || _disposed)
+        {
+            return;
+        }
+        foreach (Action<HostThemeInfo> handler in handlers.GetInvocationList().Cast<Action<HostThemeInfo>>())
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Theme changed handler threw.", ex);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        _source.Changed -= _onChanged;
+        Changed = null;
+    }
+}
+
+/// <summary>
+/// 没有主题服务的宿主(headless 测试)用的兜底:交出一套固定的默认主题与空配色,
+/// 插件照常跑 —— 与其它能力"缺席即退化,不崩溃"的口径一致。
+/// </summary>
+internal sealed class StaticHostTheme : IHostThemeApi
+{
+    /// <inheritdoc />
+    public HostThemeInfo Current { get; } = new(
+        Core.Models.UiThemeCatalog.DefaultDark.Id,
+        Core.Models.UiThemeCatalog.DefaultDark.Name,
+        Core.Models.UiThemeCatalog.DefaultDark.IsDark,
+        FollowsSystem: false,
+        Core.Models.UiThemeCatalog.DefaultDark.Palette.Accent);
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> Colors { get; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public event Action<HostThemeInfo>? Changed
+    {
+        add { }
+        remove { }
+    }
+
+    /// <inheritdoc />
+    public string? GetColor(string token) => null;
+}

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/HostThemeSource.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/HostThemeSource.cs
@@ -1,0 +1,134 @@
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.PluginSdk.Rpc;
+using VelaShell.PluginSdk.Theming;
+
+namespace VelaShell.Infrastructure.Plugins.Capabilities;
+
+/// <summary>
+/// 宿主主题的**单一**采集点:订阅 <see cref="IThemeService.EffectiveThemeChanged" />,
+/// 每次变化重算一次主题身份与整套 <c>Vela*</c> 颜色快照,再一次性广播给所有插件
+/// (每插件一个 <see cref="HostThemeCapability" /> 挂在这上面)。
+/// <para>
+/// 之所以不让每个插件各自去采:采一次要跳到 UI 线程遍历整棵资源树,装了十个插件就是
+/// 十次 —— 而它们要的是同一份东西。这里采一次,大家共用同一个不可变快照。
+/// </para>
+/// </summary>
+internal sealed class HostThemeSource : IDisposable
+{
+    private readonly IThemeService? _theme;
+    private readonly SystemDarkModeProbe? _systemPrefersDark;
+    private readonly Func<Task<IReadOnlyList<ThemeTokenDto>>>? _tokens;
+    private readonly Action _onEffectiveThemeChanged;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private bool _disposed;
+
+    /// <summary>当前主题身份。构造后即有值(不必等第一次刷新)。</summary>
+    public HostThemeInfo Current { get; private set; }
+
+    /// <summary>当前颜色快照。整体替换,永不就地改写 —— 插件拿去的实例不会在手里变。</summary>
+    public IReadOnlyDictionary<string, string> Colors { get; private set; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// 生效配色已变、且 <see cref="Current" /> / <see cref="Colors" /> 都已更新。
+    /// 在线程池线程上触发。
+    /// </summary>
+    public event Action<HostThemeInfo>? Changed;
+
+    public HostThemeSource(
+        IThemeService? theme,
+        SystemDarkModeProbe? systemPrefersDark,
+        Func<Task<IReadOnlyList<ThemeTokenDto>>>? tokens)
+    {
+        _theme = theme;
+        _systemPrefersDark = systemPrefersDark;
+        _tokens = tokens;
+        Current = Resolve();
+        _onEffectiveThemeChanged = () => _ = RefreshAsync();
+        _theme?.EffectiveThemeChanged += _onEffectiveThemeChanged;
+    }
+
+    /// <summary>
+    /// 重算身份与颜色,然后广播。**次序是契约的一部分**:插件在 <c>Changed</c> 里读
+    /// <c>Colors</c>,先播后采就会读到上一套颜色。
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        // 一次只跑一趟:连着切三次主题不该并发采三份快照、再以不确定的次序互相覆盖。
+        await _refreshGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            HostThemeInfo info = Resolve();
+            Colors = await CollectColorsAsync().ConfigureAwait(false);
+            Current = info;
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+        Changed?.Invoke(Current);
+    }
+
+    /// <summary>把主题服务的持久化值解析成插件看得懂的身份(“跟随系统”在这里落地)。</summary>
+    private HostThemeInfo Resolve()
+    {
+        string? id = _theme?.CurrentTheme;
+        bool followsSystem = UiThemeCatalog.Find(id) is null;
+        // 只有"跟随系统"才需要问 UI 层此刻是明是暗;问不到(headless)时按暗色兜底,
+        // 与 UiThemeCatalog.Resolve 对未知值的兜底一致。
+        UiTheme resolved = UiThemeCatalog.Resolve(id, !followsSystem || (_systemPrefersDark?.Invoke() ?? true));
+        // 强调色以用户覆盖优先 —— 插件问"当前强调色是什么",要的是屏幕上那个,
+        // 不是主题出厂那个。
+        string accent = _theme?.AccentColor ?? resolved.Palette.Accent;
+        return new(resolved.Id, resolved.Name, resolved.IsDark, followsSystem, accent);
+    }
+
+    /// <summary>取一份颜色令牌快照(brush / color 两类;字号与字体不属于配色)。</summary>
+    private async Task<IReadOnlyDictionary<string, string>> CollectColorsAsync()
+    {
+        if (_tokens is null)
+        {
+            return Colors;
+        }
+        try
+        {
+            IReadOnlyList<ThemeTokenDto> tokens = await _tokens().ConfigureAwait(false);
+            var colors = new Dictionary<string, string>(tokens.Count, StringComparer.Ordinal);
+            foreach (ThemeTokenDto token in tokens)
+            {
+                if (token.Kind is "brush" or "color")
+                {
+                    colors[token.Key] = token.Value;
+                }
+            }
+            // 采空了当采集失败:宁可留着上一份(颜色偏一档),也不要交出一份空表
+            // ——那会让插件的取色全落到兜底灰上。
+            return colors.Count > 0 ? colors : Colors;
+        }
+        catch (Exception)
+        {
+            return Colors;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        _theme?.EffectiveThemeChanged -= _onEffectiveThemeChanged;
+        Changed = null;
+        _refreshGate.Dispose();
+    }
+}

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
@@ -48,38 +48,50 @@ internal sealed class PluginCapabilityRouter : IDisposable
         context.Events.SessionDisconnected += session =>
             _ = rpc.NotifyAsync(PluginRpc.HostEvent, new HostEventNotification("sessionDisconnected", session, null));
         context.Events.ThemeChanged += theme =>
-        {
             _ = rpc.NotifyAsync(PluginRpc.HostEvent, new HostEventNotification("themeChanged", null, theme));
-            // 主题切换重推令牌快照。稍等一拍:宿主应用新明暗变体与令牌重解析都在 UI
-            // 线程队列里,等它落定再取值,插件拿到的才是新主题的颜色。
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(100).ConfigureAwait(false);
-                await PushThemeTokensAsync().ConfigureAwait(false);
-            });
-        };
+        // 令牌快照跟的是**生效配色**而不是 themeChanged。三条理由,每条都对应一个真实的漏推:
+        //   · 换具名主题时 themeChanged 的参数不变(VelaDark→Tokyo Night 都报 "dark"),
+        //     它作为信号还在,但插件侧没法拿参数判断;
+        //   · "跟随系统"下系统明暗翻转根本不经过 themeChanged —— 主题 id 一直是 "system";
+        //   · 用户改强调色同样不经过它。
+        // 后两种情况下隔离插件原本会一直停在上一套配色上。IHostThemeApi.Changed 是三者的并集,
+        // 而且它在触发前已经把新快照采好了 —— 从前那个"等 100ms 让 UI 线程落定"的权宜也就
+        // 不需要了(HostThemeSource 采集时自己会跳 UI 线程,天然排在贴令牌之后)。
+        context.Theme.Changed += info => { _ = PushThemeTokensAsync(); };
         context.Events.LocaleChanged += locale =>
             _ = rpc.NotifyAsync(PluginRpc.HostEvent, new HostEventNotification("localeChanged", null, locale));
     }
 
-    /// <summary>下发主题令牌快照(尽力而为:无提供者或采集失败则跳过)。</summary>
+    /// <summary>
+    /// 下发主题状态(整套令牌 + 主题身份)。
+    /// <para>
+    /// 身份**总是**发,即使宿主没有令牌提供者(headless):隔离插件的
+    /// <see cref="PluginSdk.Theming.IHostThemeApi.Current" /> 靠它更新,没有令牌不等于没有主题。
+    /// 令牌采集失败时只是发一份空表,插件侧会保留上一份颜色。
+    /// </para>
+    /// </summary>
     public async Task PushThemeTokensAsync()
     {
-        if (_themeTokens is null)
+        ThemeTokenDto[] tokens = [];
+        if (_themeTokens is not null)
         {
-            return;
+            try
+            {
+                tokens = [.. await _themeTokens().ConfigureAwait(false)];
+            }
+            catch (Exception ex)
+            {
+                _context.Log.Warn($"Theme token collection failed: {ex.Message}");
+            }
         }
         try
         {
-            IReadOnlyList<ThemeTokenDto> tokens = await _themeTokens().ConfigureAwait(false);
-            if (tokens.Count > 0)
-            {
-                await _rpc.NotifyAsync(PluginRpc.ThemeTokens, new ThemeTokensNotification([.. tokens])).ConfigureAwait(false);
-            }
+            await _rpc.NotifyAsync(PluginRpc.ThemeTokens,
+                new ThemeTokensNotification(tokens, _context.Theme.Current)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            _context.Log.Warn($"Theme token push failed: {ex.Message}");
+            _context.Log.Warn($"Theme state push failed: {ex.Message}");
         }
     }
 
@@ -457,7 +469,10 @@ internal sealed class PluginCapabilityRouter : IDisposable
         _handshakeDone = true;
         _handshake.TrySetResult();
         return new(VelaPluginApi.Level, _hostVersion, _context.Host.Locale, _context.Host.Theme,
-            SupportsEmbedding: _embedHost is { IsSupported: true });
+            SupportsEmbedding: _embedHost is { IsSupported: true },
+            // 主题身份握手就给:插件在 Activate 里建界面时就要知道自己长在哪套主题上,
+            // 等第一条 theme/tokens 通知就晚了。
+            ThemeInfo: _context.Theme.Current);
     }
 
     /// <summary>取已打开的 measurement 句柄;插件必须先 <see cref="PluginRpc.TimeSeriesOpen" />。</summary>

--- a/src/VelaShell.Infrastructure/Plugins/PluginContext.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginContext.cs
@@ -34,6 +34,7 @@ internal sealed class PluginContext : IPluginContext, IDisposable
     public required IRemoteTunnelApi RemoteTunnel { get; init; }
     public required ICommandsApi Commands { get; init; }
     public required IHostEvents Events { get; init; }
+    public required PluginSdk.Theming.IHostThemeApi Theme { get; init; }
     public required IUiApi Ui { get; init; }
     public required ISecretsApi Secrets { get; init; }
     public required IClipboardApi Clipboard { get; init; }
@@ -47,6 +48,7 @@ internal sealed class PluginContext : IPluginContext, IDisposable
     {
         (Commands as IDisposable)?.Dispose();
         (Events as IDisposable)?.Dispose();
+        (Theme as IDisposable)?.Dispose();
         (Ui as IDisposable)?.Dispose();
         // 协议/工作台注册要在这里撤:它们握着插件实现的引用,不撤 ALC 就回收不掉,
         // 而且用户还会在连接页看到一个再也连不上的页签。

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -84,6 +84,12 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     }
 
     private readonly List<PluginRuntime> _plugins = [];
+    /// <summary>
+    /// 主题快照的共享采集点。惰性:一个插件都没有的宿主不该为此订阅主题服务、
+    /// 更不该去遍历资源树。见 <see cref="HostThemeSource" />。
+    /// </summary>
+    private readonly Lazy<HostThemeSource> _themeSource = new(() =>
+        new(options.Theme, options.SystemPrefersDark, options.ThemeTokensProvider));
     private readonly Lock _gate = new();
     private readonly CancellationTokenSource _shutdown = new();
     private readonly List<FileSystemWatcher> _devWatchers = [];
@@ -1903,6 +1909,11 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                 : new UnavailableRemoteTunnel(),
             Commands = GetOrCreateCommandsApi(runtime),
             Events = new PluginEventHub(log, options.Connections, options.Theme, options.Localization),
+            // 主题能力挂在共享采集点上(每次换肤只采一份快照,全部插件共用)。
+            // 没有主题服务的宿主(headless 测试)退化成一套固定的默认主题。
+            Theme = options.Theme is null
+                ? new StaticHostTheme()
+                : new HostThemeCapability(log, _themeSource.Value),
             Ui = options.UiFactory?.Invoke(manifest.Id, log) ?? new NullUiApi(log),
             Secrets = options.DataStore is { } dataStore
                 ? dataStore.CreateSecrets(manifest.Id)
@@ -1949,6 +1960,10 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         {
             (runtime.CommandsApi as IDisposable)?.Dispose();
             runtime.CommandsApi = null;
+        }
+        if (_themeSource.IsValueCreated)
+        {
+            _themeSource.Value.Dispose();
         }
         _shutdown.Dispose();
     }

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -124,6 +124,14 @@ public sealed class PluginManagerOptions
     public Func<Task<IReadOnlyList<ThemeTokenDto>>>? ThemeTokensProvider { get; init; }
 
     /// <summary>
+    /// 系统是否偏好暗色(由 UI 层提供:Avalonia 的 <c>ActualThemeVariant</c>)。
+    /// 只在用户选了“跟随系统”时用得到 —— 那时 <see cref="IThemeService.CurrentTheme" />
+    /// 是字面量 <c>system</c>,光看它不知道此刻该报哪一套主题给插件。
+    /// 缺席时按暗色兜底(与 <c>UiThemeCatalog.Resolve</c> 对未知值的兜底一致)。
+    /// </summary>
+    public SystemDarkModeProbe? SystemPrefersDark { get; init; }
+
+    /// <summary>
     /// 插件数据后端(SonnetDB):KV 与机密按插件 id 命名空间化落库,卸载可整体清除。
     /// 缺席时退回插件数据目录下的 JSON/加密 JSON 文件(headless 测试路径)。
     /// </summary>

--- a/src/VelaShell.PluginHost/PluginHostApp.cs
+++ b/src/VelaShell.PluginHost/PluginHostApp.cs
@@ -18,20 +18,20 @@ internal sealed class PluginHostApp : Application
         Styles.Add(new FluentTheme());
     }
 
-    /// <summary>把宿主主题名映射到明暗变体并应用(任意线程可调)。</summary>
-    public static void ApplyHostTheme(string theme)
+    /// <summary>
+    /// 把宿主的明暗基底应用到本进程(任意线程可调)。
+    /// <para>
+    /// 参数是**已解析**的布尔而不是主题名。老实现按主题名里有没有 "light"/"dark" 猜,
+    /// 那在只有明暗两套时碰巧成立;宿主长出具名主题之后就错了 —— "tokyo-night"、"nord"、
+    /// "sakura" 里一个关键字都没有,会被判成"跟随系统"从而去跟**插件进程自己**的系统设置,
+    /// 而 "one-light" 又会碰巧蒙对。解析归宿主,这里只负责贴。
+    /// </para>
+    /// </summary>
+    public static void ApplyHostTheme(bool isDark)
     {
         Dispatcher.UIThread.Post(() =>
         {
-            if (Current is null)
-            {
-                return;
-            }
-            Current.RequestedThemeVariant = theme.Contains("light", StringComparison.OrdinalIgnoreCase)
-                ? ThemeVariant.Light
-                : theme.Contains("dark", StringComparison.OrdinalIgnoreCase)
-                    ? ThemeVariant.Dark
-                    : ThemeVariant.Default;
+            Current?.RequestedThemeVariant = isDark ? ThemeVariant.Dark : ThemeVariant.Light;
         });
     }
 }

--- a/src/VelaShell.PluginHost/Program.cs
+++ b/src/VelaShell.PluginHost/Program.cs
@@ -139,8 +139,8 @@ internal static class Program
                                       new HandshakeRequest(token, pluginId, pluginVersion, [VelaPluginApi.Level]),
                                       TimeSpan.FromSeconds(10)).ConfigureAwait(false)
                                   ?? throw new InvalidOperationException("Empty handshake response.");
+        // 构造上下文时即按握手带来的主题身份把明暗基底贴好(见 RemotePluginContext)。
         context = new(connection, pluginId, pluginVersion, dataDirectory, hello, shutdownSource.Token);
-        PluginHostApp.ApplyHostTheme(hello.Theme); // 明暗跟随宿主
 
         int code = await ExitCode.Task.ConfigureAwait(false);
         await connection.DisposeAsync().ConfigureAwait(false);
@@ -149,10 +149,13 @@ internal static class Program
 
     private static void DispatchNotification(RemotePluginContext? context, string method, JsonElement? payload)
     {
-        // 主题令牌在激活流程前就会下发(宿主握手后立即推送),不依赖上下文。
-        if (method == PluginRpc.ThemeTokens && Deserialize<ThemeTokensNotification>(payload) is { } tokens)
+        // 主题状态在激活流程前就会下发(宿主握手后立即推送),令牌那一半不依赖上下文。
+        if (method == PluginRpc.ThemeTokens && Deserialize<ThemeTokensNotification>(payload) is { } theme)
         {
-            PluginHostThemeTokens.Apply(tokens);
+            PluginHostThemeTokens.Apply(theme);
+            // 身份那一半要有上下文才有处安放;握手前那一发只有令牌有意义,
+            // 身份的初值本来就在握手应答里。
+            context?.ThemeHub.OnThemeState(theme);
             return;
         }
         if (context is null)

--- a/src/VelaShell.PluginHost/RemoteHostTheme.cs
+++ b/src/VelaShell.PluginHost/RemoteHostTheme.cs
@@ -1,0 +1,80 @@
+using VelaShell.PluginSdk.Logging;
+using VelaShell.PluginSdk.Rpc;
+using VelaShell.PluginSdk.Theming;
+
+namespace VelaShell.PluginHost;
+
+/// <summary>
+/// 隔离进程侧的 <see cref="IHostThemeApi" />:身份与配色都来自宿主的
+/// <see cref="PluginRpc.ThemeTokens" /> 通知(握手应答里带初值)。
+/// <para>
+/// 令牌与身份走同一条通知,所以这里能保证一件事:<see cref="Changed" /> 触发时
+/// <see cref="Current" /> 与 <see cref="Colors" /> 都已经是新的。拆成两条消息就做不到 ——
+/// 插件会在“身份已换、颜色还旧”的中间态里被叫醒。
+/// </para>
+/// </summary>
+internal sealed class RemoteHostTheme(IPluginLogger log, HostThemeInfo initial) : IHostThemeApi
+{
+    private volatile HostThemeInfo _current = initial;
+    private volatile IReadOnlyDictionary<string, string> _colors =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public HostThemeInfo Current => _current;
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> Colors => _colors;
+
+    /// <inheritdoc />
+    public event Action<HostThemeInfo>? Changed;
+
+    /// <inheritdoc />
+    public string? GetColor(string token) =>
+        token is not null && _colors.TryGetValue(token, out string? value) ? value : null;
+
+    /// <summary>
+    /// 宿主下发了一份新的主题状态(已在线程池上)。
+    /// 身份缺席(老宿主)时保留旧身份,只更新颜色。
+    /// </summary>
+    internal void OnThemeState(ThemeTokensNotification notification)
+    {
+        var colors = new Dictionary<string, string>(notification.Tokens.Length, StringComparer.Ordinal);
+        foreach (ThemeTokenDto token in notification.Tokens)
+        {
+            if (token.Kind is "brush" or "color")
+            {
+                colors[token.Key] = token.Value;
+            }
+        }
+        // 空表当"这次没采到颜色":留着上一份(偏一档)也好过让插件的取色全落到兜底灰上。
+        if (colors.Count > 0)
+        {
+            _colors = colors;
+        }
+        if (notification.Theme is { } info)
+        {
+            _current = info;
+        }
+        Forward(_current);
+    }
+
+    /// <summary>逐处理器转发,插件处理器抛出只记入插件日志。</summary>
+    private void Forward(HostThemeInfo payload)
+    {
+        if (Changed is not { } handlers)
+        {
+            return;
+        }
+        foreach (Action<HostThemeInfo> handler in handlers.GetInvocationList().Cast<Action<HostThemeInfo>>())
+        {
+            try
+            {
+                handler(payload);
+            }
+            catch (Exception ex)
+            {
+                log.Error("Theme changed handler threw.", ex);
+            }
+        }
+    }
+}

--- a/src/VelaShell.PluginHost/RemotePluginContext.cs
+++ b/src/VelaShell.PluginHost/RemotePluginContext.cs
@@ -45,13 +45,30 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
         Clipboard = new RpcClipboard(rpc);
         Terminal = new RpcTerminal(rpc);
 
-        // 语言/主题事件顺带刷新 HostInfo 的实时值;主题同步给本进程 Avalonia。
+        // 主题:身份的初值来自握手。老宿主不带 ThemeInfo 时按粗粒度的明暗名兜一个 ——
+        // 认不出是哪套具名主题,但至少明暗与强调色的占位是对的。
+        ThemeHub = new(Log, hello.ThemeInfo ?? FallbackThemeInfo(hello.Theme));
+        // 生效配色变了就把本进程的明暗基底也跟过去(Fluent 控件模板认的是 ThemeVariant,
+        // 它不看 Vela* 令牌)。认 IsDark 而不是解析主题名 —— "tokyo-night" 里既没有 dark
+        // 也没有 light,靠字符串匹配的老写法会把它判成"跟随系统"。
+        ThemeHub.Changed += info => PluginHostApp.ApplyHostTheme(info.IsDark);
+        PluginHostApp.ApplyHostTheme(ThemeHub.Current.IsDark);
+
+        // 语言/主题事件顺带刷新 HostInfo 的实时值(粗粒度那一档,保留兼容)。
         EventsHub.LocaleChanged += locale => HostInfo.Locale = locale;
-        EventsHub.ThemeChanged += theme =>
-        {
-            HostInfo.Theme = theme;
-            PluginHostApp.ApplyHostTheme(theme);
-        };
+        EventsHub.ThemeChanged += theme => HostInfo.Theme = theme;
+    }
+
+    /// <summary>
+    /// 握手应答没带主题身份时的兜底(宿主比本 PluginHost 旧)。
+    /// <c>system</c> 落到暗色,与宿主 <c>UiThemeCatalog.Resolve</c> 对未知值的兜底一致。
+    /// </summary>
+    private static PluginSdk.Theming.HostThemeInfo FallbackThemeInfo(string variant)
+    {
+        bool isDark = !string.Equals(variant, "light", StringComparison.OrdinalIgnoreCase);
+        bool followsSystem = string.Equals(variant, "system", StringComparison.OrdinalIgnoreCase);
+        return new(isDark ? "dark" : "light", isDark ? "VelaDark" : "VelaLight", isDark, followsSystem,
+            isDark ? "#BD93F9" : "#644AC9");
     }
 
     public string PluginId { get; }
@@ -66,6 +83,7 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
     public IRemoteExecApi RemoteExec { get; }
     public ICommandsApi Commands => CommandsProxy;
     public IHostEvents Events => EventsHub;
+    public PluginSdk.Theming.IHostThemeApi Theme => ThemeHub;
     public IUiApi Ui => UiLocal;
     public PluginSdk.Secrets.ISecretsApi Secrets { get; }
     public PluginSdk.Clipboard.IClipboardApi Clipboard { get; }
@@ -176,6 +194,9 @@ internal sealed class RemotePluginContext : IPluginContext, IDisposable
 
     /// <inheritdoc cref="HostInfo" />
     internal RemoteEventHub EventsHub { get; }
+
+    /// <summary>主题状态接收端;<c>Program</c> 把 <c>theme/tokens</c> 通知喂给它。</summary>
+    internal RemoteHostTheme ThemeHub { get; }
 
     /// <inheritdoc cref="HostInfo" />
     internal PluginHostUi UiLocal { get; }

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -64,6 +64,11 @@ public class App : Application
             // 插件的 {DynamicResource VelaXxx} 跨进程同样生效(进程内天然可用)。
             .AddSingleton<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(_ =>
                 VelaShell.Services.Plugins.PluginThemeTokens.CollectAsync)
+            // "跟随系统"落到明还是暗,只有 Avalonia 知道(Core 与 Infrastructure 都不引用它)。
+            // 插件的主题身份靠这一支把 "system" 解析掉。
+            // 读的是缓存字段而不是 ActualThemeVariant 本身:调用方(插件上下文的构造、
+            // 主题快照的刷新)在后台线程上,而 Avalonia 的属性读取是有线程归属的。
+            .AddSingleton<SystemDarkModeProbe>(_ => () => _systemPrefersDark)
             // 插件剪贴板能力:经主窗口系统剪贴板(隔离插件经 RPC 路由到同一实现)。
             .AddSingleton<PluginSdk.Clipboard.IClipboardApi>(new Services.Plugins.HostClipboard())
             // 隔离插件的停靠请求默认回退为独立卡片窗口(跨进程 dock 嵌入与 dock reparenting
@@ -137,14 +142,26 @@ public class App : Application
         // 不贴的话界面会停在上一套配色上,只有 Fluent 控件跟着变,看上去像半边换了主题。
         ActualThemeVariantChanged += (_, _) =>
         {
+            _systemPrefersDark = ActualThemeVariant != ThemeVariant.Light;
             if (UiThemeCatalog.Find(_themeService?.CurrentTheme) is null)
             {
                 ApplyThemeTokens();
+                // 主题 id 没变(还是 "system"),所以 ThemeChanged 不会响 —— 但整套颜色换了。
+                // 不吆喝这一声,隔离插件的令牌快照就停在上一套配色上,而插件里一次性取色的
+                // 地方(转换器、语法高亮定义)在进程内也一样停着。
+                _themeService?.NotifySystemVariantChanged();
             }
         };
         ApplyThemeVariant(_themeService.CurrentTheme);
         ApplyAccent(_themeService.AccentColor);
+        _systemPrefersDark = ActualThemeVariant != ThemeVariant.Light;
     }
+
+    /// <summary>
+    /// 系统当前是否偏好暗色。在 UI 线程上随 <c>ActualThemeVariantChanged</c> 更新,
+    /// 供后台线程(插件的主题解析)无锁读取 —— 直接去读 <c>ActualThemeVariant</c> 会踩线程归属。
+    /// </summary>
+    private volatile bool _systemPrefersDark = true;
 
     /// <summary>框架初始化完成后应用已持久化的偏好并创建主窗口。</summary>
     public override void OnFrameworkInitializationCompleted()

--- a/src/VelaShell/Services/ThemeTokenApplier.cs
+++ b/src/VelaShell/Services/ThemeTokenApplier.cs
@@ -108,6 +108,12 @@ internal static class ThemeTokenApplier
         Color textTertiary = Parse(p.TextTertiary);
         Color bgPage = Parse(p.BgPage);
         Color bgTerminal = Parse(p.BgTerminal);
+        Color accentForeground = Parse(p.AccentForeground);
+
+        // 遮罩:模态浮层压住底下的界面。一律偏黑 —— 亮色主题上铺一层浅遮罩读不出"下面那层
+        // 不可点了",而这正是遮罩唯一要传达的事。掺三成窗口底色是为了不让它在带色相的主题
+        // (Sakura 的粉、Gruvbox 的棕)上显得是一块外来的死黑。
+        Color scrim = Blend(bgPage, Colors.Black, 0.3);
 
         // 图表面积填充的不透明度:亮底上要更淡一档,否则几条曲线糊成一片。
         byte dim = dark ? (byte)0x38 : (byte)0x28;
@@ -134,6 +140,19 @@ internal static class ThemeTokenApplier
             ["VelaWarning"] = warning,
             ["VelaError"] = error,
             ["VelaInfo"] = info,
+
+            // 压在实心语义色上的文字/图标(危险按钮的字、状态徽标的字)。
+            // 不能一律用白:暗色主题的语义色本身就是**亮**色(VelaDark 的红 #FF5555、
+            // Obsidian 的 #F87171),白字压上去只有 2.7~3.1:1,读不出来 —— 那些位置
+            // 需要的是**深**字。派生规则见 OnSolid。
+            ["VelaErrorForeground"] = OnSolid(error, accentForeground),
+            ["VelaWarningForeground"] = OnSolid(warning, accentForeground),
+            ["VelaSuccessForeground"] = OnSolid(success, accentForeground),
+
+            // ——— 遮罩 ———
+            // 两档:轻(点空白处即关的浮层)与重(模态抽屉/对话框)。
+            ["VelaScrim"] = WithAlpha(scrim, 0x99),
+            ["VelaScrimStrong"] = WithAlpha(scrim, 0xCC),
 
             // ——— 文件浏览器行(设计 dyuii) ———
             ["VelaFileFolderIcon"] = Parse(p.FolderIcon),
@@ -199,7 +218,61 @@ internal static class ThemeTokenApplier
             ["VelaHeat3"] = WithAlpha(accent, dark ? (byte)0x55 : (byte)0x44),
             ["VelaHeat4"] = WithAlpha(yellow, dark ? (byte)0x55 : (byte)0x44),
             ["VelaHeat5"] = WithAlpha(error, dark ? (byte)0x66 : (byte)0x55),
+
+            // ——— 滚动条(ScrollBarThemes.axaml 的控件模板按这几个键取色) ———
+            // 滑道是**唯一**带主题色的一支:它是正文底上凹下去的一道槽,必须跟着底色走。
+            // 原先它在 axaml 里按明暗写死两个值(Dracula 的 #232532 / Alucard 的 #EDE7D0),
+            // 于是 Tokyo Night、Nord、Sakura… 的滚动条槽都顶着别人的颜色。
+            // 取法:正文底压暗一档(暗色 15%、亮色 7%)。
+            // 不从窗口铬色/描边色去推 —— 那两支与正文底的关系逐主题不同,Gruvbox 的
+            // 铬色掺描边正好等于它自己的正文底 #282828,槽就此消失。压暗才是与底色**恒定**
+            // 的关系,十二套主题一视同仁。亮色那一档更浅是照 Windows 的比例(#FFFFFF → #F0F0F0)。
+            ["VelaScrollBarTrackFill"] = Blend(bgTerminal, Colors.Black, dark ? 0.85 : 0.93),
+            // 滑块与箭头**故意**不跟主题:它们是 Windows 滚动条那套中性灰(逐像素量的,
+            // 见 ScrollBarThemes.axaml 的文件头)。滚动条是覆盖在内容之上的系统级构件,
+            // 染上主题色反而会跟正文抢注意力 —— 这里只按明暗分两套。
+            ["VelaScrollBarThumbFill"] = Parse(dark ? "#959595" : "#8C8C8C"),
+            ["VelaScrollBarThumbFillPointerOver"] = Parse(dark ? "#B9B9B9" : "#6B6B6B"),
+            ["VelaScrollBarThumbFillPressed"] = Parse(dark ? "#D6D6D6" : "#4A4A4A"),
+            ["VelaScrollBarThumbFillDisabled"] = Parse("#00000000"),
+            ["VelaScrollBarArrowFill"] = Parse(dark ? "#959595" : "#5D5D5D"),
+            ["VelaScrollBarArrowFillPointerOver"] = Parse(dark ? "#E8E8E8" : "#1F1F1F"),
+            ["VelaScrollBarArrowFillDisabled"] = Parse(dark ? "#5A5A5A" : "#AFAFAF"),
+            ["VelaScrollBarButtonBackgroundPointerOver"] = Parse(dark ? "#1AFFFFFF" : "#14000000"),
+            ["VelaScrollBarButtonBackgroundPressed"] = Parse(dark ? "#2EFFFFFF" : "#26000000"),
         };
+    }
+
+    /// <summary>
+    /// 压在**实心**语义色上的文字/图标色。
+    /// <para>
+    /// 先用主题自己指定的「实心底上的字」色 <see cref="UiThemePalette.AccentForeground" /> ——
+    /// 它本来就是为强调色实底挑的(暗色主题是近黑、亮色主题是近白),用它能保住主题的调子。
+    /// 那一支够不到 AA(4.5:1)时才退到纯黑/纯白里对比更高的一边:One Light 的红 #E45649
+    /// 配它自己的近白只有 3.7:1,而配纯黑有 5.7:1 —— 这种情况下"保调子"就是让人读不见字。
+    /// </para>
+    /// </summary>
+    private static Color OnSolid(Color fill, Color accentForeground) =>
+        Contrast(fill, accentForeground) >= 4.5
+            ? accentForeground
+            : Contrast(fill, Colors.Black) >= Contrast(fill, Colors.White) ? Colors.Black : Colors.White;
+
+    /// <summary>WCAG 相对对比度(1:1 ~ 21:1)。</summary>
+    private static double Contrast(Color a, Color b)
+    {
+        double la = RelativeLuminance(a);
+        double lb = RelativeLuminance(b);
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+
+    /// <summary>WCAG 相对亮度。</summary>
+    private static double RelativeLuminance(Color color) =>
+        (0.2126 * Linearize(color.R)) + (0.7152 * Linearize(color.G)) + (0.0722 * Linearize(color.B));
+
+    private static double Linearize(byte channel)
+    {
+        double value = channel / 255.0;
+        return value <= 0.03928 ? value / 12.92 : Math.Pow((value + 0.055) / 1.055, 2.4);
     }
 
     /// <summary>解析 <c>#RRGGBB</c> / <c>#AARRGGBB</c>;种子色都是常量,解析失败即是写错了色值。</summary>

--- a/src/VelaShell/Themes/DarkTheme.axaml
+++ b/src/VelaShell/Themes/DarkTheme.axaml
@@ -24,6 +24,13 @@
     <SolidColorBrush x:Key="VelaError"   Color="#FF5555" />
     <SolidColorBrush x:Key="VelaInfo"    Color="#8BE9FD" />
 
+    <!-- 压在实心语义色上的字/图标。暗色主题的语义色本身是**亮**色,白字压上去只有 3:1
+         左右 —— 危险按钮上的"删除"两个字就是这么消失的。这里取 Dracula 的近黑,
+         与强调色实底上的字同一支。运行时由 ThemeTokenApplier 按各主题重算。 -->
+    <SolidColorBrush x:Key="VelaErrorForeground"   Color="#0A0E14" />
+    <SolidColorBrush x:Key="VelaWarningForeground" Color="#0A0E14" />
+    <SolidColorBrush x:Key="VelaSuccessForeground" Color="#0A0E14" />
+
     <!-- 终端颜色标记 -->
     <SolidColorBrush x:Key="VelaShellWhite"   Color="#F8F8F2" />
     <SolidColorBrush x:Key="VelaShellGreen"   Color="#50FA7B" />

--- a/src/VelaShell/Themes/LightTheme.axaml
+++ b/src/VelaShell/Themes/LightTheme.axaml
@@ -15,6 +15,13 @@
     <SolidColorBrush x:Key="VelaError" Color="#CB3A2A" />
     <SolidColorBrush x:Key="VelaInfo" Color="#036A96" />
 
+    <!-- 压在实心语义色上的字/图标(与暗色同义,亮色这边语义色是深色,故取奶白)。
+         注意这一支**不是**每套亮色主题都能用自己的近白:One Light 的红 #E45649 配近白
+         只有 3.7:1,那种情况下展开器会退到纯黑。运行时按各主题重算。 -->
+    <SolidColorBrush x:Key="VelaErrorForeground"   Color="#FFFBEB" />
+    <SolidColorBrush x:Key="VelaWarningForeground" Color="#FFFBEB" />
+    <SolidColorBrush x:Key="VelaSuccessForeground" Color="#FFFBEB" />
+
     <!-- 终端颜色标记(Alucard 口径)。原先只在暗色主题里定义,亮色下资源图表会拿不到画刷。 -->
     <SolidColorBrush x:Key="VelaShellWhite"   Color="#1F1F1F" />
     <SolidColorBrush x:Key="VelaShellGreen"   Color="#14710A" />

--- a/src/VelaShell/Themes/ScrollBarThemes.axaml
+++ b/src/VelaShell/Themes/ScrollBarThemes.axaml
@@ -24,16 +24,24 @@
                                           不是一条更亮的带子(这一点最容易做反);
          滑块 #959595,6px 宽,滑道共 17px(左 6 右 5 的留白,即居中);
          箭头 #959595,约 6~7px 宽的实心细人字纹。
-       故本主题:滑道取比各深色面板底暗一格的 #232532,滑块/箭头取中性灰 #959595。 -->
+       故本主题:滑道取各主题正文底压暗一档的结果(VelaDark 是 #22242E),
+       滑块/箭头取中性灰 #959595。 -->
 
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Dark">
       <!-- 滑道底/滑块/箭头三支色是照着 Windows 11 深色滚动条逐像素取的(见文件头注释):
            滑道并不比正文底更亮,而是【略暗一格】—— 参考图里正文 #191919、滑道 #171717,
            差一两级,几乎只是一条"凹槽"的暗示;滑块与箭头则是中性灰 #959595。
-           这里的 #232532 相对侧栏 #252734、终端 #282A36 正好也是暗一格的关系。
-           不透明:滚动条是覆盖式的,半透明会让正文文字从滑道里透出来。 -->
-      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#232532" />
+           这里的 #22242E 就是终端底 #282A36 压暗 15% 的结果。
+           不透明:滚动条是覆盖式的,半透明会让正文文字从滑道里透出来。
+
+           【滑道跟主题走】滑道原先按明暗写死两个值,于是 Tokyo Night / Nord / Sakura 之类
+           具名主题的滚动条槽全顶着 Dracula / Alucard 的颜色。现在它由 ThemeTokenApplier
+           从各主题的正文底派生(压暗 15%,亮色那档 7%),这里这两行只是**编译期缺省**
+           (设计器、headless 测试、贴令牌之前的那一瞬间),值必须与展开器对 VelaDark /
+           VelaLight 算出来的一致 —— ThemeTokenApplierTests 会核对。
+           滑块与箭头是中性灰,故意不跟主题(理由见展开器里的注释),照旧写死。 -->
+      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#22242E" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFill" Color="#959595" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFillPointerOver" Color="#B9B9B9" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFillPressed" Color="#D6D6D6" />
@@ -46,8 +54,8 @@
     </ResourceDictionary>
     <ResourceDictionary x:Key="Light">
       <!-- 浅色同理:滑道比正文底暗一格(Windows 浅色是白底 #FFFFFF 配 #F0F0F0 滑道),
-           滑块/箭头是中性灰。 -->
-      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#EDE7D0" />
+           滑块/箭头是中性灰。滑道同样只是编译期缺省,运行时由展开器按主题派生。 -->
+      <SolidColorBrush x:Key="VelaScrollBarTrackFill" Color="#EDE9DB" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFill" Color="#8C8C8C" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFillPointerOver" Color="#6B6B6B" />
       <SolidColorBrush x:Key="VelaScrollBarThumbFillPressed" Color="#4A4A4A" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <!-- 插件契约与测试替身,由插件工具链仓库(joesdu/velashell-plugin-toolchain)
          发布到 nuget.org。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.5.1" />
-    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.5.1" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="1.6.0" />
+    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.6.0" />
     <PackageVersion Include="Avalonia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 真实光栅化后端。headless 平台默认 UseHeadlessDrawing=true(绘制是空操作,

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <!-- 插件契约与测试替身,由插件工具链仓库(joesdu/velashell-plugin-toolchain)
          发布到 nuget.org。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="1.6.0" />
-    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="1.6.0" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.0" />
+    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="2.0.0" />
     <PackageVersion Include="Avalonia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
     <!-- 真实光栅化后端。headless 平台默认 UseHeadlessDrawing=true(绘制是空操作,

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/EmbedRoutingTests.cs
@@ -73,6 +73,7 @@ public class EmbedRoutingTests
         TerminalView = new FakeTerminalViewApi(),
         Commands = new RecordingCommands(),
         Events = new PluginEventHub(new CollectingLogger(), null, null, null),
+        Theme = new StaticHostTheme(),
         Ui = new FakeUi(),
         Secrets = new FakeSecrets(),
         Clipboard = new FakeClipboard(),

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
@@ -46,6 +46,7 @@ public class StreamingRoutingTests
             TerminalView = new FakeTerminalViewApi(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
+            Theme = new StaticHostTheme(),
             Ui = new FakeUi(),
             Secrets = new FakeSecrets(),
             Clipboard = new FakeClipboard(),

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
@@ -55,6 +55,7 @@ public class TimeSeriesRoutingTests
             TerminalView = new FakeTerminalViewApi(),
             Commands = new RecordingCommands(),
             Events = new PluginEventHub(new CollectingLogger(), null, null, null),
+            Theme = new StaticHostTheme(),
             Ui = new FakeUi(),
             Secrets = new FakeSecrets(),
             Clipboard = new FakeClipboard(),

--- a/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
@@ -85,10 +85,132 @@ public sealed class ThemeTokenApplierTests
             Color.Parse(midnight.Palette.AccentForeground),
             ColorOf(resources, "VelaAccentForeground"));
         Color dim = ColorOf(resources, "VelaAccentDim")!.Value;
-        Color accent = Color.Parse(midnight.Palette.Accent);
+        var accent = Color.Parse(midnight.Palette.Accent);
         Assert.AreEqual((accent.R, accent.G, accent.B), (dim.R, dim.G, dim.B),
             "淡底只能改透明度,不能改色相。");
         Assert.AreNotEqual(0xFF, dim.A, "淡底必须是半透明的。");
+    }
+
+    /// <summary>
+    /// 压在实心语义色上的字必须在**每一套**主题上都达到 AA(4.5:1)。
+    /// <para>
+    /// 这条不是形式主义:危险按钮上的 <c>#FFFFFF</c> 曾经是硬编码的,而暗色主题的红是**亮**红
+    /// (VelaDark 的 #FF5555、Obsidian 的 #F87171),白字压上去只有 2.7~3.1:1 —— 那几个字
+    /// 在屏幕上是糊的。派生规则(OnSolid)优先用主题自己的近黑/近白,够不到才退纯黑/纯白。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void OnSolidForegrounds_MeetWcagAaOnEveryTheme()
+    {
+        (string Fill, string Foreground)[] pairs =
+        [
+            ("VelaError", "VelaErrorForeground"),
+            ("VelaWarning", "VelaWarningForeground"),
+            ("VelaStatusConnected", "VelaSuccessForeground"),
+        ];
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            var resources = new ResourceDictionary();
+            ThemeTokenApplier.Fill(resources, theme);
+            foreach ((string fill, string foreground) in pairs)
+            {
+                double ratio = Contrast(ColorOf(resources, fill)!.Value, ColorOf(resources, foreground)!.Value);
+                if (ratio < 4.5)
+                {
+                    failures.Add($"{theme.Name} {foreground} 压在 {fill} 上只有 {ratio:F2}:1");
+                }
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>
+    /// 遮罩必须**真的**能压暗底下的界面。
+    /// <para>
+    /// 核的是相对亮度的**跌幅**而不是对比度:暗色主题的正文底本来就接近黑,一层深色遮罩
+    /// 压上去算出来的对比度永远只有 1.x —— 但它确实把界面压暗了,而这正是模态遮罩要做的事。
+    /// 跌幅在明暗两侧都说得通:亮色主题上"铺了一层浅色什么也没发生"会被这一条抓住。
+    /// </para>
+    /// <para>按最亮的一层平面(终端底)核 —— 遮罩在那一层上最不容易起作用。</para>
+    /// </summary>
+    [TestMethod]
+    public void Scrims_ActuallyDarkenTheBrightestSurface()
+    {
+        var failures = new List<string>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            var resources = new ResourceDictionary();
+            ThemeTokenApplier.Fill(resources, theme);
+            var under = Color.Parse(theme.Palette.BgTerminal);
+            double baseline = Luminance(under);
+            double previous = double.MaxValue;
+            foreach (string key in new[] { "VelaScrim", "VelaScrimStrong" })
+            {
+                Color scrim = ColorOf(resources, key)!.Value;
+                Assert.AreNotEqual(0xFF, scrim.A, $"{theme.Name} 的 {key} 必须是半透明的。");
+                double lit = Luminance(Over(scrim, under));
+                double drop = 1 - (lit / baseline);
+                if (drop < 0.35)
+                {
+                    failures.Add($"{theme.Name} 的 {key} 压在 {theme.Palette.BgTerminal} 上只压暗了 {drop:P0}");
+                }
+                // 重的那一档必须比轻的更暗,否则两个令牌就没有分别。
+                if (lit >= previous)
+                {
+                    failures.Add($"{theme.Name} 的 VelaScrimStrong 没有比 VelaScrim 更暗。");
+                }
+                previous = lit;
+            }
+        }
+        Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures));
+    }
+
+    /// <summary>滚动条滑道要跟着主题走 —— 12 套主题不该共用两个值。</summary>
+    [TestMethod]
+    public void ScrollBarTrack_FollowsEachTheme()
+    {
+        var byTrack = new Dictionary<Color, List<string>>();
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            var resources = new ResourceDictionary();
+            ThemeTokenApplier.Fill(resources, theme);
+            Color track = ColorOf(resources, "VelaScrollBarTrackFill")!.Value;
+            (byTrack.TryGetValue(track, out List<string>? names) ? names : byTrack[track] = []).Add(theme.Name);
+            // 槽必须与它所在的正文底分得开,否则未填充段看不见,滚动条变成一颗孤零零的胶囊。
+            Assert.AreNotEqual(Color.Parse(theme.Palette.BgTerminal), track,
+                $"{theme.Name} 的滚动条滑道与终端底同色。");
+        }
+        Assert.HasCount(UiThemeCatalog.All.Length, byTrack,
+            "各主题的滚动条滑道应互不相同(说明它是派生的,不是写死的两个值)。");
+    }
+
+    /// <summary>把半透明色压在不透明底色上(源覆盖合成)。</summary>
+    private static Color Over(Color top, Color bottom)
+    {
+        double a = top.A / 255.0;
+        return new(
+            0xFF,
+            (byte)Math.Round((top.R * a) + (bottom.R * (1 - a))),
+            (byte)Math.Round((top.G * a) + (bottom.G * (1 - a))),
+            (byte)Math.Round((top.B * a) + (bottom.B * (1 - a))));
+    }
+
+    private static double Contrast(Color a, Color b)
+    {
+        double la = Luminance(a);
+        double lb = Luminance(b);
+        return (Math.Max(la, lb) + 0.05) / (Math.Min(la, lb) + 0.05);
+    }
+
+    private static double Luminance(Color color)
+    {
+        static double Channel(byte value)
+        {
+            double c = value / 255.0;
+            return c <= 0.03928 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+        }
+        return (0.2126 * Channel(color.R)) + (0.7152 * Channel(color.G)) + (0.0722 * Channel(color.B));
     }
 
     [TestMethod]
@@ -117,7 +239,7 @@ public sealed class ThemeTokenApplierTests
                 failures.Add($"{key}:axaml 里有,展开器没写");
                 continue;
             }
-            Color expected = Color.Parse(literal);
+            var expected = Color.Parse(literal);
             if (color != expected)
             {
                 failures.Add($"{key}:axaml={literal} 展开器={color}");
@@ -136,7 +258,7 @@ public sealed class ThemeTokenApplierTests
     {
         var tokens = new Dictionary<string, string>(StringComparer.Ordinal);
         XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
-        foreach (string file in new[] { "VelaTokens.axaml", "VelaShellTokens.axaml" })
+        foreach (string file in new[] { "VelaTokens.axaml", "VelaShellTokens.axaml", "ScrollBarThemes.axaml" })
         {
             string path = Path.Combine(AppContext.BaseDirectory, "Themes", file);
             Assert.IsTrue(File.Exists(path), $"令牌文件未复制到输出目录:{path}");

--- a/tests/VelaShell.Tests/VelaShell.Tests.csproj
+++ b/tests/VelaShell.Tests/VelaShell.Tests.csproj
@@ -40,6 +40,11 @@
              Link="Themes\DarkTheme.axaml" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\src\VelaShell\Themes\LightTheme.axaml"
              Link="Themes\LightTheme.axaml" CopyToOutputDirectory="PreserveNewest" />
+    <!-- 滚动条的滑道色现在也由展开器按主题派生(原先按明暗写死两个 Dracula/Alucard 值,
+         于是具名主题的滚动条槽全顶着别人的颜色);这一份跟着进来,让同一条"缺省不许漂"
+         的核对也罩住它。 -->
+    <Content Include="..\..\src\VelaShell\Themes\ScrollBarThemes.axaml"
+             Link="Themes\ScrollBarThemes.axaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
