### PR TITLE
侧栏折叠/展开新增动画，优化细条与分隔条逻辑

### DIFF
--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Avalonia;
+using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -111,6 +113,19 @@ public partial class MainWindow : Window
     private double _lastSidebarWidth = 260;
 
     private bool _sidebarCollapsed;
+
+    /// <summary>侧栏折叠/展开的动画时长与缓动:沿用停靠区的 0:0:0.18 + CubicEaseOut(DockGroupControl)。</summary>
+    private static readonly TimeSpan SidebarAnimationDuration = TimeSpan.FromMilliseconds(180);
+
+    private static readonly Easing SidebarAnimationEasing = new CubicEaseOut();
+
+    private DispatcherTimer? _sidebarAnimation;
+
+    /// <summary>
+    /// 侧栏动画是否已启用。启动阶段回填持久化的折叠态必须是瞬时的 ——
+    /// 否则窗口刚出来就自己收一下,像是卡了一帧,而不是用户要的那个过渡。
+    /// </summary>
+    private bool _sidebarAnimationsEnabled;
 
     private AppSettings? _settings;
 
@@ -243,19 +258,96 @@ public partial class MainWindow : Window
             {
                 _lastSidebarWidth = width.Value;
             }
-            // MinWidth 必须先归零:它是 180,不清掉的话 40 的宽度会被顶回 180。
-            sidebarCol.MinWidth = 0;
-            sidebarCol.Width = new(SidebarRailWidth);
-            cols[1].Width = new(0);
         }
-        else
+
+        // 动画途中列宽会一路低于 MinWidth(180),约束不摘掉就会被顶回去、动画走不动;
+        // 分隔条则在整个过程中收起 —— 半途中的中间宽度不是一个能拖的状态。
+        // 展开落定后由 FinishSidebarCollapse 把两者装回去。
+        sidebarCol.MinWidth = 0;
+        cols[1].Width = new(0);
+        SidebarSplitterLine.IsVisible = false;
+        SidebarSplitter.IsVisible = false;
+
+        double target = collapsed ? SidebarRailWidth : _lastSidebarWidth;
+        if (!_sidebarAnimationsEnabled)
         {
-            sidebarCol.MinWidth = SidebarMinWidth;
-            sidebarCol.Width = new(_lastSidebarWidth);
-            cols[1].Width = new(5);
+            StopSidebarAnimation();
+            sidebarCol.Width = new(target);
+            FinishSidebarCollapse(cols, sidebarCol, collapsed);
+            return;
         }
-        SidebarSplitterLine.IsVisible = !collapsed;
-        SidebarSplitter.IsVisible = !collapsed;
+
+        // 起点取当前实际宽度,连点折叠/展开时从半路接着走,不会先跳回端点再动。
+        double from = sidebarCol.ActualWidth > 0
+            ? sidebarCol.ActualWidth
+            : (collapsed ? _lastSidebarWidth : SidebarRailWidth);
+        AnimateSidebarWidth(sidebarCol, from, target,
+                            () => FinishSidebarCollapse(cols, sidebarCol, collapsed));
+    }
+
+    /// <summary>动画落定后的收尾:只有展开态才重新装上宽度下限与可拖拽的分隔条。</summary>
+    private void FinishSidebarCollapse(ColumnDefinitions cols, ColumnDefinition sidebarCol, bool collapsed)
+    {
+        if (collapsed)
+        {
+            return;
+        }
+        sidebarCol.MinWidth = SidebarMinWidth;
+        cols[1].Width = new(5);
+        SidebarSplitterLine.IsVisible = true;
+        SidebarSplitter.IsVisible = true;
+    }
+
+    /// <summary>
+    /// 把侧栏列宽从 <paramref name="from" /> 推到 <paramref name="to" />。
+    /// </summary>
+    /// <remarks>
+    /// 自己按帧推而不是挂 Transitions:列宽是 <see cref="GridLength" />,而 ColumnDefinition
+    /// 并非 Animatable,套不上过渡。但时长与缓动直接复用停靠区那套(DockGroupControl 的
+    /// <c>0:0:0.18</c> + <c>CubicEaseOut</c>),整个应用的动效口径仍然只有一份。
+    /// 注意这期间终端会随列宽逐帧 reflow —— 与用户拖动分隔条完全同一条路径(终端有意不对
+    /// resize 做防抖,见 VelaTerminalControl.ApplyGrid 的注释),故负载与一次快速拖拽相当。
+    /// </remarks>
+    private void AnimateSidebarWidth(ColumnDefinition column, double from, double to, Action onCompleted)
+    {
+        StopSidebarAnimation();
+        if (Math.Abs(to - from) < 1)
+        {
+            column.Width = new(to);
+            onCompleted();
+            return;
+        }
+        long startedAt = Stopwatch.GetTimestamp();
+        DispatcherTimer timer = new(DispatcherPriority.Render)
+        {
+            Interval = TimeSpan.FromMilliseconds(16)
+        };
+        timer.Tick += (_, _) =>
+        {
+            double progress = Math.Clamp(
+                Stopwatch.GetElapsedTime(startedAt) / SidebarAnimationDuration, 0, 1);
+            column.Width = new(from + ((to - from) * SidebarAnimationEasing.Ease(progress)));
+            if (progress < 1)
+            {
+                return;
+            }
+            // DispatcherTimer 被调度器强引用,不停表会一直唤醒本窗口(同 TerminalTabView 的处置)。
+            timer.Stop();
+            if (ReferenceEquals(_sidebarAnimation, timer))
+            {
+                _sidebarAnimation = null;
+            }
+            column.Width = new(to);
+            onCompleted();
+        };
+        _sidebarAnimation = timer;
+        timer.Start();
+    }
+
+    private void StopSidebarAnimation()
+    {
+        _sidebarAnimation?.Stop();
+        _sidebarAnimation = null;
     }
 
     private async void OnWindowOpened(object? sender, EventArgs e)
@@ -269,6 +361,10 @@ public partial class MainWindow : Window
             return;
         }
         _openedInitialized = true;
+        // 启动期的侧栏状态回填(设置/AppState 异步读回来的折叠态)不做动画,过了这一阵才开闸。
+        // 用定时器而不是接在某个初始化步骤之后:回填是视图模型那边异步完成的,这里等不到确切时机,
+        // 而"启动后短暂静默"本身就是这道闸要表达的全部意思。
+        DispatcherTimer.RunOnce(() => _sidebarAnimationsEnabled = true, TimeSpan.FromSeconds(1));
         if (DataContext is MainWindowViewModel vm)
         {
             vm.TerminalSearchRequested += OnTerminalSearchRequested;
@@ -707,6 +803,8 @@ public partial class MainWindow : Window
         cols[mainCol].MaxWidth = double.PositiveInfinity;
         Grid.SetColumn(sidebar, sidebarCol);
         Grid.SetColumn(main, mainCol);
+        // 折叠态细条要贴住侧栏的外缘(左栏贴左、右栏贴右),否则折叠动画里它会站错边。
+        sidebar.SetRailEdge(right);
     }
 
     /// <summary>托盘“退出”/关闭确认后的真正退出:跳过托盘拦截与确认弹窗。</summary>

--- a/src/VelaShell/Views/SidebarView.axaml
+++ b/src/VelaShell/Views/SidebarView.axaml
@@ -12,8 +12,10 @@
              x:DataType="vm:SidebarViewModel">
 
   <!-- 底色画在最外层 Panel 上:展开态与折叠态是同一条侧栏的两副面孔,
-       底色若跟着其中一个走,切换的瞬间会闪一下窗口底色。 -->
-  <Panel Background="{DynamicResource VelaBgSidebar}">
+       底色若跟着其中一个走,切换的瞬间会闪一下窗口底色。
+       ClipToBounds 是折叠动画的前提:Grid 默认不裁剪子元素,列宽收窄的过程中
+       完整侧栏那 260px 的内容会直接溢出画到终端上去。 -->
+  <Panel Background="{DynamicResource VelaBgSidebar}" ClipToBounds="True">
 
   <Grid x:Name="SidebarGrid" RowDefinitions="36,*,40">
 
@@ -281,7 +283,8 @@
        在别处没有第二个入口,而消息面板本就锚在左下角贴着铃铛开出来。
        行高与展开态一一对应(36 顶栏 / * 中部 / 底部入口),切换时上下两条
        分隔线停在同一水平位置,不会跳。 -->
-  <Grid x:Name="CollapsedRail" RowDefinitions="36,*,Auto" IsVisible="False">
+  <Grid x:Name="CollapsedRail" RowDefinitions="36,*,Auto" IsVisible="False"
+        Width="40" HorizontalAlignment="Left">
 
     <!-- 顶:展开回去。折叠态自带回程入口,不必非得回标题栏找那个按钮。 -->
     <Border Grid.Row="0" BorderThickness="0,0,0,1"

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -117,6 +117,20 @@ public partial class SidebarView : UserControl
         _viewModel?.IsCollapsed = false;
     }
 
+    /// <summary>
+    /// 折叠态细条贴哪一边(随设置 → 外观 → 侧边栏位置)。
+    /// </summary>
+    /// <remarks>
+    /// 细条钉死 40px 而不是随列拉伸:折叠动画途中列宽一路从 260 收到 40,细条若跟着拉伸,
+    /// 图标会在列里滑一段距离。钉住并贴紧侧栏的外缘之后,过程就只剩"面板从内侧退走",
+    /// 细条本身纹丝不动 —— 这也正是它作为常驻入口该有的观感。
+    /// </remarks>
+    // 枚举名必须写全:在 UserControl 里裸写 HorizontalAlignment 会先解析到控件自己那个同名属性。
+    public void SetRailEdge(bool right) =>
+        CollapsedRail.HorizontalAlignment = right
+            ? Avalonia.Layout.HorizontalAlignment.Right
+            : Avalonia.Layout.HorizontalAlignment.Left;
+
     /// <summary>工具栏折叠按钮。只出现在展开态,所以直接置位而不是取反。</summary>
     private void CollapseSidebar_Click(object? sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

为侧栏折叠/展开添加180ms CubicEaseOut动画，提升交互流畅度。新增私有字段、定时器及辅助方法，实现宽度平滑过渡。启动时回填状态不触发动画，窗口初始化1秒后才允许动画，避免不自然效果。Panel 增加 ClipToBounds 防止内容溢出。细条宽度固定40px，动态贴边且动画中位置不变，提升视觉一致性。新增 SetRailEdge 方法控制细条对齐。调整分隔条显示与拖拽逻辑，动画期间禁用拖动，动画结束后恢复。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
