### PR TITLE
供应商目录:补上 opencode 有而这边没有的那些

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Auth/LoopbackRedirectListener.cs
+++ b/plugins/VelaShell.Plugin.Ai/Auth/LoopbackRedirectListener.cs
@@ -74,9 +74,15 @@ public sealed class LoopbackRedirectListener : IDisposable
     /// </remarks>
     /// <param name="pageTitle">回给浏览器那一页的标题(已登录成功的提示)。</param>
     /// <param name="pageBody">页面正文(告诉用户可以关掉这个标签页了)。</param>
+    /// <param name="fragment">
+    /// 隐式流:结果在地址的 <c>#fragment</c> 里。
+    /// <b>片段根本不会随请求发过来</b>(这是浏览器的规矩,不是哪家的实现细节),
+    /// 所以这里先回一页只做一件事的 HTML:把 <c>location.hash</c> 原样再请求一次。
+    /// 第二次进来时它就变成普通查询串了,后面的路径与授权码流程完全一致。
+    /// </param>
     /// <param name="cancellationToken">取消(用户点了"取消登录",或超时)。</param>
     public async Task<Dictionary<string, string>> WaitAsync(string pageTitle, string pageBody,
-        CancellationToken cancellationToken = default)
+        bool fragment = false, CancellationToken cancellationToken = default)
     {
         while (true)
         {
@@ -95,6 +101,13 @@ public sealed class LoopbackRedirectListener : IDisposable
                 await WriteAsync(stream, "404 Not Found", "<p>Not found.</p>", cancellationToken).ConfigureAwait(false);
                 continue;
             }
+            // 隐式流的第一跳:什么参数都没有(令牌全在 # 后面,服务端看不见)。
+            // 出错时对方是拿<b>查询串</b>回的(?error=…),那一跳照常当结果收,别再去要片段
+            if (fragment && split < 0)
+            {
+                await WriteAsync(stream, pageTitle, FragmentBootstrap(_path), cancellationToken).ConfigureAwait(false);
+                continue;
+            }
             Dictionary<string, string> query = split < 0
                 ? []
                 : OAuthClient.ParseQuery(target[(split + 1)..]);
@@ -102,6 +115,29 @@ public sealed class LoopbackRedirectListener : IDisposable
             return query;
         }
     }
+
+    /// <summary>
+    /// 把 <c>#fragment</c> 搬成查询串再请求一次的那一小段脚本。
+    /// </summary>
+    /// <remarks>
+    /// 用 <c>location.replace</c> 而不是 <c>assign</c>:别在用户的历史记录里留下一条带令牌的地址。
+    /// 片段为空(用户直接手敲了这个地址)时不跳转 —— 否则会和自己来回弹。
+    /// </remarks>
+    private static string FragmentBootstrap(string path) => $$"""
+        <p>Finishing sign-in…</p>
+        <script>
+        (function () {
+          var h = window.location.hash;
+          if (h && h.length > 1) {
+            window.location.replace({{Json(path)}} + "?" + h.substring(1));
+          }
+        })();
+        </script>
+        """;
+
+    /// <summary>把一个字符串安全地嵌进 <c>&lt;script&gt;</c> 里(转义 <c>&lt;</c> 防提前闭合标签)。</summary>
+    private static string Json(string text) =>
+        System.Text.Json.JsonSerializer.Serialize(text).Replace("<", "\\u003c", StringComparison.Ordinal);
 
     /// <summary>读到请求头结束,取出请求行里的目标(<c>GET /callback?... HTTP/1.1</c> 的中间那段)。</summary>
     private static async Task<string?> ReadRequestTargetAsync(NetworkStream stream, CancellationToken cancellationToken)

--- a/plugins/VelaShell.Plugin.Ai/Auth/OAuthClient.cs
+++ b/plugins/VelaShell.Plugin.Ai/Auth/OAuthClient.cs
@@ -77,6 +77,20 @@ public sealed class OAuthClient(HttpClient http)
             query.Add(new("code_challenge", pkce.Challenge));
             query.Add(new("code_challenge_method", PkceCodes.Method));
         }
+        else if (config.Flow == OAuthFlow.ImplicitFragment)
+        {
+            // 隐式流:直接要令牌,没有授权码,也就<b>没有 PKCE 可用</b>
+            // (challenge 是给"换码"那一步验的,这里根本没有那一步)。
+            // state 照发 —— 它防的是别人往我的回调里塞东西,与 PKCE 是两回事
+            query.Add(new("response_type", "token"));
+            query.Add(new("client_id", config.ClientId));
+            query.Add(new("redirect_uri", redirectUri));
+            query.Add(new("state", pkce.State));
+            if (!string.IsNullOrWhiteSpace(config.Scopes))
+            {
+                query.Add(new("scope", config.Scopes.Trim()));
+            }
+        }
         else
         {
             query.Add(new("response_type", "code"));
@@ -285,6 +299,12 @@ public sealed class OAuthClient(HttpClient http)
         if (!string.IsNullOrWhiteSpace(config.Scopes))
         {
             form.Add(new("scope", config.Scopes.Trim()));
+        }
+        // 设备码请求就是这一路的"授权请求",所以额外参数在这儿带上
+        // (xAI 要一个 referrer 说明来路;不带也能过,但对方分不清是谁在用)
+        foreach (KeyValuePair<string, string> extra in ParsePairs(config.ExtraAuthorizeParams))
+        {
+            form.Add(extra);
         }
         Dictionary<string, string> payload = await PostAsync(config.DeviceCodeUrl, form, cancellationToken).ConfigureAwait(false);
         if (!payload.TryGetValue("device_code", out string? deviceCode) || deviceCode.Length == 0)

--- a/plugins/VelaShell.Plugin.Ai/Auth/ProviderLogin.cs
+++ b/plugins/VelaShell.Plugin.Ai/Auth/ProviderLogin.cs
@@ -77,7 +77,8 @@ public sealed class ProviderLogin(OAuthClient oauth, Func<Uri, CancellationToken
         try
         {
             callback = await listener
-                .WaitAsync(prompts.BrowserTitle, prompts.BrowserBody, timeout.Token)
+                .WaitAsync(prompts.BrowserTitle, prompts.BrowserBody,
+                    config.Flow == OAuthFlow.ImplicitFragment, timeout.Token)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
@@ -96,6 +97,23 @@ public sealed class ProviderLogin(OAuthClient oauth, Func<Uri, CancellationToken
             && !string.Equals(state, pkce.State, StringComparison.Ordinal))
         {
             throw new OAuthException("invalid_state", "The callback state did not match; the sign-in was discarded.");
+        }
+        // 隐式流到这里就结束了:令牌本身就在回调参数里,没有"拿码去换"这一步
+        if (config.Flow == OAuthFlow.ImplicitFragment)
+        {
+            if (!callback.TryGetValue("access_token", out string? token) || token.Length == 0)
+            {
+                throw new OAuthException("The callback did not carry an access token.");
+            }
+            return new OAuthTokens
+            {
+                AccessToken = token,
+                Scope = callback.GetValueOrDefault("scope") ?? "",
+                // 隐式流没有 refresh token —— 过期就得重登,这一点如实记下来
+                ExpiresAt = int.TryParse(callback.GetValueOrDefault("expires_in"), out int seconds) && seconds > 0
+                    ? DateTimeOffset.UtcNow.AddSeconds(seconds)
+                    : null
+            };
         }
         if (!callback.TryGetValue("code", out string? code) || code.Length == 0)
         {

--- a/plugins/VelaShell.Plugin.Ai/Configuration/AiProvider.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/AiProvider.cs
@@ -165,16 +165,28 @@ public sealed class AiProvider
     /// 而用户真正该看到的是"先把客户端 id 填上"。
     /// </remarks>
     [JsonIgnore]
-    public bool CanSignIn => Auth == AuthMethod.Subscription && OAuth is { } oauth
-                             && !string.IsNullOrWhiteSpace(oauth.TokenUrl)
-                             // OpenRouter 那一路本来就没有 client_id,别把它一起卡掉
-                             && (oauth.Flow == OAuthFlow.OpenRouterPkce
-                                 || !string.IsNullOrWhiteSpace(oauth.ClientId))
-                             // 设备码类流程用不到授权页地址,要的是设备码地址(别只判 DeviceCode
-                             // 一个值 —— 两段式的 Copilot 也是设备码起手,漏了它就永远"登不了")
-                             && (oauth.Flow is OAuthFlow.DeviceCode or OAuthFlow.GitHubCopilotDevice
-                                 ? !string.IsNullOrWhiteSpace(oauth.DeviceCodeUrl)
-                                 : !string.IsNullOrWhiteSpace(oauth.AuthorizationUrl));
+    public bool CanSignIn => Auth == AuthMethod.Subscription && OAuth is { } oauth && Ready(oauth);
+
+    /// <summary>这一套 OAuth 参数够不够发起一次登录。每种流程要的东西不一样,分开判。</summary>
+    private static bool Ready(OAuthConfig oauth)
+    {
+        // OpenRouter 那一路本来就没有 client_id,别把它一起卡掉
+        if (oauth.Flow != OAuthFlow.OpenRouterPkce && string.IsNullOrWhiteSpace(oauth.ClientId))
+        {
+            return false;
+        }
+        return oauth.Flow switch
+        {
+            // 设备码类要的是设备码地址,用不到授权页(别只判 DeviceCode 一个值 ——
+            // 两段式的 Copilot 也是设备码起手,漏了它就永远"登不了")
+            OAuthFlow.DeviceCode or OAuthFlow.GitHubCopilotDevice =>
+                !string.IsNullOrWhiteSpace(oauth.DeviceCodeUrl) && !string.IsNullOrWhiteSpace(oauth.TokenUrl),
+            // 隐式流<b>没有 token 端点</b> —— 令牌直接从授权页的 #fragment 回来。
+            // 拿 TokenUrl 一刀切会把这一路整条判死,而界面上只会显示"登不了",查不出为什么
+            OAuthFlow.ImplicitFragment => !string.IsNullOrWhiteSpace(oauth.AuthorizationUrl),
+            _ => !string.IsNullOrWhiteSpace(oauth.AuthorizationUrl) && !string.IsNullOrWhiteSpace(oauth.TokenUrl)
+        };
+    }
 }
 
 /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Configuration/ProviderAuth.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/ProviderAuth.cs
@@ -47,7 +47,20 @@ public enum OAuthFlow
     /// 之所以单列:标准流程里"刷新"是拿 refresh token 走 <c>refresh_token</c> 授权,
     /// 而这一路的刷新是<b>重新做一次交换</b> —— GitHub token 本身不过期,过期的是换来的那枚。
     /// </remarks>
-    GitHubCopilotDevice
+    GitHubCopilotDevice,
+
+    /// <summary>
+    /// 隐式流(<c>response_type=token</c>):令牌直接放在回调地址的 <b>#fragment</b> 里。
+    /// </summary>
+    /// <remarks>
+    /// 片段<b>不会随请求发到服务端</b>,所以本机监听根本读不到它 —— 必须先回一页 HTML,
+    /// 让浏览器自己把 <c>location.hash</c> 再回传一次。DigitalOcean Gradient 走的就是这一路。
+    /// <para>
+    /// 隐式流在 OAuth 2.1 里已被劝退,这里实现它<b>只为接上还在用它的服务</b>,
+    /// 不作为新接入的推荐:令牌进过浏览器地址栏,而且没有 refresh token,过期只能重登。
+    /// </para>
+    /// </remarks>
+    ImplicitFragment
 }
 
 /// <summary>登录换回来的东西是什么 —— 决定它存到哪、请求头怎么带。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Configuration/ProviderCatalog.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/ProviderCatalog.cs
@@ -175,6 +175,20 @@ public static class ProviderCatalog
         /// <summary>GitHub 官方 Copilot 编辑器插件的客户端 id。性质同上。</summary>
         public const string GitHubCopilot = "Iv1.b507a08c87ecfe98";
 
+        /// <summary>Grok CLI 的公共客户端 id。性质同 <see cref="OpenAiCodex" />。</summary>
+        /// <remarks>
+        /// xAI 在 <c>auth.x.ai/.well-known/openid-configuration</c> 里公开声明了
+        /// <c>device_authorization_endpoint</c> 与对应的 <c>device_code</c> 授权类型 ——
+        /// 也就是说设备码这条路是它自己宣告支持的,不是猜出来的。
+        /// </remarks>
+        public const string XaiGrok = "b1a00492-073a-47ea-816f-4c329264a828";
+
+        /// <summary>
+        /// DigitalOcean Gradient 的公共 OAuth 客户端 id(隐式流,见 <see cref="OAuthFlow.ImplicitFragment" />)。
+        /// </summary>
+        public const string DigitalOcean =
+            "b1a6c5158156caac821fd1b30253ca8acb52454a48fa744420e41889cb589f82";
+
         /// <summary>Google Cloud Console → API 和服务 → 凭据 → OAuth 客户端 ID(类型选"桌面应用")。</summary>
         public const string Google = "";
     }
@@ -200,6 +214,8 @@ public static class ProviderCatalog
         ["anthropic-claude"] = "anthropic",
         ["github-copilot"] = "github-copilot",
         ["xai"] = "xai",
+        ["xai-grok"] = "xai",
+        ["digitalocean"] = "digitalocean",
         ["google"] = "google",
         ["deepseek"] = "deepseek",
         ["moonshot"] = "moonshotai",
@@ -209,6 +225,16 @@ public static class ProviderCatalog
         ["fireworks"] = "fireworks-ai",
         ["groq"] = "groq",
         ["mistral"] = "mistral",
+        ["cerebras"] = "cerebras",
+        ["deepinfra"] = "deepinfra",
+        ["nvidia"] = "nvidia",
+        ["perplexity"] = "perplexity",
+        ["cohere"] = "cohere",
+        ["baseten"] = "baseten",
+        ["upstage"] = "upstage",
+        ["minimax"] = "minimax",
+        ["zenmux"] = "zenmux",
+        ["llmgateway"] = "llmgateway",
         ["openrouter"] = "openrouter",
         ["huggingface"] = "huggingface",
         ["azure-openai"] = "azure"
@@ -313,6 +339,48 @@ public static class ProviderCatalog
                     // 交换响应里会带 endpoints.api —— 企业账户与个人账户不是同一个地址,
                     // 那时以它为准(见 ProviderCredential.BaseUrl)
                     ExtraHeaders = "Copilot-Integration-Id: vscode-chat\nEditor-Version: VelaShell/1.0",
+                    Credential = OAuthCredential.AccessToken
+                }))
+        {
+            Experimental = true
+        },
+
+        new("xai-grok", "xAI Grok (SuperGrok 订阅)", "e.g. grok-4.6 · grok-code-fast", "XG",
+            AuthMethod.Subscription, () => Subscription(
+                "xAI Grok", "https://api.x.ai/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "grok-4.6", MaxInputTokens = 256000 },
+                new OAuthConfig
+                {
+                    // 只走设备码:xAI 在自己的 openid-configuration 里公开声明了
+                    // device_authorization_endpoint 与 device_code 授权类型,
+                    // 而授权码那一路它没有登记任何第三方可用的回调地址
+                    Flow = OAuthFlow.DeviceCode,
+                    DeviceCodeUrl = "https://auth.x.ai/oauth2/device/code",
+                    TokenUrl = "https://auth.x.ai/oauth2/token",
+                    ClientId = ClientIds.XaiGrok,
+                    Scopes = "openid profile email offline_access grok-cli:access api:access",
+                    // 设备码请求里带上来路,便于对方区分是哪个客户端在用
+                    ExtraAuthorizeParams = "referrer=velashell",
+                    Credential = OAuthCredential.AccessToken
+                }))
+        {
+            Experimental = true
+        },
+
+        new("digitalocean", "DigitalOcean Gradient", "e.g. Llama · Qwen · DeepSeek(托管推理)", "DO",
+            AuthMethod.Subscription, () => Subscription(
+                "DigitalOcean", "https://inference.do-ai.run/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "llama3.3-70b-instruct", MaxInputTokens = 128000 },
+                new OAuthConfig
+                {
+                    // 隐式流:令牌落在回调地址的 #fragment 里,得靠一页 HTML 把它回传
+                    Flow = OAuthFlow.ImplicitFragment,
+                    AuthorizationUrl = "https://cloud.digitalocean.com/v1/oauth/authorize",
+                    ClientId = ClientIds.DigitalOcean,
+                    Scopes = "genai:read inference:query",
+                    // 回调必须与登记的那条完全一致,所以端口固定
+                    RedirectPort = 43920,
+                    RedirectPath = "/callback",
                     Credential = OAuthCredential.AccessToken
                 }))
         {
@@ -424,6 +492,47 @@ public static class ProviderCatalog
         new("mistral", "Mistral AI", "e.g. mistral-large-latest", "MI", AuthMethod.ApiKey,
             () => Key("Mistral AI", "https://api.mistral.ai/v1", ChatProtocol.OpenAiChatCompletions,
                 new AiModelConfig { Model = "mistral-large-latest", MaxInputTokens = 128000 })),
+
+        new("cerebras", "Cerebras", "e.g. qwen-3-coder-480b · gpt-oss-120b", "CB", AuthMethod.ApiKey,
+            () => Key("Cerebras", "https://api.cerebras.ai/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "qwen-3-coder-480b", MaxInputTokens = 128000 })),
+
+        new("deepinfra", "Deep Infra", "e.g. deepseek-ai/DeepSeek-V3 · Qwen/Qwen3-235B", "DI", AuthMethod.ApiKey,
+            () => Key("Deep Infra", "https://api.deepinfra.com/v1/openai", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "deepseek-ai/DeepSeek-V3", MaxInputTokens = 128000 })),
+
+        new("nvidia", "NVIDIA NIM", "e.g. deepseek-ai/deepseek-r1 · qwen/qwen3-coder", "NV", AuthMethod.ApiKey,
+            () => Key("NVIDIA NIM", "https://integrate.api.nvidia.com/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "deepseek-ai/deepseek-r1", MaxInputTokens = 128000 })),
+
+        new("perplexity", "Perplexity", "e.g. sonar-pro · sonar-reasoning-pro", "PX", AuthMethod.ApiKey,
+            () => Key("Perplexity", "https://api.perplexity.ai", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "sonar-pro", MaxInputTokens = 200000 })),
+
+        new("cohere", "Cohere", "e.g. command-a-03-2025 · command-r-plus", "CO", AuthMethod.ApiKey,
+            () => Key("Cohere", "https://api.cohere.com/compatibility/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "command-a-03-2025", MaxInputTokens = 256000 })),
+
+        new("baseten", "Baseten", "e.g. deepseek-ai/DeepSeek-V3 · moonshotai/Kimi-K2", "BT", AuthMethod.ApiKey,
+            () => Key("Baseten", "https://inference.baseten.co/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "deepseek-ai/DeepSeek-V3", MaxInputTokens = 128000 })),
+
+        new("upstage", "Upstage Solar", "e.g. solar-pro2", "UP", AuthMethod.ApiKey,
+            () => Key("Upstage", "https://api.upstage.ai/v1/solar", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "solar-pro2", MaxInputTokens = 64000 })),
+
+        new("minimax", "MiniMax", "e.g. MiniMax-M2", "MM", AuthMethod.ApiKey,
+            // 这一家给的是 Anthropic 兼容端点,不是 OpenAI 的 —— 协议别跟着邻居抄
+            () => Key("MiniMax", "https://api.minimax.io/anthropic/v1", ChatProtocol.AnthropicMessages,
+                new AiModelConfig { Model = "MiniMax-M2", MaxInputTokens = 200000 })),
+
+        new("zenmux", "ZenMux", "Multiple models behind one key", "ZM", AuthMethod.ApiKey,
+            () => Key("ZenMux", "https://zenmux.ai/api/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "anthropic/claude-sonnet-4.5", MaxInputTokens = 200000 })),
+
+        new("llmgateway", "LLM Gateway", "Multiple models behind one key", "LG", AuthMethod.ApiKey,
+            () => Key("LLM Gateway", "https://api.llmgateway.io/v1", ChatProtocol.OpenAiChatCompletions,
+                new AiModelConfig { Model = "openai/gpt-5", MaxInputTokens = 200000 })),
 
         new("ollama", "Ollama (local)", "Locally served models · no key needed", "OL", AuthMethod.ApiKey,
             () => Key("Ollama", "http://localhost:11434/v1", ChatProtocol.OpenAiChatCompletions,

--- a/tests/VelaShell.Plugin.Ai.Tests/OpencodeProvidersTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/OpencodeProvidersTests.cs
@@ -1,0 +1,217 @@
+using System.Net;
+using VelaShell.Plugin.Ai.Auth;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 照着 opencode 的 <c>/connect</c> 补进来的两家:xAI SuperGrok(标准设备码)与
+/// DigitalOcean Gradient(隐式流)。前者复用现成流程,后者带进来一套新机制。
+/// </summary>
+[TestClass]
+[TestCategory("Plugins")]
+public sealed class OpencodeProvidersTests
+{
+    private static readonly LoginPrompts Prompts =
+        new("Signed in", "Close this tab.", "waiting", "exchanging", "code {0}");
+
+    // ---- xAI SuperGrok ----
+
+    [TestMethod]
+    public void Xai_IsADeviceCodeSubscriptionAndIsReadyToUse()
+    {
+        ProviderCatalogEntry entry = ProviderCatalog.Find("xai-grok")!;
+        AiProvider provider = entry.CreateProvider();
+        OAuthConfig oauth = provider.OAuth!;
+
+        Assert.AreEqual(OAuthFlow.DeviceCode, oauth.Flow);
+        Assert.AreEqual("https://auth.x.ai/oauth2/device/code", oauth.DeviceCodeUrl);
+        Assert.AreEqual("https://auth.x.ai/oauth2/token", oauth.TokenUrl);
+        Assert.Contains("grok-cli:access", oauth.Scopes);
+        // 借的是 Grok CLI 的客户端身份,得如实标出来
+        Assert.IsTrue(entry.Experimental);
+        Assert.IsTrue(provider.CanSignIn, "端点和 client_id 都齐了,不该判成「登不了」");
+    }
+
+    [TestMethod]
+    public async Task Xai_SignsInThroughTheDeviceCodeFlow()
+    {
+        var stub = new OAuthStub()
+            .Json("""
+                {"device_code":"dc-1","user_code":"WXYZ-1234",
+                 "verification_uri":"https://x.ai/device","interval":1}
+                """)
+            .Json("""{"access_token":"xai-at","refresh_token":"xai-rt","expires_in":3600}""");
+        using var http = new HttpClient(stub);
+        var login = new ProviderLogin(
+            new OAuthClient(http) { Delay = (_, _) => Task.CompletedTask },
+            (_, _) => Task.CompletedTask);
+
+        OAuthTokens tokens = await login.SignInAsync(
+            ProviderCatalog.Find("xai-grok")!.CreateProvider().OAuth!, Prompts);
+
+        Assert.AreEqual("xai-at", tokens.AccessToken);
+        Assert.AreEqual("xai-rt", tokens.RefreshToken);
+        Assert.IsNotNull(tokens.ExpiresAt);
+    }
+
+    /// <summary>
+    /// 设备码请求本身就是这一路的"授权请求",所以 <c>ExtraAuthorizeParams</c> 要落在它上面。
+    /// 之前只有授权码那一路会带,设备码这边是空的。
+    /// </summary>
+    [TestMethod]
+    public async Task DeviceCodeRequest_CarriesTheExtraAuthorizeParams()
+    {
+        var stub = new OAuthStub()
+            .Json("""{"device_code":"dc","user_code":"AB","verification_uri":"https://x.ai/device"}""");
+        using var http = new HttpClient(stub);
+
+        await new OAuthClient(http).StartDeviceCodeAsync(
+            ProviderCatalog.Find("xai-grok")!.CreateProvider().OAuth!);
+
+        Assert.Contains("referrer=velashell", stub.Requests[0].Body);
+    }
+
+    // ---- DigitalOcean:隐式流 ----
+
+    [TestMethod]
+    public void DigitalOcean_IsAnImplicitFlowWithNoTokenEndpoint()
+    {
+        ProviderCatalogEntry entry = ProviderCatalog.Find("digitalocean")!;
+        AiProvider provider = entry.CreateProvider();
+        OAuthConfig oauth = provider.OAuth!;
+
+        Assert.AreEqual(OAuthFlow.ImplicitFragment, oauth.Flow);
+        Assert.IsEmpty(oauth.TokenUrl, "隐式流没有 token 端点 —— 令牌直接从授权页回来");
+        // 上一版的 CanSignIn 拿 TokenUrl 一刀切,会把这一整路判死,而界面上只说"登不了"
+        Assert.IsTrue(provider.CanSignIn, "没有 token 端点不等于登不了");
+    }
+
+    [TestMethod]
+    public void ImplicitFlow_AsksForATokenNotACode()
+    {
+        OAuthConfig oauth = ProviderCatalog.Find("digitalocean")!.CreateProvider().OAuth!;
+
+        string url = OAuthClient
+            .BuildAuthorizationUrl(oauth, PkceCodes.Create(), "http://127.0.0.1:43920/callback")
+            .ToString();
+
+        Assert.Contains("response_type=token", url);
+        // 隐式流没有"拿码去换"那一步,challenge 无处可验 —— 发出去只是噪音
+        Assert.DoesNotContain("code_challenge", url);
+        Assert.Contains("state=", url, "state 防的是别人往回调里塞东西,与 PKCE 是两回事,照发");
+    }
+
+    /// <summary>
+    /// 片段(<c>#</c> 后面那段)<b>根本不会随请求发到服务端</b>。所以监听得先回一页
+    /// 把它搬成查询串再请求一次 —— 少了这一跳,隐式流在本机永远收不到令牌。
+    /// </summary>
+    [TestMethod]
+    public async Task Loopback_RecoversTheTokenOutOfTheUrlFragment()
+    {
+        using var listener = new LoopbackRedirectListener(0, "/callback");
+        using var http = new HttpClient();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        Task<Dictionary<string, string>> waiting =
+            listener.WaitAsync("t", "b", fragment: true, timeout.Token);
+
+        // 第一跳:浏览器带着 #access_token=… 打回来,服务端只看得到一个光秃秃的 /callback
+        string bootstrap = await http.GetStringAsync(
+            $"http://127.0.0.1:{listener.Port}/callback", timeout.Token);
+        Assert.IsFalse(waiting.IsCompleted, "还没拿到令牌,不能就此收工");
+        Assert.Contains("location.hash", bootstrap, "得回一页去取片段");
+        Assert.Contains("location.replace", bootstrap, "别在历史记录里留下带令牌的地址");
+
+        // 第二跳:那一页把片段原样再请求一次
+        await http.GetStringAsync(
+            $"http://127.0.0.1:{listener.Port}/callback?access_token=do-tok&expires_in=3600&token_type=bearer",
+            timeout.Token);
+
+        Dictionary<string, string> result = await waiting;
+        Assert.AreEqual("do-tok", result["access_token"]);
+    }
+
+    /// <summary>
+    /// 用户点了拒绝时,对方是拿<b>查询串</b>回的(<c>?error=…</c>)。
+    /// 那一跳要当场收下 —— 再去要片段的话,页面上什么都不会发生,登录就那么挂着。
+    /// </summary>
+    [TestMethod]
+    public async Task Loopback_InFragmentMode_StillTakesAQueryStringError()
+    {
+        using var listener = new LoopbackRedirectListener(0, "/callback");
+        using var http = new HttpClient();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        Task<Dictionary<string, string>> waiting =
+            listener.WaitAsync("t", "b", fragment: true, timeout.Token);
+        await http.GetStringAsync(
+            $"http://127.0.0.1:{listener.Port}/callback?error=access_denied", timeout.Token);
+
+        Assert.AreEqual("access_denied", (await waiting)["error"]);
+    }
+
+    [TestMethod]
+    public async Task ImplicitFlow_TakesTheTokenStraightOffTheCallback()
+    {
+        OAuthConfig oauth = ProviderCatalog.Find("digitalocean")!.CreateProvider().OAuth!.Clone();
+        oauth.RedirectPort = 0; // 测试里别占那个固定端口,并行跑会互相踩
+        // 没有 token 端点可打:任何一次 HTTP 都说明走错路了
+        var stub = new OAuthStub().Json("""{"should":"never be called"}""", HttpStatusCode.InternalServerError);
+        using var http = new HttpClient(stub);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var browser = new HttpClient();
+
+        // 真实顺序是"先开浏览器,再回来等回调",所以这一下必须<b>立刻返回</b> ——
+        // 在这里同步去打监听的话,监听还没开始 accept,测试会把自己锁死
+        var login = new ProviderLogin(new OAuthClient(http), (uri, ct) =>
+        {
+            Dictionary<string, string> query = OAuthClient.ParseQuery(uri.Query.TrimStart('?'));
+            string redirect = query["redirect_uri"];
+            // state 照原样带回来 —— 真实服务端就是这么做的,少了它这一轮会被判成"回调对不上"
+            string state = query["state"];
+            _ = Task.Run(async () =>
+            {
+                await browser.GetStringAsync(redirect, ct);
+                await browser.GetStringAsync(
+                    $"{redirect}?access_token=do-tok&expires_in=7200&state={Uri.EscapeDataString(state)}", ct);
+            }, ct);
+            return Task.CompletedTask;
+        });
+
+        OAuthTokens tokens = await login.SignInAsync(oauth, Prompts, cancellationToken: timeout.Token);
+
+        Assert.AreEqual("do-tok", tokens.AccessToken);
+        Assert.IsEmpty(tokens.RefreshToken ?? "", "隐式流不发 refresh token,过期只能重登");
+        Assert.AreEqual(0, stub.Requests.Count, "这一路不该有任何 token 交换");
+    }
+
+    // ---- 目录整体 ----
+
+    [TestMethod]
+    public void Catalog_EveryEntryHasAnEndpointUnlessItAsksForOne()
+    {
+        foreach (ProviderCatalogEntry entry in ProviderCatalog.All)
+        {
+            AiProvider provider = entry.CreateProvider();
+            if (entry.NeedsBaseUrl)
+            {
+                continue; // 自定义那几条本来就等着用户填
+            }
+            Assert.IsNotEmpty(provider.BaseUrl, $"{entry.Id} 没有基地址");
+            Assert.IsNotEmpty(provider.Models[0].Model, $"{entry.Id} 没有起手模型");
+        }
+    }
+
+    [TestMethod]
+    public void Catalog_IdsAreUnique()
+    {
+        List<string> duplicates = [.. ProviderCatalog.All
+            .GroupBy(e => e.Id, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)];
+
+        Assert.IsEmpty(duplicates, $"目录 id 撞了:{string.Join(", ", duplicates)}");
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/ProviderLoginTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ProviderLoginTests.cs
@@ -232,7 +232,7 @@ public sealed class ProviderLoginTests
         using var http = new HttpClient();
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
 
-        Task<Dictionary<string, string>> waiting = listener.WaitAsync("t", "b", timeout.Token);
+        Task<Dictionary<string, string>> waiting = listener.WaitAsync("t", "b", cancellationToken: timeout.Token);
         // 浏览器在打开回调页之后顺手来要图标 —— 拿它当结果的话,登录会在用户点同意前就"失败"
         HttpResponseMessage favicon = await http.GetAsync($"http://127.0.0.1:{listener.Port}/favicon.ico", timeout.Token);
         Assert.AreEqual(HttpStatusCode.OK, favicon.StatusCode);


### PR DESCRIPTION
接在 #332 之后。对着 opencode 的 `/connect` 逐条比对,把这边缺的供应商搬过来。

opencode 的结构是:框架在 `packages/opencode/src/provider/auth.ts`,每家供应商是一个 plugin,声明 `auth: { provider, methods: [{ type: "oauth" | "api", label, authorize() }] }`;各家的端点与 client_id 写死在 `src/plugin/*.ts` 里。和这边的 `ProviderCatalog` 是同一个思路,所以能一条一条对。

## 订阅登录两家

**xAI Grok(SuperGrok 订阅)** —— 标准设备码。之前这一条是**故意空着**的:查不到可核实的端点,与其猜一个填上,不如不做。现在有依据了 —— xAI 在自己的 `auth.x.ai/.well-known/openid-configuration` 里公开声明了 `device_authorization_endpoint` 和对应的 `device_code` 授权类型。借的是 Grok CLI 的公共客户端 id,与 Codex / Claude / Copilot 同性质,一样标 `Experimental`。

**DigitalOcean Gradient** —— 隐式流(`response_type=token`)。这一条带进来一套**新机制**:令牌落在回调地址的 `#fragment` 里,而**片段根本不会随请求发到服务端**(这是浏览器的规矩,不是哪家的实现细节)。所以监听得先回一页只做一件事的 HTML,把 `location.hash` 搬成查询串再请求一次,第二跳之后路径就与授权码流程完全一致了。用 `location.replace` 而不是 `assign` —— 别在用户的历史记录里留下一条带令牌的地址。

> 隐式流在 OAuth 2.1 里已被劝退,这里实现它只为接上还在用它的服务,不作为新接入的推荐:令牌进过浏览器地址栏,而且没有 refresh token,过期只能重登。

## 顺带修的两处

- **`CanSignIn` 原来拿 `TokenUrl` 一刀切。** 隐式流**没有** token 端点,那样会把这一整路判死 —— 而界面上只会显示「登不了」,查不出为什么。改成按流程分开判。
- **`ExtraAuthorizeParams` 原来只有授权码那一路会带。** 设备码请求本身就是那一路的「授权请求」,xAI 要的 `referrer` 就落在那儿。

## 填 Key 十家

Cerebras、Deep Infra、NVIDIA NIM、Perplexity、Cohere、Baseten、Upstage、MiniMax、ZenMux、LLM Gateway。

端点优先取 **models.dev 的 `api` 字段**;那边没给的四家(Cerebras / Deep Infra / Perplexity / Cohere)从 opencode 仓库里取 —— **一个都没有靠印象填**。基地址填错了不会报错,只会在用户那儿变成一句连不上,这类值不该猜。

MiniMax 给的是 **Anthropic 兼容**端点而不是 OpenAI 的,协议没跟着邻居抄。

## 没搬的几条

| 供应商 | 为什么 |
| --- | --- |
| Azure Entra ID | opencode 是 shell 出去调 `az` CLI 取令牌,不是应用内 OAuth,与这边的形态不是一回事 |
| Amazon Bedrock / Google Vertex / GitLab / SAP AI Core | 要 SigV4 或 GCP 凭据链,不是 OpenAI 兼容那条路 |
| OpenCode Zen | 对方自家的商业网关 |

## 测试

新增 `OpencodeProvidersTests`(10 条),重点在隐式流那套新机制:

- `Loopback_RecoversTheTokenOutOfTheUrlFragment` —— 两跳都验:第一跳只回引导页、不能就此收工;第二跳才拿到令牌
- `Loopback_InFragmentMode_StillTakesAQueryStringError` —— 用户点拒绝时对方是拿**查询串**回的(`?error=…`),那一跳要当场收下。再去要片段的话页面上什么都不会发生,登录就那么挂着
- `ImplicitFlow_TakesTheTokenStraightOffTheCallback` —— 桩打成"任何一次 HTTP 都算失败",确认这一路真的不做 token 交换
- `DigitalOcean_IsAnImplicitFlowWithNoTokenEndpoint` —— 给上面那个 `CanSignIn` 的坑上棘轮
- `DeviceCodeRequest_CarriesTheExtraAuthorizeParams` —— 同上

`dotnet test VelaShell.slnx`:**2493 通过 / 1 失败**。那一条失败是 `ShortcutCatalogTests.Doc_ListsEveryCatalogEntry`,它读 `docs/快捷键参考.md` 而 `docs/` 没有被 git 跟踪 —— 在干净的 `origin/main` 上同样失败,与本 PR 无关(#332 里也说明过)。

AI 插件测试 340 → 350,全过。0 错误 0 警告。


## 真机验证

**xAI Grok(SuperGrok 订阅)的登录已在真机上跑通**:设备码流程走完整条路,换回令牌,拿它发出去的推理请求被 xAI **认了身份** —— 服务端回的是 402(该账号额度/订阅的问题),不是 401。也就是说 OAuth 这一段确实能用,不再只是"协议对得上"。

至于某个具体账号有没有权益,那是账号自己的事,不在本 PR 的范围里。

DigitalOcean Gradient 的隐式流仍只有**协议层验证**(打桩,见上面那三条测试)—— 需要有 DO 账号的人点一次才算数。它带进来的片段回收机制本身是被测试盯着的,但真机上浏览器那一跳没实走过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
