### PR TITLE
侧栏折叠按钮位置调整及异常处理优化

### DIFF
--- a/src/VelaShell.Core/Models/AppState.cs
+++ b/src/VelaShell.Core/Models/AppState.cs
@@ -28,7 +28,7 @@ public class AppState
     public double SidebarRecentConnectionsHeight { get; set; } = 180;
 
     /// <summary>
-    /// 整条左侧资源管理器是否处于折叠状态(标题栏折叠按钮 / Ctrl+B)。
+    /// 整条左侧资源管理器是否处于折叠状态(侧栏工具栏折叠按钮 / Ctrl+B)。
     /// 与上面两个区域内的展开状态是两码事:那两个折的是侧栏**里面**的分区,这个折的是侧栏本身。
     /// </summary>
     public bool SidebarCollapsed { get; set; }

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -81,6 +81,9 @@
 
 開いているウィンドウに切り替えてください。同時に実行できるインスタンスは 1 つだけです。</value>
   </data>
+  <data name="Boot_DatabaseLocked" xml:space="preserve">
+    <value>VelaShell のデータベースが別のプロセスで使用中です。実行中の他の VelaShell を終了して(タスクトレイをご確認ください)から再試行してください。</value>
+  </data>
   <data name="Boot_StartupErrorTitle" xml:space="preserve">
     <value>VelaShell - 起動エラー</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -81,6 +81,9 @@
 
 열려 있는 창으로 전환하세요. 한 번에 하나의 인스턴스만 실행할 수 있습니다.</value>
   </data>
+  <data name="Boot_DatabaseLocked" xml:space="preserve">
+    <value>VelaShell 데이터베이스를 다른 프로세스가 사용 중입니다. 실행 중인 다른 VelaShell을 종료한 뒤(시스템 트레이 확인) 다시 시도하세요.</value>
+  </data>
   <data name="Boot_StartupErrorTitle" xml:space="preserve">
     <value>VelaShell - 시작 오류</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -803,6 +803,9 @@
 
 Please switch to the open window; only one instance can run at a time.</value>
   </data>
+  <data name="Boot_DatabaseLocked" xml:space="preserve">
+    <value>VelaShell's database is in use by another process. Close any other running VelaShell instance (check the system tray) and try again.</value>
+  </data>
   <data name="Boot_StartupErrorTitle" xml:space="preserve">
     <value>VelaShell - Startup Error</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -914,6 +914,9 @@
 
 请切换到已打开的窗口;同一时间只能运行一个实例。</value>
   </data>
+  <data name="Boot_DatabaseLocked" xml:space="preserve">
+    <value>VelaShell 的数据库正被另一个进程占用。请关闭其他正在运行的 VelaShell(留意系统托盘),然后重试。</value>
+  </data>
   <data name="Boot_StartupErrorTitle" xml:space="preserve">
     <value>VelaShell - 启动错误</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -914,6 +914,9 @@
 
 請切換至已開啟的視窗;同一時間只能執行一個實例。</value>
   </data>
+  <data name="Boot_DatabaseLocked" xml:space="preserve">
+    <value>VelaShell 的資料庫正被另一個處理程序占用。請關閉其他正在執行的 VelaShell(留意系統匣),然後重試。</value>
+  </data>
   <data name="Boot_StartupErrorTitle" xml:space="preserve">
     <value>VelaShell - 啟動錯誤</value>
   </data>

--- a/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SidebarViewModel.cs
@@ -52,7 +52,7 @@ public sealed class SidebarViewModel(
     } = 180;
 
     /// <summary>
-    /// 整条侧边栏是否折叠成图标细条(标题栏折叠按钮 / Ctrl+B)。
+    /// 整条侧边栏是否折叠成图标细条(侧栏工具栏折叠按钮 / Ctrl+B)。
     /// 折叠后侧栏只剩底部那几个入口图标,列宽由宿主窗口收到 40px ——
     /// 上面 <see cref="QuickCommandsExpanded" /> 等折的是侧栏**里面**的分区,与这个是两码事。
     /// </summary>

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -51,6 +51,18 @@ public class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+
+        // 设计期(Avalonia 预览器 / VS 设计器)到此为止,绝不往下建 DI 容器。
+        // 预览器是通过 Program.BuildAvaloniaApp() 实例化本类并调用 Initialize() 的,
+        // 但它**不走 Program.Main**,因此从不获取单实例互斥锁。若继续往下走,它就会以
+        // 真实用户数据根打开 SonnetDB 并独占 WAL —— 此后正常启动应用时,互斥锁是空的、
+        // 守卫放行,却在 Tsdb.Open 撞上「SDBWAL 被另一进程占用」的 IOException 崩溃。
+        // 编辑 .axaml 时预览器常驻后台,这条路径极易踩到。
+        // 预览渲染只需要上面那行加载出来的资源与样式,不需要任何运行期服务。
+        if (Design.IsDesignMode)
+        {
+            return;
+        }
         _serviceProvider = new ServiceCollection()
             .AddVelaShellPresentation()
             .AddVelaShellControls()

--- a/src/VelaShell/Program.cs
+++ b/src/VelaShell/Program.cs
@@ -77,6 +77,15 @@ internal static partial class Program
             FinalizePendingUpdate();
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
+        catch (Exception ex) when (IsDatabaseLockedFailure(ex))
+        {
+            // 数据库被别的进程占着,是可预期且用户自己能处理的情况,不该以崩溃收场。
+            // 上面的单实例守卫挡不住这一类:持锁者可能压根不是一个正常实例(Avalonia 预览器 /
+            // VS 设计器曾经就会 —— 见 App.Initialize 的设计期守卫),也可能是上一个实例
+            // 尚未退干净;两种情况下互斥锁都是空的。给一句说得清的提示后干净退出,不再 rethrow。
+            Trace.WriteLine($"[VelaShell] Database locked at startup: {ex}");
+            ShowMessage(Strings.Get("Boot_DatabaseLocked"), Strings.Get("Boot_StartupErrorTitle"));
+        }
         catch (Exception ex)
         {
             // 最后手段:向测试人员弹出可读对话框,而非原始的 .NET 崩溃框。
@@ -162,6 +171,27 @@ internal static partial class Program
     /// SeCreateGlobalPrivilege);罕见的同用户跨会话冲突,会在之后由 SonnetDB 的文件锁与启动错误
     /// 对话框捕获,而非静默继续直至崩溃。
     /// </summary>
+    /// <summary>
+    /// 判断启动失败是否源于「数据库文件被其他进程占用」(SonnetDB 对其 WAL 持独占锁)。
+    /// </summary>
+    /// <remarks>
+    /// 按 <c>.SDBWAL</c> 这个扩展名匹配而不是比对异常文本:共享冲突的 IOException 消息本身
+    /// 会随系统语言变化,但消息里带的那个文件路径不会 —— 用路径判断才跨语言可靠。
+    /// 逐层看 InnerException:DI 是在工厂委托里构造引擎的,异常常被包了一层。
+    /// </remarks>
+    private static bool IsDatabaseLockedFailure(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is IOException
+                && current.Message.Contains(".SDBWAL", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static bool TryAcquireSingleInstanceLock(TimeSpan waitTimeout)
     {
         try

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -464,12 +464,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>显示或隐藏当前 SSH 会话的远程文件面板。</summary>
     public ReactiveCommand<RxVoid, RxVoid> ToggleFileBrowserCommand { get; }
 
-    /// <summary>把左侧资源管理器折叠成 40px 图标细条,或还原成完整侧栏(标题栏按钮 / Ctrl+B)。</summary>
+    /// <summary>把左侧资源管理器折叠成 40px 图标细条,或还原成完整侧栏(Ctrl+B / 命令面板)。</summary>
     public ReactiveCommand<RxVoid, RxVoid> ToggleSidebarCommand { get; }
 
     /// <summary>
     /// 折叠/展开左侧资源管理器。列宽的收放在 <see cref="Views.MainWindow" /> 里做,
-    /// 这里只翻状态位 —— 标题栏按钮、Ctrl+B、命令面板与细条上的展开按钮共用这一处。
+    /// 这里只翻状态位 —— Ctrl+B 与命令面板走这条;侧栏工具栏的折叠按钮与细条顶部的
+    /// 展开按钮各自直接置位(它们只出现在其中一态,取反反而绕)。
     /// </summary>
     public void ToggleSidebar() => Sidebar.IsCollapsed = !Sidebar.IsCollapsed;
 

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -49,6 +49,15 @@
               </MenuFlyout>
             </Button.Flyout>
           </Button>
+          <!-- 折叠成图标细条(Ctrl+B)。按钮就长在它要收起的这条侧栏自己的工具栏上,
+               不占标题栏 —— 折叠后细条顶部有对应的展开按钮,回程入口不缺。 -->
+          <Button Background="Transparent" Padding="0" Width="24" Height="24"
+                  CornerRadius="3" Cursor="Hand"
+                  Click="CollapseSidebar_Click"
+                  ToolTip.Tip="{loc:Localize Cmd_ToggleSidebar}">
+            <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.panel-left}"
+                           Foreground="{DynamicResource VelaTextTertiary}" />
+          </Button>
         </StackPanel>
       </Grid>
     </Border>
@@ -267,7 +276,7 @@
     </Border>
   </Grid>
 
-  <!-- 折叠态:40px 图标细条(标题栏折叠按钮 / Ctrl+B)。会话树、快捷命令、
+  <!-- 折叠态:40px 图标细条(侧栏工具栏折叠按钮 / Ctrl+B)。会话树、快捷命令、
        最近连接整块收起,但底部这三个入口必须留在原位 —— 消息中心与插件管理器
        在别处没有第二个入口,而消息面板本就锚在左下角贴着铃铛开出来。
        行高与展开态一一对应(36 顶栏 / * 中部 / 底部入口),切换时上下两条

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -60,15 +60,9 @@ public partial class SidebarView : UserControl
     /// </summary>
     private void HookSessionTree()
     {
-        if (_sessionTree is not null)
-        {
-            _sessionTree.ConnectRequested -= OnSessionConnectRequested;
-        }
+        _sessionTree?.ConnectRequested -= OnSessionConnectRequested;
         _sessionTree = _viewModel?.SessionTree;
-        if (_sessionTree is not null)
-        {
-            _sessionTree.ConnectRequested += OnSessionConnectRequested;
-        }
+        _sessionTree?.ConnectRequested += OnSessionConnectRequested;
     }
 
     /// <summary>
@@ -120,10 +114,13 @@ public partial class SidebarView : UserControl
 
     private void ExpandSidebar_Click(object? sender, RoutedEventArgs e)
     {
-        if (_viewModel is not null)
-        {
-            _viewModel.IsCollapsed = false;
-        }
+        _viewModel?.IsCollapsed = false;
+    }
+
+    /// <summary>工具栏折叠按钮。只出现在展开态,所以直接置位而不是取反。</summary>
+    private void CollapseSidebar_Click(object? sender, RoutedEventArgs e)
+    {
+        _viewModel?.IsCollapsed = true;
     }
 
     private void OpenConnectionProfile_Click(object? sender, RoutedEventArgs e)

--- a/src/VelaShell/Views/TitleBarView.axaml
+++ b/src/VelaShell/Views/TitleBarView.axaml
@@ -96,7 +96,7 @@
           BorderBrush="{DynamicResource VelaBorderPrimary}"
           BorderThickness="0,0,0,1"
           PointerPressed="Bar_PointerPressed">
-    <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,*,Auto,Auto">
 
       <!-- 左:logo + 产品名(不参与命中,拖动透传到底层 Border)。 -->
       <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8"
@@ -109,25 +109,11 @@
                    VerticalAlignment="Center" />
       </StackPanel>
 
-      <!-- 折叠资源管理器(Ctrl+B):按钮长在它控制的那片区域这一侧,一眼知道管的是左边;
-           右边那组图标全是"打开某个东西",布局开关混进去会让那一排变成杂物抽屉。
-           折叠态图标转强调色,与文件浏览器按钮同一套高亮语言。 -->
-      <Button Grid.Column="1" Theme="{StaticResource VelaTitleActionButton}"
-              ToolTip.Tip="{loc:Localize Cmd_ToggleSidebar}"
-              Command="{Binding ToggleSidebarCommand}">
-        <Panel>
-          <pc:LucideIcon Width="12" Height="12" Data="{StaticResource Icon.panel-left}"
-                         Foreground="{DynamicResource VelaTextMuted}"
-                         IsVisible="{Binding !Sidebar.IsCollapsed}" />
-          <pc:LucideIcon Width="12" Height="12" Data="{StaticResource Icon.panel-left}"
-                         Foreground="{DynamicResource VelaAccent}"
-                         IsVisible="{Binding Sidebar.IsCollapsed}" />
-        </Panel>
-      </Button>
-
       <!-- 右:全局功能图标组(与命令注册表同源;多终端同步输入已移至标签右键菜单
-           “同步输入”频道,不再占用标题栏图标)。 -->
-      <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4"
+           “同步输入”频道,不再占用标题栏图标)。
+           侧栏折叠按钮不放这里:它是布局开关,而这一排全是"打开某个东西",
+           混进去这排就开始变成杂物抽屉 —— 折叠入口在侧栏工具栏自己那一行。 -->
+      <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
                   VerticalAlignment="Center" Margin="0,0,10,0">
         <Button Theme="{StaticResource VelaTitleActionButton}"
                 ToolTip.Tip="{loc:Localize Menu_SearchTerminalTip}"
@@ -177,7 +163,7 @@
       </StackPanel>
 
       <!-- 窗口控制:最小化 / 最大化(还原) / 关闭(常规 Click,纯客户区必然可点)。 -->
-      <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Top">
+      <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Top">
         <Button Theme="{StaticResource VelaCaptionButton}" Click="Minimize_Click">
           <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.minus}"
                          Foreground="{DynamicResource VelaTextTertiary}" />


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

将侧栏折叠/展开按钮移至工具栏，优化交互与布局，避免入口重复。完善注释，区分折叠状态及触发来源。新增数据库被占用时的异常捕获与友好提示。优化相关 ViewModel 属性、方法及注释，提升代码可读性和维护性。调整相关视图文件控件布局与事件绑定。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
