### PR TITLE
修复vela-plugin install 安装的插件被误判为收据缺失问题

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -802,3 +802,48 @@ bright 一档,名字直接把这件事说出来,原版 "Gruvbox Dark" 仍在列�
 
 `ThemeTokenShadowingUiTests.ApplyingATheme_NotifiesTheTreeAConstantNumberOfTimes` 数的是**通知次数**
 (≤ 4)而不是耗时 —— 耗时断言在 CI 上必然抖,而次数一旦回到逐个写就会线性涨到六十多,一测就红。
+
+## 29. 2026-09-01 命令行装的插件被判「收据缺失」(用户反馈)
+
+`vela-plugin install velashell.redis` 一路正常(下载、摘要、验签、兼容性都过,末尾打印
+`signature Valid`),重启后插件管理页却把它标成**无效**:
+
+> Protected installation receipt is missing. Reinstall this plugin through the plugin manager.
+
+### 一、错在宿主,不在命令行
+
+安装收据落在宿主进程的信任库里(SonnetDB + `ISecretProtector` 认证加密),命令行够不着 ——
+这一点 CLI 手册、dev-guide、publishing 三处都写明了,而且都写的是「代价仅仅是没有事后防篡改」。
+但 `PluginManager` 把「没有收据」实现成了**拒绝装载**,收养只在升级后第一次启动做一轮
+(`LegacyInstallMigrationCompleted`)。于是那一轮之后新出现的目录永远拿不到基线:
+命令行装的、以及 dev-guide 里「方式三:直接放目录」,全部卡在这条错误上。
+
+### 二、收养改成随用随做
+
+`PluginManager.ValidateInstallReceipt` → `VerifyOrAdoptInstallReceiptAsync`,两种收据给出的保证
+第一次被明确区分:
+
+| 收据来源 | 内容变了怎么办 |
+| --- | --- |
+| 管理页安装(`LegacyAdopted == false`) | 宿主在解包后亲手落的,确实等于「目录出自那个包」;变了一律拒装载 |
+| 旁装(命令行 / 直接放目录) | 第一次见到时记的 TOFU 基线;变了(多半是 `vela-plugin update`)重记一遍 + 一条日志 |
+
+基线写不进信任库时**不放行** —— 否则每次启动都要重新收养一遍,这份保护等于不存在。
+
+### 三、顺手清掉孤儿收据
+
+`vela-plugin uninstall` 只删目录,够不着信任库。留着那份收据,同一个 id 下次装回来时内容必然
+与旧收据对不上,插件会以「文件被改过」被拒,而用户什么都没改过。启动加载信任状态时,
+把目录已经不存在的收据清掉(`PruneReceiptsWithoutDirectory`)。
+
+### 四、代价说清楚
+
+安全上没有让步:值钱的是第一种收据,一个字没动。旁装目录先于宿主存在,没有任何东西能证明它
+出自哪个包,拒绝它挡不住「能往插件目录写文件的进程」(那种进程本就以用户身份在跑),
+却会把文档写明支持的两条安装路径全堵死。**但同一个插件别把两条路混着用**:用命令行覆盖一个
+经管理页装的插件,宿主只会看到内容变了,仍会标 Invalid —— 先在管理页卸载再装即可。
+
+测试:`PluginInstallUninstallTests` 新增/改写三条(直接放进去的目录被收养并激活、旁装内容变了
+重记基线不标红、目录被外部删掉后收据清掉且同 id 能重装),原有两条防篡改用例保持通过;
+`TestCategory=Plugins` 127 条全绿。文档已在 velashell-docs 同步(`{zh,en}/cli/cli.md`、
+`{zh,en}/templates/dev-guide.md`、`{zh,en}/plugins/STATUS.md`)。

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -587,10 +587,8 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                         _trustedPackageKeys.Add(publisher.PublicKey);
                     }
                 }
-                if (!_trustState.LegacyInstallMigrationCompleted)
+                if (PruneReceiptsWithoutDirectory(_trustState))
                 {
-                    AdoptExistingUserPlugins(_trustState);
-                    _trustState.LegacyInstallMigrationCompleted = true;
                     await options.TrustRepository.SaveAsync(_trustState, cancellationToken).ConfigureAwait(false);
                 }
                 _trustInitialized = true;
@@ -617,30 +615,27 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         }
     }
 
-    private void AdoptExistingUserPlugins(PluginTrustState state)
+    /// <summary>
+    /// 丢掉目录已经不在了的收据。返回是否真的改动过状态。
+    /// <para>
+    /// 卸载有两条路:管理页那条会顺手删收据,命令行 <c>vela-plugin uninstall</c> 只删目录 ——
+    /// 它够不着宿主进程里的信任库。留着那份孤儿收据的后果是:同一个 id 下次再装回来时,
+    /// 内容哈希必然与旧收据对不上,插件会以"文件被改过"被拒,而用户什么都没改过。
+    /// 目录都不在了,收据保护的东西也就不在了,启动时清掉是安全的。
+    /// </para>
+    /// </summary>
+    private bool PruneReceiptsWithoutDirectory(PluginTrustState state)
     {
         if (options.UserPluginRoot is not { } root || !Directory.Exists(root))
         {
-            return;
+            return false;
         }
-        foreach (string directory in Directory.EnumerateDirectories(root))
+        string[] orphans = [.. state.Receipts.Keys.Where(id => !Directory.Exists(Path.Combine(root, id)))];
+        foreach (string id in orphans)
         {
-            string manifestPath = Path.Combine(directory, PluginManifestReader.FileName);
-            if (!File.Exists(manifestPath))
-            {
-                continue;
-            }
-            try
-            {
-                PluginManifest manifest = PluginManifestReader.Load(manifestPath);
-                state.Receipts[manifest.Id] = new(manifest.Id, ComputePluginContentSha256(directory), null, null,
-                    LegacyAdopted: true, DateTimeOffset.UtcNow);
-            }
-            catch (PluginManifestException)
-            {
-                // 原本就无效的遗留目录不建立可信基线，发现阶段仍会给出清单错误。
-            }
+            state.Receipts.Remove(id);
         }
+        return orphans.Length > 0;
     }
 
     private async Task SaveInstallReceiptAsync(
@@ -1188,10 +1183,10 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
             {
                 // 校验读的是信任仓储里的凭据,仓储没初始化就无从比对。
                 await EnsureTrustInitializedAsync(_shutdown.Token).ConfigureAwait(false);
-                bool ok = ValidateInstallReceipt(runtime.Descriptor.Id, runtime.Descriptor.Directory,
-                    out string? error);
+                string? error = await VerifyOrAdoptInstallReceiptAsync(
+                    runtime.Descriptor.Id, runtime.Descriptor.Directory).ConfigureAwait(false);
                 runtime.ContentRead = true; // 刚把整个目录读了一遍 —— 预热不必再来一次。
-                return ok ? null : error;
+                return error;
             });
         }
     }
@@ -1637,38 +1632,98 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
     private bool IsUserPluginDirectory(string directory) =>
         options.UserPluginRoot is { } root && IsUnder(directory, root);
 
-    private bool ValidateInstallReceipt(string pluginId, string directory, out string? error)
+    /// <summary>
+    /// 比对插件目录内容与安装收据;没有收据的旁装目录在这里被**收养**成基线。
+    /// 通过返回 <see langword="null" />,否则返回面向用户的拒绝原因。
+    /// <para>
+    /// 收据分两种,给出的保证也不同:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// 管理页装的(<c>LegacyAdopted == false</c>):收据是宿主亲手在解包之后立刻落下的,
+    /// 它确实等于"这个目录出自那个包"。此后内容变了就是被别的程序动过,一律拒装载。
+    /// </item>
+    /// <item>
+    /// 旁装的(命令行 <c>vela-plugin install</c>,或者直接把目录放进插件根):
+    /// 宿主第一次看见它时目录已经在那儿了,没有任何东西能证明它出自哪个包 ——
+    /// 此时建立的基线只是"我第一次见到它时长这样",TOFU 而已。
+    /// 这类收据不作为拒装载的依据(命令行手册写明旁装换来的代价就是没有事后防篡改),
+    /// 内容变了就重新记一遍并留一条日志。
+    /// </item>
+    /// </list>
+    /// <para>
+    /// 之所以要收养而不是直接拒绝:装载前的把关(签名、清单、apiLevel、容器摘要)命令行一条不少,
+    /// 拒绝旁装目录并不能挡住"能往插件目录写文件的进程"—— 那种进程本来就以用户身份在跑 ——
+    /// 却会把文档里写明支持的两条安装路径全部堵死。真正值钱的是第一种收据,它没有被削弱。
+    /// </para>
+    /// </summary>
+    private async Task<string?> VerifyOrAdoptInstallReceiptAsync(string pluginId, string directory)
     {
         if (_trustLoadError is not null)
         {
-            error = $"Plugin trust store is unavailable; refusing to load user plugin ({_trustLoadError}).";
-            return false;
+            return $"Plugin trust store is unavailable; refusing to load user plugin ({_trustLoadError}).";
         }
-        InstalledPluginReceipt? receipt = null;
-        _trustState?.Receipts.TryGetValue(pluginId, out receipt);
-        if (receipt is null)
+        if (options.TrustRepository is null || _trustState is null)
         {
-            error = "Protected installation receipt is missing. Reinstall this plugin through the plugin manager.";
-            return false;
+            return "Plugin trust store is unavailable; refusing to load user plugin.";
         }
+        string actual;
         try
         {
-            string actual = ComputePluginContentSha256(directory);
-            if (!CryptographicOperations.FixedTimeEquals(
-                    Encoding.ASCII.GetBytes(actual), Encoding.ASCII.GetBytes(receipt.ContentSha256)))
-            {
-                error = "Installed plugin files changed after installation. Reinstall the original package.";
-                return false;
-            }
+            actual = ComputePluginContentSha256(directory);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
         {
-            error = $"Installed plugin files could not be verified: {ex.Message}";
-            return false;
+            return $"Installed plugin files could not be verified: {ex.Message}";
         }
-        error = null;
-        return true;
+
+        // 读与写都在同一把锁里:写收据的那几条路径(装、卸、这里)会就地改同一个字典。
+        await _trustStateGate.WaitAsync(_shutdown.Token).ConfigureAwait(false);
+        try
+        {
+            InstalledPluginReceipt? receipt = _trustState.Receipts.GetValueOrDefault(pluginId);
+            if (receipt is not null && ContentMatches(actual, receipt.ContentSha256))
+            {
+                return null;
+            }
+            if (receipt is { LegacyAdopted: false })
+            {
+                return "Installed plugin files changed after installation. Reinstall the original package "
+                       + "from the plugin manager.";
+            }
+            _trustState.Receipts[pluginId] = new(pluginId, actual, null, null,
+                LegacyAdopted: true, DateTimeOffset.UtcNow);
+            try
+            {
+                await options.TrustRepository.SaveAsync(_trustState, _shutdown.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                if (receipt is null)
+                {
+                    _trustState.Receipts.Remove(pluginId);
+                }
+                else
+                {
+                    _trustState.Receipts[pluginId] = receipt;
+                }
+                // 记不下基线就不放行:否则每次启动都要重新收养,等于这份保护根本不存在。
+                return $"Installation baseline for this plugin could not be recorded: {ex.Message}";
+            }
+            Log(receipt is null
+                ? $"Adopted side-loaded plugin '{pluginId}' as its own installation baseline "
+                  + "(installed outside the plugin manager; no post-install tamper detection)."
+                : $"Side-loaded plugin '{pluginId}' changed on disk; installation baseline re-recorded.");
+            return null;
+        }
+        finally
+        {
+            _trustStateGate.Release();
+        }
     }
+
+    private static bool ContentMatches(string actual, string expected) =>
+        CryptographicOperations.FixedTimeEquals(Encoding.ASCII.GetBytes(actual), Encoding.ASCII.GetBytes(expected));
 
     /// <summary>宿主版本是否低于要求(数字段比较,忽略预发布后缀;不可解析时不拦)。</summary>
     private bool IsHostOlderThan(string minHostVersion) => IsOlder(options.HostVersion, minHostVersion);

--- a/src/VelaShell.Infrastructure/Plugins/PluginTrustRepository.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginTrustRepository.cs
@@ -9,7 +9,11 @@ public sealed class PluginTrustState
 {
     /// <summary>持久化结构版本。</summary>
     public int SchemaVersion { get; set; } = 1;
-    /// <summary>是否已经为升级前存在的插件目录建立过一次基线。</summary>
+    /// <summary>
+    /// 老版本用来记"是否已经为升级前存在的插件目录一次性建立过基线"。
+    /// 现在收养是按目录随用随做的(见 PluginManager 的 VerifyOrAdoptInstallReceiptAsync),
+    /// 这个字段不再被读;字段本身留着,免得旧状态反序列化时凭空多出一次格式变更。
+    /// </summary>
     public bool LegacyInstallMigrationCompleted { get; set; }
     /// <summary>用户明确信任的发布者。</summary>
     public List<TrustedPluginPublisher> Publishers { get; set; } = [];

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginInstallUninstallTests.cs
@@ -325,12 +325,14 @@ public class PluginInstallUninstallTests
     }
 
     [TestMethod]
-    public async Task Restart_DirectlyDroppedPlugin_IsRejectedWhenReceiptIsMissing()
+    public async Task Restart_DirectlyDroppedPlugin_IsAdoptedAsItsOwnBaseline()
     {
+        // 命令行 vela-plugin install 与"直接把目录放进插件根"落到的都是这条路径:
+        // 目录先于宿主存在,没有受保护收据。文档写明这两条路都能装,宿主必须收养它而不是拒绝。
         using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "direct-drop-db"));
         var repository = new PluginTrustRepository(engine, new TestSecretProtector());
         PluginManager firstRun = CreateManager(repository);
-        await firstRun.StartAsync(); // 完成一次空目录迁移；此后不再自动收养新目录。
+        await firstRun.StartAsync(); // 先建一次空的信任状态。
         await firstRun.DisposeAsync();
 
         const string id = "acme.direct-drop";
@@ -339,8 +341,73 @@ public class PluginInstallUninstallTests
         await restarted.StartAsync();
 
         PluginDescriptor descriptor = Assert.ContainsSingle(plugin => plugin.Id == id, restarted.Plugins);
-        Assert.AreEqual(PluginState.Invalid, descriptor.State);
-        Assert.Contains("receipt is missing", descriptor.Error);
+        Assert.AreEqual(PluginState.Active, descriptor.State, descriptor.Error);
+        await restarted.DisposeAsync();
+
+        // 收养必须真的落进了信任库:下一次启动不该再收养一遍。
+        PluginTrustState state = await repository.LoadAsync();
+        InstalledPluginReceipt receipt = state.Receipts[id];
+        Assert.IsTrue(receipt.LegacyAdopted, "旁装目录建立的是 TOFU 基线,不是管理页那份收据。");
+        Assert.IsNull(receipt.PackageSha256, "没有包可以证明它出自哪儿,不该伪造一个包摘要。");
+    }
+
+    [TestMethod]
+    public async Task Restart_SideLoadedPluginChangedOnDisk_IsRebaselinedNotRejected()
+    {
+        // 旁装换来的代价就是没有事后防篡改(CLI 手册明写)。这里的内容变化通常是
+        // `vela-plugin update` 换了版本 —— 把它判成"被人动过"会让更新完的插件全变红。
+        using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "sideload-update-db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        const string id = "acme.sideload-update";
+        Directory.Move(StagePlugin(id), Path.Combine(_userRoot, id));
+
+        PluginManager first = CreateManager(repository);
+        await first.StartAsync();
+        Assert.AreEqual(PluginState.Active, first.Plugins.Single(p => p.Id == id).State);
+        await first.DisposeAsync();
+
+        await File.AppendAllTextAsync(Path.Combine(_userRoot, id, "extra.txt"), "updated");
+        PluginManager restarted = CreateManager(repository);
+        await restarted.StartAsync();
+
+        PluginDescriptor descriptor = restarted.Plugins.Single(p => p.Id == id);
+        Assert.AreEqual(PluginState.Active, descriptor.State, descriptor.Error);
+        await restarted.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Restart_ReceiptWithoutDirectory_IsDroppedSoTheIdCanBeInstalledAgain()
+    {
+        // vela-plugin uninstall 只删目录,够不着宿主进程里的信任库。留着那份孤儿收据,
+        // 同一个 id 再装回来时内容必然与旧收据对不上,插件会以"文件被改过"被拒。
+        using var engine = new SonnetDbEngine(Path.Combine(_dataRoot, "orphan-receipt-db"));
+        var repository = new PluginTrustRepository(engine, new TestSecretProtector());
+        const string id = "acme.reinstalled";
+        // 懒激活:入口 dll 始终没被装载,测试才能像命令行那样把目录整个删掉。
+        const string lazy = """, "activationEvents": ["onWorkspace:acme.reinstalled.ws"], "contributes": { "workspaces": [ { "id": "acme.reinstalled.ws", "displayName": "WS", "defaultPort": 6379 } ] }""";
+
+        PluginManager manager = CreateManager(repository);
+        await manager.StartAsync();
+        await manager.InstallFromVpxAsync(BuildVpx(id, lazy), allowUntrustedPackage: true);
+        await manager.DisposeAsync();
+
+        // 宿主之外把目录删掉 —— 命令行 uninstall 就是这个形状,它够不着信任库。
+        Directory.Delete(Path.Combine(_userRoot, id), recursive: true);
+        PluginManager afterUninstall = CreateManager(repository);
+        await afterUninstall.StartAsync();
+        await afterUninstall.DisposeAsync();
+        Assert.IsFalse((await repository.LoadAsync()).Receipts.ContainsKey(id), "目录没了,收据该跟着清掉。");
+
+        // 同一个 id 再装回来(内容与上一次不同)时必须能正常装载。
+        string replacement = StagePlugin(id, lazy);
+        await File.WriteAllTextAsync(Path.Combine(replacement, "extra.txt"), "second install");
+        Directory.Move(replacement, Path.Combine(_userRoot, id));
+
+        PluginManager restarted = CreateManager(repository);
+        await restarted.StartAsync();
+
+        PluginDescriptor descriptor = restarted.Plugins.Single(p => p.Id == id);
+        Assert.AreEqual(PluginState.Discovered, descriptor.State, descriptor.Error);
         await restarted.DisposeAsync();
     }
 


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次更新优化了 PluginManager 对旁装插件的处理：首次加载时自动收养并写入信任库（TOFU），避免误判为“收据缺失”。旁装插件内容变更将自动重记基线并记录日志，仅插件管理页安装的插件严格校验内容。卸载时自动清理无目录的孤儿收据，防止重装时误判。新增/调整相关测试用例，确保功能正确，文档已同步更新，明确两种安装路径的安全保证与代价。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
