### PR TITLE
输入框旁边加一个思考档位下拉,只管这一轮

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Configuration/AiProvider.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/AiProvider.cs
@@ -256,6 +256,16 @@ public sealed class AiModelConfig
     /// </remarks>
     public ReasoningLevel Reasoning { get; set; } = ReasoningLevel.Default;
 
+    /// <summary>
+    /// 这个模型会不会思考(来自 models.dev 的 <c>reasoning</c>);<c>null</c> = 还不知道。
+    /// </summary>
+    /// <remarks>
+    /// 三态而不是布尔:<b>"没拉过规格库"和"拉过、答案是不会"是两回事</b>。
+    /// 手工添加的模型、中转站的私有型号都落在 null 上 —— 那时界面照常放开档位选择,
+    /// 因为我们确实不知道,凭"默认 false"去灰掉一个其实能思考的模型才是更糟的错。
+    /// </remarks>
+    public bool? SupportsReasoning { get; set; }
+
     /// <summary>界面上显示的名字:名称,没填就退回模型 id。</summary>
     [JsonIgnore]
     public string DisplayName => string.IsNullOrWhiteSpace(Name) ? Model : Name;
@@ -336,8 +346,28 @@ public sealed class ResolvedModel
     /// <inheritdoc cref="AiModelConfig.CachedInputPricePerMillion" />
     public double CachedInputPricePerMillion => Config.CachedInputPricePerMillion;
 
+    /// <summary>
+    /// 这一轮临时用的思考档位;<c>null</c> = 用模型自己配的那个。
+    /// </summary>
+    /// <remarks>
+    /// 输入框旁边那个下拉设的就是它。<b>不落盘</b> —— "这一问要不要多想想"往往是逐条变的,
+    /// 让它改写设置页里的值,下次打开就会发现档位莫名其妙换了,而用户根本不记得动过设置。
+    /// </remarks>
+    public ReasoningLevel? ReasoningOverride { get; init; }
+
     /// <inheritdoc cref="AiModelConfig.Reasoning" />
-    public ReasoningLevel Reasoning => Config.Reasoning;
+    public ReasoningLevel Reasoning => ReasoningOverride ?? Config.Reasoning;
+
+    /// <summary>能不能调思考档位:只有<b>确知不会思考</b>时才是 false(不知道就放开)。</summary>
+    public bool ReasoningAdjustable => Config.SupportsReasoning != false;
+
+    /// <summary>套一个临时档位,返回一份新的(本对象不可变)。</summary>
+    /// <remarks>
+    /// 做成"换一个对象"而不是"改一个字段":<see cref="ResolvedModel" /> 会被界面缓存并共享,
+    /// 就地改的话,某一轮的临时选择会渗到别处去。
+    /// </remarks>
+    public ResolvedModel WithReasoning(ReasoningLevel? level)
+        => level is null ? this : new ResolvedModel(Provider, Config) { ReasoningOverride = level };
 }
 
 /// <summary>插件持久化设置(经 Storage 存 JSON)。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Configuration/ModelsDevCatalog.cs
+++ b/plugins/VelaShell.Plugin.Ai/Configuration/ModelsDevCatalog.cs
@@ -346,6 +346,9 @@ public sealed class ModelsDevCatalog(IPluginContext context)
         {
             model.CachedInputPricePerMillion = spec.CachedInputPrice;
         }
+        // 这一项与上面几个不同:false 是有意义的答案("这个模型不会思考"),
+        // 不能照搬"0 就当没说过"的规矩 —— 那样永远回不到 false
+        model.SupportsReasoning = spec.Reasoning;
     }
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -512,6 +512,29 @@
       <Setter Property="Foreground" Value="{Binding $parent[ComboBox].Foreground}" />
     </Style>
 
+    <!-- 思考档位:没改过档时<b>一个属性都不设</b> —— 就让它和旁边的模型选择器长得一模一样。
+         (曾经在代码里 FindResource 取色再写到控件上,可这个插件允许在拿不到宿主主题令牌的
+         环境下装载,那时取回 null,前景色被设成 null,文字整个消失、只剩一个下拉箭头。)
+         改过档才挂 .overridden 点亮成芯片:"这一轮和你平常设的不一样"要能被余光看见,
+         不必再去翻设置页确认。 -->
+    <Style Selector="ComboBox#ReasoningCombo.overridden /template/ Border#Background,
+                     ComboBox#ReasoningCombo.overridden:pointerover /template/ Border#Background,
+                     ComboBox#ReasoningCombo.overridden:focus /template/ Border#Background,
+                     ComboBox#ReasoningCombo.overridden /template/ Border#HighlightBackground,
+                     ComboBox#ReasoningCombo.overridden:pointerover /template/ Border#HighlightBackground,
+                     ComboBox#ReasoningCombo.overridden:focus /template/ Border#HighlightBackground">
+      <Setter Property="Background" Value="{DynamicResource VelaAccentDim}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+    <Style Selector="ComboBox#ReasoningCombo.overridden /template/ ContentControl#ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <Style Selector="ComboBox#ReasoningCombo.overridden /template/ PathIcon#DropDownGlyph">
+      <Setter Property="Foreground" Value="{DynamicResource VelaAccent}" />
+    </Style>
+
     <!-- ===== 阻塞类卡片:审批与失败 =====
          两者都是"这一轮停在这儿了",与工具日志不是一个分量:左边一道 3px 语义色竖条,
          整张卡从工具卡的灰描边里拎出来。 -->
@@ -791,9 +814,12 @@
                      VerticalAlignment="Top" TextWrapping="Wrap" />
         </Panel>
 
-        <!-- 只放"发这一条要用什么":模型 / Agent / 发送。模型那列是 * —— 面板收窄时
-             先挤模型名(下拉里仍看得全),而不是把发送按钮挤出边界。 -->
-        <Grid x:Name="InputToolbar" Grid.Row="1" ColumnDefinitions="Auto,*,Auto,Auto" Margin="6,0,5,5">
+        <!-- 只放"发这一条要用什么":模型 / 思考档位 / Agent / 发送。
+             模型与思考档位<b>必须紧挨着</b> —— 后者改的正是"这个模型这一问想多深",
+             两者是一件事的两半;中间隔开的话读起来像是两件不相干的设置。
+             所以空档(*)放在它们<b>之后</b>:面板收窄时先吃掉这段空白,
+             而不是把发送按钮挤出边界。 -->
+        <Grid x:Name="InputToolbar" Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto" Margin="6,0,5,5">
           <Button x:Name="AttachButton" Theme="{StaticResource AiGhostIconButtonTheme}" Margin="0,0,4,0">
             <Viewbox Width="13" Height="13">
               <Path Width="24" Height="24" Data="{DynamicResource Icon.plus}"
@@ -802,9 +828,15 @@
             </Viewbox>
           </Button>
           <ComboBox x:Name="ProviderCombo" Grid.Column="1" MaxWidth="230" HorizontalAlignment="Left" />
+          <!-- 思考档位:只管这一轮,不写回设置(见 ResolvedModel.ReasoningOverride)。
+               外观<b>不在代码里设</b> —— 本插件允许在拿不到宿主主题令牌的环境下装载
+               (见 Panel_Loads_WithoutHostThemeTokens),那时 FindResource 返回 null,
+               把前景色设成 null 会让文字整个消失、只剩一个下拉箭头。改过档时挂 .overridden 类,
+               配色交给下面的样式与 DynamicResource,取不到令牌时自然退回主题默认值。 -->
+          <ComboBox x:Name="ReasoningCombo" Grid.Column="2" Margin="6,0,0,0" MinWidth="76" />
           <!-- 对话模式:纯对话 / 计划 / Agent(对齐 Copilot 的模式选择) -->
-          <ComboBox x:Name="ModeCombo" Grid.Column="2" Margin="6,0,0,0" MinWidth="88" />
-          <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="6" Margin="8,0,0,0" VerticalAlignment="Center">
+          <ComboBox x:Name="ModeCombo" Grid.Column="4" Margin="6,0,0,0" MinWidth="88" />
+          <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="6" Margin="8,0,0,0" VerticalAlignment="Center">
             <!-- 主操作带文字(设计图):这一枚是整个面板唯一的"提交",纯图标要靠猜。
                  模型那列是 * ,面板收窄时先挤模型名,挤不到这里。 -->
             <Button x:Name="SendButton" Theme="{DynamicResource VelaAccentPillButtonTheme}"

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -63,6 +63,18 @@ public partial class ChatPanelView : UserControl
     private SettingsView? _settingsView;
     private GlobalSettingsView? _globalSettingsView;
     private List<ResolvedModel> _providers = [];
+
+    /// <summary>
+    /// 输入框旁边那个下拉设的临时思考档位;<c>null</c> = 就用模型自己配的那个。
+    /// </summary>
+    /// <remarks>
+    /// <b>不落盘,也不写回模型配置</b>:"这一问要不要多想想"是逐条变的,
+    /// 而设置页里那个值代表的是这个模型平常怎么用。换模型时清掉(见 ProviderCombo 的处理)。
+    /// </remarks>
+    private ReasoningLevel? _reasoningOverride;
+
+    /// <summary>正在由代码回填下拉选中项(别把这一下当成用户在选)。</summary>
+    private bool _syncingReasoning;
     private List<SessionInfo> _sessions = [];
     private CancellationTokenSource? _cts;
     private bool _busy;
@@ -167,8 +179,26 @@ public partial class ChatPanelView : UserControl
                 _settings.ActiveModelId = _providers[ProviderCombo.SelectedIndex].Id;
                 _ = PersistSettingsAsync();
             }
+            // 换了模型,上一个模型的临时档位就不作数了 —— 各家的档位含义与默认值本来就不同,
+            // 留着它等于把"我为 Codex 选的高"悄悄套到 Claude 头上
+            _reasoningOverride = null;
+            SyncReasoningUi();
             // 上下文窗口是按接入配的,换模型就得按新分母重算占比
             UpdateUsageText();
+        };
+        ReasoningCombo.SelectionChanged += (_, _) =>
+        {
+            if (_syncingReasoning || ReasoningCombo.SelectedIndex < 0)
+            {
+                return;
+            }
+            // 选回模型自己配的那一档 = 取消覆盖(而不是"覆盖成同一个值")——
+            // 否则芯片会一直亮着,而它本该只在"这一轮不一样"时才亮
+            var picked = (ReasoningLevel)ReasoningCombo.SelectedIndex;
+            _reasoningOverride = picked == (ActiveProvider?.Config.Reasoning ?? ReasoningLevel.Default)
+                ? null
+                : picked;
+            SyncReasoningUi();
         };
 
         _context.Events.SessionConnected += OnSessionEvent;
@@ -254,6 +284,15 @@ public partial class ChatPanelView : UserControl
         ReloadApprovalItems();
         ModeCombo.SelectedIndex = mode;
         ApprovalCombo.SelectedIndex = approval;
+        // 顺序与 ReasoningLevel 一一对应(默认 / 关 / 低 / 中 / 高),下面按索引强转回枚举
+        _syncingReasoning = true;
+        ReasoningCombo.ItemsSource = (string[])
+        [
+            _loc["ReasoningAuto"], _loc["ReasoningOff"],
+            _loc["ReasoningLow"], _loc["ReasoningMedium"], _loc["ReasoningHigh"]
+        ];
+        _syncingReasoning = false;
+        SyncReasoningUi();
         SyncModeUi();
         // 「新会话」也是纯图标钮了(顶栏四枚统一 26×30),文案只剩提示这一处
         ToolTip.SetTip(NewChatButton, $"{_loc["NewChat"]} — {_loc["NewChatTip"]}");
@@ -557,6 +596,45 @@ public partial class ChatPanelView : UserControl
             ? _providers[ProviderCombo.SelectedIndex]
             : null;
 
+    /// <summary>这一轮真正要用的接入:带上输入框旁边那个临时档位(没改过就是原样)。</summary>
+    private ResolvedModel? ActiveProviderForRequest => ActiveProvider?.WithReasoning(_reasoningOverride);
+
+    /// <summary>
+    /// 把下拉的选中项、可用性与外观同步到当前状态。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 改过档就挂 <c>.overridden</c> 点亮成芯片,否则一个属性都不设 ——
+    /// 「这一轮和我平常设的不一样」得能被余光看见,不然过几条消息就忘了自己动过它。
+    /// </para>
+    /// <para>
+    /// <b>外观走样式类而不是在这里取色写属性。</b>本插件允许在拿不到宿主主题令牌的环境下装载
+    /// (见 <c>Panel_Loads_WithoutHostThemeTokens</c>),那时 <c>FindResource</c> 返回 null,
+    /// 把前景色设成 null 会让文字整个消失、只剩一个下拉箭头 —— 真机上就是这么撞见的。
+    /// </para>
+    /// </remarks>
+    private void SyncReasoningUi()
+    {
+        ResolvedModel? active = ActiveProvider;
+        ReasoningLevel effective = _reasoningOverride ?? active?.Config.Reasoning ?? ReasoningLevel.Default;
+        _syncingReasoning = true;
+        ReasoningCombo.SelectedIndex = (int)effective;
+        _syncingReasoning = false;
+
+        // 只有 models.dev 明说"不会思考"时才灰掉。不知道就放开 ——
+        // 凭"默认不支持"去灰掉一个其实能思考的模型,比多给一个无效档位糟得多
+        bool adjustable = active?.ReasoningAdjustable ?? true;
+        ReasoningCombo.IsEnabled = adjustable;
+
+        bool overridden = _reasoningOverride is not null;
+        ReasoningCombo.Classes.Set("overridden", overridden);
+        ToolTip.SetTip(ReasoningCombo, _loc[!adjustable
+            ? "ReasoningUnsupportedTip"
+            : overridden
+                ? "ReasoningOverrideTip"
+                : "ReasoningTip"]);
+    }
+
     /// <summary>
     /// 刷新输入框下方那块用量:可见文字只留最要紧的一项(知道上下文窗口就给占比,
     /// 否则给累计的进/出),完整明细压进悬停提示 —— 工具条那点宽度经不起铺开。
@@ -856,7 +934,8 @@ public partial class ChatPanelView : UserControl
             await QueueWhileBusyAsync(text, fromUser);
             return;
         }
-        if (ActiveProvider is not { } provider)
+        // 取带临时档位的那一份:输入框旁边选的"这一问想多深"就是在这儿生效的
+        if (ActiveProviderForRequest is not { } provider)
         {
             // 这次是用户主动发消息才撞上"没配接入",直接把设置窗口开给他
             StatusText.Text = _loc["NoProvider"];

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -212,7 +212,13 @@ public sealed class Loc(string locale)
         ["ReasoningLow"] = ["Low", "低", "低", "低", "낮음"],
         ["ReasoningMedium"] = ["Medium", "中", "中", "中", "보통"],
         ["ReasoningHigh"] = ["High", "高", "高", "高", "높음"],
-        ["ReasoningOffHint"] = ["This model's Thinking setting is \"Don't ask for thinking\", so no thinking is requested and none comes back. Pick a level in the model settings to see it.", "当前模型的「思考过程」设为不请求,所以服务端不会返回思考内容 —— 想看就在模型配置里选一个档位。", "目前模型的「思考過程」設為不請求,所以伺服器不會回傳思考內容 —— 想看就在模型設定裡選一個檔位。", "このモデルの「思考プロセス」は「要求しない」に設定されているため、思考は返ってきません。表示したいならモデル設定でレベルを選んでください。", "이 모델의 「사고 과정」이 \"요청하지 않음\"으로 설정되어 있어 사고 내용이 오지 않습니다. 보려면 모델 설정에서 레벨을 선택하세요."],
+        // 输入框旁边那个下拉用的短形:工具条只有几十像素宽,设置页那句完整说明进不去。
+        // 「默认」在这里的含义与设置页的 ReasoningDefault 完全一致(不带 reasoning 参数)
+        ["ReasoningAuto"] = ["Auto", "默认", "預設", "既定", "기본"],
+        ["ReasoningTip"] = ["Thinking level for this model. Changing it here applies to this conversation only — it does not touch the model's saved setting.", "当前模型的思考档位。在这儿改只对本次对话生效,不会动模型配置里保存的那个值。", "目前模型的思考檔位。在這裡改只對本次對話生效,不會動模型設定裡儲存的那個值。", "このモデルの思考レベル。ここでの変更はこの会話にのみ適用され、モデルの保存設定は変わりません。", "이 모델의 사고 레벨. 여기서 바꾸면 이번 대화에만 적용되며 모델의 저장된 설정은 바뀌지 않습니다."],
+        ["ReasoningOverrideTip"] = ["This conversation is using a thinking level different from the model's saved setting. Pick the saved one again to clear it; switching models clears it too.", "本次对话用的思考档位与模型配置里保存的不一样。选回保存的那一档即可取消;换模型也会自动取消。", "本次對話用的思考檔位與模型設定裡儲存的不一樣。選回儲存的那一檔即可取消;換模型也會自動取消。", "この会話はモデルの保存設定とは異なる思考レベルを使っています。保存された値を選び直すと解除されます。モデルを切り替えても解除されます。", "이 대화는 모델의 저장된 설정과 다른 사고 레벨을 사용 중입니다. 저장된 값을 다시 선택하면 해제되며, 모델을 바꿔도 해제됩니다."],
+        ["ReasoningUnsupportedTip"] = ["This model doesn't do thinking (per models.dev), so there is no level to set.", "据 models.dev,这个模型不会思考,没有档位可调。", "據 models.dev,這個模型不會思考,沒有檔位可調。", "models.dev によれば、このモデルは思考しないため、設定できるレベルはありません。", "models.dev에 따르면 이 모델은 사고 기능이 없어 설정할 레벨이 없습니다."],
+        ["ReasoningOffHint"] =["This model's Thinking setting is \"Don't ask for thinking\", so no thinking is requested and none comes back. Pick a level in the model settings to see it.", "当前模型的「思考过程」设为不请求,所以服务端不会返回思考内容 —— 想看就在模型配置里选一个档位。", "目前模型的「思考過程」設為不請求,所以伺服器不會回傳思考內容 —— 想看就在模型設定裡選一個檔位。", "このモデルの「思考プロセス」は「要求しない」に設定されているため、思考は返ってきません。表示したいならモデル設定でレベルを選んでください。", "이 모델의 「사고 과정」이 \"요청하지 않음\"으로 설정되어 있어 사고 내용이 오지 않습니다. 보려면 모델 설정에서 레벨을 선택하세요."],
         ["Temperature"] = ["Temperature", "温度", "溫度", "温度", "온도"],
         ["TopP"] = ["Top-P", "Top-P", "Top-P", "Top-P", "Top-P"],
         ["StopSequences"] = ["Stop (one per line)", "停止序列(每行一条)", "停止序列(每行一條)", "停止シーケンス(1 行に 1 つ)", "정지 시퀀스(줄마다 하나)"],

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Reasoning.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Reasoning.cs
@@ -1,0 +1,361 @@
+using Avalonia.Controls;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 输入框旁边那个思考档位下拉。它的全部意义在"临时"两个字上:
+/// 改了要对下一条消息生效,但<b>不能</b>动模型配置里保存的那个值。
+/// </summary>
+public sealed partial class ChatPanelViewUiTests
+{
+    /// <summary>一个供应商挂两个模型,用来验"换模型会不会把上一个的临时档位带过去"。</summary>
+    private static AiProvider TwoModels(ReasoningLevel first, ReasoningLevel second)
+        => new()
+        {
+            Name = "stub",
+            BaseUrl = "http://127.0.0.1:1/v1",
+            DefaultProtocol = ChatProtocol.OpenAiChatCompletions,
+            Models =
+            [
+                new AiModelConfig { Model = "m1", Reasoning = first },
+                new AiModelConfig { Model = "m2", Reasoning = second }
+            ]
+        };
+
+    private static async Task<(Window Window, ChatPanelView Panel, ComboBox Combo)> WithReasoningPickerAsync(
+        TestPluginContext context, AiProvider provider)
+    {
+        await new AiSettingsStore(context).SaveAsync(
+            new AiSettings { Providers = [provider], ActiveModelId = provider.Models[0].Id });
+        (Window window, ChatPanelView panel) = await ShowAsync(context);
+        return (window, panel, Find<ComboBox>(panel, "ReasoningCombo"));
+    }
+
+    [TestMethod]
+    public void ReasoningPicker_StartsOnTheLevelTheModelIsConfiguredWith()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.High, ReasoningLevel.Default));
+            try
+            {
+                // 枚举值就是索引(Default/Off/Low/Medium/High)
+                Assert.AreEqual((int)ReasoningLevel.High, combo.SelectedIndex);
+                Assert.HasCount(5, (System.Collections.IEnumerable)combo.ItemsSource!);
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 这一条是整个功能的要害:在工具条上改档位,<b>不能</b>写回模型配置。
+    /// 写回去的话,下次打开设置页会发现档位莫名其妙换了,而用户根本不记得动过设置。
+    /// </summary>
+    [TestMethod]
+    public void PickingALevel_DoesNotWriteBackToTheSavedModelSetting()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            var store = new AiSettingsStore(context);
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.High, ReasoningLevel.Default));
+            try
+            {
+                combo.SelectedIndex = (int)ReasoningLevel.Low;
+                await PumpAsync(10);
+
+                AiSettings saved = await store.LoadAsync();
+                Assert.AreEqual(ReasoningLevel.High, saved.Providers[0].Models[0].Reasoning,
+                    "工具条上的选择是临时的,不该改动保存的配置");
+                Assert.AreEqual((int)ReasoningLevel.Low, combo.SelectedIndex, "但界面上得停在选中的那一档");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 选回模型自己那一档 = 取消覆盖,而不是"覆盖成同一个值"——
+    /// 否则芯片会一直亮着,而它本该只在"这一轮不一样"时才亮。
+    /// </summary>
+    [TestMethod]
+    public void PickingTheSavedLevelAgain_ClearsTheOverride()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.High, ReasoningLevel.Default));
+            try
+            {
+                object? plain = ToolTip.GetTip(combo);
+
+                combo.SelectedIndex = (int)ReasoningLevel.Low;
+                await PumpAsync(10);
+                object? lit = ToolTip.GetTip(combo);
+                Assert.AreNotEqual(plain, lit, "改过档之后,提示语要换成解释怎么取消的那一条");
+
+                combo.SelectedIndex = (int)ReasoningLevel.High;
+                await PumpAsync(10);
+                Assert.AreEqual(plain, ToolTip.GetTip(combo), "选回原档就该恢复成没改过的样子");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 档位下拉要<b>紧挨着</b>模型选择器 —— 它改的正是"这个模型这一问想多深",
+    /// 中间隔一段空白就读成了两件不相干的设置。空档要排在两者之后。
+    /// </summary>
+    [TestMethod]
+    public void ReasoningPicker_SitsRightNextToTheModelPicker()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.Default, ReasoningLevel.Default));
+            try
+            {
+                ComboBox model = Find<ComboBox>(panel, "ProviderCombo");
+                Assert.AreEqual(Grid.GetColumn(model) + 1, Grid.GetColumn(combo), "就在模型那一列的右边一列");
+
+                var toolbar = Find<Grid>(panel, "InputToolbar");
+                Assert.AreEqual(GridUnitType.Auto, toolbar.ColumnDefinitions[Grid.GetColumn(model)].Width.GridUnitType,
+                    "模型那列若是 *,下拉会被推到星号列的最右端,中间空一大段");
+                Assert.AreEqual(GridUnitType.Star,
+                    toolbar.ColumnDefinitions[Grid.GetColumn(combo) + 1].Width.GridUnitType,
+                    "空档排在两者之后 —— 收窄时先吃空白,而不是把发送按钮挤出去");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 没改过档时<b>一个外观属性都不该设</b>。
+    /// </summary>
+    /// <remarks>
+    /// 这条是真机上撞出来的:原先在代码里 <c>FindResource</c> 取色写到控件上,
+    /// 而本插件允许在拿不到宿主主题令牌的环境下装载(见 <c>Panel_Loads_WithoutHostThemeTokens</c>)——
+    /// 那时取回 null,前景色被设成 null,文字整个消失,下拉只剩一个箭头。
+    /// </remarks>
+    [TestMethod]
+    public void ReasoningPicker_Unchanged_LooksExactlyLikeTheModelPicker()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.Default, ReasoningLevel.Default));
+            try
+            {
+                ComboBox model = Find<ComboBox>(panel, "ProviderCombo");
+                Assert.AreEqual(model.Foreground, combo.Foreground, "前景色不该被代码写过 —— 写成 null 就没字了");
+                Assert.AreEqual(model.Background, combo.Background);
+                Assert.AreEqual(model.BorderBrush, combo.BorderBrush);
+                Assert.DoesNotContain("overridden", combo.Classes);
+
+                combo.SelectedIndex = (int)ReasoningLevel.High;
+                await PumpAsync(10);
+                Assert.Contains("overridden", combo.Classes, "改过档才点亮,而且只经样式类,不写属性");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>models.dev 明说不会思考的模型,档位没得调 —— 灰掉,并说明为什么。</summary>
+    [TestMethod]
+    public void ReasoningPicker_IsDisabledForModelsThatCannotThink()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            AiProvider provider = TwoModels(ReasoningLevel.Default, ReasoningLevel.Default);
+            provider.Models[0].SupportsReasoning = false; // 拉过规格库,答案是"不会"
+            provider.Models[1].SupportsReasoning = true;
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, provider);
+            try
+            {
+                Assert.IsFalse(combo.IsEnabled);
+
+                Find<ComboBox>(panel, "ProviderCombo").SelectedIndex = 1;
+                await PumpAsync(10);
+                Assert.IsTrue(combo.IsEnabled, "换到会思考的模型就该放开");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 手工添加的模型、中转站的私有型号都没拉过规格库 —— 那时是"不知道",不是"不会"。
+    /// 凭默认值去灰掉一个其实能思考的模型,比多给一个无效档位糟得多。
+    /// </summary>
+    [TestMethod]
+    public void ReasoningPicker_StaysOpenWhenTheCapabilityIsUnknown()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            AiProvider provider = TwoModels(ReasoningLevel.Default, ReasoningLevel.Default);
+            Assert.IsNull(provider.Models[0].SupportsReasoning, "没拉过规格库就该是 null");
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, provider);
+            try
+            {
+                Assert.IsTrue(combo.IsEnabled);
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// 换模型要清掉。各家的档位含义与默认值本来就不同,留着它等于把
+    /// "我给上一个模型选的高"悄悄套到下一个头上。
+    /// </summary>
+    [TestMethod]
+    public void SwitchingModels_DropsTheTemporaryLevel()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel, ComboBox combo) =
+                await WithReasoningPickerAsync(context, TwoModels(ReasoningLevel.Default, ReasoningLevel.Off));
+            try
+            {
+                combo.SelectedIndex = (int)ReasoningLevel.High;
+                await PumpAsync(10);
+
+                Find<ComboBox>(panel, "ProviderCombo").SelectedIndex = 1;
+                await PumpAsync(10);
+
+                Assert.AreEqual((int)ReasoningLevel.Off, combo.SelectedIndex,
+                    "换到第二个模型,显示的该是它自己配的那一档,不是上一个模型的临时选择");
+            }
+            finally
+            {
+                panel.Detach();
+                window.Close();
+            }
+        });
+    }
+}
+
+/// <summary>临时档位在模型层的语义(与界面无关,单独测)。</summary>
+[TestClass]
+[TestCategory("Plugins")]
+public sealed class ReasoningOverrideTests
+{
+    private static ResolvedModel Model(ReasoningLevel configured)
+    {
+        var config = new AiModelConfig { Model = "m", Reasoning = configured };
+        return new ResolvedModel(
+            new AiProvider { Name = "p", BaseUrl = "http://127.0.0.1:1/v1", Models = [config] }, config);
+    }
+
+    [TestMethod]
+    public void WithReasoning_LeavesTheOriginalAlone()
+    {
+        ResolvedModel original = Model(ReasoningLevel.Low);
+
+        ResolvedModel raised = original.WithReasoning(ReasoningLevel.High);
+
+        Assert.AreEqual(ReasoningLevel.High, raised.Reasoning);
+        // 界面会缓存并共享 ResolvedModel —— 就地改的话,某一轮的临时选择会渗到别处去
+        Assert.AreEqual(ReasoningLevel.Low, original.Reasoning, "原对象不能被改动");
+        Assert.AreEqual(ReasoningLevel.Low, original.Config.Reasoning, "更不该动到底下的配置");
+    }
+
+    [TestMethod]
+    public void WithReasoning_Null_MeansUseWhateverTheModelSays()
+    {
+        ResolvedModel original = Model(ReasoningLevel.Medium);
+
+        Assert.AreSame(original, original.WithReasoning(null));
+        Assert.AreEqual(ReasoningLevel.Medium, original.WithReasoning(null).Reasoning);
+    }
+
+    /// <summary>临时档位得真的走到请求里去,而不是只改了个界面显示。</summary>
+    [TestMethod]
+    public void TheTemporaryLevel_ReachesTheRequest()
+    {
+        var options = new Microsoft.Extensions.AI.ChatOptions();
+
+        AiSettingsStore.ApplyReasoning(options, Model(ReasoningLevel.Default).WithReasoning(ReasoningLevel.High));
+
+        Assert.IsNotNull(options.Reasoning);
+        Assert.AreEqual(Microsoft.Extensions.AI.ReasoningEffort.High, options.Reasoning.Effort);
+    }
+
+    [TestMethod]
+    public void WithoutAnOverride_DefaultStillMeansSendNothing()
+    {
+        var options = new Microsoft.Extensions.AI.ChatOptions();
+
+        AiSettingsStore.ApplyReasoning(options, Model(ReasoningLevel.Default));
+
+        Assert.IsNull(options.Reasoning, "Default 的含义就是请求里不带 reasoning 参数");
+    }
+
+    /// <summary>
+    /// models.dev 的 <c>reasoning</c> 要落到模型配置上,而且 <c>false</c> 必须能写进去 ——
+    /// 其余几项走的是"0 就当没说过",照搬那条规矩的话永远回不到 false。
+    /// </summary>
+    [TestMethod]
+    public void PullingSpecs_RecordsWhetherTheModelCanThink()
+    {
+        var model = new AiModelConfig { Model = "m" };
+
+        ModelsDevCatalog.Apply(model, new ModelSpec("m", "M", 128000, 8192, 1, 2, 0, true));
+        Assert.IsTrue(model.SupportsReasoning);
+
+        ModelsDevCatalog.Apply(model, new ModelSpec("m", "M", 128000, 8192, 1, 2, 0, false));
+        Assert.IsFalse(model.SupportsReasoning, "拉到「不会思考」就得真的写下来");
+    }
+
+    [TestMethod]
+    public void ReasoningAdjustable_OnlyClosesWhenWeActuallyKnow()
+    {
+        var unknown = new AiModelConfig { Model = "m" };
+        var cannot = new AiModelConfig { Model = "m", SupportsReasoning = false };
+        var can = new AiModelConfig { Model = "m", SupportsReasoning = true };
+        AiProvider p = new() { Name = "p", BaseUrl = "http://127.0.0.1:1/v1", Models = [unknown, cannot, can] };
+
+        Assert.IsTrue(new ResolvedModel(p, unknown).ReasoningAdjustable, "不知道就放开");
+        Assert.IsFalse(new ResolvedModel(p, cannot).ReasoningAdjustable);
+        Assert.IsTrue(new ResolvedModel(p, can).ReasoningAdjustable);
+    }
+}


### PR DESCRIPTION
## 为什么

改思考档位原来要:开设置窗口 → 找到那个模型 → 改 → 保存 → 关掉。而**"这一问要不要多想想"是逐条变的** —— 它属于「发这条消息用什么」,和模型、Agent 模式是同一类选择,就该摆在同一排。

现在它就在模型选择器右边,五档:默认 / 关闭 / 低 / 中 / 高。

## 「临时」的确切含义

**改了对下一条消息生效,但不写回模型配置。** 写回去的话,下次打开设置页会发现档位莫名换了,而用户根本不记得动过设置。

几条随之而来的决定:

- **`ResolvedModel.WithReasoning` 返回新对象,不就地改。** 界面会缓存并共享 `ResolvedModel`,就地改的话某一轮的临时选择会渗到别处去。
- **换模型自动清空。** 各家档位的含义与默认值本来就不同,留着等于把「我给 Codex 选的高」悄悄套到 Claude 头上。
- **选回模型自己那一档 = 取消覆盖**,而不是"覆盖成同一个值" —— 否则芯片会一直亮着,而它本该只在「这一轮不一样」时才亮。
- 改过档时挂 `.overridden` 点亮成芯片,悬停提示也跟着换成「选回保存的那一档即可取消」。

## 按能力灰掉

`AiModelConfig.SupportsReasoning` 记下 models.dev 的 `reasoning` 位。

做成**三态 `bool?`** 而不是布尔:**「没拉过规格库」和「拉过、答案是不会」是两回事**。手工添加的模型、中转站的私有型号都落在 `null` 上,那时照常放开 —— 凭「默认不支持」去灰掉一个其实能思考的模型,比多给一个无效档位糟得多。只有确知不会思考时才灰掉,并在提示里说明原因。

> `ModelsDevCatalog.Apply` 里这一项**不能**照搬其余字段"0 就当没说过"的写法:`false` 是有意义的答案,那样写永远回不到 `false`。已上测试。

## 两处真机上撞出来的问题

**一、下拉曾经"只剩一个图标"。** 原先在代码里 `FindResource` 取主题色再写到控件上,而本插件**允许在拿不到宿主主题令牌的环境下装载**(仓库里就有 `Panel_Loads_WithoutHostThemeTokens` 盯着这件事)—— 那时取回 `null`,前景色被设成 `null`,文字整个消失,只剩下拉箭头。

现在**素色态一个属性都不设**(与旁边的模型选择器完全同源),配色全部交给样式类 + `DynamicResource`,取不到令牌时自然退回主题默认值。`ReasoningPicker_Unchanged_LooksExactlyLikeTheModelPicker` 就是给这个上的棘轮 —— 把那行错误代码放回去跑过一遍,测试当场红在 `model.Foreground` vs `combo.Foreground` 上。

**二、下拉离模型选择器隔了一大段。** 工具条的列定义原是 `Auto,*,Auto,Auto`,模型那列是 `*`,会把档位下拉推到星号列的最右端。改成 `Auto,Auto,Auto,*,Auto,Auto`,**空档挪到两者之后**:收窄面板时先吃那段空白,发送按钮照样挤不出去(原来那个 `*` 的用意也正是这个)。

## 测试

新增 12 条(`ChatPanelViewUiTests.Reasoning.cs`),AI 插件 342 → 354。

| 测的是什么 | 用例 |
| --- | --- |
| 不写回保存的配置 | `PickingALevel_DoesNotWriteBackToTheSavedModelSetting` |
| 选回原档即取消 | `PickingTheSavedLevelAgain_ClearsTheOverride` |
| 换模型清空 | `SwitchingModels_DropsTheTemporaryLevel` |
| 素色态与模型选择器一模一样 | `ReasoningPicker_Unchanged_LooksExactlyLikeTheModelPicker` |
| 紧挨模型选择器、空档在其后 | `ReasoningPicker_SitsRightNextToTheModelPicker` |
| 确知不会思考才灰掉 | `ReasoningPicker_IsDisabledForModelsThatCannotThink` |
| 不知道就放开 | `ReasoningPicker_StaysOpenWhenTheCapabilityIsUnknown` |
| 临时档位真的走进请求 | `TheTemporaryLevel_ReachesTheRequest` |
| 原对象不被改动 | `WithReasoning_LeavesTheOriginalAlone` |

`SwitchingModels_DropsTheTemporaryLevel` 与素色态那条都做过棘轮验证(把对应实现改坏,确认测试变红)。

`dotnet test VelaShell.slnx`:**2497 通过 / 1 失败**。那条失败是 `ShortcutCatalogTests.Doc_ListsEveryCatalogEntry`,它读 `docs/快捷键参考.md` 而 `docs/` 没有被 git 跟踪 —— 在干净的 `origin/main` 上同样失败,与本 PR 无关(#332 / #333 里都说明过)。

0 错误 0 警告。功能已在真机上验过。

## 与 #333 的关系

互不依赖,都基于合并后的 `main`,分开合并即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
