### PR TITLE
新增侧栏折叠/展开功能及多入口切换

### DIFF
--- a/src/VelaShell.Controls/Themes/Icons.axaml
+++ b/src/VelaShell.Controls/Themes/Icons.axaml
@@ -64,6 +64,7 @@
   <StreamGeometry x:Key="Icon.folder-up">M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z M12 10v6 M9 13l3-3 3 3</StreamGeometry>
   <StreamGeometry x:Key="Icon.rows-2">M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z M3 12h18</StreamGeometry>
   <StreamGeometry x:Key="Icon.panel-top">M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z M3 9h18</StreamGeometry>
+  <StreamGeometry x:Key="Icon.panel-left">M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z M9 3v18</StreamGeometry>
   <StreamGeometry x:Key="Icon.triangle-alert">M21.73 18l-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z M12 9v4 M12 17h.01</StreamGeometry>
   <StreamGeometry x:Key="Icon.circle-alert">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M12 8v4 M12 16h.01</StreamGeometry>
   <StreamGeometry x:Key="Icon.circle-help">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3 M12 17h.01</StreamGeometry>

--- a/src/VelaShell.Core/Models/AppState.cs
+++ b/src/VelaShell.Core/Models/AppState.cs
@@ -26,6 +26,12 @@ public class AppState
 
     /// <summary>最近连接侧栏区域上次展开时的高度。</summary>
     public double SidebarRecentConnectionsHeight { get; set; } = 180;
+
+    /// <summary>
+    /// 整条左侧资源管理器是否处于折叠状态(标题栏折叠按钮 / Ctrl+B)。
+    /// 与上面两个区域内的展开状态是两码事:那两个折的是侧栏**里面**的分区,这个折的是侧栏本身。
+    /// </summary>
+    public bool SidebarCollapsed { get; set; }
 }
 
 /// <summary>窗口在屏幕上的位置坐标。</summary>

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -148,6 +148,9 @@
   <data name="Cmd_SftpFileManager" xml:space="preserve">
     <value>SFTP ファイルマネージャー</value>
   </data>
+  <data name="Cmd_ToggleSidebar" xml:space="preserve">
+    <value>エクスプローラーの表示切り替え</value>
+  </data>
   <data name="Cmd_TunnelManager" xml:space="preserve">
     <value>トンネル管理</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -148,6 +148,9 @@
   <data name="Cmd_SftpFileManager" xml:space="preserve">
     <value>SFTP 파일 관리자</value>
   </data>
+  <data name="Cmd_ToggleSidebar" xml:space="preserve">
+    <value>탐색기 사이드바 전환</value>
+  </data>
   <data name="Cmd_TunnelManager" xml:space="preserve">
     <value>터널 관리</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -855,6 +855,9 @@ If this keeps happening, close any other VelaShell windows and try again.</value
   <data name="Cmd_SftpFileManager" xml:space="preserve">
     <value>SFTP File Manager</value>
   </data>
+  <data name="Cmd_ToggleSidebar" xml:space="preserve">
+    <value>Toggle Explorer Sidebar</value>
+  </data>
   <data name="Cmd_TunnelManager" xml:space="preserve">
     <value>Tunnel Manager</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -966,6 +966,9 @@
   <data name="Cmd_SftpFileManager" xml:space="preserve">
     <value>SFTP 文件管理器</value>
   </data>
+  <data name="Cmd_ToggleSidebar" xml:space="preserve">
+    <value>折叠/展开资源管理器</value>
+  </data>
   <data name="Cmd_TunnelManager" xml:space="preserve">
     <value>隧道管理</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -966,6 +966,9 @@
   <data name="Cmd_SftpFileManager" xml:space="preserve">
     <value>SFTP 檔案管理器</value>
   </data>
+  <data name="Cmd_ToggleSidebar" xml:space="preserve">
+    <value>摺疊/展開資源管理器</value>
+  </data>
   <data name="Cmd_TunnelManager" xml:space="preserve">
     <value>隧道管理</value>
   </data>

--- a/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
@@ -51,6 +51,17 @@ public sealed class SidebarViewModel(
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = 180;
 
+    /// <summary>
+    /// 整条侧边栏是否折叠成图标细条(标题栏折叠按钮 / Ctrl+B)。
+    /// 折叠后侧栏只剩底部那几个入口图标,列宽由宿主窗口收到 40px ——
+    /// 上面 <see cref="QuickCommandsExpanded" /> 等折的是侧栏**里面**的分区,与这个是两码事。
+    /// </summary>
+    public bool IsCollapsed
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
     /// <summary>当前会话树视图模型,未加载时为 null。</summary>
     public SessionTreeViewModel? SessionTree
     {

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -126,6 +126,21 @@
         <Setter Property="Opacity" Value="0.35" />
     </Style>
 
+    <!-- 裸浮层(Flyout FlyoutPresenterClasses="bare"):把 presenter 剥成纯定位容器,
+         外观全部交给内容自己那一层 Border。默认的 FlyoutPresenter 自带底色、描边、
+         内边距与圆角,套在内容已有的 Border 外面就是两层框 —— 浮层外面多一圈黑边
+         (会话浮层实测)。MinWidth 也得清:Fluent 默认给了下限,窄浮层会被撑宽。
+         【只作用于挂了 bare 类的浮层】:状态栏后台任务浮层的内容是裸 StackPanel,
+         靠的正是 presenter 这层底,全局剥掉它会变成一块没有背景的悬空文字。 -->
+    <Style Selector="FlyoutPresenter.bare">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="MinWidth" Value="0" />
+        <Setter Property="MinHeight" Value="0" />
+    </Style>
+
     <!-- 标签列表下拉框(以及任意 MenuFlyout):与右键菜单相同的 small-flyout 外观。 -->
     <Style Selector="MenuFlyoutPresenter">
         <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -395,6 +395,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             )
             .Switch();
         ToggleFileBrowserCommand = ReactiveCommand.Create(ToggleFileBrowser, canToggleFileBrowser);
+        // 侧栏折叠与会话状态无关(没有活动标签时照样能收),故不挂 canExecute。
+        ToggleSidebarCommand = ReactiveCommand.Create(ToggleSidebar);
         IObservable<bool> canOpenProcessManager = this.WhenAnyValue(x => x.ActiveTerminalTab)
             .Select(tab =>
                 tab is null
@@ -461,6 +463,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
     /// <summary>显示或隐藏当前 SSH 会话的远程文件面板。</summary>
     public ReactiveCommand<RxVoid, RxVoid> ToggleFileBrowserCommand { get; }
+
+    /// <summary>把左侧资源管理器折叠成 40px 图标细条,或还原成完整侧栏(标题栏按钮 / Ctrl+B)。</summary>
+    public ReactiveCommand<RxVoid, RxVoid> ToggleSidebarCommand { get; }
+
+    /// <summary>
+    /// 折叠/展开左侧资源管理器。列宽的收放在 <see cref="Views.MainWindow" /> 里做,
+    /// 这里只翻状态位 —— 标题栏按钮、Ctrl+B、命令面板与细条上的展开按钮共用这一处。
+    /// </summary>
+    public void ToggleSidebar() => Sidebar.IsCollapsed = !Sidebar.IsCollapsed;
 
     /// <summary>当前活动标签是否支持打开远程文件面板。</summary>
     public bool CanToggleFileBrowser =>
@@ -828,6 +839,16 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 Strings.Get("CmdCat_Edit"),
                 ToggleLineGutter,
                 Shortcut: "Ctrl+Shift+L"
+            )
+        );
+        Commands.Register(
+            new(
+                "view.sidebar",
+                Strings.Get("Cmd_ToggleSidebar"),
+                Strings.Get("CmdCat_Actions"),
+                ToggleSidebar,
+                Shortcut: "Ctrl+B",
+                Icon: "Icon.panel-left"
             )
         );
         Commands.Register(
@@ -1915,6 +1936,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 state.SidebarRecentConnectionsHeight,
                 180
             );
+            Sidebar.IsCollapsed = state.SidebarCollapsed;
         }
         finally
         {
@@ -1937,6 +1959,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     or nameof(SidebarViewModel.QuickCommandsHeight)
                     or nameof(SidebarViewModel.RecentConnectionsExpanded)
                     or nameof(SidebarViewModel.RecentConnectionsHeight)
+                    or nameof(SidebarViewModel.IsCollapsed)
                 )
         )
         {
@@ -1961,6 +1984,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             Sidebar.RecentConnectionsHeight,
             180
         );
+        _appState.SidebarCollapsed = Sidebar.IsCollapsed;
     }
 
     private async Task SaveSidebarStateAfterDelayAsync(CancellationToken cancellationToken)

--- a/src/VelaShell/ViewModels/ShortcutCatalog.cs
+++ b/src/VelaShell/ViewModels/ShortcutCatalog.cs
@@ -96,6 +96,7 @@ public static class ShortcutCatalog
                     Item("CloseTab", [Ctrl, "W"]),
                     Item("Sc_NextTab", [Ctrl, "Tab"]),
                     Item("Sc_PrevTab", [Ctrl, Shift, "Tab"]),
+                    Item("Cmd_ToggleSidebar", [Ctrl, "B"]),
                     Item("Sc_ToggleFileBrowser", [Ctrl, Shift, "F"]),
                     Item("Cmd_TunnelManager", [Ctrl, Shift, "T"]),
                     Item("Cmd_ToggleLineGutter", [Ctrl, Shift, "L"]),

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -37,6 +37,8 @@
     <KeyBinding Gesture="Ctrl+Shift+T" Command="{Binding RunCommand}" CommandParameter="tools.tunnel" />
     <KeyBinding Gesture="Ctrl+Shift+F" Command="{Binding RunCommand}" CommandParameter="tools.files" />
     <KeyBinding Gesture="Ctrl+Shift+L" Command="{Binding RunCommand}" CommandParameter="terminal.linegutter" />
+    <!-- Ctrl+B:折叠/展开左侧资源管理器(与 VS Code / Zed 同键位)。 -->
+    <KeyBinding Gesture="Ctrl+B" Command="{Binding ToggleSidebarCommand}" />
   </Window.KeyBindings>
 
   <!-- 无边框窗体:与本应用全部对话框同款的 WindowDecorations="None" 全自绘模式
@@ -95,10 +97,12 @@
       <!-- Sidebar -->
       <views:SidebarView x:Name="SidebarHost" Grid.Column="0" DataContext="{Binding Sidebar}" />
 
-      <!-- 侧栏拖拽条:5px 透明抓取区画成 1px 细线,使侧栏宽度可拖拽调整。 -->
-      <Border Grid.Column="1" Width="1" HorizontalAlignment="Center"
+      <!-- 侧栏拖拽条:5px 透明抓取区画成 1px 细线,使侧栏宽度可拖拽调整。
+           折叠成图标细条时整条隐藏 —— 40px 的细条没有可调的宽度,留着只会让人
+           拖出一个既不是细条也不是侧栏的中间态。 -->
+      <Border x:Name="SidebarSplitterLine" Grid.Column="1" Width="1" HorizontalAlignment="Center"
               Background="{DynamicResource VelaBorderPrimary}" />
-      <GridSplitter Grid.Column="1" Background="Transparent" ResizeDirection="Columns"
+      <GridSplitter x:Name="SidebarSplitter" Grid.Column="1" Background="Transparent" ResizeDirection="Columns"
                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
 
       <!-- 主区域(终端、文件浏览器)。文件行初始折叠(0),当 FileBrowser.IsVisible

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -49,6 +49,7 @@ public partial class MainWindow : Window
     private readonly Dictionary<string, TraceRouteWindow> _traceWindows = [with(StringComparer.OrdinalIgnoreCase)];
 
     private IDisposable? _fileBrowserVisibilitySub;
+    private IDisposable? _sidebarCollapsedSub;
     private bool _forceClose;
     private bool _confirmationInProgress;
     private bool _standaloneSftpShutdownInProgress;
@@ -97,6 +98,20 @@ public partial class MainWindow : Window
     /// </summary>
     private double _lastFileRowHeight = 360;
 
+    /// <summary>折叠态侧栏的图标细条宽度(与 SidebarView 的 CollapsedRail 一致)。</summary>
+    private const double SidebarRailWidth = 40;
+
+    /// <summary>展开态侧栏的最小宽度,与 MainWindow.axaml 的 ColumnDefinition 保持一致。</summary>
+    private const double SidebarMinWidth = 180;
+
+    /// <summary>
+    /// 侧栏展开时的宽度。**必须存在字段里**:折叠后列宽是 40,此时若去设置里切换
+    /// 侧栏左右位置,ApplySidebarPosition 从列上读到的就是 40,展开回来会缩成细条。
+    /// </summary>
+    private double _lastSidebarWidth = 260;
+
+    private bool _sidebarCollapsed;
+
     private AppSettings? _settings;
 
     private ISettingsService? _settingsService;
@@ -120,7 +135,11 @@ public partial class MainWindow : Window
             sidebar.PluginsRequested += (_, _) => OpenPluginManager();
             sidebar.ImportSessionsRequested += (_, _) => _ = OpenSessionImportDialogAsync();
         }
-        DataContextChanged += (_, _) => HookFileBrowserVisibility();
+        DataContextChanged += (_, _) =>
+        {
+            HookFileBrowserVisibility();
+            HookSidebarCollapsed();
+        };
         // 主题(暗/亮)切换时,按新主题色重建背景令牌覆盖画刷。否则之前设的覆盖仍持旧主题色、
         // 一直 shadow 掉换主题后的令牌值,导致终端/SFTP/侧栏等背景停在旧色,须再动一次滑杆才同步。
         ActualThemeVariantChanged += (_, _) =>
@@ -182,6 +201,61 @@ public partial class MainWindow : Window
             fileRow.Height = new(0);
             splitterRow.Height = new(0);
         }
+    }
+
+    /// <summary>
+    /// 随 Sidebar.IsCollapsed 收放侧栏列宽。与 <see cref="HookFileBrowserVisibility" /> 同一套写法:
+    /// WhenAnyValue 跟踪 Sidebar 属性本身,侧栏视图模型整体替换时会自动重新订阅。
+    /// </summary>
+    private void HookSidebarCollapsed()
+    {
+        _sidebarCollapsedSub?.Dispose();
+        _sidebarCollapsedSub = null;
+        if (DataContext is not MainWindowViewModel vm)
+        {
+            return;
+        }
+        _sidebarCollapsedSub = vm.WhenAnyValue(x => x.Sidebar.IsCollapsed)
+            .Subscribe(collapsed => Dispatcher.UIThread.Post(() => SetSidebarCollapsed(collapsed)));
+    }
+
+    /// <summary>
+    /// 把侧栏列在「展开宽度」与「40px 图标细条」之间切换,并连带收起拖拽条 ——
+    /// 细条没有可调的宽度,留着分隔条只会让人拖出一个既不是细条也不是侧栏的中间态。
+    /// 侧栏里显示哪一副面孔由 SidebarView 自己按同一个状态位决定。
+    /// </summary>
+    private void SetSidebarCollapsed(bool collapsed)
+    {
+        if (
+            this.FindControl<SidebarView>("SidebarHost") is not { Parent: Grid contentGrid }
+            || contentGrid.ColumnDefinitions.Count < 3
+        )
+        {
+            return;
+        }
+        _sidebarCollapsed = collapsed;
+        ColumnDefinitions cols = contentGrid.ColumnDefinitions;
+        ColumnDefinition sidebarCol = cols[_sidebarOnRight ? 2 : 0];
+        if (collapsed)
+        {
+            // 记住用户拖出来的宽度,以便展开时恢复(与文件区 _lastFileRowHeight 同一处置)。
+            if (sidebarCol.Width is { IsAbsolute: true } width && width.Value >= SidebarMinWidth)
+            {
+                _lastSidebarWidth = width.Value;
+            }
+            // MinWidth 必须先归零:它是 180,不清掉的话 40 的宽度会被顶回 180。
+            sidebarCol.MinWidth = 0;
+            sidebarCol.Width = new(SidebarRailWidth);
+            cols[1].Width = new(0);
+        }
+        else
+        {
+            sidebarCol.MinWidth = SidebarMinWidth;
+            sidebarCol.Width = new(_lastSidebarWidth);
+            cols[1].Width = new(5);
+        }
+        SidebarSplitterLine.IsVisible = !collapsed;
+        SidebarSplitter.IsVisible = !collapsed;
     }
 
     private async void OnWindowOpened(object? sender, EventArgs e)
@@ -618,14 +692,15 @@ public partial class MainWindow : Window
         int sidebarCol = right ? 2 : 0;
         int mainCol = right ? 0 : 2;
 
-        // 保留用户拖出来的侧边栏宽度。
+        // 保留用户拖出来的侧边栏宽度。**只认展开态的列宽**:折叠时列宽是 40(细条),
+        // 拿它当"用户宽度"记下来,展开回去侧栏就缩成一条 40px 的残条了。
         GridLength sidebarWidth = cols[right ? 0 : 2].Width;
-        if (!sidebarWidth.IsAbsolute)
+        if (!_sidebarCollapsed && sidebarWidth is { IsAbsolute: true } dragged && dragged.Value >= SidebarMinWidth)
         {
-            sidebarWidth = new(260);
+            _lastSidebarWidth = dragged.Value;
         }
-        cols[sidebarCol].Width = sidebarWidth;
-        cols[sidebarCol].MinWidth = 180;
+        cols[sidebarCol].Width = new(_sidebarCollapsed ? SidebarRailWidth : _lastSidebarWidth);
+        cols[sidebarCol].MinWidth = _sidebarCollapsed ? 0 : SidebarMinWidth;
         cols[sidebarCol].MaxWidth = 520;
         cols[mainCol].Width = new(1, GridUnitType.Star);
         cols[mainCol].MinWidth = 400;

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -11,8 +11,11 @@
              x:Class="VelaShell.Views.SidebarView"
              x:DataType="vm:SidebarViewModel">
 
-  <Grid x:Name="SidebarGrid" RowDefinitions="36,*,40"
-        Background="{DynamicResource VelaBgSidebar}">
+  <!-- 底色画在最外层 Panel 上:展开态与折叠态是同一条侧栏的两副面孔,
+       底色若跟着其中一个走,切换的瞬间会闪一下窗口底色。 -->
+  <Panel Background="{DynamicResource VelaBgSidebar}">
+
+  <Grid x:Name="SidebarGrid" RowDefinitions="36,*,40">
 
     <!-- 工具栏 -->
     <Border Grid.Row="0"
@@ -263,4 +266,102 @@
       </Grid>
     </Border>
   </Grid>
+
+  <!-- 折叠态:40px 图标细条(标题栏折叠按钮 / Ctrl+B)。会话树、快捷命令、
+       最近连接整块收起,但底部这三个入口必须留在原位 —— 消息中心与插件管理器
+       在别处没有第二个入口,而消息面板本就锚在左下角贴着铃铛开出来。
+       行高与展开态一一对应(36 顶栏 / * 中部 / 底部入口),切换时上下两条
+       分隔线停在同一水平位置,不会跳。 -->
+  <Grid x:Name="CollapsedRail" RowDefinitions="36,*,Auto" IsVisible="False">
+
+    <!-- 顶:展开回去。折叠态自带回程入口,不必非得回标题栏找那个按钮。 -->
+    <Border Grid.Row="0" BorderThickness="0,0,0,1"
+            BorderBrush="{DynamicResource VelaBorderPrimary}">
+      <Button Width="24" Height="24" Background="Transparent" Padding="0"
+              CornerRadius="3" Cursor="Hand"
+              HorizontalAlignment="Center" VerticalAlignment="Center"
+              Click="ExpandSidebar_Click"
+              ToolTip.Tip="{loc:Localize Cmd_ToggleSidebar}" ToolTip.Placement="Right">
+        <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.panel-left}"
+                       Foreground="{DynamicResource VelaAccent}" />
+      </Button>
+    </Border>
+
+    <!-- 中:会话入口 + 新建连接。 -->
+    <StackPanel Grid.Row="1" Orientation="Vertical" Spacing="6"
+                HorizontalAlignment="Center" Margin="0,8,0,0">
+
+      <!-- 折叠态打开已保存会话:浮层里放的就是展开态那棵树本身(同一个
+           SessionTreeViewModel),所以双击连接、右键编辑、打开 SFTP 全部照旧走
+           它自己的 ConnectRequested / EditRequested —— 这里一行接线都不用加。
+           点击触发而非悬停:鼠标横穿细条去终端是高频动作,悬停浮层会一路误触。
+           连上之后浮层自动收起(见 OnSessionConnectRequested)—— 折叠态图的就是
+           别让侧栏占着宽度,连完还杵在那儿挡着终端就本末倒置了。 -->
+      <Button x:Name="RailSessionsButton"
+              Width="24" Height="24" Background="Transparent" Padding="0"
+              CornerRadius="3" Cursor="Hand"
+              ToolTip.Tip="{loc:Localize Sidebar_Explorer}" ToolTip.Placement="Right">
+        <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.folder-tree}"
+                       Foreground="{DynamicResource VelaTextTertiary}" />
+        <Button.Flyout>
+          <!-- 外观与快捷命令的目标选择器同款(QuickCommandsView):由内容这层 Border
+               自己画。bare 类把 presenter 自带的底色/描边/内边距剥掉(见 DockStyles),
+               否则内容的 Border 外面还会套一圈 presenter 的框,浮层变成两层边。 -->
+          <Flyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="bare">
+            <Border Width="248" MaxHeight="420" Padding="0,6"
+                    Background="{DynamicResource VelaBgSurface}"
+                    BorderBrush="{DynamicResource VelaBorderSecondary}"
+                    BorderThickness="1" CornerRadius="5">
+              <ScrollViewer VerticalScrollBarVisibility="Auto"
+                            HorizontalScrollBarVisibility="Disabled">
+                <views:SessionTreeView DataContext="{Binding SessionTree}" />
+              </ScrollViewer>
+            </Border>
+          </Flyout>
+        </Button.Flyout>
+      </Button>
+
+      <Button Width="24" Height="24" Background="Transparent" Padding="0"
+              CornerRadius="3" Cursor="Hand"
+              Click="OpenConnectionProfile_Click"
+              ToolTip.Tip="{x:Static res:Strings.Sessions}" ToolTip.Placement="Right">
+        <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.plus}"
+                       Foreground="{DynamicResource VelaTextTertiary}" />
+      </Button>
+    </StackPanel>
+
+    <!-- 底:与展开态底部栏同一组入口,顺序也一致(铃铛 → 插件 → 设置)。 -->
+    <Border Grid.Row="2" BorderThickness="0,1,0,0"
+            BorderBrush="{DynamicResource VelaBorderPrimary}" Padding="0,8">
+      <StackPanel Orientation="Vertical" Spacing="6" HorizontalAlignment="Center">
+        <Button Width="24" Height="24" Background="Transparent" Padding="0"
+                CornerRadius="3" Command="{Binding NotificationsCommand}"
+                ToolTip.Tip="{x:Static res:Strings.Notifications}" ToolTip.Placement="Right" Cursor="Hand">
+          <Panel>
+            <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.bell}"
+                           Foreground="{DynamicResource VelaTextTertiary}" />
+            <Ellipse Width="6" Height="6"
+                     HorizontalAlignment="Right" VerticalAlignment="Top"
+                     Margin="0,-1,-1,0"
+                     Fill="{DynamicResource VelaAccent}"
+                     IsVisible="{Binding HasUnreadNotifications}" />
+          </Panel>
+        </Button>
+        <Button Width="24" Height="24" Background="Transparent" Padding="0"
+                CornerRadius="3" Click="OpenPlugins_Click"
+                ToolTip.Tip="{x:Static res:Strings.Plugins}" ToolTip.Placement="Right" Cursor="Hand">
+          <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.plug}"
+                         Foreground="{DynamicResource VelaTextTertiary}" />
+        </Button>
+        <Button Width="24" Height="24" Background="Transparent" Padding="0"
+                CornerRadius="3" Click="OpenSettings_Click"
+                ToolTip.Tip="{x:Static res:Strings.Settings}" ToolTip.Placement="Right" Cursor="Hand">
+          <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.settings}"
+                         Foreground="{DynamicResource VelaTextTertiary}" />
+        </Button>
+      </StackPanel>
+    </Border>
+  </Grid>
+
+  </Panel>
 </UserControl>

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -16,6 +16,7 @@ public partial class SidebarView : UserControl
     private const double MinimumExpandedHeight = 100;
     private const double MaximumRememberedHeight = 1200;
     private SidebarViewModel? _viewModel;
+    private SessionTreeViewModel? _sessionTree;
 
     /// <summary>创建侧边栏视图并加载其可视组件。</summary>
     public SidebarView()
@@ -48,7 +49,34 @@ public partial class SidebarView : UserControl
         _viewModel?.PropertyChanged += OnViewModelPropertyChanged;
         ApplyQuickCommandsVisibility();
         ApplyRecentConnectionsState();
+        ApplyCollapsedState();
+        HookSessionTree();
     }
+
+    /// <summary>
+    /// 订阅会话树的连接事件,只为在折叠态浮层里连上之后把浮层收起来。
+    /// 会话树视图模型是宿主后建的(<c>SidebarViewModel.SessionTree</c> 可被整体替换),
+    /// 故随属性变化重新接线,并先摘掉旧的 —— 否则每换一次就多留一条订阅。
+    /// </summary>
+    private void HookSessionTree()
+    {
+        if (_sessionTree is not null)
+        {
+            _sessionTree.ConnectRequested -= OnSessionConnectRequested;
+        }
+        _sessionTree = _viewModel?.SessionTree;
+        if (_sessionTree is not null)
+        {
+            _sessionTree.ConnectRequested += OnSessionConnectRequested;
+        }
+    }
+
+    /// <summary>
+    /// 连上就收起会话浮层。折叠态图的就是别让侧栏占着宽度,连完还杵在那儿挡着终端
+    /// 就本末倒置了。展开态没有浮层,Hide 是空操作,不必分情况。
+    /// </summary>
+    private void OnSessionConnectRequested(SessionProfile profile) =>
+        RailSessionsButton.Flyout?.Hide();
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -68,6 +96,33 @@ public partial class SidebarView : UserControl
         )
         {
             ApplyRecentConnectionsState();
+        }
+        if (e.PropertyName is nameof(SidebarViewModel.IsCollapsed))
+        {
+            ApplyCollapsedState();
+        }
+        if (e.PropertyName is nameof(SidebarViewModel.SessionTree))
+        {
+            HookSessionTree();
+        }
+    }
+
+    /// <summary>
+    /// 在完整侧栏与 40px 图标细条之间切换。两副面孔互斥显示,列宽由宿主窗口
+    /// (<see cref="MainWindow" />)收放 —— 这里只管显示哪一副。
+    /// </summary>
+    private void ApplyCollapsedState()
+    {
+        bool collapsed = _viewModel?.IsCollapsed == true;
+        SidebarGrid.IsVisible = !collapsed;
+        CollapsedRail.IsVisible = collapsed;
+    }
+
+    private void ExpandSidebar_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.IsCollapsed = false;
         }
     }
 

--- a/src/VelaShell/Views/TitleBarView.axaml
+++ b/src/VelaShell/Views/TitleBarView.axaml
@@ -96,7 +96,7 @@
           BorderBrush="{DynamicResource VelaBorderPrimary}"
           BorderThickness="0,0,0,1"
           PointerPressed="Bar_PointerPressed">
-    <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
 
       <!-- 左:logo + 产品名(不参与命中,拖动透传到底层 Border)。 -->
       <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8"
@@ -109,9 +109,25 @@
                    VerticalAlignment="Center" />
       </StackPanel>
 
+      <!-- 折叠资源管理器(Ctrl+B):按钮长在它控制的那片区域这一侧,一眼知道管的是左边;
+           右边那组图标全是"打开某个东西",布局开关混进去会让那一排变成杂物抽屉。
+           折叠态图标转强调色,与文件浏览器按钮同一套高亮语言。 -->
+      <Button Grid.Column="1" Theme="{StaticResource VelaTitleActionButton}"
+              ToolTip.Tip="{loc:Localize Cmd_ToggleSidebar}"
+              Command="{Binding ToggleSidebarCommand}">
+        <Panel>
+          <pc:LucideIcon Width="12" Height="12" Data="{StaticResource Icon.panel-left}"
+                         Foreground="{DynamicResource VelaTextMuted}"
+                         IsVisible="{Binding !Sidebar.IsCollapsed}" />
+          <pc:LucideIcon Width="12" Height="12" Data="{StaticResource Icon.panel-left}"
+                         Foreground="{DynamicResource VelaAccent}"
+                         IsVisible="{Binding Sidebar.IsCollapsed}" />
+        </Panel>
+      </Button>
+
       <!-- 右:全局功能图标组(与命令注册表同源;多终端同步输入已移至标签右键菜单
            “同步输入”频道,不再占用标题栏图标)。 -->
-      <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
+      <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4"
                   VerticalAlignment="Center" Margin="0,0,10,0">
         <Button Theme="{StaticResource VelaTitleActionButton}"
                 ToolTip.Tip="{loc:Localize Menu_SearchTerminalTip}"
@@ -161,7 +177,7 @@
       </StackPanel>
 
       <!-- 窗口控制:最小化 / 最大化(还原) / 关闭(常规 Click,纯客户区必然可点)。 -->
-      <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Top">
+      <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Top">
         <Button Theme="{StaticResource VelaCaptionButton}" Click="Minimize_Click">
           <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.minus}"
                          Foreground="{DynamicResource VelaTextTertiary}" />


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

实现左侧资源管理器（侧栏）折叠/展开，支持标题栏按钮、Ctrl+B 快捷键、命令面板等多入口切换。核心 ViewModel 和状态类增加折叠状态的持久化与同步。UI 布局文件完善折叠/展开切换、细条样式、按钮与分隔线。折叠态下会话树浮层支持事件处理与自动收起，优化浮层样式。多语言资源补充相关本地化字符串。记忆用户上次拖拽的展开宽度，切换时自动调整，避免宽度异常。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
