### PR TITLE
feat: 协作接入 —— IM 桥接(飞书/钉钉/Telegram/企微)+ 对外 MCP 服务端

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -985,3 +985,322 @@ Ollama 走它的 OpenAI 兼容层。回应认三种形状:`{"data":[…]}`、裸
 > **一处与本条无关的既有失败**:`ShortcutCatalogTests.Doc_ListsEveryCatalogEntry` 读
 > `docs/快捷键参考.md`,而该文件在 `f0f492a`(文档搬去 velashell-docs)时已从本仓库删除,
 > 测试没跟着改 —— 现在必然抛 `FileNotFoundException`。不在本次改动范围内,单独处理。
+## 33. 2026-09-02 协作接入:IM 桥接(飞书/钉钉/Telegram/企微)+ 对外 MCP 服务端
+
+两件事一起做,因为它们是同一个能力的两个方向,而且共用同一套安全观念:
+
+- **往外**:团队在飞书/钉钉/Telegram/企微里 @ 机器人,VelaShell 的 agent 在**已连上的**
+  SSH 会话上干活,结果回帖到群里 —— 对齐 Hermes Agent 的消息网关那一层;
+- **往内**:Claude Code / Codex 这类外部 agent 把 VelaShell 当 MCP 服务端调,
+  用的就是 `AgentToolbox` 里那套工具。
+
+全部落在 `plugins/VelaShell.Plugin.Ai/`(`Bridge/` 与 `Interop/`)。**AI 插件因此改为
+`onStartup` 激活** —— 桥接必须常驻,不能等用户点开面板才建连;换来的代价是启动多一次
+程序集装载与一次配置读取(两条服务都关着时立刻返回)。
+
+### 一、四个渠道,四种入站传输
+
+抽象是 `IMessageChannel`:只管收发,"跑到断为止";重连退避统一在 `ChannelHub`。
+四家刻意各选一种传输,把抽象压到位:
+
+| 渠道 | 入站 | 能改已发消息 | 备注 |
+| --- | --- | --- | --- |
+| 飞书 / Lark | 官方长连接(WebSocket + pbbp2 帧) | 能 | 帧格式官方未公开,照 `larksuite/oapi-sdk-go` 的 `ws/pbbp2.pb.go` **手写**编解码,不引 protobuf 运行时 |
+| 钉钉 | Stream 模式(WebSocket + JSON 帧) | 不能 | 协议官方有公开文档;发消息走带令牌的接口,**不用 sessionWebhook**(只能发 5 条、1.5 小时过期) |
+| Telegram | Bot API 长轮询 | 能 | 走宿主全局代理 |
+| 企业微信 | 公网回调(本机 HTTP 监听) | 不能 | 唯一需要公网入口的一家;只绑 127.0.0.1,前面自己接隧道 / 反代 |
+
+飞书那条长连接有两个坑写在代码注释里:一个应用最多 50 条连接,而且多客户端时平台按
+**集群**投递(随机挑一个)—— 同一套凭证别在两台机器上同时跑。
+
+### 二、安全默认:能少给就少给
+
+- **白名单为空 = 谁都不理**。群 id 在飞书/钉钉界面上看不到,所以第一次被 @ 时回一句
+  (且只回一句)带 id 的提示,否则用户根本没法完成配置;
+- 桥接默认**计划档(只读)**,比面板保守一档 —— 面板前面坐着人,IM 那头的人可能在地铁上;
+- `/mode` **默认只能往低了调**。白名单里任何人都能 `/mode agent` 的话,设置页那个"只读"
+  就形同虚设;要放开得去设置页勾 `AllowModeEscalation`;
+- 审批走**文本回复**(`y`/`n`/`a`)而不是交互卡片:四家的卡片回传各有各的坑
+  (飞书 `card.action.trigger` 在长连接上并不总能收到,上游项目挂着同样的 issue),
+  文本是唯一四家都稳的通道。审批人可与"能说话的人"分开配;
+- 绑定存 `user@host:port` 而**不是 SessionId** —— 后者断线重连就换一个,存它的话群里的绑定
+  过夜就失效。
+
+### 三、无头 agent 回合另起一条,不动聊天面板
+
+`Bridge/BridgeAgentRunner`。`ChatPanelView.SendAsync` 把装配、流式渲染、审批卡片、插话与压缩
+缝在一起、每一步都直接写 UI 控件;把它抽成界面无关要动那个 2500 行文件的骨架,风险远大于
+并排写一条只做桥接需要的路。真正值钱的零件(`AgentToolbox` / `ContextBuilder` /
+`AiSettingsStore` / `McpManager` / `ChatHistoryStore`)本来就界面无关,直接复用,重复的只有编排。
+
+### 四、对外 MCP 服务端
+
+`Interop/McpEndpoint`:Streamable HTTP(不是 stdio —— stdio 的前提是客户端能把服务端拉起来,
+而 VelaShell 是一个已经开着的桌面程序)。只绑 127.0.0.1,**每个请求必须带令牌**:本机端口
+同机任何进程(包括浏览器里的页面)都能敲,令牌是唯一的门。工具直接由 `AgentToolbox` 产出,
+外加一个 `use_session` 让外部 agent 挑机器(工具箱靠 `SessionIdProvider` 拿会话,签名里没有这个参数)。
+
+**审批在这条路上没有界面**,所以 `ApprovalMode.Ask` 等于一律拒绝写操作(工具箱在
+`ApprovalHandler` 为 null 时就是这个行为)。要让外部 agent 能改东西,用户得显式选只读放行
+或绕过审批 —— 这是一个明摆着的选择,而不是一个悄悄的默认。
+
+### 五、已知限制(需要 SDK 新契约才能解)
+
+`ISessionsApi` 只有 `ListAsync` / `GetAsync`,**开不了新会话**。所以两条路上的 agent 都只能
+操作"用户已经连上的机器";没有连上的,只能回一句让人去 VelaShell 里连。要让它自己按保存的
+配置连一台,得给 SDK 加契约(按 AGENTS.md 走 velashell-plugin-sdk 的发版流程)。
+
+### 六、踩到的坑
+
+**`TextWrapping="Wrap"` 的多行 TextBox + 竖滚动条 Auto = 布局死循环。**外层 ScrollViewer 的
+滚动条一旦出现就压窄可用宽度 → 文本重排变高 → 还是要滚动条 → 收回…… measure/arrange 无限
+震荡,窗口整个卡死;headless 测试里表现为一分钟超时,**连异常都没有**。内容为空时不发作,
+填上内容才挂 —— 所以它很容易溜过第一版用例。协作页那个"接入方式"框因此固定 NoWrap
+(内容本来就是整段复制走的,横向滚动够用),注释已留在 `CollaborationView.axaml`。
+
+测试:`Pbbp2Tests`(帧编解码,含未知字段跳过与截断报错)、`WeComCryptoTests`(验签与报文布局)、
+`McpEndpointTests`(真起 HTTP:initialize / tools/list / tools/call / 鉴权拒绝)、
+`BridgeRouterTests`(白名单、群里没 @ 不理、斜杠命令、`/mode` 不许提权)、`SessionTargetsTests`、
+`CollaborationViewUiTests`(headless 真装载)、`LocTableTests`(插件那张多语言表必须齐五语 ——
+少一项是运行时 `IndexOutOfRangeException`,而且只有切到日/韩才撞得到)。
+`VelaShell.Plugin.Ai.Tests` 256 条全绿,全仓 `dotnet build` 无警告。
+
+**待办**:velashell-docs 尚未同步 —— 需要新增 `{zh,en}/plugins/协作接入.md`(渠道配置步骤、
+安全模型、MCP 接入方式),并在 `{zh,en}/plugins/STATUS.md` 登记。
+
+## 34. 2026-09-02 协作接入的配置流程返工(用户反馈:"要填一堆文本框")
+
+第一版把开发者后台的东西原样誊了一遍。真正费事的其实不是那两个凭证(各复制一次而已),
+而是后面那趟:**加机器人进群 → 发一句 → 看它回的群 id → 复制 → 回电脑粘进白名单 → 保存 → 重连**。
+人在手机跟前,电脑在工位上,这一趟纯属受罪。
+
+### 一、先说清楚 Hermes 的"扫码"是什么
+
+用户提到 Hermes 可以扫码接入。它其实是两件不同的事:
+
+- **WhatsApp / Signal**:设备链接 —— agent 挂成你账号的一台已链接设备,压根没有"应用"要注册,
+  所以确实一扫就完;
+- **飞书/钉钉/企微**:bot 的 `app_secret` 只能从开发者后台拿,**没有任何扫码能变出它来**。
+
+(中文教程里流传的"扫码自动创建飞书应用"未经官方文档证实,没有照它实现。)
+
+所以这一版不去做"扫码替代填凭证",而是把真正冗长的那一段砍掉。
+
+### 二、配对码:授权一个群不用再回电脑
+
+`Bridge/PairingService.cs`。设置页点一下生成六位码,在要授权的聊天里发 `/pair 428913` 即可。
+
+- 一次性、十分钟过期、**猜错五次直接作废**,随机数走 `RandomNumberGenerator`(它在有效期内
+  是一个能把陌生聊天放进白名单的凭据,用 `Random` 等于给知道规律的人留门);
+- **只能加白名单**,动不了挡位与审批 —— 能不能在服务器上干活仍旧归那两项管;
+- `/pair` 刻意**不要求群里先 @ 机器人**:此刻它还不在白名单里,再叠一条"先 @ 我"
+  等于把配对本身也挡在门外;
+- 放行同时写内存与库:只写库要等重载才认,只写内存重启就没。库里还没有这个渠道
+  (设置页加了没保存)时给一条 warn,不让它静默地只活到下次重启。
+
+### 三、一键放行:敲过门的聊天直接列出来
+
+被白名单挡掉的聊天会被记下(`PendingChat`),设置页一行一个卡片:哪个渠道、群还是单聊、
+谁在说话、聊天 id,右侧 [允许] / [忽略]。点允许即时生效并落盘,同时把 id 填进上面那个
+白名单框 —— 否则用户接着点保存,反而把刚放行的又抹掉了。
+
+清单挂在 `BridgeService` 而不是路由器上:设置页一保存就整体重建路由器,
+"刚才有个群敲过门"这条线索不该被那一下抹掉。
+
+### 四、[测试] 按钮:填完当场验,不用保存再翻日志
+
+`Bridge/ChannelProbe.cs`,用界面上**当前**填的值去试(不保存)。飞书那条特意多走一步:
+换到令牌之后再问一次长连接接入点 —— 接飞书最常见的两种翻车不是密钥填错,而是
+**事件订阅没改成长连接**与**改完没发布版本**,这两种情况下密钥完全正确却一条消息都收不到。
+探测全程只读:换令牌、查自身信息、问接入点,不发消息不改配置。
+
+### 五、二维码用在真正省事的地方
+
+测试通过后,如果拿得到"把机器人加进群"的链接就渲染成二维码(飞书 `applink.feishu.cn`、
+Telegram `t.me/<bot>?startgroup=true`),手机扫一下直接跳过去,省掉在手机上按名字搜应用。
+新引 `QRCoder`(MIT、netstandard2.0、无传递依赖),走 `PngByteQRCode` 出字节流交给
+Avalonia 的 `Bitmap` —— 不碰 `System.Drawing`,Linux/macOS 上不需要 libgdiplus。
+
+自己写 QR 编码器要 Reed-Solomon 与掩码评分,几百行且没有额外价值:与自研 VT/ZMODEM 不同,
+这里没有需要拿捏的协议细节。
+
+### 六、顺手修的一处 UX
+
+设置页原来要等三秒(定时器)才刷出待放行清单,现在加载完就先刷一次;定时器只负责
+"页面开着时后来又有人敲门"。
+
+于是整条链路变成:**填两个框 → 点测试 → 扫码把机器人拉进群 → 群里发一句 `/pair` → 完事**,
+全程不用抄任何 id。
+
+测试:`PairingServiceTests` 8 条(六位数字、一次性、猜错五次作废、重发作废旧码、待放行去重与排序)、
+`BridgeRouterTests` 新增 6 条(有效码放行且落盘、错码不放行、没发过码不放行、缺参数给用法、
+陌生聊天被记下、放行后从清单消失)、`CollaborationViewUiTests` 新增 4 条
+(配对码显示、没开桥接时说明原因、待放行卡片带「允许」、**二维码真的画得出 Bitmap** ——
+新依赖里这条最可能"编译得过、运行才炸")。
+`VelaShell.Plugin.Ai.Tests` 275 条全绿,全仓 `dotnet build` 无警告。
+
+### 七、真机联调抓到的第一个 bug:`PostAsJsonAsync` 把字段名 camelCase 掉了
+
+用户拿真凭证一测,报 `credentials OK, but the long-connection endpoint was refused:
+Feishu endpoint request failed: Bad Request (code 9499)`。
+
+拿真凭证对同一个接口打两次,把两种写法并排比:
+
+```
+camelCase   → HTTP 400  {"code":9499,"msg":"Bad Request"}
+PascalCase  → HTTP 200  {"code":0,...,"URL":"wss://msg-frontier.feishu.cn/..."}
+```
+
+`HttpClient.PostAsJsonAsync` 用的是 `JsonSerializerDefaults.Web`,它会把属性名转成
+camelCase —— 匿名对象里写 `AppID` 发出去是 `appID`,而飞书这个接口要的是逐字的
+`AppID` / `AppSecret`。
+
+**阴险的是同一个类里换令牌那条用的是 `app_id`(本来就小写开头),camelCase 动不了它。**
+于是症状是"凭证明明是对的,只有接入点这一步被拒" —— 最不容易往序列化上想的那种组合。
+
+修法不是"调用时记得传对 options",而是把字段名用 `[JsonPropertyName]` 钉在类型上
+(`FeishuApi.EndpointRequest`):选项跟着每一个调用点走,特性跟着类型走,下次谁再加一个
+调用点也不会中。回归用例 `FeishuApiTests` 刻意**按 Web 默认值**序列化一次 ——
+用 `JsonSerializerOptions.Default` 是测不出这个 bug 的,那正是当初漏掉它的原因。
+
+其余三家不受影响:钉钉本来就是 camelCase(平台也要 camelCase),Telegram 与飞书发消息用
+snake_case,企微用全小写,camelCase 策略对这些名字都是恒等变换。
+
+### 八、协作接入页没吃上主题(用户反馈:"逐个检查处理")
+
+不是"按钮没居中"一处,是我建这一页时**整体没照 `DESIGN.md` 走**。逐个控件对完之后:
+
+| 问题 | 后果 |
+| --- | --- |
+| 六个按钮都没挂宿主的按钮主题 | `VelaOutlineButtonTheme` 里带着 `HorizontalContentAlignment="Center"` —— 不挂就是文字不居中(用户先看出来的那一条),配色也不是同一套 |
+| 保存栏写了 `VelaBorderSubtle` | **这个令牌根本不存在**(只有 `VelaBorderPrimary` / `VelaBorderSecondary`)。那条分隔线从落地起就没画出来过 |
+| 代码建的两个勾选框只挂了 `AiCheckBoxTheme` | 那个主题只管方块的画法,旁边那行字仍旧用控件自己的 `FontSize` / `Foreground` —— 于是比 XAML 里的大一号、颜色也不跟主题走 |
+| 待放行卡片里的标题 `TextBlock` 没有 class | 拿到的是 Fluent 默认前景色,换主题不跟着变 |
+| 卡片自己另写了 `Padding`、标签自己另写了 `Margin` | 把 `Border.card` / `TextBlock.label` 里定好的那一档盖掉了 |
+| 二维码是张裸的黑白图 | 直接糊在深色卡片上;现在套一层 `Border.card`(码本身不跟着主题反色 —— 反色的 QR 很多扫码器读不出来) |
+
+顺带:平台名补上拉丁写法(`钉钉 / DingTalk`)—— 界面能切日/韩,"钉钉"两个字对那边的用户不是可读的品牌名。
+`DialogStyles.axaml` 新增一档 `TextBlock.body`(12 / Primary):在这之前"卡片里的正文一行"只能靠不写 class 蒙混过去。
+
+### 九、加两道守门用例,免得再漂回去
+
+**`{DynamicResource Xxx}` 拼错不会报错,只是什么都不做。** 而 headless 用例挡不住这一类:
+测试进程里压根没装载宿主的令牌字典,所有键都解析不到,拼对拼错看起来一模一样。
+所以 `ThemeTokenUsageTests` 按**文本**比对:
+
+- `EveryResourceKeyUsedByThePluginIsDefinedSomewhere` —— 扫插件全部 `Ui/*.axaml` 引用的资源键,
+  必须能在 `src` / `plugins` 的 axaml(`x:Key`)或 C#(`Resources["…"] =`,本地化提示就是这么给的)里
+  找到定义。剥掉 XML 注释,否则注释里举例用的键会被算成引用。
+- `EveryButtonOnTheCollaborationPageWearsAHostTheme` —— 这一页 XAML 里的每个 `<Button>` 都必须挂
+  `Vela*ButtonTheme`。
+
+两条都**先把 bug 放回去验过会红**:一条点名 `VelaBorderSubtle`,一条把没挂主题的那个按钮整行打印出来。
+守门用例不验证它抓得住,和没有是一回事。
+
+找不到仓库根时这两条**失败**而不是跳过 —— MSTest 把跳过记成通过,一条永远绿的守门用例比没有更糟。
+
+**顺带发现但没动**:宿主自己的 axaml 里 `VelaBgPrimary` 与 `VelaStatusError` 两个键也找不到定义
+(`StringScrollBar*` 是 Avalonia 内置的,不算)。不在本次范围内,单独记一笔。
+
+`VelaShell.Plugin.Ai.Tests` 279 条全绿,全仓 `dotnet build` 无警告。
+
+### 十、按钮居中:前两次都没修对(用户第三次反馈)
+
+前两次都是"看着像对的"就交了,实际没解决。真原因有两条,单看代码都看不出来:
+
+1. **`VelaAccentPillButtonTheme` 没有 `HorizontalContentAlignment` 这个 setter**
+   (`VelaOutlineButtonTheme` 第 85 行有)。它只在模板里 `TemplateBinding`,而 `ContentControl`
+   的默认值是 `Stretch` —— 纯文字内容被拉开,看起来就是没居中。保存按钮用的正是这个主题。
+   宿主自己那几个 pill 按钮都塞了带 `VerticalAlignment` 的 `StackPanel` 当内容,恰好盖住了这一点。
+2. **代码里 `new` 出来的按钮不能用 `TryFindResource` 取主题**:资源查找沿逻辑树往上走,
+   而那时控件还没进树,一律落空,**而且是静默落空**。`测试` / `移除` / `允许` / `忽略`
+   四个按钮从来没挂上过主题。
+
+改法:不再在每个按钮上写 `Theme=`,改成样式表里的 `Button.host` / `Button.primary` / `CheckBox.host`
+三档 class。样式是在控件**进树时**套上去的,`DynamicResource` 那时才解析 —— 时序问题自然消失;
+两档里都显式补了 `HorizontalContentAlignment="Center"`,不指望宿主哪天会给 pill 补上。
+
+### 十一、这次是渲染出来看过的
+
+前两次的教训是:**headless 用例证明不了主题真的挂上了** —— 测试进程里宿主的资源字典根本没装载,
+`VelaAccentPillButtonTheme` 解析不到,于是按钮退回 Fluent 默认主题(它自带居中),
+"修了"和"没修"在 headless 里长得一模一样。文本级用例更弱,只能看出 XAML 里写没写。
+
+所以在 scratchpad 起了一个 Skia 控制台工程,merge 宿主真实的令牌与 `ButtonThemes.axaml`,
+把整页渲染成 PNG 看。做法记进了记忆(`previewing-plugin-ui-headlessly`),其中最坑的一步:
+**必须挂到真正的 `Window` 上再 `CaptureRenderedFrame()`** —— 对脱离 TopLevel 的控件手工
+`Measure/Arrange` 再 `RenderTargetBitmap.Render`,出来的是纯白图。
+
+图上确认:添加 / 测试 / 移除 / 生成 / 允许 / 忽略 / 保存,七个按钮的文字全部居中,描边与配色一致。
+
+### 十二、渲染顺手抓出另一个 bug:`Loc` 表里两个同名键
+
+图上"单轮超时(秒)"旁边那个标签显示成了一整句 **"没人应答,按拒绝处理。"**。
+
+`Loc.Table` 是用索引器 `["key"] = […]` 初始化的,**重复键是静默覆盖**(换成集合初始化器的 `Add`
+才会抛)。设置页的「审批超时(秒)」标签与 IM 里那句超时提示都叫 `BridgeApprovalTimeout`,
+后写的把前面盖掉。编译、测试、启动全都正常 —— 只有把界面画出来才看得见。
+IM 那条改名 `BridgeApprovalTimedOut`。
+
+### 十三、这一轮加的守门用例
+
+- `EveryButtonCentresItsLabel`(headless)—— 遍历页面上每个 `Button`(排掉 `ToggleButton`,
+  勾选框的文字本来就该左对齐),断言 `HorizontalContentAlignment == Center`。
+  这条在 headless 里**成立**,因为样式表里那个 setter 的值是字面量,不依赖宿主资源。
+  验证过:抽掉 `Button.primary` 的那一行,它精确报出 `SaveButton:Save`。
+- `EveryButtonAndCheckBoxOnTheCollaborationPageCarriesItsClass`(文本级)—— 挡住"退回去每个按钮
+  自己写 `Theme=`"那种改法。
+- `NoKeyIsDefinedTwice`(源码级)—— 只能按源码查,运行时的字典里看不出曾经有过两条。
+
+`VelaShell.Plugin.Ai.Tests` 281 条全绿。
+
+**过程教训**:中间还有一次"注入 bug 验证守门用例"的 perl 替换没匹配上,于是"用例仍然通过"被我
+当成了证据 —— 注入之后要先确认文件真的变了,再看用例的结果。
+
+### 十四、过程问题:整轮功能是在落后 18 个提交的基线上做的(用户反馈)
+
+这一整轮从头到尾没有 `git fetch` 过。做完才发现落后 `origin/main` **18 个提交**,
+而且其中好几个正好动 AI 插件:订阅登录(`Auth/`)、思考档位下拉、供应商目录、
+自定义供应商拉模型清单 —— 与本次改动的文件高度重叠。
+
+补救:`git stash --include-untracked` → `git merge --ff-only origin/main` → `git stash pop`。
+新增文件都是未跟踪的,不参与合并;四个被同时改过的文件里只有 `plan.md` 真冲突
+(两边都往文件尾追加小节),上游占 30/31/32,本次的两节顺延为 33/34。
+`DialogStyles.axaml` / `Loc.cs` / `plugin.json` 自动合上 —— 但"文本能合"不等于"语义没坏",
+所以在新基线上重跑了一遍:全仓 `dotnet build` 无警告,`VelaShell.Plugin.Ai.Tests`
+**466 条全绿**(本次 281 + 上游新增),协作页也重新渲染确认过外观没被上游的
+`DialogStyles` 改动(新增了一条 `ListBox.nav ListBoxItem TextBlock.count`)影响。
+
+**教训**:动手之前先 `git fetch` 看一眼落后多少。这次运气好只撞了一个文件;
+如果上游重构了 `AiSettingsStore` 或 `AgentToolbox`(这两个都在本次依赖里),
+返工量会大得多。
+
+### 十五、飞书里 401,而面板同一刻好好的:桥接吃的是启动时那份 AI 设置快照
+
+现象:群里报
+`OpenAI Codex / gpt-5.6-sol: Service request failed. Status: 401 — {"detail":"Could not parse your authentication token."}`,
+而 VelaShell 里的 AI 助手用同一个模型完全正常。
+
+(顺带说明上一轮"把模型名带进错误里"那个改动是值得的 —— 没有那句 `OpenAI Codex / gpt-5.6-sol`,
+这条线索根本立不起来:光看 401 会以为是飞书的凭证问题。)
+
+面板与桥接走的是**同一个** `AiSettingsStore.CreateClientAsync`,里面刷新令牌、附加头、
+账户级 BaseUrl 一应俱全。差别在传进去的那个 `AiProvider` 对象:
+
+- 面板在设置窗口登录之后会刷新自己的 `AiSettings`;
+- **桥接的那份是启动时读的,之后再没更新过**(只在设置页保存触发 `ReloadAsync` 时才换)。
+
+于是用户登录订阅制供应商之后,桥接手里那份 provider 还是登录之前的形态(`Auth` 仍是 `ApiKey`、
+没有 `OAuth` 配置),`ResolveCredentialAsync` 走了"取 API Key"那条岔路,把一个空 Key 发了出去 ——
+服务端回的正是"解析不了你的认证令牌"。
+
+改法:`BridgeAgentRunner` **每轮现读** `AiSettings`,`ConversationRouter` 不再缓存它
+(`Apply` 只收桥接设置与语言)。代价是每轮多读一次 JSON,与一次模型调用比可以忽略;
+换来的是"面板里改了什么,桥接下一句就跟上" —— 换模型、重新登录、改 MCP 配置都不必重启桥接。
+
+回归用例 `BridgeAgentRunnerTests.RunAsync_RereadsTheAiSettingsEveryTurn`:**先**造 runner、
+**之后**才往库里写供应商,第一轮必须说"没配模型",第二轮的报错里必须带上刚写进去的模型名。
+快照式实现连编译都过不去(`ai` 是参数),所以这条用例是结构性的。
+另有一条钉住"报错必须点名哪个模型"。
+
+`VelaShell.Plugin.Ai.Tests` 469 条全绿。

--- a/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
+++ b/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
@@ -1,4 +1,6 @@
+using VelaShell.Plugin.Ai.Bridge;
 using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Interop;
 using VelaShell.Plugin.Ai.Ui;
 using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Commands;
@@ -8,8 +10,8 @@ using VelaShell.PluginSdk.Ui;
 namespace VelaShell.Plugin.Ai;
 
 /// <summary>
-/// AI 助手插件入口。经 manifest 的 <c>onCommand</c> 惰性激活:
-/// 用户第一次触发 AI 命令才装载本程序集。
+/// AI 助手插件入口。<b>启动即激活</b>(见 <c>plugin.json</c> 的 <c>onStartup</c>)——
+/// IM 桥接要常驻,不能等用户点开面板才建连;聊天面板本身仍是首次触发命令才构造。
 /// 命令:打开聊天(标签页/窗口)、解释当前终端输出。
 /// </summary>
 [VelaPlugin]
@@ -18,8 +20,17 @@ public sealed class AiPlugin : IVelaPlugin
     private IPluginContext? _context;
     private AiSettingsStore? _store;
     private IPluginPanel? _panel;
+    private IPluginPanel? _collaborationPanel;
     private ChatPanelView? _view;
+    private BridgeService? _bridge;
+    private McpEndpoint? _mcpServer;
     private readonly List<IDisposable> _commands = [];
+
+    /// <summary>IM 桥接(设置页保存后调它的 <c>ReloadAsync</c>)。</summary>
+    public BridgeService? Bridge => _bridge;
+
+    /// <summary>对外的 MCP 服务端(设置页保存后调它的 <c>ReloadAsync</c>)。</summary>
+    public McpEndpoint? McpServer => _mcpServer;
 
     /// <inheritdoc />
     public Task ActivateAsync(IPluginContext context, CancellationToken cancellationToken)
@@ -29,19 +40,63 @@ public sealed class AiPlugin : IVelaPlugin
         RegisterCommands();
         // 命令标题本地化:语言切换时按同 id 重注册替换
         context.Events.LocaleChanged += _ => RegisterCommands();
+        StartServices(context, cancellationToken);
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// 拉起两条常驻服务:IM 桥接(往外接飞书/钉钉/Telegram)与 MCP 服务端
+    /// (往内让 Claude Code / Codex 这类外部 agent 调 VelaShell)。
+    /// </summary>
+    /// <remarks>
+    /// <b>不 await。</b>建连与监听都要碰系统资源,而插件激活是在启动路径上 ——
+    /// 一台连不上的飞书、一个被占用的端口,都不该把 VelaShell 的启动拖住。
+    /// 两者关着时各自读一次配置就返回。
+    /// </remarks>
+    private void StartServices(IPluginContext context, CancellationToken cancellationToken)
+    {
+        _bridge = new BridgeService(context, _store!);
+        _mcpServer = new McpEndpoint(context, new McpServerSettingsStore(context));
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _bridge.ReloadAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                context.Log.Error($"Starting the IM bridge failed: {ex}");
+            }
+            try
+            {
+                await _mcpServer.ReloadAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                context.Log.Error($"Starting the MCP server failed: {ex}");
+            }
+        }, cancellationToken);
+    }
+
     /// <inheritdoc />
-    public Task DeactivateAsync(CancellationToken cancellationToken)
+    public async Task DeactivateAsync(CancellationToken cancellationToken)
     {
         // 命令、事件订阅与面板由宿主自动清理;这里只拆自己的引用。
         _view?.Detach();
         _view = null;
         _panel = null;
         _commands.Clear();
+        if (_bridge is { } bridge)
+        {
+            await bridge.DisposeAsync();
+            _bridge = null;
+        }
+        if (_mcpServer is { } mcp)
+        {
+            await mcp.DisposeAsync();
+            _mcpServer = null;
+        }
         _context = null;
-        return Task.CompletedTask;
     }
 
     private void RegisterCommands()
@@ -62,6 +117,50 @@ public sealed class AiPlugin : IVelaPlugin
         _commands.Add(context.Commands.Register(new PluginCommandDescriptor(
             $"{context.PluginId}.explain-terminal", loc["CmdExplain"], "AI",
             ExplainTerminalAsync)));
+        _commands.Add(context.Commands.Register(new PluginCommandDescriptor(
+            $"{context.PluginId}.collaboration", loc["CmdCollaboration"], "AI",
+            _ => OpenCollaborationAsync())));
+    }
+
+    /// <summary>
+    /// 打开「协作接入」设置窗口(IM 桥接 + 对外 MCP 服务端)。
+    /// </summary>
+    /// <remarks>
+    /// 这一页<b>不挂在聊天面板下面</b>:它配的是两条常驻服务,与"当前这段对话"无关,
+    /// 而且用户很可能根本没开过聊天面板就想去配它。所以入口在命令面板上,自己一个窗口。
+    /// </remarks>
+    private async Task OpenCollaborationAsync()
+    {
+        IPluginContext context = _context!;
+        if (_collaborationPanel is { IsOpen: true } opened)
+        {
+            await opened.ActivateAsync();
+            return;
+        }
+        var loc = new Loc(context.Host.Locale);
+        _collaborationPanel = await context.Ui.ShowPanelAsync(
+            new PanelOptions
+            {
+                Title = loc["Collaboration"],
+                DisplayMode = PanelDisplayMode.Window,
+                WindowWidth = 860,
+                WindowHeight = 780
+            },
+            () => new CollaborationView(context, loc, RestartServicesAsync, _bridge));
+        _collaborationPanel.Closed += () => _collaborationPanel = null;
+    }
+
+    /// <summary>设置页保存后按新配置重起两条服务。</summary>
+    private async Task RestartServicesAsync()
+    {
+        if (_bridge is { } bridge)
+        {
+            await bridge.ReloadAsync();
+        }
+        if (_mcpServer is { } mcp)
+        {
+            await mcp.ReloadAsync();
+        }
     }
 
     private async Task<ChatPanelView?> OpenPanelAsync(PanelDisplayMode mode)

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
@@ -1,0 +1,268 @@
+using System.Text;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Agent.Web;
+using VelaShell.Plugin.Ai.Chat;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>一轮跑完的结果。</summary>
+/// <param name="Text">给 IM 的最终回复。</param>
+/// <param name="Model">用的模型(日志与页脚)。</param>
+/// <param name="Elapsed">耗时。</param>
+/// <param name="ToolCalls">这一轮调了几次工具。</param>
+public readonly record struct BridgeTurn(string Text, string Model, TimeSpan Elapsed, int ToolCalls);
+
+/// <summary>
+/// 无头的 agent 回合:没有气泡、没有状态行,只有"一段文本进、一段文本出"。
+/// </summary>
+/// <remarks>
+/// <b>为什么不复用聊天面板那条路。</b><c>ChatPanelView.SendAsync</c> 把装配、流式渲染、
+/// 审批卡片、插话与压缩缝在一起,每一步都直接写 UI 控件;把它抽成"界面无关"要动的是
+/// 那个 2500 行文件的骨架,风险远大于在旁边并排写一条只做桥接需要的路。
+/// 真正值钱的零件 —— <see cref="AgentToolbox" />、<see cref="ContextBuilder" />、
+/// <see cref="AiSettingsStore" />、<see cref="McpManager" />、<see cref="ChatHistoryStore" /> ——
+/// 本来就都是界面无关的,这里直接拿来用,重复的只有编排这一层。
+/// </remarks>
+public sealed class BridgeAgentRunner(
+    IPluginContext context,
+    AiSettingsStore store,
+    ChatHistoryStore history,
+    McpManager mcp)
+{
+    /// <summary>函数调用循环的单轮上限。IM 那头没人盯着,给得比面板保守一点。</summary>
+    private const int MaxToolIterations = 20;
+
+    /// <summary>
+    /// 跑一轮。<paramref name="progress" /> 每拿到一批增量就被调一次(参数是<b>累计</b>文本),
+    /// 由调用方决定是改同一条消息还是攒到最后再发。
+    /// </summary>
+    public async Task<BridgeTurn> RunAsync(
+        BridgeConversation conversation,
+        BridgeSettings bridge,
+        InboundMessage message,
+        Func<ApprovalRequest, Task<bool>> approve,
+        Loc loc,
+        Action<string>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(conversation);
+        ArgumentNullException.ThrowIfNull(bridge);
+        ArgumentNullException.ThrowIfNull(message);
+
+        long startedAt = Environment.TickCount64;
+        // AI 设置**每轮现读**,不吃桥接启动时的那份快照。
+        //
+        // 踩过:用户在设置窗口登录了订阅制供应商(OpenAI Codex),面板立刻好用,
+        // 而桥接手里那份 provider 还是登录之前的形态(Auth 仍是 ApiKey、没有 OAuth 配置),
+        // 于是 ResolveCredentialAsync 走了"取 API Key"那条岔路,把一个空 Key 发了出去 ——
+        // 群里看到的是 401「Could not parse your authentication token」,
+        // 而同一刻聊天面板一切正常,极难往"快照过期"上想。
+        //
+        // 代价是每轮多读一次 JSON,与一次模型调用比可以忽略;换来的是"面板里改了什么,
+        // 桥接下一句就跟上"——换模型、重新登录、改 MCP 配置,都不必再去重启桥接。
+        AiSettings ai = await store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        if (ResolveModel(ai, bridge) is not { } model)
+        {
+            return new BridgeTurn(loc["BridgeNoModel"], "", TimeSpan.Zero, 0);
+        }
+        ChatMode mode = conversation.ModeOverride ?? bridge.Mode;
+
+        // 目标服务器在**回合开始时**解析一次:工具箱要的是同步的 id 提供者,
+        // 而"这一轮在哪台机器上干活"本来就不该跑到一半换人。
+        SessionInfo? session = conversation.BoundTarget.Length > 0
+            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        var toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => session?.SessionId,
+            ApprovalHandler = approve,
+            Approval = bridge.Approval,
+            DisabledTools = new HashSet<string>(
+                (ai.DisabledBuiltinTools ?? "").Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase),
+            WebSearch = ai.WebSearch
+        };
+
+        IChatClient client = await store.CreateClientAsync(model, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var options = new ChatOptions
+        {
+            MaxOutputTokens = model.MaxTokens,
+            Temperature = model.Temperature,
+            TopP = model.TopP
+        };
+        AiSettingsStore.ApplyReasoning(options, model);
+        // 这一家端点不认的参数在这儿摘掉。机器人这条路与聊天面板发的是<b>同一批模型</b>,
+        // 少了这一步,订阅型的私有后端(ChatGPT 的 Codex 后端最典型)会整轮 400,
+        // 而且面板里好好的、只有机器人报错 —— 最难想到是这儿漏了。
+        AiSettingsStore.ApplyEndpointQuirks(options, model);
+
+        bool nativeSearch = mode != ChatMode.Chat
+                            && ai.WebSearch.Enabled
+                            && ai.WebSearch.PreferProviderNative
+                            && NativeWebSearch.IsSupported(model.Protocol);
+        if (mode != ChatMode.Chat)
+        {
+            mcp.Approval = bridge.Approval;
+            mcp.ApprovalHandler = approve;
+            IList<AITool> tools = toolbox.CreateTools(mode, nativeSearch);
+            if (mode == ChatMode.Agent && ai.McpServers.Any(s => s.Enabled))
+            {
+                (List<AITool> mcpTools, List<string> errors) =
+                    await mcp.GetToolsAsync(ai.McpServers, cancellationToken).ConfigureAwait(false);
+                foreach (AITool tool in mcpTools)
+                {
+                    tools.Add(tool);
+                }
+                if (errors.Count > 0)
+                {
+                    context.Log.Warn($"Bridge: MCP servers reported: {string.Join("; ", errors)}");
+                }
+            }
+            if (nativeSearch)
+            {
+                NativeWebSearch.Apply(options, model, tools, ai.WebSearch.MaxResults);
+            }
+            options.Tools = tools;
+            client = client.AsBuilder()
+                .UseFunctionInvocation(configure: c => c.MaximumIterationsPerRequest = MaxToolIterations)
+                .Build();
+        }
+
+        conversation.History.Add(new ChatMessage(ChatRole.User, message.Text));
+        await PersistAsync(conversation, "user", message.Text, cancellationToken).ConfigureAwait(false);
+
+        RequestContext request = ContextBuilder.Build(
+            BuildSystemPrompt(ai, bridge, mode, message, session, nativeSearch),
+            conversation.History, model.MaxInputTokens, model.MaxTokens);
+        // 有的订阅型端点不收 system 角色(ChatGPT 的 Codex 后端会回
+        // 400 {"detail":"System messages are not allowed"})。那时把系统提示词挪到
+        // Responses 协议自己的 instructions 字段上 —— 内容一个字不少,只是换了个位置。
+        if (!EndpointQuirks.Of(model.Provider).AllowSystemMessages)
+        {
+            options.Instructions = ContextBuilder.MoveSystemPromptOut(request.Messages);
+        }
+
+        var accumulated = new StringBuilder();
+        var updates = new List<ChatResponseUpdate>();
+        int toolCalls = 0;
+        string modelLabel = $"{model.ProviderName} / {model.Name}";
+        try
+        {
+            await foreach (ChatResponseUpdate update in client
+                               .GetStreamingResponseAsync(request.Messages, options, cancellationToken)
+                               .ConfigureAwait(false))
+            {
+                updates.Add(update);
+                foreach (AIContent content in update.Contents)
+                {
+                    switch (content)
+                    {
+                        case TextContent { Text.Length: > 0 } text:
+                            accumulated.Append(text.Text);
+                            progress?.Invoke(accumulated.ToString());
+                            break;
+
+                        case FunctionCallContent call:
+                            toolCalls++;
+                            // 进度里带一句"正在干什么" —— IM 那头看不到工具卡片,
+                            // 一分钟没动静会让人以为机器人死了。
+                            progress?.Invoke($"{accumulated}\n\n_{loc.F("BridgeRunningTool", call.Name)}_");
+                            break;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // 把<b>哪个模型</b>带进错误里。群里只看到一句 "401 Unauthorized" 时,
+            // 人第一反应会去查飞书的凭证 —— 而这条 401 来自模型服务商,两者差着十万八千里。
+            // ApiErrorText 顺带把 Anthropic 那种"只有一句 Status Code"的异常展开成服务端原话。
+            throw new InvalidOperationException(
+                $"{modelLabel}: {ApiErrorText.Describe(ex)}", ex);
+        }
+
+        ChatResponse response = updates.ToChatResponse();
+        conversation.History.AddMessages(response);
+        string reply = response.Text.Trim();
+        if (reply.Length > 0)
+        {
+            await PersistAsync(conversation, "assistant", reply, cancellationToken).ConfigureAwait(false);
+        }
+        client.Dispose();
+        return new BridgeTurn(
+            reply.Length > 0 ? reply : loc["BridgeEmptyReply"],
+            modelLabel,
+            TimeSpan.FromMilliseconds(Environment.TickCount64 - startedAt),
+            toolCalls);
+    }
+
+    /// <summary>桥接用哪个模型:设置里指定的优先,没指定就跟着面板当前那个。</summary>
+    private static ResolvedModel? ResolveModel(AiSettings ai, BridgeSettings bridge)
+        => ai.FindModel(string.IsNullOrWhiteSpace(bridge.ModelId) ? ai.ActiveModelId : bridge.ModelId)
+           ?? ai.ResolveModels().FirstOrDefault();
+
+    /// <summary>
+    /// 桥接侧的系统提示词。在面板那套之上补三件 IM 特有的事:
+    /// 回复要短、当前是谁在问、这个聊天绑的是哪台机器。
+    /// </summary>
+    private string BuildSystemPrompt(AiSettings ai, BridgeSettings bridge, ChatMode mode,
+        InboundMessage message, SessionInfo? session, bool nativeWebSearch)
+    {
+        var prompt = new StringBuilder(
+            "You are the VelaShell assistant, reachable from a team chat. " +
+            "You help with servers, shell commands, log analysis and DevOps questions. " +
+            $"Respond in the user's language (UI locale: {context.Host.Locale}). ");
+        // IM 不是聊天面板:没有折叠、没有滚动条,一大段 Markdown 在群里就是刷屏。
+        prompt.Append("You are replying INTO A CHAT MESSAGE: keep it short (a few lines), plain, and actionable. " +
+                      "No headings, no long tables. Put commands in fenced code blocks. " +
+                      "If the answer is long, give the conclusion first and offer details on request. ");
+        prompt.Append($"The person asking is {message.UserName} ")
+              .Append(message.IsGroup ? "in a group chat with other people watching. " : "in a direct message. ");
+        prompt.Append(session is not null
+            ? $"This chat is bound to the SSH session {session.Username}@{session.Host}:{session.Port}; tools act on that server. "
+            : "This chat is NOT bound to any connected SSH session, so server tools will fail — "
+              + "tell the user to run /sessions and then /use <user@host:port> to bind one. ");
+        if (nativeWebSearch)
+        {
+            prompt.Append(NativeWebSearch.SystemHint).Append(' ');
+        }
+        prompt.Append(mode switch
+        {
+            ChatMode.Agent =>
+                "You can call tools to inspect the bound session and to change things on it. " +
+                "Destructive commands and file writes are put to a human in this chat for approval — " +
+                "propose them deliberately, one at a time, and say what they will do. ",
+            ChatMode.Plan =>
+                "You are in PLAN mode: read-only tools only. Investigate freely, but you cannot change anything. " +
+                "Produce a short ordered plan with the exact commands, the risk, and the rollback. ",
+            _ => "You have no tools in this mode: answer from the conversation itself. "
+        });
+        if (!string.IsNullOrWhiteSpace(ai.SystemPrompt))
+        {
+            prompt.Append("\n\nOperator instructions: ").Append(ai.SystemPrompt.Trim());
+        }
+        if (!string.IsNullOrWhiteSpace(bridge.ExtraSystemPrompt))
+        {
+            prompt.Append("\n\n").Append(bridge.ExtraSystemPrompt.Trim());
+        }
+        return prompt.ToString();
+    }
+
+    private async Task PersistAsync(BridgeConversation conversation, string role, string text,
+        CancellationToken cancellationToken)
+    {
+        if (!history.IsAvailable || string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        int sequence = conversation.PersistedCount++;
+        await history.AppendAsync(conversation.ConversationId, conversation.CreatedAt, sequence, role, text,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeConversation.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeConversation.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Configuration;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 一个 IM 聊天(群或单聊)在桥接这边的状态:上下文、绑定的服务器、正在跑的那一轮。
+/// </summary>
+/// <remarks>
+/// 一个聊天一份,<b>串行</b>跑 —— <see cref="Gate" /> 保证同一个群里两个人同时发问时
+/// 后一条排队而不是插进上一轮的工具循环中间。跨群则各跑各的(总并发另有上限)。
+/// </remarks>
+public sealed class BridgeConversation(string channelId, string chatId)
+{
+    /// <summary>会话键(<c>渠道 id/聊天 id</c>)。</summary>
+    public string ChatKey { get; } = $"{channelId}/{chatId}";
+
+    /// <summary>所属渠道实例 id。</summary>
+    public string ChannelId { get; } = channelId;
+
+    /// <summary>聊天 id。</summary>
+    public string ChatId { get; } = chatId;
+
+    /// <summary>回消息的落点。</summary>
+    public OutboundTarget Reply => new(ChatId, ThreadId);
+
+    /// <summary>话题 id(平台支持话题时,回到同一串里)。</summary>
+    public string? ThreadId { get; set; }
+
+    /// <summary>历史库里的会话 id(翻回旧对话时用)。</summary>
+    public string ConversationId { get; set; } = Chat.ChatHistoryStore.NewConversationId();
+
+    /// <summary>送给模型的对话历史(不含系统提示词)。</summary>
+    public List<ChatMessage> History { get; } = [];
+
+    /// <summary>绑定的服务器(<c>user@host:port</c>;空 = 用渠道的默认绑定)。</summary>
+    public string BoundTarget { get; set; } = "";
+
+    /// <summary>本聊天单独设的模式(null = 跟随桥接设置)。</summary>
+    public ChatMode? ModeOverride { get; set; }
+
+    /// <summary>同一个聊天里的多条消息串行处理。</summary>
+    public SemaphoreSlim Gate { get; } = new(1, 1);
+
+    /// <summary>最后一次活动时刻(闲置回收看它)。</summary>
+    public DateTimeOffset LastActivity { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>本会话内"总是允许"过的操作键(见 <c>ApprovalRequest.RepeatKey</c>)。</summary>
+    public HashSet<string> AlwaysApproved { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>会话创建时刻(历史库里那个"每会话一个点"的摘要用它当时间戳)。</summary>
+    public DateTimeOffset CreatedAt { get; private set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>已落库的消息条数(= 下一条的序号)。</summary>
+    public int PersistedCount { get; set; }
+
+    /// <summary>正在跑的那一轮的取消源(<c>/stop</c> 用它掐掉)。</summary>
+    public CancellationTokenSource? Running { get; set; }
+
+    /// <summary>丢掉上下文,开一段新的。</summary>
+    public void Reset()
+    {
+        History.Clear();
+        PersistedCount = 0;
+        CreatedAt = DateTimeOffset.UtcNow;
+        AlwaysApproved.Clear();
+        ConversationId = Chat.ChatHistoryStore.NewConversationId();
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
@@ -1,0 +1,158 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Chat;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// IM 桥接的总装:读设置 → 造渠道 → 起 <see cref="ChannelHub" /> → 把消息接到
+/// <see cref="ConversationRouter" />。插件激活时调一次 <see cref="ReloadAsync" />,
+/// 设置页保存后再调一次即可 —— 起停的差异由它自己算。
+/// </summary>
+public sealed class BridgeService(IPluginContext context, AiSettingsStore aiStore) : IAsyncDisposable
+{
+    private readonly BridgeSettingsStore _bridgeStore = new(context);
+    private readonly ChatHistoryStore _history = new(context);
+    private readonly McpManager _mcp = new(context);
+    private readonly Loc _loc = new(context.Host.Locale);
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
+
+    private ChannelHub? _hub;
+    private ConversationRouter? _router;
+    private ImApprovalBroker? _approvals;
+    private Timer? _idleTimer;
+
+    /// <summary>
+    /// 配对码与待放行聊天。
+    /// </summary>
+    /// <remarks>
+    /// <b>由本服务持有而不是路由器</b> —— 设置页一保存就整体重建路由器,
+    /// 而"刚才有个群敲过门"这件事不该跟着一起丢掉,不然用户点保存的那一下就把线索抹了。
+    /// </remarks>
+    public PairingService Pairing { get; } = new();
+
+    /// <summary>任一渠道的状态变化(设置页刷状态灯)。</summary>
+    public event Action<ChannelStatus>? StatusChanged;
+
+    /// <summary>桥接此刻是不是开着。</summary>
+    public bool IsRunning => _hub is not null;
+
+    /// <summary>各渠道的状态快照。</summary>
+    public IReadOnlyList<ChannelStatus> Statuses => _hub?.Snapshot() ?? [];
+
+    /// <summary>读设置并把桥接调到该有的样子(关着就全停,开着就按配置起)。</summary>
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _reloadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            BridgeSettings bridge = await _bridgeStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+            AiSettings ai = await aiStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+            _loc.Switch(context.Host.Locale);
+            if (!bridge.Enabled || bridge.Channels.Count(c => c.Enabled) == 0)
+            {
+                await StopCoreAsync().ConfigureAwait(false);
+                return;
+            }
+            // 简单起见:重载一律整体重建。渠道的建连成本是一次握手,
+            // 而"只重启变了的那个"要比对的字段散在配置与机密两处,不值这个复杂度。
+            await StopCoreAsync().ConfigureAwait(false);
+            await _history.InitAsync(cancellationToken).ConfigureAwait(false);
+
+            var hub = new ChannelHub(context);
+            var approvals = new ImApprovalBroker(hub, context);
+            var runner = new BridgeAgentRunner(context, aiStore, _history, _mcp);
+            var router = new ConversationRouter(context, hub, runner, approvals, _bridgeStore, Pairing);
+            router.Apply(bridge, _loc);
+            hub.StatusChanged += status => StatusChanged?.Invoke(status);
+            _hub = hub;
+            _router = router;
+            _approvals = approvals;
+
+            foreach (ChannelConfig config in bridge.Channels.Where(c => c.Enabled))
+            {
+                IMessageChannel? channel = await ChannelFactory
+                    .CreateAsync(context, _bridgeStore, config, cancellationToken).ConfigureAwait(false);
+                if (channel is null)
+                {
+                    continue;
+                }
+                await hub.StartAsync(channel, router.HandleAsync).ConfigureAwait(false);
+            }
+            _idleTimer = new Timer(_ => _router?.EvictIdle(), null,
+                TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
+            context.Log.Info($"Bridge: started with {bridge.Channels.Count(c => c.Enabled)} channel(s), " +
+                             $"mode {bridge.Mode}, approval {bridge.Approval}.");
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// 放行一个待放行的聊天(设置页上那个「允许」按钮)。
+    /// </summary>
+    /// <remarks>
+    /// 桥接正开着就走路由器那条路(内存 + 落盘,立刻生效);没开着就只落盘 ——
+    /// 用户完全可能先在设置页把门开好,再去打开桥接。
+    /// </remarks>
+    public async Task AllowAsync(PendingChat chat, CancellationToken cancellationToken = default)
+    {
+        if (_router is { } router
+            && router.Settings.Channels.FirstOrDefault(c => c.Id == chat.ChannelId) is { } live)
+        {
+            await router.AllowChatAsync(live, chat.ChatId).ConfigureAwait(false);
+            return;
+        }
+        BridgeSettings stored = await _bridgeStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+        if (stored.Channels.FirstOrDefault(c => c.Id == chat.ChannelId) is { } config
+            && !config.AllowedChats.Contains(chat.ChatId))
+        {
+            config.AllowedChats.Add(chat.ChatId);
+            await _bridgeStore.SaveAsync(stored, cancellationToken).ConfigureAwait(false);
+        }
+        Pairing.Forget(chat.ChannelId, chat.ChatId);
+    }
+
+    /// <summary>停掉桥接(设置里关掉、或插件停用时)。</summary>
+    public async Task StopAsync()
+    {
+        await _reloadGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await StopCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
+    private async Task StopCoreAsync()
+    {
+        if (_idleTimer is { } timer)
+        {
+            await timer.DisposeAsync().ConfigureAwait(false);
+            _idleTimer = null;
+        }
+        _router?.CancelAll();
+        if (_hub is { } hub)
+        {
+            await hub.DisposeAsync().ConfigureAwait(false);
+        }
+        _hub = null;
+        _router = null;
+        _approvals = null;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        await _mcp.DisposeAsync().ConfigureAwait(false);
+        _reloadGate.Dispose();
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>桥接支持的 IM 平台。</summary>
+/// <remarks>
+/// 枚举值决定的是<b>入站传输</b>怎么走,这是各家真正的差别所在:
+/// 前三种都能从内网主动连出去(长连接 / 长轮询),桌面端开箱即用;
+/// <see cref="WeCom" /> 只有"平台回调到你的地址"一条路,必须有公网可达的入口。
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ChannelKind
+{
+    /// <summary>飞书 / Lark:官方长连接(WebSocket + pbbp2 帧),不需要公网地址。</summary>
+    Feishu,
+
+    /// <summary>钉钉:Stream 模式(WebSocket + JSON 帧),不需要公网地址。</summary>
+    DingTalk,
+
+    /// <summary>Telegram:Bot API 长轮询(getUpdates),不需要公网地址。</summary>
+    Telegram,
+
+    /// <summary>企业微信:只有回调 URL 一条路,需要公网可达的入口(见 WeCom 渠道的说明)。</summary>
+    WeCom
+}
+
+/// <summary>一个已配置的渠道。</summary>
+/// <remarks>
+/// <b>机密不在这里。</b>应用密钥(飞书 app_secret / 钉钉 clientSecret / Telegram bot token /
+/// 企微 secret 与 EncodingAESKey)一律走 <see cref="VelaShell.PluginSdk.Secrets.ISecretsApi" />,
+/// 键名见 <see cref="BridgeSettingsStore.SecretName" /> —— 这份配置是明文 JSON,躺在插件存储里。
+/// </remarks>
+public sealed class ChannelConfig
+{
+    /// <summary>渠道实例 id(机密键与会话键的命名空间;生成后不再变)。</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("n");
+
+    /// <summary>平台。</summary>
+    public ChannelKind Kind { get; set; }
+
+    /// <summary>是否启用(关掉即不建连,配置保留)。</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>显示名(设置页与日志里用;空则回落成平台名)。</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>飞书 app_id / 钉钉 clientId / 企微 corpid。Telegram 不用(令牌本身就是身份)。</summary>
+    public string AppId { get; set; } = "";
+
+    /// <summary>企业微信自建应用的 agentid。其它平台留空。</summary>
+    public string AgentId { get; set; } = "";
+
+    /// <summary>飞书:用国际版(larksuite.com)而不是国内版(feishu.cn)。</summary>
+    public bool International { get; set; }
+
+    /// <summary>企业微信回调:本机监听端口。</summary>
+    public int WebhookPort { get; set; } = 8378;
+
+    /// <summary>企业微信回调:本机监听路径。</summary>
+    public string WebhookPath { get; set; } = "/wecom";
+
+    /// <summary>
+    /// 允许对话的群 / 单聊 id 白名单。<b>空 = 一个都不放行</b> ——
+    /// 这是安全默认:一个能在生产机上敲命令的机器人,不该因为被拉进某个群就开始听话。
+    /// </summary>
+    public List<string> AllowedChats { get; set; } = [];
+
+    /// <summary>允许对话的用户 id 白名单(空 = 白名单群里的任何人都可以)。</summary>
+    public List<string> AllowedUsers { get; set; } = [];
+
+    /// <summary>
+    /// 能批准危险操作的用户 id(空 = 与 <see cref="AllowedUsers" /> 相同;两者都空 = 群里任何人)。
+    /// 单独一份是因为"能指使"和"能放行"本来就该分开 —— 值班的谁都能问,重启服务得管事的点头。
+    /// </summary>
+    public List<string> Approvers { get; set; } = [];
+
+    /// <summary>该渠道默认绑定的服务器(<c>user@host:port</c>,见 <see cref="BridgeSettings.ChatBindings" />)。</summary>
+    public string DefaultTarget { get; set; } = "";
+
+    /// <summary>平台名(显示名为空时的回落)。</summary>
+    public string Label => DisplayName.Length > 0 ? DisplayName : Kind.ToString();
+}
+
+/// <summary>IM 桥接的设置。</summary>
+/// <remarks>
+/// <b>刻意与 <see cref="AiSettings" /> 分开一个存储键。</b>聊天面板每次保存都是整份
+/// <c>AiSettings</c> 覆盖写(见 <c>AiPlugin.RememberPanelWidth</c> 的注释),桥接设置若混在里面,
+/// 用户在设置页改完渠道、再回聊天面板勾一个工具,就会被面板内存里那份旧值盖回去。
+/// </remarks>
+public sealed class BridgeSettings
+{
+    /// <summary>总开关。关着时插件启动后什么都不做(连一条网络连接都不建)。</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>已配置的渠道。</summary>
+    public List<ChannelConfig> Channels { get; set; } = [];
+
+    /// <summary>
+    /// 桥接这一侧的对话模式。<b>默认是计划模式</b> —— 只读工具。
+    /// 面板那边人就坐在屏幕前,点一下就能拦住;IM 这边发起人可能在地铁上,
+    /// 所以默认挡位比面板保守一档,要放开得用户自己去设置页点。
+    /// </summary>
+    public ChatMode Mode { get; set; } = ChatMode.Plan;
+
+    /// <summary>危险操作的审批方式(<see cref="ApprovalMode.Ask" /> 时审批卡片发到 IM 里等回复)。</summary>
+    public ApprovalMode Approval { get; set; } = ApprovalMode.Ask;
+
+    /// <summary>
+    /// 允许群里用 <c>/mode agent</c> 把挡位往<b>高</b>了调。默认关 ——
+    /// 提权该在 VelaShell 的设置页里做,不该由聊天里的一句话完成。
+    /// </summary>
+    public bool AllowModeEscalation { get; set; }
+
+    /// <summary>桥接用哪个模型(空 = 跟随聊天面板当前选中的那个)。</summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>同时最多跑几轮(跨全部渠道;每个会话本身天然串行)。</summary>
+    public int MaxConcurrentTurns { get; set; } = 2;
+
+    /// <summary>一轮最长跑多久(秒),到点掐掉并回一句超时。</summary>
+    public int TurnTimeoutSeconds { get; set; } = 300;
+
+    /// <summary>等审批回复的时限(秒),超时按拒绝处理。</summary>
+    public int ApprovalTimeoutSeconds { get; set; } = 120;
+
+    /// <summary>一个会话闲置多久后丢掉上下文(分钟)。</summary>
+    public int ConversationIdleMinutes { get; set; } = 120;
+
+    /// <summary>
+    /// 会话 → 服务器的绑定(键 <c>渠道 id/会话 id</c>,值 <c>user@host:port</c>)。
+    /// </summary>
+    /// <remarks>
+    /// <b>不存宿主的 SessionId。</b>那是一次连接的不透明 id,断线重连就换一个;
+    /// 存 <c>user@host:port</c> 才能在下一次连接后仍然对得上(解析见 <c>SessionTargets</c>)。
+    /// </remarks>
+    public Dictionary<string, string> ChatBindings { get; set; } = [];
+
+    /// <summary>额外追加给桥接侧的系统提示词(空 = 只用内置那段)。</summary>
+    public string ExtraSystemPrompt { get; set; } = "";
+}
+
+/// <summary>桥接设置的读写(配置走 Storage,机密走 Secrets)。</summary>
+public sealed class BridgeSettingsStore(IPluginContext context)
+{
+    private const string SettingsKey = "bridge";
+
+    /// <summary>某渠道某项机密的键名。</summary>
+    /// <param name="channelId">渠道实例 id。</param>
+    /// <param name="slot">机密槽位(<c>secret</c> / <c>token</c> / <c>aeskey</c>)。</param>
+    public static string SecretName(string channelId, string slot) => $"bridge:{channelId}:{slot}";
+
+    /// <summary>读取设置(没有则返回默认值)。</summary>
+    public async Task<BridgeSettings> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        JsonElement raw = await context.Storage.GetAsync<JsonElement>(SettingsKey, cancellationToken).ConfigureAwait(false);
+        if (raw.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return new BridgeSettings();
+        }
+        return raw.Deserialize<BridgeSettings>() ?? new BridgeSettings();
+    }
+
+    /// <summary>持久化设置。</summary>
+    public Task SaveAsync(BridgeSettings settings, CancellationToken cancellationToken = default)
+        => context.Storage.SetAsync(SettingsKey, settings, cancellationToken);
+
+    /// <summary>读某渠道的机密(未配置返回 null)。</summary>
+    public Task<string?> GetSecretAsync(string channelId, string slot, CancellationToken cancellationToken = default)
+        => context.Secrets.GetAsync(SecretName(channelId, slot), cancellationToken);
+
+    /// <summary>写某渠道的机密;传空串即删除。</summary>
+    public Task SetSecretAsync(string channelId, string slot, string? value, CancellationToken cancellationToken = default)
+        => string.IsNullOrEmpty(value)
+            ? context.Secrets.DeleteAsync(SecretName(channelId, slot), cancellationToken)
+            : context.Secrets.SetAsync(SecretName(channelId, slot), value, cancellationToken);
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelContracts.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelContracts.cs
@@ -1,0 +1,100 @@
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>渠道连接状态(设置页的状态灯用)。</summary>
+public enum ChannelState
+{
+    /// <summary>没在跑(未启用,或桥接总开关关着)。</summary>
+    Stopped,
+
+    /// <summary>正在建连或重连。</summary>
+    Connecting,
+
+    /// <summary>已连上,能收消息。</summary>
+    Connected,
+
+    /// <summary>连不上,正在按退避重试(<see cref="ChannelStatus.Detail" /> 是最后一次的错因)。</summary>
+    Faulted
+}
+
+/// <summary>一个渠道此刻的状态。</summary>
+/// <param name="ChannelId">渠道实例 id。</param>
+/// <param name="State">状态。</param>
+/// <param name="Detail">出错时的错因;正常时为 null。</param>
+/// <param name="ChangedAt">进入该状态的时刻。</param>
+public readonly record struct ChannelStatus(string ChannelId, ChannelState State, string? Detail, DateTimeOffset ChangedAt);
+
+/// <summary>
+/// 一条从 IM 收到的消息。各平台的信封在渠道实现里就剥掉了,
+/// 到桥接核心手上只剩这几项 —— 核心不认识任何平台。
+/// </summary>
+/// <param name="ChannelId">来自哪个渠道实例。</param>
+/// <param name="ChatId">群 / 单聊 id(回消息就发回这里)。</param>
+/// <param name="IsGroup">是不是群聊。</param>
+/// <param name="UserId">发送者 id(白名单与审批人比对的就是它)。</param>
+/// <param name="UserName">发送者显示名(只用于日志与回帖里的称呼)。</param>
+/// <param name="Text">纯文本正文(@机器人 的部分已剔除)。</param>
+/// <param name="MessageId">平台消息 id(去重与"回复这条"用)。</param>
+/// <param name="MentionsBot">群里是不是 @ 了机器人。单聊恒为 true。</param>
+/// <param name="ThreadId">话题 / 回复线程 id(平台支持时)。</param>
+public sealed record InboundMessage(
+    string ChannelId,
+    string ChatId,
+    bool IsGroup,
+    string UserId,
+    string UserName,
+    string Text,
+    string MessageId,
+    bool MentionsBot,
+    string? ThreadId = null)
+{
+    /// <summary>会话键:同一个渠道下的同一个聊天,共用一份上下文。</summary>
+    public string ChatKey => $"{ChannelId}/{ChatId}";
+}
+
+/// <summary>回消息的落点。</summary>
+/// <param name="ChatId">群 / 单聊 id。</param>
+/// <param name="ThreadId">话题 id(平台支持时,回到同一话题里)。</param>
+public readonly record struct OutboundTarget(string ChatId, string? ThreadId = null);
+
+/// <summary>渠道能做什么。桥接据此决定进度提示是"改同一条"还是"再发一条"。</summary>
+/// <param name="CanEdit">能不能改已发出的消息。</param>
+/// <param name="MaxMessageChars">单条消息的字符上限(超出由桥接切段)。</param>
+public readonly record struct ChannelCapabilities(bool CanEdit, int MaxMessageChars = 4000);
+
+/// <summary>
+/// 一个 IM 渠道。<b>只管收发,不认识 agent</b> —— 谁能说话、说了要不要干活,
+/// 全在 <see cref="ConversationRouter" /> 那一层。
+/// </summary>
+/// <remarks>
+/// <see cref="RunAsync" /> 的约定是"跑到断开为止":正常断开就返回,出错就抛。
+/// 重连退避统一由 <see cref="ChannelHub" /> 做 —— 四个平台的入站传输各不相同
+/// (长连接 / Stream / 长轮询 / 回调监听),但"断了要重来"的策略只该有一份。
+/// </remarks>
+public interface IMessageChannel : IAsyncDisposable
+{
+    /// <summary>渠道实例 id(= <see cref="ChannelConfig.Id" />)。</summary>
+    string Id { get; }
+
+    /// <summary>平台。</summary>
+    ChannelKind Kind { get; }
+
+    /// <summary>显示名。</summary>
+    string Label { get; }
+
+    /// <summary>能力。</summary>
+    ChannelCapabilities Capabilities { get; }
+
+    /// <summary>握手成功时触发一次(状态灯转绿,并把重连退避复位)。</summary>
+    event Action? Connected;
+
+    /// <summary>跑到断开为止。取消即正常收摊,其它异常交给上层重连。</summary>
+    /// <param name="onMessage">收到消息时的回调(桥接保证它不抛)。</param>
+    /// <param name="cancellationToken">停止信号。</param>
+    Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken);
+
+    /// <summary>发一条文本消息,返回平台消息 id(拿不到则返回 null)。</summary>
+    Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken);
+
+    /// <summary>改掉之前发出的一条消息。<see cref="ChannelCapabilities.CanEdit" /> 为 false 时不会被调用。</summary>
+    Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken);
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelFactory.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelFactory.cs
@@ -1,0 +1,93 @@
+using VelaShell.Plugin.Ai.Bridge.Channels.DingTalk;
+using VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+using VelaShell.Plugin.Ai.Bridge.Channels.Telegram;
+using VelaShell.Plugin.Ai.Bridge.Channels.WeCom;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>按配置造渠道实例。凭证缺一半就<b>不造</b>,并在日志里说清楚缺什么。</summary>
+internal static class ChannelFactory
+{
+    /// <summary>造一个渠道;配置不完整或平台还没接就返回 null(由调用方跳过)。</summary>
+    public static async Task<IMessageChannel?> CreateAsync(IPluginContext context, BridgeSettingsStore store,
+        ChannelConfig config, CancellationToken cancellationToken)
+    {
+        string? secret = await store.GetSecretAsync(config.Id, "secret", cancellationToken).ConfigureAwait(false);
+        switch (config.Kind)
+        {
+            case ChannelKind.Feishu:
+                if (string.IsNullOrWhiteSpace(config.AppId) || string.IsNullOrWhiteSpace(secret))
+                {
+                    context.Log.Warn($"Bridge: {config.Label} needs an App ID and an App Secret; skipping it.");
+                    return null;
+                }
+                return new FeishuChannel(config, secret, context);
+
+            case ChannelKind.DingTalk:
+                if (string.IsNullOrWhiteSpace(config.AppId) || string.IsNullOrWhiteSpace(secret))
+                {
+                    context.Log.Warn($"Bridge: {config.Label} needs a Client ID (AppKey) and Client Secret; skipping it.");
+                    return null;
+                }
+                return new DingTalkChannel(config, secret, context);
+
+            case ChannelKind.Telegram:
+                // Telegram 只有一个令牌,它同时是身份与凭据,所以不看 AppId
+                if (string.IsNullOrWhiteSpace(secret))
+                {
+                    context.Log.Warn($"Bridge: {config.Label} needs a bot token; skipping it.");
+                    return null;
+                }
+                return new TelegramChannel(config, secret, context);
+
+            case ChannelKind.WeCom:
+            {
+                // 企微要三份东西:corpsecret、回调 Token、EncodingAESKey。缺哪个说哪个 ——
+                // 三个空框里到底少填了哪一个,不点破的话用户只会看到"连不上"。
+                string? callbackToken = await store.GetSecretAsync(config.Id, "token", cancellationToken).ConfigureAwait(false);
+                string? aesKey = await store.GetSecretAsync(config.Id, "aeskey", cancellationToken).ConfigureAwait(false);
+                List<string> missing = [];
+                if (string.IsNullOrWhiteSpace(config.AppId))
+                {
+                    missing.Add("CorpID");
+                }
+                if (string.IsNullOrWhiteSpace(config.AgentId))
+                {
+                    missing.Add("AgentID");
+                }
+                if (string.IsNullOrWhiteSpace(secret))
+                {
+                    missing.Add("Secret");
+                }
+                if (string.IsNullOrWhiteSpace(callbackToken))
+                {
+                    missing.Add("callback Token");
+                }
+                if (string.IsNullOrWhiteSpace(aesKey))
+                {
+                    missing.Add("EncodingAESKey");
+                }
+                if (missing.Count > 0)
+                {
+                    context.Log.Warn($"Bridge: {config.Label} is missing {string.Join(", ", missing)}; skipping it.");
+                    return null;
+                }
+                try
+                {
+                    return new WeComChannel(config, secret!, callbackToken!, aesKey!, context);
+                }
+                catch (Exception ex) when (ex is ArgumentException or FormatException)
+                {
+                    // EncodingAESKey 填错(长度/字符集不对)在构造时就炸,别让它变成一条重连风暴
+                    context.Log.Error($"Bridge: {config.Label} has an unusable EncodingAESKey: {ex.Message}");
+                    return null;
+                }
+            }
+
+            default:
+                context.Log.Warn($"Bridge: channel type {config.Kind} is not wired up yet; skipping {config.Label}.");
+                return null;
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
@@ -1,0 +1,202 @@
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 渠道的起停与重连。四个平台的入站传输各不相同,但"断了要重来、重来要退避、
+/// 连上了要把退避复位"这套策略只该有一份 —— 就在这里。
+/// </summary>
+public sealed class ChannelHub(IPluginContext context) : IAsyncDisposable
+{
+    /// <summary>重连退避的上限。再久用户就该怀疑是不是配错了,而不是等它自己好。</summary>
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(60);
+
+    private sealed class Entry(IMessageChannel channel)
+    {
+        public IMessageChannel Channel { get; } = channel;
+        public CancellationTokenSource Cts { get; } = new();
+        public Task? Loop { get; set; }
+        public ChannelStatus Status { get; set; } = new(channel.Id, ChannelState.Stopped, null, DateTimeOffset.UtcNow);
+    }
+
+    private readonly Dictionary<string, Entry> _entries = [];
+    private readonly Lock _sync = new();
+
+    /// <summary>任一渠道的状态变化(设置页据此刷状态灯)。</summary>
+    public event Action<ChannelStatus>? StatusChanged;
+
+    /// <summary>当前全部渠道的状态快照。</summary>
+    public IReadOnlyList<ChannelStatus> Snapshot()
+    {
+        lock (_sync)
+        {
+            return [.. _entries.Values.Select(e => e.Status)];
+        }
+    }
+
+    /// <summary>挂上一个渠道并开始跑(已存在同 id 则先停掉旧的)。</summary>
+    public async Task StartAsync(IMessageChannel channel, Func<InboundMessage, Task> onMessage)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        await StopAsync(channel.Id).ConfigureAwait(false);
+        var entry = new Entry(channel);
+        lock (_sync)
+        {
+            _entries[channel.Id] = entry;
+        }
+        channel.Connected += () => SetStatus(entry, ChannelState.Connected, null);
+        entry.Loop = RunWithRetryAsync(entry, onMessage);
+    }
+
+    /// <summary>停掉一个渠道并释放它。</summary>
+    public async Task StopAsync(string channelId)
+    {
+        Entry? entry;
+        lock (_sync)
+        {
+            if (!_entries.Remove(channelId, out entry))
+            {
+                return;
+            }
+        }
+        await entry.Cts.CancelAsync().ConfigureAwait(false);
+        if (entry.Loop is { } loop)
+        {
+            // 循环里已经把异常都吞掉了,这里只是等它收摊
+            await loop.ConfigureAwait(false);
+        }
+        entry.Cts.Dispose();
+        await entry.Channel.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>停掉全部渠道。</summary>
+    public async Task StopAllAsync()
+    {
+        string[] ids;
+        lock (_sync)
+        {
+            ids = [.. _entries.Keys];
+        }
+        foreach (string id in ids)
+        {
+            await StopAsync(id).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>往某渠道发一条消息(渠道已停则静默丢弃 —— 掉线时不该把整轮拖崩)。</summary>
+    public async Task<string?> SendAsync(string channelId, OutboundTarget target, string text,
+        CancellationToken cancellationToken)
+    {
+        if (Find(channelId) is not { } channel)
+        {
+            return null;
+        }
+        try
+        {
+            return await channel.SendAsync(target, text, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            context.Log.Warn($"Bridge: sending to {channel.Label} failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>改掉之前发出的一条消息(渠道不支持编辑或已停则什么都不做)。</summary>
+    public async Task EditAsync(string channelId, OutboundTarget target, string messageId, string text,
+        CancellationToken cancellationToken)
+    {
+        if (Find(channelId) is not { Capabilities.CanEdit: true } channel)
+        {
+            return;
+        }
+        try
+        {
+            await channel.EditAsync(target, messageId, text, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            context.Log.Warn($"Bridge: editing a message on {channel.Label} failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>取某渠道的能力(找不到则返回默认值)。</summary>
+    public ChannelCapabilities CapabilitiesOf(string channelId)
+        => Find(channelId)?.Capabilities ?? new ChannelCapabilities(false);
+
+    private IMessageChannel? Find(string channelId)
+    {
+        lock (_sync)
+        {
+            return _entries.TryGetValue(channelId, out Entry? entry) ? entry.Channel : null;
+        }
+    }
+
+    private async Task RunWithRetryAsync(Entry entry, Func<InboundMessage, Task> onMessage)
+    {
+        TimeSpan backoff = TimeSpan.FromSeconds(1);
+        CancellationToken token = entry.Cts.Token;
+        while (!token.IsCancellationRequested)
+        {
+            SetStatus(entry, ChannelState.Connecting, null);
+            try
+            {
+                // 连上的那一刻由渠道自己报(Connected 事件),这里只负责"跑到断为止"
+                await entry.Channel.RunAsync(Guard(onMessage), token).ConfigureAwait(false);
+                // 正常返回 = 对端把连接关了。这在长连接上是常事(平台会定期换端),
+                // 所以不当故障:马上重来,退避也不涨。
+                backoff = TimeSpan.FromSeconds(1);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                context.Log.Warn($"Bridge: {entry.Channel.Label} dropped ({ex.Message}); retrying in {backoff.TotalSeconds:0}s.");
+                SetStatus(entry, ChannelState.Faulted, ex.Message);
+            }
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+            try
+            {
+                await Task.Delay(backoff, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            backoff = backoff >= MaxBackoff ? MaxBackoff : backoff * 2;
+        }
+        SetStatus(entry, ChannelState.Stopped, null);
+    }
+
+    /// <summary>
+    /// 把消息回调裹一层。渠道实现里那条读循环不该因为"这条消息处理出错"就整个断掉 ——
+    /// 断掉的代价是重连,而重连期间的消息平台不会补发。
+    /// </summary>
+    private Func<InboundMessage, Task> Guard(Func<InboundMessage, Task> onMessage)
+        => async message =>
+        {
+            try
+            {
+                await onMessage(message).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                context.Log.Error($"Bridge: handling a message from {message.ChatKey} failed: {ex}");
+            }
+        };
+
+    private void SetStatus(Entry entry, ChannelState state, string? detail)
+    {
+        var status = new ChannelStatus(entry.Channel.Id, state, detail, DateTimeOffset.UtcNow);
+        entry.Status = status;
+        StatusChanged?.Invoke(status);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() => await StopAllAsync().ConfigureAwait(false);
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelProbe.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelProbe.cs
@@ -1,0 +1,149 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+using VelaShell.PluginSdk.Logging;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>一次凭证体检的结果。</summary>
+/// <param name="Ok">凭证能用。</param>
+/// <param name="Summary">给用户看的一句话:成了是机器人叫什么,不成是卡在哪一步。</param>
+/// <param name="InviteUrl">
+/// 把机器人加进群的链接(拿得到时)。设置页把它渲染成二维码 ——
+/// 手机扫一下直接跳过去,省掉在手机上搜应用名这一步。
+/// </param>
+public readonly record struct ChannelProbeResult(bool Ok, string Summary, string? InviteUrl);
+
+/// <summary>
+/// 保存之前先把凭证拿去试一次。
+/// </summary>
+/// <remarks>
+/// <b>为什么值得单独做一个。</b>接飞书最常见的两种翻车不是密钥填错,而是
+/// 「事件订阅没改成长连接」与「改完没发布版本」—— 这两种情况下密钥完全正确,
+/// 桥接却一条消息都收不到。原来只能保存、重连、翻日志去猜;现在填完点一下就知道卡在哪。
+/// <para>
+/// 探测<b>只读</b>:换一次令牌、查一次自身信息、问一次长连接接入点。不发消息、不改任何配置。
+/// </para>
+/// </remarks>
+internal static class ChannelProbe
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    /// <summary>按渠道类型做对应的体检。</summary>
+    public static async Task<ChannelProbeResult> TestAsync(ChannelConfig config, string secret,
+        string encodingAesKey, IPluginLogger log, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return config.Kind switch
+            {
+                ChannelKind.Feishu => await FeishuAsync(config, secret, log, cancellationToken).ConfigureAwait(false),
+                ChannelKind.DingTalk => await DingTalkAsync(config, secret, cancellationToken).ConfigureAwait(false),
+                ChannelKind.Telegram => await TelegramAsync(secret, cancellationToken).ConfigureAwait(false),
+                _ => await WeComAsync(config, secret, encodingAesKey, cancellationToken).ConfigureAwait(false)
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // 体检本身失败也是一种结果,不该把设置页炸掉
+            return new ChannelProbeResult(false, ex.Message, null);
+        }
+    }
+
+    private static async Task<ChannelProbeResult> FeishuAsync(ChannelConfig config, string secret,
+        IPluginLogger log, CancellationToken cancellationToken)
+    {
+        using var api = new FeishuApi(config.AppId, secret, config.International, log);
+        await api.TokenAsync(cancellationToken).ConfigureAwait(false);
+
+        // 走到这里说明 AppID/Secret 是对的。接下来问长连接接入点 ——
+        // 这一步失败几乎总是「事件订阅没选长连接」或「改了没发版本」,而不是凭证问题。
+        try
+        {
+            await api.EndpointAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new ChannelProbeResult(false,
+                $"credentials OK, but the long-connection endpoint was refused: {ex.Message}", null);
+        }
+        string? botOpenId = await api.BotOpenIdAsync(cancellationToken).ConfigureAwait(false);
+        // 飞书<b>没有</b>"扫码把机器人加进群"的链接。applink 的 client/app/open 是打开小程序页面用的,
+        // 纯机器人应用根本没有那个页面 —— 拿它生成二维码,扫出来是"此页面无效"(实测)。
+        // 官方路径只有客户端里的 群设置 → 群机器人 → 添加机器人,所以这里不给链接,
+        // 由界面直接把这句话写出来。给一个扫了不能用的码,比不给码更糟。
+        return new ChannelProbeResult(true,
+            botOpenId is { Length: > 0 } ? $"connected (bot {botOpenId})" : "connected",
+            null);
+    }
+
+    private static async Task<ChannelProbeResult> DingTalkAsync(ChannelConfig config, string secret,
+        CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await Http.PostAsJsonAsync(
+            "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+            new { appKey = config.AppId, appSecret = secret }, cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+        return document.RootElement.TryGetProperty("accessToken", out _)
+            ? new ChannelProbeResult(true, "credentials OK", null)
+            : new ChannelProbeResult(false, Describe(document.RootElement, "message", "code"), null);
+    }
+
+    private static async Task<ChannelProbeResult> TelegramAsync(string token, CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await Http
+            .GetAsync($"https://api.telegram.org/bot{token}/getMe", cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+        JsonElement root = document.RootElement;
+        if (!root.TryGetProperty("ok", out JsonElement ok) || !ok.GetBoolean())
+        {
+            return new ChannelProbeResult(false, Describe(root, "description", "error_code"), null);
+        }
+        string username = root.TryGetProperty("result", out JsonElement result)
+                          && result.TryGetProperty("username", out JsonElement name)
+            ? name.GetString() ?? ""
+            : "";
+        // startgroup=true 让扫码的人直接进「把这个机器人加进哪个群」的选择界面
+        return new ChannelProbeResult(true, $"connected (@{username})",
+            username.Length > 0 ? $"https://t.me/{username}?startgroup=true" : null);
+    }
+
+    private static async Task<ChannelProbeResult> WeComAsync(ChannelConfig config, string secret,
+        string encodingAesKey, CancellationToken cancellationToken)
+    {
+        // AESKey 是回调那一侧的东西,换令牌用不到它;但填错了回调必然全军覆没,
+        // 所以在这里顺手验一次格式 —— 比等到平台第一次推消息时才发现要早得多。
+        if (encodingAesKey.Length > 0)
+        {
+            try
+            {
+                Channels.WeCom.WeComCrypto.ParseKey(encodingAesKey);
+            }
+            catch (ArgumentException ex)
+            {
+                return new ChannelProbeResult(false, $"EncodingAESKey is unusable: {ex.Message}", null);
+            }
+        }
+        string url = $"https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid={Uri.EscapeDataString(config.AppId)}"
+                     + $"&corpsecret={Uri.EscapeDataString(secret)}";
+        using HttpResponseMessage response = await Http.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+        return document.RootElement.TryGetProperty("access_token", out _)
+            ? new ChannelProbeResult(true, "credentials OK", null)
+            : new ChannelProbeResult(false, Describe(document.RootElement, "errmsg", "errcode"), null);
+    }
+
+    private static string Describe(JsonElement root, string messageField, string codeField)
+    {
+        string message = root.TryGetProperty(messageField, out JsonElement m) ? m.GetString() ?? "" : "";
+        string code = root.TryGetProperty(codeField, out JsonElement c) ? c.ToString() : "";
+        return message.Length > 0 ? $"{message} ({code})" : $"rejected ({code})";
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
@@ -1,0 +1,310 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.DingTalk;
+
+/// <summary>
+/// 钉钉渠道:Stream 模式(WebSocket + JSON 帧)。
+/// </summary>
+/// <remarks>
+/// 与飞书同样是"从内网连出去",但帧是明文 JSON 而不是 protobuf,协议本身官方有公开文档,
+/// 所以这一份比飞书那份短得多。
+///
+/// <para><b>发消息不能走 sessionWebhook。</b>事件里带的那个回调地址只能发 5 条、有效期
+/// 一个半小时,而一轮对话光是"占位 + 审批 + 结果"就可能超。所以统一走带令牌的
+/// <c>robot/groupMessages/send</c> 与 <c>robot/oToMessages/batchSend</c>;代价是发消息时
+/// 需要知道这个会话是群还是单聊,所以收到消息时把这点记下来(见 <see cref="_routes" />)。</para>
+/// </remarks>
+internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret, IPluginContext context)
+    : IMessageChannel
+{
+    private const string ApiBase = "https://api.dingtalk.com";
+    private const int MaxFrameBytes = 4 * 1024 * 1024;
+
+    /// <summary>会话 id → 发消息需要的那点信息(收到消息时记下)。</summary>
+    private readonly ConcurrentDictionary<string, (bool IsGroup, string UserId, string RobotCode)> _routes = new();
+
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private readonly SemaphoreSlim _tokenGate = new(1, 1);
+    private string? _token;
+    private DateTimeOffset _tokenExpiresAt = DateTimeOffset.MinValue;
+    private ClientWebSocket? _socket;
+
+    /// <inheritdoc />
+    public string Id => config.Id;
+
+    /// <inheritdoc />
+    public ChannelKind Kind => ChannelKind.DingTalk;
+
+    /// <inheritdoc />
+    public string Label => config.Label;
+
+    /// <inheritdoc />
+    /// <remarks>钉钉的普通机器人消息发出去就改不了,所以进度只能另发一条 —— 由桥接决定别刷屏。</remarks>
+    public ChannelCapabilities Capabilities => new(false, 3000);
+
+    /// <inheritdoc />
+    public event Action? Connected;
+
+    /// <inheritdoc />
+    public async Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        (string endpoint, string ticket) = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var socket = new ClientWebSocket();
+        socket.Options.Proxy = HttpClient.DefaultProxy;
+        await socket.ConnectAsync(new Uri($"{endpoint}?ticket={Uri.EscapeDataString(ticket)}"), cancellationToken)
+            .ConfigureAwait(false);
+        _socket = socket;
+        Connected?.Invoke();
+        context.Log.Info($"Bridge: {Label} connected to DingTalk stream.");
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+            {
+                using var message = new MemoryStream();
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        return;
+                    }
+                    message.Write(buffer, 0, result.Count);
+                    if (message.Length > MaxFrameBytes)
+                    {
+                        throw new InvalidDataException("DingTalk sent an oversized websocket message.");
+                    }
+                }
+                while (!result.EndOfMessage);
+
+                if (!await DispatchAsync(socket, message.ToArray(), onMessage, cancellationToken).ConfigureAwait(false))
+                {
+                    return; // 平台要求断开
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            _socket = null;
+        }
+    }
+
+    /// <summary>处理一帧;返回 false 表示平台让我们断开。</summary>
+    private async Task<bool> DispatchAsync(ClientWebSocket socket, byte[] raw,
+        Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        using JsonDocument document = JsonDocument.Parse(raw);
+        JsonElement root = document.RootElement;
+        string type = root.TryGetProperty("type", out JsonElement t) ? t.GetString() ?? "" : "";
+        JsonElement headers = root.TryGetProperty("headers", out JsonElement h) ? h : default;
+        string topic = headers.ValueKind == JsonValueKind.Object && headers.TryGetProperty("topic", out JsonElement tp)
+            ? tp.GetString() ?? ""
+            : "";
+        string messageId = headers.ValueKind == JsonValueKind.Object
+                           && headers.TryGetProperty("messageId", out JsonElement mid)
+            ? mid.GetString() ?? ""
+            : "";
+        string data = root.TryGetProperty("data", out JsonElement d) ? d.GetString() ?? "" : "";
+
+        switch (type)
+        {
+            case "SYSTEM" when topic == "ping":
+                // ping 的 data 里带一个 opaque,原样回去即可
+                await RespondAsync(socket, messageId, data, cancellationToken).ConfigureAwait(false);
+                return true;
+
+            case "SYSTEM" when topic == "disconnect":
+                context.Log.Info($"Bridge: {Label} was asked to disconnect by DingTalk; reconnecting.");
+                return false;
+
+            case "CALLBACK" when topic == "/v1.0/im/bot/messages/get":
+                // 先应答再干活:平台等的是"收到了",不是"处理完了"
+                await RespondAsync(socket, messageId, "{}", cancellationToken).ConfigureAwait(false);
+                if (Parse(data) is { } inbound)
+                {
+                    await onMessage(inbound).ConfigureAwait(false);
+                }
+                return true;
+
+            default:
+                if (messageId.Length > 0)
+                {
+                    await RespondAsync(socket, messageId, "{}", cancellationToken).ConfigureAwait(false);
+                }
+                return true;
+        }
+    }
+
+    private static async Task RespondAsync(ClientWebSocket socket, string messageId, string data,
+        CancellationToken cancellationToken)
+    {
+        if (socket.State != WebSocketState.Open)
+        {
+            return;
+        }
+        string payload = JsonSerializer.Serialize(new
+        {
+            code = 200,
+            headers = new { contentType = "application/json", messageId },
+            message = "OK",
+            data
+        });
+        await socket.SendAsync(Encoding.UTF8.GetBytes(payload), WebSocketMessageType.Text, true, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private InboundMessage? Parse(string data)
+    {
+        if (data.Length == 0)
+        {
+            return null;
+        }
+        using JsonDocument document = JsonDocument.Parse(data);
+        JsonElement root = document.RootElement;
+        string messageType = root.TryGetProperty("msgtype", out JsonElement mt) ? mt.GetString() ?? "" : "";
+        if (messageType != "text")
+        {
+            return null;
+        }
+        string text = root.TryGetProperty("text", out JsonElement textNode)
+                      && textNode.TryGetProperty("content", out JsonElement content)
+            ? content.GetString()?.Trim() ?? ""
+            : "";
+        string chatId = root.TryGetProperty("conversationId", out JsonElement cid) ? cid.GetString() ?? "" : "";
+        // conversationType: "1" = 单聊, "2" = 群聊
+        bool isGroup = root.TryGetProperty("conversationType", out JsonElement ct) && ct.GetString() == "2";
+        string userId = root.TryGetProperty("senderStaffId", out JsonElement staff) ? staff.GetString() ?? "" : "";
+        string userName = root.TryGetProperty("senderNick", out JsonElement nick) ? nick.GetString() ?? "" : userId;
+        string messageId = root.TryGetProperty("msgId", out JsonElement mid) ? mid.GetString() ?? "" : "";
+        string robotCode = root.TryGetProperty("robotCode", out JsonElement rc) ? rc.GetString() ?? "" : config.AppId;
+        if (chatId.Length == 0)
+        {
+            return null;
+        }
+        // 群聊发消息要 openConversationId(就是这个 conversationId),单聊要 userId ——
+        // 两者只在这条事件里出现一次,所以收到时就记下来
+        _routes[chatId] = (isGroup, userId, robotCode.Length > 0 ? robotCode : config.AppId);
+        // 钉钉只会把 @ 了机器人的群消息推过来,所以群里收到就等于被 @ 了
+        return new InboundMessage(config.Id, chatId, isGroup, userId, userName, text, messageId, true);
+    }
+
+    private async Task<(string Endpoint, string Ticket)> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await _http.PostAsJsonAsync(
+            $"{ApiBase}/v1.0/gateway/connections/open",
+            new
+            {
+                clientId = config.AppId,
+                clientSecret,
+                ua = "velashell-bridge/1.0",
+                subscriptions = new[]
+                {
+                    new { type = "CALLBACK", topic = "/v1.0/im/bot/messages/get" }
+                }
+            }, cancellationToken).ConfigureAwait(false);
+        string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(body);
+        JsonElement root = document.RootElement;
+        if (!root.TryGetProperty("endpoint", out JsonElement endpoint) || !root.TryGetProperty("ticket", out JsonElement ticket))
+        {
+            throw new InvalidOperationException($"DingTalk refused the stream connection: {Truncate(body)}");
+        }
+        return (endpoint.GetString()!, ticket.GetString()!);
+    }
+
+    private async Task<string> TokenAsync(CancellationToken cancellationToken)
+    {
+        await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_token is { } cached && DateTimeOffset.UtcNow < _tokenExpiresAt)
+            {
+                return cached;
+            }
+            using HttpResponseMessage response = await _http.PostAsJsonAsync($"{ApiBase}/v1.0/oauth2/accessToken",
+                new { appKey = config.AppId, appSecret = clientSecret }, cancellationToken).ConfigureAwait(false);
+            string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            using JsonDocument document = JsonDocument.Parse(body);
+            if (!document.RootElement.TryGetProperty("accessToken", out JsonElement token))
+            {
+                throw new InvalidOperationException($"DingTalk token request failed: {Truncate(body)}");
+            }
+            _token = token.GetString();
+            int expire = document.RootElement.TryGetProperty("expireIn", out JsonElement e) ? e.GetInt32() : 7200;
+            _tokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expire - 300));
+            return _token!;
+        }
+        finally
+        {
+            _tokenGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
+    {
+        if (!_routes.TryGetValue(target.ChatId, out (bool IsGroup, string UserId, string RobotCode) route))
+        {
+            context.Log.Warn($"Bridge: {Label} has no route for conversation {target.ChatId}; dropping the reply.");
+            return null;
+        }
+        string token = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        string parameters = JsonSerializer.Serialize(new { content = text });
+        object body = route.IsGroup
+            ? new
+            {
+                msgKey = "sampleText",
+                msgParam = parameters,
+                openConversationId = target.ChatId,
+                robotCode = route.RobotCode
+            }
+            : new
+            {
+                msgKey = "sampleText",
+                msgParam = parameters,
+                robotCode = route.RobotCode,
+                userIds = new[] { route.UserId }
+            };
+        string path = route.IsGroup ? "/v1.0/robot/groupMessages/send" : "/v1.0/robot/oToMessages/batchSend";
+        using var request = new HttpRequestMessage(HttpMethod.Post, ApiBase + path)
+        {
+            Content = JsonContent.Create(body)
+        };
+        request.Headers.TryAddWithoutValidation("x-acs-dingtalk-access-token", token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        string payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"DingTalk {path} failed ({(int)response.StatusCode}): {Truncate(payload)}");
+        }
+        // 群消息返回 processQueryKey,单聊返回 processQueryKey/flowControlledStaffIdList;
+        // 两者都不是"可以再改的消息 id",所以不往上报。
+        return null;
+    }
+
+    /// <inheritdoc />
+    public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
+        => Task.CompletedTask; // Capabilities.CanEdit = false,不会走到这里
+
+    private static string Truncate(string text) => text.Length <= 200 ? text : string.Concat(text.AsSpan(0, 200), "…");
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _socket?.Abort();
+        _http.Dispose();
+        _tokenGate.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
@@ -1,0 +1,227 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using VelaShell.PluginSdk.Logging;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+
+/// <summary>
+/// 飞书开放平台的 REST 调用:租户令牌、发消息、改消息、取机器人自己的 open_id。
+/// </summary>
+/// <remarks>
+/// 只用到 <c>im.v1</c> 的三个接口,所以不引任何飞书 SDK。
+/// <see cref="HttpClient" /> 走默认代理 —— 宿主启动时把
+/// <c>HttpClient.DefaultProxy</c> 换成了自己的 <c>VelaWebProxy</c>(设置 → 代理),
+/// 不显式设 Proxy 才能跟着全局那份走。
+/// </remarks>
+internal sealed class FeishuApi(string appId, string appSecret, bool international, IPluginLogger log) : IDisposable
+{
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private readonly SemaphoreSlim _tokenGate = new(1, 1);
+    private string? _token;
+    private DateTimeOffset _tokenExpiresAt = DateTimeOffset.MinValue;
+    private string? _botOpenId;
+
+    /// <summary>开放平台域名(国内 / 国际两套)。</summary>
+    public string Domain { get; } = international ? "https://open.larksuite.com" : "https://open.feishu.cn";
+
+    /// <summary>取租户令牌(带缓存;快到期就提前换)。</summary>
+    public async Task<string> TokenAsync(CancellationToken cancellationToken)
+    {
+        await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_token is { } cached && DateTimeOffset.UtcNow < _tokenExpiresAt)
+            {
+                return cached;
+            }
+            using HttpResponseMessage response = await _http.PostAsJsonAsync(
+                $"{Domain}/open-apis/auth/v3/tenant_access_token/internal",
+                new { app_id = appId, app_secret = appSecret }, cancellationToken).ConfigureAwait(false);
+            using JsonDocument document = await ReadAsync(response, cancellationToken).ConfigureAwait(false);
+            JsonElement root = document.RootElement;
+            int code = root.TryGetProperty("code", out JsonElement c) ? c.GetInt32() : -1;
+            if (code != 0 || !root.TryGetProperty("tenant_access_token", out JsonElement tokenElement))
+            {
+                throw new InvalidOperationException(
+                    $"Feishu token request failed: {Message(root)} (code {code}).");
+            }
+            _token = tokenElement.GetString();
+            int expire = root.TryGetProperty("expire", out JsonElement e) ? e.GetInt32() : 7200;
+            // 提前 5 分钟换,免得刚好卡在过期那一秒发消息
+            _tokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expire - 300));
+            return _token!;
+        }
+        finally
+        {
+            _tokenGate.Release();
+        }
+    }
+
+    /// <summary>往一个会话发文本,返回消息 id。</summary>
+    public async Task<string?> SendTextAsync(string chatId, string text, CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await CallAsync(HttpMethod.Post,
+            "/open-apis/im/v1/messages?receive_id_type=chat_id",
+            new
+            {
+                receive_id = chatId,
+                msg_type = "text",
+                content = JsonSerializer.Serialize(new { text })
+            }, cancellationToken).ConfigureAwait(false);
+        return document.RootElement.TryGetProperty("data", out JsonElement data)
+               && data.TryGetProperty("message_id", out JsonElement id)
+            ? id.GetString()
+            : null;
+    }
+
+    /// <summary>
+    /// 改一条已发出的文本消息。
+    /// </summary>
+    /// <remarks>
+    /// 平台对<b>同一条消息</b>的编辑次数有上限(实测量级为个位到二十次),所以流式进度
+    /// 必须限流 —— 见 <c>ConversationRouter</c> 里的编辑间隔与次数预算。
+    /// </remarks>
+    public async Task EditTextAsync(string messageId, string text, CancellationToken cancellationToken)
+    {
+        using JsonDocument _ = await CallAsync(HttpMethod.Put,
+            $"/open-apis/im/v1/messages/{Uri.EscapeDataString(messageId)}",
+            new { msg_type = "text", content = JsonSerializer.Serialize(new { text }) },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 机器人自己的 open_id。群里判断"这条消息 @ 的是不是我"要用它。
+    /// </summary>
+    public async Task<string?> BotOpenIdAsync(CancellationToken cancellationToken)
+    {
+        if (_botOpenId is { } cached)
+        {
+            return cached;
+        }
+        try
+        {
+            using JsonDocument document = await CallAsync(HttpMethod.Get, "/open-apis/bot/v3/info", null, cancellationToken)
+                .ConfigureAwait(false);
+            if (document.RootElement.TryGetProperty("bot", out JsonElement bot)
+                && bot.TryGetProperty("open_id", out JsonElement id))
+            {
+                _botOpenId = id.GetString();
+            }
+        }
+        catch (Exception ex)
+        {
+            // 拿不到就退化成"群里有 @ 就算 @ 我" —— 比整个渠道起不来强
+            log.Warn($"Feishu: could not read the bot's own open_id ({ex.Message}); @-mention matching will be loose.");
+        }
+        return _botOpenId;
+    }
+
+    /// <summary>
+    /// 长连接接入点的请求体。
+    /// </summary>
+    /// <remarks>
+    /// <b>字段名必须逐字是 <c>AppID</c> / <c>AppSecret</c>,所以用特性钉死,不靠序列化选项。</b>
+    /// <para>
+    /// 这里踩过一次:<see cref="HttpClientJsonExtensions.PostAsJsonAsync{TValue}(HttpClient,string,TValue,CancellationToken)" />
+    /// 用的是 <see cref="JsonSerializerDefaults.Web" />,它会把属性名转成 camelCase ——
+    /// 匿名对象写 <c>AppID</c> 发出去却是 <c>appID</c>,平台回
+    /// <c>{"code":9499,"msg":"Bad Request"}</c>。而同一个类里换令牌那一条用的是
+    /// <c>app_id</c>(本来就小写开头),camelCase 动不了它,于是症状是"凭证明明是对的,
+    /// 只有接入点这一步失败" —— 最难往序列化上想的那种组合。
+    /// </para>
+    /// <para>
+    /// 用 <see cref="JsonPropertyNameAttribute" /> 而不是"调用时记得传对 options":
+    /// 前者跟着类型走,后者跟着每一个调用点走,下次谁再加一个调用点就又中一次。
+    /// </para>
+    /// </remarks>
+    /// <remarks>
+    /// <c>internal</c> 而不是 <c>private</c>:字段名是这条协议的一部分,由
+    /// <c>FeishuApiTests</c> 按 <see cref="JsonSerializerDefaults.Web" /> 序列化一次钉住。
+    /// </remarks>
+    internal sealed record EndpointRequest(
+        [property: JsonPropertyName("AppID")] string AppId,
+        [property: JsonPropertyName("AppSecret")] string AppSecret);
+
+    /// <summary>
+    /// 取长连接的接入点。<b>这一条不带租户令牌</b> —— 它是用应用凭证换连接地址,
+    /// 与业务接口的鉴权方式不同。
+    /// </summary>
+    public async Task<(string Url, int PingIntervalSeconds)> EndpointAsync(CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await _http.PostAsJsonAsync(
+            $"{Domain}/callback/ws/endpoint",
+            new EndpointRequest(appId, appSecret), cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = await ReadAsync(response, cancellationToken).ConfigureAwait(false);
+        JsonElement root = document.RootElement;
+        int code = root.TryGetProperty("code", out JsonElement c) ? c.GetInt32() : -1;
+        if (code != 0)
+        {
+            // 1000040350 = 连接数超限(一个应用最多 50 条),这个错因值得原样报给用户
+            throw new InvalidOperationException($"Feishu endpoint request failed: {Message(root)} (code {code}).");
+        }
+        JsonElement data = root.GetProperty("data");
+        string url = data.GetProperty("URL").GetString()
+                     ?? throw new InvalidOperationException("Feishu endpoint response has no URL.");
+        int ping = 120;
+        if (data.TryGetProperty("ClientConfig", out JsonElement config)
+            && config.TryGetProperty("PingInterval", out JsonElement interval))
+        {
+            ping = interval.GetInt32();
+        }
+        return (url, ping);
+    }
+
+    private async Task<JsonDocument> CallAsync(HttpMethod method, string path, object? body,
+        CancellationToken cancellationToken)
+    {
+        string token = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        using var request = new HttpRequestMessage(method, Domain + path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null)
+        {
+            request.Content = JsonContent.Create(body);
+        }
+        using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        JsonDocument document = await ReadAsync(response, cancellationToken).ConfigureAwait(false);
+        JsonElement root = document.RootElement;
+        if (root.TryGetProperty("code", out JsonElement code) && code.GetInt32() != 0)
+        {
+            string detail = $"{Message(root)} (code {code.GetInt32()})";
+            document.Dispose();
+            throw new InvalidOperationException($"Feishu {method} {path} failed: {detail}");
+        }
+        return document;
+    }
+
+    private static async Task<JsonDocument> ReadAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (body.Length == 0)
+        {
+            throw new InvalidOperationException($"Feishu returned an empty body ({(int)response.StatusCode}).");
+        }
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"Feishu returned a non-JSON body ({(int)response.StatusCode}): {Truncate(body)}", ex);
+        }
+    }
+
+    private static string Message(JsonElement root)
+        => root.TryGetProperty("msg", out JsonElement msg) ? msg.GetString() ?? "" : "";
+
+    private static string Truncate(string text) => text.Length <= 200 ? text : string.Concat(text.AsSpan(0, 200), "…");
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _http.Dispose();
+        _tokenGate.Dispose();
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
@@ -1,0 +1,408 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Web;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+
+/// <summary>
+/// 飞书 / Lark 渠道:官方长连接(WebSocket + pbbp2 帧)。
+/// </summary>
+/// <remarks>
+/// <b>为什么是长连接而不是 Webhook。</b>VelaShell 是桌面程序,绝大多数时候躲在 NAT 后面 ——
+/// 回调模式要求平台能主动连上你,那就得有公网地址加内网穿透,配置成本比整个功能本身还高。
+/// 长连接是从本机连出去的,开箱即用。代价是<b>一个应用最多 50 条连接</b>,而且同一个应用
+/// 起多个客户端时平台按<b>集群</b>投递(随机挑一个),不是广播 —— 所以同一套应用凭证
+/// 不要在两台机器上同时跑,否则消息会随机落到另一台上。
+///
+/// <para>协议细节(端点、帧字段号、控制帧、应答与分片)照官方 Go SDK 的 <c>ws/</c> 实现,
+/// 见 <see cref="Pbbp2" /> 的注释。</para>
+/// </remarks>
+internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPluginContext context) : IMessageChannel
+{
+    /// <summary>单个 WebSocket 消息的接收上限(飞书事件远小于此,超了说明对端出问题了)。</summary>
+    private const int MaxFrameBytes = 4 * 1024 * 1024;
+
+    /// <summary>分片缓存的寿命。官方实现也是 5 秒 —— 收不齐就当这条消息丢了。</summary>
+    private static readonly TimeSpan FragmentTtl = TimeSpan.FromSeconds(5);
+
+    private readonly FeishuApi _api = new(config.AppId, appSecret, config.International, context.Log);
+    private readonly Dictionary<string, (byte[]?[] Parts, DateTimeOffset At)> _fragments = [];
+    private readonly Queue<string> _seenEvents = new();
+    private readonly HashSet<string> _seenEventSet = new(StringComparer.Ordinal);
+    private readonly Lock _sync = new();
+
+    private ClientWebSocket? _socket;
+    private int _serviceId;
+    private string? _botOpenId;
+
+    /// <inheritdoc />
+    public string Id => config.Id;
+
+    /// <inheritdoc />
+    public ChannelKind Kind => ChannelKind.Feishu;
+
+    /// <inheritdoc />
+    public string Label => config.Label;
+
+    /// <inheritdoc />
+    /// <remarks>飞书能改已发出的文本消息,所以进度可以就地刷新,不必刷屏。</remarks>
+    public ChannelCapabilities Capabilities => new(true, 3000);
+
+    /// <inheritdoc />
+    public event Action? Connected;
+
+    /// <inheritdoc />
+    public async Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        (string url, int pingSeconds) = await _api.EndpointAsync(cancellationToken).ConfigureAwait(false);
+        _serviceId = ReadServiceId(url);
+        _botOpenId = await _api.BotOpenIdAsync(cancellationToken).ConfigureAwait(false);
+
+        using var socket = new ClientWebSocket();
+        // 全局代理:宿主把 HttpClient.DefaultProxy 换成了自己的实现(设置 → 代理),
+        // 而 ClientWebSocket 不会自动跟着走,得显式交给它。
+        socket.Options.Proxy = HttpClient.DefaultProxy;
+        socket.Options.CollectHttpResponseDetails = true;
+        socket.Options.KeepAliveInterval = TimeSpan.Zero; // 心跳由协议自己的 ping 帧负责
+        try
+        {
+            await socket.ConnectAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
+        }
+        catch (WebSocketException ex)
+        {
+            throw new InvalidOperationException($"Feishu handshake failed: {HandshakeDetail(socket) ?? ex.Message}", ex);
+        }
+        _socket = socket;
+        Connected?.Invoke();
+        context.Log.Info($"Bridge: {Label} connected to Feishu (service {_serviceId}, ping every {pingSeconds}s).");
+
+        using var pings = new CancellationTokenSource();
+        using CancellationTokenSource linked =
+            CancellationTokenSource.CreateLinkedTokenSource(pings.Token, cancellationToken);
+        Task pingLoop = PingLoopAsync(socket, pingSeconds, linked.Token);
+        try
+        {
+            await ReceiveLoopAsync(socket, onMessage, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await pings.CancelAsync().ConfigureAwait(false);
+            try
+            {
+                await pingLoop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // 收摊时的正常取消
+            }
+            _socket = null;
+        }
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, Func<InboundMessage, Task> onMessage,
+        CancellationToken cancellationToken)
+    {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+            {
+                using var message = new MemoryStream();
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        return; // 对端主动关 —— 交给 ChannelHub 重连
+                    }
+                    message.Write(buffer, 0, result.Count);
+                    if (message.Length > MaxFrameBytes)
+                    {
+                        throw new InvalidDataException("Feishu sent an oversized websocket message.");
+                    }
+                }
+                while (!result.EndOfMessage);
+
+                Pbbp2.Frame frame = Pbbp2.Decode(message.GetBuffer().AsSpan(0, (int)message.Length));
+                await DispatchAsync(socket, frame, onMessage, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task DispatchAsync(ClientWebSocket socket, Pbbp2.Frame frame,
+        Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        if (frame.Method == Pbbp2.FrameTypeControl)
+        {
+            // pong 里可能捎回新的 ClientConfig;目前只有心跳间隔有用,而它变了也不影响正确性
+            return;
+        }
+        if (frame.Method != Pbbp2.FrameTypeData
+            || !string.Equals(frame.Header(Pbbp2.HeaderNames.Type), "event", StringComparison.Ordinal))
+        {
+            // card 类型(卡片按钮回传)先不处理:审批走文本回复,见 ImApprovalBroker 的注释
+            return;
+        }
+        byte[]? payload = Reassemble(frame);
+        if (payload is null)
+        {
+            return; // 分片还没收齐
+        }
+        long startedAt = Environment.TickCount64;
+        try
+        {
+            if (Parse(payload) is { } inbound)
+            {
+                await onMessage(inbound).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            context.Log.Error($"Bridge: {Label} failed to handle an event: {ex.Message}");
+        }
+        finally
+        {
+            // 平台要求 3 秒内应答,否则会重投。所以应答一定要走在业务处理之后**但不等业务结果** ——
+            // 这里业务已经是"排队 + 后台跑",Parse/入队本身是毫秒级的。
+            await AckAsync(socket, frame, Environment.TickCount64 - startedAt, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>应答一帧:原样回去 + 补一个耗时头 + 一段 200 的 JSON。</summary>
+    private static async Task AckAsync(ClientWebSocket socket, Pbbp2.Frame frame, long elapsedMs,
+        CancellationToken cancellationToken)
+    {
+        frame.SetHeader(Pbbp2.HeaderNames.BizRt, elapsedMs.ToString());
+        frame.Payload = Encoding.UTF8.GetBytes("""{"code":200,"headers":null,"data":null}""");
+        await SendFrameAsync(socket, frame, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task PingLoopAsync(ClientWebSocket socket, int pingSeconds, CancellationToken cancellationToken)
+    {
+        TimeSpan interval = TimeSpan.FromSeconds(Math.Clamp(pingSeconds, 10, 600));
+        while (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
+        {
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            var ping = new Pbbp2.Frame { Method = Pbbp2.FrameTypeControl, Service = _serviceId };
+            ping.SetHeader(Pbbp2.HeaderNames.Type, "ping");
+            await SendFrameAsync(socket, ping, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task SendFrameAsync(ClientWebSocket socket, Pbbp2.Frame frame,
+        CancellationToken cancellationToken)
+    {
+        if (socket.State != WebSocketState.Open)
+        {
+            return;
+        }
+        await socket.SendAsync(Pbbp2.Encode(frame), WebSocketMessageType.Binary, true, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>分片重组。<c>sum</c> ≤ 1 就是完整的一帧。</summary>
+    private byte[]? Reassemble(Pbbp2.Frame frame)
+    {
+        int sum = frame.HeaderInt(Pbbp2.HeaderNames.Sum, 1);
+        if (sum <= 1)
+        {
+            return frame.Payload;
+        }
+        string messageId = frame.Header(Pbbp2.HeaderNames.MessageId);
+        int seq = frame.HeaderInt(Pbbp2.HeaderNames.Seq);
+        if (messageId.Length == 0 || seq < 0 || seq >= sum)
+        {
+            return frame.Payload;
+        }
+        lock (_sync)
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            foreach (string stale in _fragments.Where(kv => now - kv.Value.At > FragmentTtl).Select(kv => kv.Key).ToArray())
+            {
+                _fragments.Remove(stale);
+            }
+            if (!_fragments.TryGetValue(messageId, out (byte[]?[] Parts, DateTimeOffset At) entry))
+            {
+                entry = (new byte[]?[sum], now);
+                _fragments[messageId] = entry;
+            }
+            entry.Parts[seq] = frame.Payload;
+            if (entry.Parts.Any(p => p is null))
+            {
+                return null;
+            }
+            _fragments.Remove(messageId);
+            return [.. entry.Parts.SelectMany(p => p!)];
+        }
+    }
+
+    /// <summary>把一条 <c>im.message.receive_v1</c> 事件翻成桥接认识的样子(其它事件返回 null)。</summary>
+    private InboundMessage? Parse(byte[] payload)
+    {
+        using JsonDocument document = JsonDocument.Parse(payload);
+        JsonElement root = document.RootElement;
+        if (!root.TryGetProperty("header", out JsonElement header)
+            || !root.TryGetProperty("event", out JsonElement body))
+        {
+            return null;
+        }
+        if (header.TryGetProperty("event_type", out JsonElement type)
+            && type.GetString() != "im.message.receive_v1")
+        {
+            return null;
+        }
+        if (header.TryGetProperty("event_id", out JsonElement eventId) && !FirstTime(eventId.GetString()))
+        {
+            return null; // 平台重投过来的同一条,别答两遍
+        }
+        if (!body.TryGetProperty("message", out JsonElement message))
+        {
+            return null;
+        }
+        string messageType = message.TryGetProperty("message_type", out JsonElement mt) ? mt.GetString() ?? "" : "";
+        if (messageType != "text")
+        {
+            return null; // 图片 / 文件 / 富文本先不接
+        }
+        string chatId = message.TryGetProperty("chat_id", out JsonElement chat) ? chat.GetString() ?? "" : "";
+        bool isGroup = message.TryGetProperty("chat_type", out JsonElement chatType)
+                       && chatType.GetString() == "group";
+        string messageId = message.TryGetProperty("message_id", out JsonElement mid) ? mid.GetString() ?? "" : "";
+        string senderId = body.TryGetProperty("sender", out JsonElement sender)
+                          && sender.TryGetProperty("sender_id", out JsonElement senderIds)
+                          && senderIds.TryGetProperty("open_id", out JsonElement openId)
+            ? openId.GetString() ?? ""
+            : "";
+        string text = message.TryGetProperty("content", out JsonElement content)
+            ? ExtractText(content.GetString())
+            : "";
+        (bool mentionsBot, string cleaned) = StripMentions(text, message);
+        return chatId.Length == 0
+            ? null
+            : new InboundMessage(config.Id, chatId, isGroup, senderId, senderId, cleaned, messageId,
+                !isGroup || mentionsBot);
+    }
+
+    /// <summary><c>content</c> 是一段 JSON 文本,文本消息里就一个 <c>text</c> 字段。</summary>
+    private static string ExtractText(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return "";
+        }
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(content);
+            return document.RootElement.TryGetProperty("text", out JsonElement text) ? text.GetString() ?? "" : "";
+        }
+        catch (JsonException)
+        {
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// 把 <c>@_user_N</c> 这类占位符从正文里去掉,顺带判断这条消息 @ 的是不是本机器人。
+    /// </summary>
+    /// <remarks>
+    /// 拿不到自己的 open_id 时(权限不够),退化成"有任何 @ 就算 @ 了我"。
+    /// 宁可多应一次,也好过在群里被 @ 了却装死 —— 后者用户会以为坏了。
+    /// </remarks>
+    private (bool MentionsBot, string Text) StripMentions(string text, JsonElement message)
+    {
+        bool mentionsBot = false;
+        if (message.TryGetProperty("mentions", out JsonElement mentions) && mentions.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement mention in mentions.EnumerateArray())
+            {
+                string key = mention.TryGetProperty("key", out JsonElement k) ? k.GetString() ?? "" : "";
+                string open = mention.TryGetProperty("id", out JsonElement id)
+                              && id.TryGetProperty("open_id", out JsonElement o)
+                    ? o.GetString() ?? ""
+                    : "";
+                if (_botOpenId is null || string.Equals(open, _botOpenId, StringComparison.Ordinal))
+                {
+                    mentionsBot = true;
+                }
+                if (key.Length > 0)
+                {
+                    text = text.Replace(key, "", StringComparison.Ordinal);
+                }
+            }
+        }
+        return (mentionsBot, text.Trim());
+    }
+
+    /// <summary>事件去重(平台在 3 秒内没收到应答会重投)。只记最近若干条,够用且不涨内存。</summary>
+    private bool FirstTime(string? eventId)
+    {
+        if (string.IsNullOrEmpty(eventId))
+        {
+            return true;
+        }
+        lock (_sync)
+        {
+            if (!_seenEventSet.Add(eventId))
+            {
+                return false;
+            }
+            _seenEvents.Enqueue(eventId);
+            while (_seenEvents.Count > 512)
+            {
+                _seenEventSet.Remove(_seenEvents.Dequeue());
+            }
+            return true;
+        }
+    }
+
+    /// <summary>ws 地址的 query 里带着 <c>service_id</c>,发帧时要原样填回去。</summary>
+    private static int ReadServiceId(string url)
+    {
+        string query = new Uri(url).Query;
+        string? value = HttpUtility.ParseQueryString(query)["service_id"];
+        return int.TryParse(value, out int id) ? id : 0;
+    }
+
+    /// <summary>握手失败时,平台把原因放在响应头里。</summary>
+    private static string? HandshakeDetail(ClientWebSocket socket)
+    {
+        if (socket.HttpResponseHeaders is not { } headers)
+        {
+            return null;
+        }
+        string? status = Get("Handshake-Status");
+        string? message = Get("Handshake-Msg");
+        string? code = Get("Handshake-Autherrcode");
+        return status is null && message is null && code is null
+            ? null
+            : $"status={status}, code={code}, msg={message}";
+
+        string? Get(string name) => headers.TryGetValue(name, out IEnumerable<string>? values)
+            ? string.Join(";", values)
+            : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
+        => await _api.SendTextAsync(target.ChatId, text, cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
+        => await _api.EditTextAsync(messageId, text, cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _socket?.Abort();
+        _api.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/Pbbp2.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/Pbbp2.cs
@@ -1,0 +1,293 @@
+using System.Text;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+
+/// <summary>
+/// 飞书长连接的帧(pbbp2)编解码。
+/// </summary>
+/// <remarks>
+/// <b>手写而不是引 protobuf 运行时。</b>整份协议只有两个 message、十一个字段,全是 varint
+/// 与长度前缀两种线格式;为它多背一个 Google.Protobuf 依赖(以及随之而来的 .proto 生成步骤)
+/// 不划算。字段号照官方 Go SDK 的 <c>ws/pbbp2.pb.go</c>:
+/// <code>
+/// Header { key = 1 (string); value = 2 (string) }
+/// Frame  { SeqID = 1 (uint64); LogID = 2 (uint64); service = 3 (int32); method = 4 (int32);
+///          headers = 5 (repeated Header); payload_encoding = 6 (string);
+///          payload_type = 7 (string); payload = 8 (bytes); LogIDNew = 9 (string) }
+/// </code>
+/// 解码遇到不认识的字段按线格式跳过 —— 平台加字段时不该把连接搞断。
+/// </remarks>
+internal static class Pbbp2
+{
+    /// <summary>帧类型(<c>Frame.method</c>)。</summary>
+    public const int FrameTypeControl = 0;
+
+    /// <summary>帧类型(<c>Frame.method</c>)。</summary>
+    public const int FrameTypeData = 1;
+
+    /// <summary>一帧。</summary>
+    public sealed class Frame
+    {
+        /// <summary>序号(应答时原样回去)。</summary>
+        public ulong SeqId { get; set; }
+
+        /// <summary>日志 id(应答时原样回去)。</summary>
+        public ulong LogId { get; set; }
+
+        /// <summary>服务 id(建连时从 ws 地址的 query 里取)。</summary>
+        public int Service { get; set; }
+
+        /// <summary>帧类型:<see cref="FrameTypeControl" /> / <see cref="FrameTypeData" />。</summary>
+        public int Method { get; set; }
+
+        /// <summary>头(<c>type</c> / <c>message_id</c> / <c>sum</c> / <c>seq</c> / <c>trace_id</c> / <c>biz_rt</c>)。</summary>
+        public List<KeyValuePair<string, string>> Headers { get; } = [];
+
+        /// <summary>载荷编码(平台目前不填)。</summary>
+        public string PayloadEncoding { get; set; } = "";
+
+        /// <summary>载荷类型(平台目前不填)。</summary>
+        public string PayloadType { get; set; } = "";
+
+        /// <summary>载荷(事件是一段 JSON)。</summary>
+        public byte[] Payload { get; set; } = [];
+
+        /// <summary>新版日志 id。</summary>
+        public string LogIdNew { get; set; } = "";
+
+        /// <summary>取一个头(没有则返回空串)。</summary>
+        public string Header(string key)
+        {
+            foreach ((string k, string v) in Headers)
+            {
+                if (string.Equals(k, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    return v;
+                }
+            }
+            return "";
+        }
+
+        /// <summary>取一个整数头(取不到或不是数字则返回 <paramref name="fallback" />)。</summary>
+        public int HeaderInt(string key, int fallback = 0)
+            => int.TryParse(Header(key), out int value) ? value : fallback;
+
+        /// <summary>加一个头(同名的先去掉,避免应答帧里出现两份 <c>biz_rt</c>)。</summary>
+        public void SetHeader(string key, string value)
+        {
+            Headers.RemoveAll(h => string.Equals(h.Key, key, StringComparison.OrdinalIgnoreCase));
+            Headers.Add(new KeyValuePair<string, string>(key, value));
+        }
+    }
+
+    /// <summary>头的名字(与官方 SDK 一致)。</summary>
+    public static class HeaderNames
+    {
+        /// <summary>消息类型:<c>event</c> / <c>card</c> / <c>ping</c> / <c>pong</c>。</summary>
+        public const string Type = "type";
+
+        /// <summary>消息 id(拆包后各片继承同一个)。</summary>
+        public const string MessageId = "message_id";
+
+        /// <summary>拆包总数(没拆包为 1)。</summary>
+        public const string Sum = "sum";
+
+        /// <summary>包序号(没拆包为 0)。</summary>
+        public const string Seq = "seq";
+
+        /// <summary>链路 id。</summary>
+        public const string TraceId = "trace_id";
+
+        /// <summary>业务处理耗时(毫秒),应答时带上。</summary>
+        public const string BizRt = "biz_rt";
+    }
+
+    /// <summary>编成一帧字节。</summary>
+    public static byte[] Encode(Frame frame)
+    {
+        var buffer = new List<byte>(256);
+        WriteVarintField(buffer, 1, frame.SeqId);
+        WriteVarintField(buffer, 2, frame.LogId);
+        WriteVarintField(buffer, 3, (ulong)(uint)frame.Service);
+        WriteVarintField(buffer, 4, (ulong)(uint)frame.Method);
+        foreach ((string key, string value) in frame.Headers)
+        {
+            var header = new List<byte>(key.Length + value.Length + 8);
+            WriteBytesField(header, 1, Encoding.UTF8.GetBytes(key));
+            WriteBytesField(header, 2, Encoding.UTF8.GetBytes(value));
+            WriteBytesField(buffer, 5, [.. header]);
+        }
+        if (frame.PayloadEncoding.Length > 0)
+        {
+            WriteBytesField(buffer, 6, Encoding.UTF8.GetBytes(frame.PayloadEncoding));
+        }
+        if (frame.PayloadType.Length > 0)
+        {
+            WriteBytesField(buffer, 7, Encoding.UTF8.GetBytes(frame.PayloadType));
+        }
+        if (frame.Payload.Length > 0)
+        {
+            WriteBytesField(buffer, 8, frame.Payload);
+        }
+        if (frame.LogIdNew.Length > 0)
+        {
+            WriteBytesField(buffer, 9, Encoding.UTF8.GetBytes(frame.LogIdNew));
+        }
+        return [.. buffer];
+    }
+
+    /// <summary>解一帧。字节流坏掉时抛 <see cref="InvalidDataException" />(由上层当作断线处理)。</summary>
+    public static Frame Decode(ReadOnlySpan<byte> data)
+    {
+        var frame = new Frame();
+        int index = 0;
+        while (index < data.Length)
+        {
+            ulong tag = ReadVarint(data, ref index);
+            int field = (int)(tag >> 3);
+            int wire = (int)(tag & 7);
+            switch (field)
+            {
+                case 1 when wire == 0:
+                    frame.SeqId = ReadVarint(data, ref index);
+                    break;
+                case 2 when wire == 0:
+                    frame.LogId = ReadVarint(data, ref index);
+                    break;
+                case 3 when wire == 0:
+                    frame.Service = (int)ReadVarint(data, ref index);
+                    break;
+                case 4 when wire == 0:
+                    frame.Method = (int)ReadVarint(data, ref index);
+                    break;
+                case 5 when wire == 2:
+                    frame.Headers.Add(DecodeHeader(ReadBytes(data, ref index)));
+                    break;
+                case 6 when wire == 2:
+                    frame.PayloadEncoding = Encoding.UTF8.GetString(ReadBytes(data, ref index));
+                    break;
+                case 7 when wire == 2:
+                    frame.PayloadType = Encoding.UTF8.GetString(ReadBytes(data, ref index));
+                    break;
+                case 8 when wire == 2:
+                    frame.Payload = ReadBytes(data, ref index).ToArray();
+                    break;
+                case 9 when wire == 2:
+                    frame.LogIdNew = Encoding.UTF8.GetString(ReadBytes(data, ref index));
+                    break;
+                default:
+                    Skip(data, ref index, wire);
+                    break;
+            }
+        }
+        return frame;
+    }
+
+    private static KeyValuePair<string, string> DecodeHeader(ReadOnlySpan<byte> data)
+    {
+        string key = "", value = "";
+        int index = 0;
+        while (index < data.Length)
+        {
+            ulong tag = ReadVarint(data, ref index);
+            int field = (int)(tag >> 3);
+            int wire = (int)(tag & 7);
+            if (field == 1 && wire == 2)
+            {
+                key = Encoding.UTF8.GetString(ReadBytes(data, ref index));
+            }
+            else if (field == 2 && wire == 2)
+            {
+                value = Encoding.UTF8.GetString(ReadBytes(data, ref index));
+            }
+            else
+            {
+                Skip(data, ref index, wire);
+            }
+        }
+        return new KeyValuePair<string, string>(key, value);
+    }
+
+    private static void WriteVarintField(List<byte> buffer, int field, ulong value)
+    {
+        WriteVarint(buffer, (ulong)(field << 3));
+        WriteVarint(buffer, value);
+    }
+
+    private static void WriteBytesField(List<byte> buffer, int field, ReadOnlySpan<byte> value)
+    {
+        WriteVarint(buffer, (ulong)((field << 3) | 2));
+        WriteVarint(buffer, (ulong)value.Length);
+        foreach (byte b in value)
+        {
+            buffer.Add(b);
+        }
+    }
+
+    private static void WriteVarint(List<byte> buffer, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            buffer.Add((byte)(value | 0x80));
+            value >>= 7;
+        }
+        buffer.Add((byte)value);
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> data, ref int index)
+    {
+        ulong result = 0;
+        int shift = 0;
+        while (true)
+        {
+            if (index >= data.Length || shift > 63)
+            {
+                throw new InvalidDataException("pbbp2: truncated varint.");
+            }
+            byte b = data[index++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                return result;
+            }
+            shift += 7;
+        }
+    }
+
+    private static ReadOnlySpan<byte> ReadBytes(ReadOnlySpan<byte> data, ref int index)
+    {
+        int length = (int)ReadVarint(data, ref index);
+        if (length < 0 || index + length > data.Length)
+        {
+            throw new InvalidDataException("pbbp2: truncated length-delimited field.");
+        }
+        ReadOnlySpan<byte> slice = data.Slice(index, length);
+        index += length;
+        return slice;
+    }
+
+    private static void Skip(ReadOnlySpan<byte> data, ref int index, int wire)
+    {
+        switch (wire)
+        {
+            case 0:
+                ReadVarint(data, ref index);
+                break;
+            case 1:
+                index += 8;
+                break;
+            case 2:
+                ReadBytes(data, ref index);
+                break;
+            case 5:
+                index += 4;
+                break;
+            default:
+                throw new InvalidDataException($"pbbp2: unsupported wire type {wire}.");
+        }
+        if (index > data.Length)
+        {
+            throw new InvalidDataException("pbbp2: truncated frame.");
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
@@ -1,0 +1,194 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.Telegram;
+
+/// <summary>
+/// Telegram 渠道:Bot API 长轮询(<c>getUpdates</c>)。
+/// </summary>
+/// <remarks>
+/// 四个渠道里最简单的一个 —— 没有握手、没有帧格式、没有应答,一次 HTTP 挂 50 秒等消息。
+/// 它在这里的价值是<b>把抽象压到位</b>:飞书是长连接、钉钉是 Stream、企微是回调,
+/// 只有再摆一条"长轮询"进来,<see cref="IMessageChannel.RunAsync" /> 那句"跑到断为止"
+/// 才算真的经得起四种传输。
+///
+/// <para>国内网络通常连不上 api.telegram.org,靠宿主的全局代理(设置 → 代理)解决:
+/// <see cref="HttpClient" /> 不显式设 Proxy 就会走 <c>HttpClient.DefaultProxy</c>,
+/// 而宿主启动时已经把那里换成了自己的实现。</para>
+/// </remarks>
+internal sealed class TelegramChannel(ChannelConfig config, string token, IPluginContext context) : IMessageChannel
+{
+    /// <summary>一次长轮询挂多久(秒)。Telegram 允许最长 50。</summary>
+    private const int PollSeconds = 50;
+
+    /// <summary>只订阅普通消息:其它更新(编辑、频道帖、成员变动)对桥接没有意义,少收一点少解析一点。</summary>
+    private static readonly string[] AllowedUpdates = ["message"];
+
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(PollSeconds + 20) };
+    private long _offset;
+    private string? _botUsername;
+
+    /// <inheritdoc />
+    public string Id => config.Id;
+
+    /// <inheritdoc />
+    public ChannelKind Kind => ChannelKind.Telegram;
+
+    /// <inheritdoc />
+    public string Label => config.Label;
+
+    /// <inheritdoc />
+    public ChannelCapabilities Capabilities => new(true, 4000);
+
+    /// <inheritdoc />
+    public event Action? Connected;
+
+    /// <inheritdoc />
+    public async Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        _botUsername = await BotUsernameAsync(cancellationToken).ConfigureAwait(false);
+        Connected?.Invoke();
+        context.Log.Info($"Bridge: {Label} polling Telegram as @{_botUsername}.");
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            using JsonDocument document = await CallAsync("getUpdates", new
+            {
+                offset = _offset,
+                timeout = PollSeconds,
+                allowed_updates = AllowedUpdates
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (!document.RootElement.TryGetProperty("result", out JsonElement updates))
+            {
+                continue;
+            }
+            foreach (JsonElement update in updates.EnumerateArray())
+            {
+                if (update.TryGetProperty("update_id", out JsonElement id))
+                {
+                    // offset 一旦推过去,平台就当这条已消费。所以先解析再推 ——
+                    // 崩在中间时下次还能重来一遍,顶多重复一条,总好过静默丢掉。
+                    _offset = Math.Max(_offset, id.GetInt64() + 1);
+                }
+                if (Parse(update) is { } inbound)
+                {
+                    await onMessage(inbound).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private InboundMessage? Parse(JsonElement update)
+    {
+        if (!update.TryGetProperty("message", out JsonElement message)
+            || !message.TryGetProperty("text", out JsonElement textElement))
+        {
+            return null;
+        }
+        string text = textElement.GetString() ?? "";
+        if (!message.TryGetProperty("chat", out JsonElement chat))
+        {
+            return null;
+        }
+        string chatId = chat.GetProperty("id").GetRawText();
+        bool isGroup = chat.TryGetProperty("type", out JsonElement chatType)
+                       && chatType.GetString() is "group" or "supergroup";
+        string userId = "", userName = "";
+        if (message.TryGetProperty("from", out JsonElement from))
+        {
+            userId = from.GetProperty("id").GetRawText();
+            userName = from.TryGetProperty("username", out JsonElement u) ? u.GetString() ?? "" : "";
+            if (userName.Length == 0 && from.TryGetProperty("first_name", out JsonElement f))
+            {
+                userName = f.GetString() ?? userId;
+            }
+        }
+        string messageId = message.TryGetProperty("message_id", out JsonElement mid) ? mid.GetRawText() : "";
+        (bool mentioned, string cleaned) = StripMention(text, message);
+        return new InboundMessage(config.Id, chatId, isGroup, userId, userName, cleaned, messageId,
+            !isGroup || mentioned);
+    }
+
+    /// <summary>
+    /// 群里认三种"在跟我说话":@我、回复我发的消息、以 <c>/命令@我</c> 起头。
+    /// 认出来之后把 @ 从正文里抹掉,免得模型把它当内容的一部分。
+    /// </summary>
+    private (bool Mentioned, string Text) StripMention(string text, JsonElement message)
+    {
+        bool mentioned = false;
+        if (_botUsername is { Length: > 0 } name)
+        {
+            string handle = "@" + name;
+            if (text.Contains(handle, StringComparison.OrdinalIgnoreCase))
+            {
+                mentioned = true;
+                text = text.Replace(handle, "", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+        if (!mentioned
+            && message.TryGetProperty("reply_to_message", out JsonElement replied)
+            && replied.TryGetProperty("from", out JsonElement repliedFrom)
+            && repliedFrom.TryGetProperty("is_bot", out JsonElement isBot)
+            && isBot.GetBoolean())
+        {
+            mentioned = true;
+        }
+        return (mentioned, text.Trim());
+    }
+
+    private async Task<string> BotUsernameAsync(CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await CallAsync("getMe", null, cancellationToken).ConfigureAwait(false);
+        return document.RootElement.TryGetProperty("result", out JsonElement result)
+               && result.TryGetProperty("username", out JsonElement username)
+            ? username.GetString() ?? ""
+            : "";
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await CallAsync("sendMessage",
+            new { chat_id = long.Parse(target.ChatId), text }, cancellationToken).ConfigureAwait(false);
+        return document.RootElement.TryGetProperty("result", out JsonElement result)
+               && result.TryGetProperty("message_id", out JsonElement id)
+            ? id.GetRawText()
+            : null;
+    }
+
+    /// <inheritdoc />
+    public async Task EditAsync(OutboundTarget target, string messageId, string text,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument _ = await CallAsync("editMessageText",
+            new { chat_id = long.Parse(target.ChatId), message_id = long.Parse(messageId), text },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<JsonDocument> CallAsync(string method, object? body, CancellationToken cancellationToken)
+    {
+        string url = $"https://api.telegram.org/bot{token}/{method}";
+        using HttpResponseMessage response = body is null
+            ? await _http.GetAsync(url, cancellationToken).ConfigureAwait(false)
+            : await _http.PostAsJsonAsync(url, body, cancellationToken).ConfigureAwait(false);
+        string payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        JsonDocument document = JsonDocument.Parse(payload);
+        if (document.RootElement.TryGetProperty("ok", out JsonElement ok) && !ok.GetBoolean())
+        {
+            string description = document.RootElement.TryGetProperty("description", out JsonElement d)
+                ? d.GetString() ?? ""
+                : "";
+            document.Dispose();
+            throw new InvalidOperationException($"Telegram {method} failed: {description}");
+        }
+        return document;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _http.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
@@ -1,0 +1,286 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.WeCom;
+
+/// <summary>
+/// 企业微信渠道:自建应用的<b>接收消息回调</b>。
+/// </summary>
+/// <remarks>
+/// <b>这一家和另外三家不一样。</b>飞书、钉钉、Telegram 都能从内网主动连出去,企业微信只有
+/// "平台把消息 POST 到你配的地址"这一条路 —— 它需要一个公网可达的入口。
+///
+/// <para>本实现<b>只监听 127.0.0.1</b>,不提供绑 0.0.0.0 的选项:把一个能在生产机上敲命令的
+/// 回调口直接开到公网,不该是一个勾选框能决定的事。要让企业微信够得着,用一条反向隧道把
+/// 公网上某台机器的端口转到这里即可 —— VelaShell 自己就有远程端口转发
+/// (会话 → 隧道 → 远程转发),转发目标填 <c>127.0.0.1:&lt;这里的端口&gt;</c>,
+/// 再在那台机器上用 nginx 之类把 HTTPS 落到该端口。</para>
+///
+/// <para>签名与解密见 <see cref="WeComCrypto" />。回调必须<b>先验签再解密</b>,
+/// 而且解出来的 receiveid 要等于自己的 corpid —— 少一步都等于让任何人都能给机器人下指令。</para>
+/// </remarks>
+internal sealed class WeComChannel(
+    ChannelConfig config,
+    string corpSecret,
+    string token,
+    string encodingAesKey,
+    IPluginContext context) : IMessageChannel
+{
+    private const string ApiBase = "https://qyapi.weixin.qq.com";
+
+    /// <summary>会话 id → 是不是群聊(发消息要挑不同的接口)。</summary>
+    private readonly ConcurrentDictionary<string, bool> _groups = new();
+
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private readonly SemaphoreSlim _tokenGate = new(1, 1);
+    private readonly byte[] _aesKey = WeComCrypto.ParseKey(encodingAesKey);
+    private HttpListener? _listener;
+    private string? _accessToken;
+    private DateTimeOffset _accessTokenExpiresAt = DateTimeOffset.MinValue;
+
+    /// <inheritdoc />
+    public string Id => config.Id;
+
+    /// <inheritdoc />
+    public ChannelKind Kind => ChannelKind.WeCom;
+
+    /// <inheritdoc />
+    public string Label => config.Label;
+
+    /// <inheritdoc />
+    public ChannelCapabilities Capabilities => new(false, 2000);
+
+    /// <inheritdoc />
+    public event Action? Connected;
+
+    /// <inheritdoc />
+    public async Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{config.WebhookPort}/");
+        listener.Start();
+        _listener = listener;
+        Connected?.Invoke();
+        context.Log.Info(
+            $"Bridge: {Label} listening for WeCom callbacks on http://127.0.0.1:{config.WebhookPort}{config.WebhookPath} " +
+            "(put a tunnel or reverse proxy in front of it).");
+        try
+        {
+            while (listener.IsListening && !cancellationToken.IsCancellationRequested)
+            {
+                HttpListenerContext http;
+                try
+                {
+                    http = await listener.GetContextAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is HttpListenerException or ObjectDisposedException)
+                {
+                    return;
+                }
+                try
+                {
+                    await HandleAsync(http, onMessage, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    context.Log.Warn($"Bridge: {Label} failed to handle a callback: {ex.Message}");
+                    http.Response.StatusCode = 500;
+                }
+                finally
+                {
+                    try
+                    {
+                        http.Response.Close();
+                    }
+                    catch (Exception)
+                    {
+                        // 对端先断了
+                    }
+                }
+            }
+        }
+        finally
+        {
+            listener.Close();
+            _listener = null;
+        }
+    }
+
+    private async Task HandleAsync(HttpListenerContext http, Func<InboundMessage, Task> onMessage,
+        CancellationToken cancellationToken)
+    {
+        HttpListenerRequest request = http.Request;
+        if (!string.Equals(request.Url?.AbsolutePath.TrimEnd('/'), config.WebhookPath.TrimEnd('/'),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            http.Response.StatusCode = 404;
+            return;
+        }
+        string signature = request.QueryString["msg_signature"] ?? "";
+        string timestamp = request.QueryString["timestamp"] ?? "";
+        string nonce = request.QueryString["nonce"] ?? "";
+
+        if (request.HttpMethod == "GET")
+        {
+            // 配置回调地址时企业微信先来这一趟:把 echostr 解开原样回去就算验证通过
+            string echo = request.QueryString["echostr"] ?? "";
+            if (!WeComCrypto.Verify(token, timestamp, nonce, echo, signature))
+            {
+                context.Log.Warn($"Bridge: {Label} rejected a callback verification with a bad signature.");
+                http.Response.StatusCode = 401;
+                return;
+            }
+            (string plain, string receiveId) = WeComCrypto.Decrypt(_aesKey, echo);
+            if (!string.Equals(receiveId, config.AppId, StringComparison.Ordinal))
+            {
+                http.Response.StatusCode = 401;
+                return;
+            }
+            await WriteAsync(http.Response, plain, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        if (request.HttpMethod != "POST")
+        {
+            http.Response.StatusCode = 405;
+            return;
+        }
+
+        string body;
+        using (var reader = new StreamReader(request.InputStream, Encoding.UTF8))
+        {
+            body = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+        string encrypted = XDocument.Parse(body).Root?.Element("Encrypt")?.Value ?? "";
+        if (encrypted.Length == 0 || !WeComCrypto.Verify(token, timestamp, nonce, encrypted, signature))
+        {
+            context.Log.Warn($"Bridge: {Label} rejected a callback with a bad signature.");
+            http.Response.StatusCode = 401;
+            return;
+        }
+        (string message, string corpId) = WeComCrypto.Decrypt(_aesKey, encrypted);
+        if (!string.Equals(corpId, config.AppId, StringComparison.Ordinal))
+        {
+            context.Log.Warn($"Bridge: {Label} got a callback for another corp ({corpId}); ignoring it.");
+            http.Response.StatusCode = 401;
+            return;
+        }
+        // 平台只等一个 200,回复走主动发消息的接口 —— 一轮 agent 要跑几十秒,回包等不了
+        http.Response.StatusCode = 200;
+        if (Parse(message) is { } inbound)
+        {
+            await onMessage(inbound).ConfigureAwait(false);
+        }
+    }
+
+    private InboundMessage? Parse(string xml)
+    {
+        XElement? root = XDocument.Parse(xml).Root;
+        if (root is null || root.Element("MsgType")?.Value != "text")
+        {
+            return null;
+        }
+        string text = root.Element("Content")?.Value.Trim() ?? "";
+        string user = root.Element("FromUserName")?.Value ?? "";
+        string chat = root.Element("ChatId")?.Value ?? "";
+        bool isGroup = chat.Length > 0;
+        string chatId = isGroup ? chat : user;
+        if (chatId.Length == 0)
+        {
+            return null;
+        }
+        _groups[chatId] = isGroup;
+        string messageId = root.Element("MsgId")?.Value ?? "";
+        // 应用收到的群消息本来就只有 @ 了它的那些,单聊更不必说
+        return new InboundMessage(config.Id, chatId, isGroup, user, user, text, messageId, true);
+    }
+
+    private async Task<string> TokenAsync(CancellationToken cancellationToken)
+    {
+        await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_accessToken is { } cached && DateTimeOffset.UtcNow < _accessTokenExpiresAt)
+            {
+                return cached;
+            }
+            string url = $"{ApiBase}/cgi-bin/gettoken?corpid={Uri.EscapeDataString(config.AppId)}"
+                         + $"&corpsecret={Uri.EscapeDataString(corpSecret)}";
+            using HttpResponseMessage response = await _http.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using JsonDocument document = JsonDocument.Parse(
+                await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            if (!document.RootElement.TryGetProperty("access_token", out JsonElement value))
+            {
+                throw new InvalidOperationException($"WeCom token request failed: {Describe(document.RootElement)}");
+            }
+            _accessToken = value.GetString();
+            int expires = document.RootElement.TryGetProperty("expires_in", out JsonElement e) ? e.GetInt32() : 7200;
+            _accessTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expires - 300));
+            return _accessToken!;
+        }
+        finally
+        {
+            _tokenGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
+    {
+        string accessToken = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        bool isGroup = _groups.TryGetValue(target.ChatId, out bool group) && group;
+        string path = isGroup ? "/cgi-bin/appchat/send" : "/cgi-bin/message/send";
+        object body = isGroup
+            ? new { chatid = target.ChatId, msgtype = "text", text = new { content = text } }
+            : new
+            {
+                touser = target.ChatId,
+                msgtype = "text",
+                agentid = int.TryParse(config.AgentId, out int agent) ? agent : 0,
+                text = new { content = text }
+            };
+        using HttpResponseMessage response = await _http.PostAsJsonAsync(
+            $"{ApiBase}{path}?access_token={Uri.EscapeDataString(accessToken)}", body, cancellationToken)
+            .ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+        if (document.RootElement.TryGetProperty("errcode", out JsonElement code) && code.GetInt32() != 0)
+        {
+            throw new InvalidOperationException($"WeCom {path} failed: {Describe(document.RootElement)}");
+        }
+        return null; // 企业微信不给可再编辑的消息 id
+    }
+
+    /// <inheritdoc />
+    public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
+        => Task.CompletedTask; // Capabilities.CanEdit = false
+
+    private static string Describe(JsonElement root)
+    {
+        int code = root.TryGetProperty("errcode", out JsonElement c) ? c.GetInt32() : -1;
+        string message = root.TryGetProperty("errmsg", out JsonElement m) ? m.GetString() ?? "" : "";
+        return $"{message} (errcode {code})";
+    }
+
+    private static async Task WriteAsync(HttpListenerResponse response, string payload,
+        CancellationToken cancellationToken)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(payload);
+        response.ContentType = "text/plain";
+        response.ContentLength64 = bytes.Length;
+        await response.OutputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _listener?.Close();
+        _http.Dispose();
+        _tokenGate.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComCrypto.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComCrypto.cs
@@ -1,0 +1,124 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.WeCom;
+
+/// <summary>
+/// 企业微信回调的签名与消息加解密(即官方 SDK 里的 WXBizMsgCrypt)。
+/// </summary>
+/// <remarks>
+/// 官方只发 Java/PHP/Python/Go/C++ 五种参考实现,.NET 那份年久失修,而算法本身很短,
+/// 所以照官方文档自己写一份:
+/// <list type="bullet">
+/// <item>密钥 = <c>Base64(EncodingAESKey + "=")</c>,32 字节;IV 取密钥的前 16 字节。</item>
+/// <item>AES-256-CBC,<b>补位块是 32 字节</b>(不是 AES 的 16),所以解密按无补位做完再自己剥。</item>
+/// <item>明文 = 16 字节随机数 + 4 字节大端长度 + 正文 + receiveid(corpid)。</item>
+/// <item>签名 = SHA1(把 token / timestamp / nonce / 密文 四个串按字典序排好再拼起来)。</item>
+/// </list>
+/// </remarks>
+internal static class WeComCrypto
+{
+    /// <summary>补位块大小。企业微信这里用 32,不是 AES 的 16。</summary>
+    private const int PadBlock = 32;
+
+    /// <summary>
+    /// 把 43 个字符的 EncodingAESKey 还原成 32 字节密钥。
+    /// 填错(长度不对、混进非 Base64 字符)一律抛 <see cref="ArgumentException" /> ——
+    /// 调用方只需要认一种失败,而不是既要防 <see cref="FormatException" /> 又要防别的。
+    /// </summary>
+    public static byte[] ParseKey(string encodingAesKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(encodingAesKey);
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(encodingAesKey.Trim() + "=");
+        }
+        catch (FormatException ex)
+        {
+            throw new ArgumentException("EncodingAESKey is not a valid 43-character Base64 string.",
+                nameof(encodingAesKey), ex);
+        }
+        return key.Length == 32
+            ? key
+            : throw new ArgumentException("EncodingAESKey must decode to 32 bytes.", nameof(encodingAesKey));
+    }
+
+    /// <summary>算签名(小写十六进制)。</summary>
+    public static string Sign(string token, string timestamp, string nonce, string encrypted)
+    {
+        string[] parts = [token, timestamp, nonce, encrypted];
+        Array.Sort(parts, StringComparer.Ordinal);
+        byte[] hash = SHA1.HashData(Encoding.UTF8.GetBytes(string.Concat(parts)));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// 校验签名。<b>用定时安全比较</b> —— 这是唯一能证明"这条回调真的来自企业微信"的东西,
+    /// 逐字符早退等于把它变成可以试探的。
+    /// </summary>
+    public static bool Verify(string token, string timestamp, string nonce, string encrypted, string signature)
+    {
+        byte[] expected = Encoding.ASCII.GetBytes(Sign(token, timestamp, nonce, encrypted));
+        byte[] presented = Encoding.ASCII.GetBytes(signature ?? "");
+        return presented.Length == expected.Length && CryptographicOperations.FixedTimeEquals(presented, expected);
+    }
+
+    /// <summary>解密,返回正文与 receiveid(调用方应比对 receiveid 是不是自己的 corpid)。</summary>
+    public static (string Message, string ReceiveId) Decrypt(byte[] key, string base64)
+    {
+        byte[] cipher = Convert.FromBase64String(base64);
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+        aes.IV = key.AsSpan(0, 16).ToArray();
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.None;
+        byte[] plain = aes.DecryptCbc(cipher, aes.IV, PaddingMode.None);
+
+        int pad = plain[^1];
+        if (pad is < 1 or > PadBlock || pad > plain.Length)
+        {
+            throw new CryptographicException("WeCom payload has an invalid padding byte.");
+        }
+        ReadOnlySpan<byte> body = plain.AsSpan(0, plain.Length - pad);
+        if (body.Length < 20)
+        {
+            throw new CryptographicException("WeCom payload is too short.");
+        }
+        int length = BinaryPrimitives.ReadInt32BigEndian(body.Slice(16, 4));
+        if (length < 0 || 20 + length > body.Length)
+        {
+            throw new CryptographicException("WeCom payload declares a length that does not fit.");
+        }
+        return (Encoding.UTF8.GetString(body.Slice(20, length)),
+            Encoding.UTF8.GetString(body[(20 + length)..]));
+    }
+
+    /// <summary>加密(自测与回包用;正常应答回调只要回空串,所以线上路径用不到它)。</summary>
+    public static string Encrypt(byte[] key, string message, string receiveId)
+    {
+        byte[] text = Encoding.UTF8.GetBytes(message);
+        byte[] id = Encoding.UTF8.GetBytes(receiveId);
+        var body = new byte[16 + 4 + text.Length + id.Length];
+        RandomNumberGenerator.Fill(body.AsSpan(0, 16));
+        BinaryPrimitives.WriteInt32BigEndian(body.AsSpan(16, 4), text.Length);
+        text.CopyTo(body, 20);
+        id.CopyTo(body, 20 + text.Length);
+
+        int pad = PadBlock - (body.Length % PadBlock);
+        if (pad == 0)
+        {
+            pad = PadBlock;
+        }
+        var padded = new byte[body.Length + pad];
+        body.CopyTo(padded, 0);
+        padded.AsSpan(body.Length).Fill((byte)pad);
+
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.None;
+        return Convert.ToBase64String(aes.EncryptCbc(padded, key.AsSpan(0, 16).ToArray(), PaddingMode.None));
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
@@ -1,0 +1,496 @@
+using System.Text;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 策略层:谁能说话、这句话是命令还是提问、一个聊天同时跑几轮、回复怎么发回去。
+/// 渠道只管收发,agent 只管跑,"要不要理你"全在这里。
+/// </summary>
+public sealed class ConversationRouter(
+    IPluginContext context,
+    ChannelHub hub,
+    BridgeAgentRunner runner,
+    ImApprovalBroker approvals,
+    BridgeSettingsStore bridgeStore,
+    PairingService pairing)
+{
+    /// <summary>两次"改同一条消息"之间至少隔这么久 —— 各家平台的编辑接口都有限流。</summary>
+    private static readonly TimeSpan EditInterval = TimeSpan.FromMilliseconds(1200);
+
+    private readonly Dictionary<string, BridgeConversation> _conversations = [];
+    private readonly HashSet<string> _unauthorizedNotified = new(StringComparer.Ordinal);
+    private readonly Lock _sync = new();
+    private SemaphoreSlim _turnGate = new(2, 2);
+
+    /// <summary>当前生效的桥接设置(由 <see cref="BridgeService" /> 在重载时换掉)。</summary>
+    public BridgeSettings Settings { get; private set; } = new();
+
+    /// <summary>界面语言(跟随宿主)。</summary>
+    public Loc Loc { get; private set; } = new("en");
+
+    /// <summary>
+    /// 换一套桥接设置(总并发跟着变)。
+    /// </summary>
+    /// <remarks>
+    /// <b>这里刻意不缓存 AI 设置</b>(模型、供应商、MCP)—— 那一份由
+    /// <see cref="BridgeAgentRunner" /> 每轮现读。缓存过一次,代价是用户在面板里
+    /// 登录订阅制供应商或换模型之后桥接毫不知情,详见那边的注释。
+    /// </remarks>
+    public void Apply(BridgeSettings bridge, Loc loc)
+    {
+        Settings = bridge;
+        Loc = loc;
+        int limit = Math.Clamp(bridge.MaxConcurrentTurns, 1, 16);
+        SemaphoreSlim old = _turnGate;
+        _turnGate = new SemaphoreSlim(limit, limit);
+        old.Dispose();
+    }
+
+    /// <summary>处理一条入站消息。<b>不抛</b> —— 上游那条读循环不该被一条消息带崩。</summary>
+    public async Task HandleAsync(InboundMessage message)
+    {
+        if (Settings.Channels.FirstOrDefault(c => c.Id == message.ChannelId) is not { } config)
+        {
+            return;
+        }
+        if (!IsChatAllowed(config, message))
+        {
+            // 配对码要在白名单之前处理 —— 它存在的全部意义就是"我还不在白名单里,请把我加进去"
+            if (await TryPairAsync(config, message).ConfigureAwait(false))
+            {
+                return;
+            }
+            pairing.Remember(new PendingChat(message.ChannelId, message.ChatId, message.IsGroup,
+                message.UserName, DateTimeOffset.UtcNow));
+            await NotifyUnauthorizedOnceAsync(message).ConfigureAwait(false);
+            return;
+        }
+        // 群里没 @ 就当没听见 —— 机器人不该插进同事之间的正常对话
+        if (message.IsGroup && !message.MentionsBot)
+        {
+            return;
+        }
+        if (config.AllowedUsers.Count > 0 && !config.AllowedUsers.Contains(message.UserId))
+        {
+            context.Log.Info($"Bridge: ignoring {message.UserName} ({message.UserId}) — not in the user allowlist.");
+            return;
+        }
+        // 审批回复优先:这句话是在回上一条"要不要放行",不该被当成新问题
+        if (approvals.TryConsume(message, config, Loc))
+        {
+            return;
+        }
+        BridgeConversation conversation = GetOrCreate(config, message);
+        conversation.LastActivity = DateTimeOffset.UtcNow;
+        string text = message.Text.Trim();
+        if (text.StartsWith('/') && await TryCommandAsync(conversation, config, message, text).ConfigureAwait(false))
+        {
+            return;
+        }
+        if (text.Length == 0)
+        {
+            return;
+        }
+        await RunTurnAsync(conversation, config, message).ConfigureAwait(false);
+    }
+
+    /// <summary>丢掉闲置太久的会话上下文(由 <see cref="BridgeService" /> 定时调)。</summary>
+    public void EvictIdle()
+    {
+        DateTimeOffset cutoff = DateTimeOffset.UtcNow.AddMinutes(-Math.Max(5, Settings.ConversationIdleMinutes));
+        lock (_sync)
+        {
+            foreach (string key in _conversations
+                         .Where(kv => kv.Value.LastActivity < cutoff && kv.Value.Running is null)
+                         .Select(kv => kv.Key)
+                         .ToArray())
+            {
+                _conversations.Remove(key);
+            }
+        }
+    }
+
+    /// <summary>掐掉全部正在跑的轮次(停桥接时)。</summary>
+    public void CancelAll()
+    {
+        lock (_sync)
+        {
+            foreach (BridgeConversation conversation in _conversations.Values)
+            {
+                conversation.Running?.Cancel();
+                approvals.Cancel(conversation.ChatKey);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 处理未授权聊天里的 <c>/pair &lt;码&gt;</c>。认下来了返回 true。
+    /// </summary>
+    /// <remarks>
+    /// <b>这里刻意不要求群里先 @ 机器人。</b>此刻它还不在白名单里,而"要不要理你"这一关就在
+    /// 前面 —— 再叠一条"先 @ 我"等于把配对本身也挡在门外。配对码本身足够窄:一次性、
+    /// 十分钟过期、猜错五次作废,而且只能把聊天加进白名单,动不了挡位与审批。
+    /// </remarks>
+    private async Task<bool> TryPairAsync(ChannelConfig config, InboundMessage message)
+    {
+        string text = message.Text.Trim();
+        if (!text.StartsWith("/pair", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        var target = new OutboundTarget(message.ChatId, message.ThreadId);
+        string code = text[5..].Trim();
+        if (code.Length == 0)
+        {
+            await hub.SendAsync(message.ChannelId, target, Loc["BridgePairUsage"], CancellationToken.None)
+                .ConfigureAwait(false);
+            return true;
+        }
+        if (!pairing.TryRedeem(code))
+        {
+            // 只记日志,不在群里说"码错了还是过期了" —— 那等于告诉试探的人他离对还有多远
+            context.Log.Warn($"Bridge: a wrong or expired pairing code was presented in {message.ChatKey}.");
+            await hub.SendAsync(message.ChannelId, target, Loc["BridgePairRejected"], CancellationToken.None)
+                .ConfigureAwait(false);
+            return true;
+        }
+        await AllowChatAsync(config, message.ChatId).ConfigureAwait(false);
+        context.Log.Info($"Bridge: {message.ChatKey} was paired by {message.UserName}.");
+        await hub.SendAsync(message.ChannelId, target, Loc["BridgePaired"], CancellationToken.None)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// 把一个聊天加进白名单:<b>内存里立刻生效</b>,同时落盘。
+    /// </summary>
+    /// <remarks>
+    /// 两处都要写。只写库的话得等下一次重载才认;只写内存的话重启就没了。
+    /// 落盘走"读—改—写"而不是把内存那份整个盖上去 —— 设置页可能正开着,
+    /// 用它内存里的快照覆盖会把用户刚改的别的字段抹掉。
+    /// </remarks>
+    public async Task AllowChatAsync(ChannelConfig config, string chatId)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (!config.AllowedChats.Contains(chatId))
+        {
+            config.AllowedChats.Add(chatId);
+        }
+        BridgeSettings stored = await bridgeStore.LoadAsync().ConfigureAwait(false);
+        if (stored.Channels.FirstOrDefault(c => c.Id == config.Id) is { } persisted)
+        {
+            if (!persisted.AllowedChats.Contains(chatId))
+            {
+                persisted.AllowedChats.Add(chatId);
+                await bridgeStore.SaveAsync(stored).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // 库里没有这个渠道(多半是设置页加了但还没点保存):内存里已经放行了,
+            // 但重启就会没。说一声,别让它静默地只活到下次重启。
+            context.Log.Warn($"Bridge: {chatId} was allowed for a channel that is not saved yet; " +
+                             "it will be forgotten on restart until the settings are saved.");
+        }
+        pairing.Forget(config.Id, chatId);
+        lock (_sync)
+        {
+            // 放行之后那句"未授权"的提醒也该复位:万一以后又被移出白名单,还得再提示一次
+            _unauthorizedNotified.Remove($"{config.Id}/{chatId}");
+        }
+    }
+
+    private async Task RunTurnAsync(BridgeConversation conversation, ChannelConfig config, InboundMessage message)
+    {
+        // 同一个聊天串行:后来的排队,而不是插进上一轮的工具循环中间
+        bool queued = conversation.Gate.CurrentCount == 0;
+        if (queued)
+        {
+            await hub.SendAsync(conversation.ChannelId, conversation.Reply, Loc["BridgeBusy"], CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        await conversation.Gate.WaitAsync().ConfigureAwait(false);
+        await _turnGate.WaitAsync().ConfigureAwait(false);
+        using var turn = new CancellationTokenSource(TimeSpan.FromSeconds(Math.Clamp(Settings.TurnTimeoutSeconds, 30, 3600)));
+        conversation.Running = turn;
+        string? placeholder = null;
+        var lastEdit = DateTimeOffset.MinValue;
+        try
+        {
+            ChannelCapabilities capabilities = hub.CapabilitiesOf(conversation.ChannelId);
+            placeholder = await hub.SendAsync(conversation.ChannelId, conversation.Reply, Loc["BridgeThinking"], turn.Token)
+                .ConfigureAwait(false);
+
+            void OnProgress(string accumulated)
+            {
+                if (!capabilities.CanEdit || placeholder is null || accumulated.Length == 0)
+                {
+                    return;
+                }
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                if (now - lastEdit < EditInterval)
+                {
+                    return;
+                }
+                lastEdit = now;
+                // 故意不 await:进度是锦上添花,改慢了、改失败了都不该拖住模型那条流
+                _ = hub.EditAsync(conversation.ChannelId, conversation.Reply, placeholder,
+                    Clip(accumulated, capabilities.MaxMessageChars), CancellationToken.None);
+            }
+
+            BridgeTurn result = await runner.RunAsync(
+                conversation, Settings, message,
+                request => approvals.RequestAsync(conversation, config, request,
+                    Settings.ApprovalTimeoutSeconds, Loc, turn.Token),
+                Loc, OnProgress, turn.Token).ConfigureAwait(false);
+
+            await DeliverAsync(conversation, placeholder, Compose(result), turn.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            await DeliverAsync(conversation, placeholder, Loc["BridgeTimeout"], CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            context.Log.Error($"Bridge: a turn in {conversation.ChatKey} failed: {ex}");
+            await DeliverAsync(conversation, placeholder, Loc.F("BridgeTurnFailed", ex.Message), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            conversation.Running = null;
+            approvals.Cancel(conversation.ChatKey);
+            _turnGate.Release();
+            conversation.Gate.Release();
+        }
+    }
+
+    /// <summary>回复落地:能改就改回那条占位消息,不能改就再发一条;超长切段。</summary>
+    private async Task DeliverAsync(BridgeConversation conversation, string? placeholder, string text,
+        CancellationToken cancellationToken)
+    {
+        ChannelCapabilities capabilities = hub.CapabilitiesOf(conversation.ChannelId);
+        List<string> parts = Split(text, capabilities.MaxMessageChars);
+        for (int i = 0; i < parts.Count; i++)
+        {
+            if (i == 0 && capabilities.CanEdit && placeholder is not null)
+            {
+                await hub.EditAsync(conversation.ChannelId, conversation.Reply, placeholder, parts[i], cancellationToken)
+                    .ConfigureAwait(false);
+                continue;
+            }
+            await hub.SendAsync(conversation.ChannelId, conversation.Reply, parts[i], cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>回复末尾那行小字:哪个模型、跑了多久、动了几次工具。</summary>
+    private string Compose(BridgeTurn turn)
+        => turn.Model.Length == 0
+            ? turn.Text
+            : $"{turn.Text}\n\n{Loc.F("BridgeFooter", turn.Model, turn.Elapsed.TotalSeconds.ToString("0.0"), turn.ToolCalls)}";
+
+    private async Task<bool> TryCommandAsync(BridgeConversation conversation, ChannelConfig config,
+        InboundMessage message, string text)
+    {
+        string[] parts = text.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        string command = parts[0].ToLowerInvariant();
+        string argument = parts.Length > 1 ? parts[1] : "";
+        string? reply = command switch
+        {
+            "/help" or "/?" => Loc["BridgeHelp"],
+            "/new" or "/reset" => Reset(conversation),
+            "/stop" => Stop(conversation),
+            "/status" => await StatusAsync(conversation, config).ConfigureAwait(false),
+            "/sessions" => await ListSessionsAsync().ConfigureAwait(false),
+            "/use" => await BindAsync(conversation, argument).ConfigureAwait(false),
+            "/mode" => SetMode(conversation, argument),
+            _ => null
+        };
+        if (reply is null)
+        {
+            return false;
+        }
+        await hub.SendAsync(message.ChannelId, conversation.Reply, reply, CancellationToken.None).ConfigureAwait(false);
+        return true;
+    }
+
+    private string Reset(BridgeConversation conversation)
+    {
+        conversation.Running?.Cancel();
+        approvals.Cancel(conversation.ChatKey);
+        conversation.Reset();
+        return Loc["BridgeNewChat"];
+    }
+
+    private string Stop(BridgeConversation conversation)
+    {
+        if (conversation.Running is not { } running)
+        {
+            return Loc["BridgeNothingRunning"];
+        }
+        running.Cancel();
+        return Loc["BridgeStopped"];
+    }
+
+    private async Task<string> StatusAsync(BridgeConversation conversation, ChannelConfig config)
+    {
+        ChatMode mode = conversation.ModeOverride ?? Settings.Mode;
+        string target = conversation.BoundTarget.Length > 0 ? conversation.BoundTarget : "—";
+        SessionInfo? session = conversation.BoundTarget.Length > 0
+            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, CancellationToken.None).ConfigureAwait(false)
+            : null;
+        return Loc.F("BridgeStatus", config.Label, mode, Settings.Approval, target,
+            session is null ? Loc["BridgeSessionOffline"] : Loc["BridgeSessionOnline"]);
+    }
+
+    private async Task<string> ListSessionsAsync()
+    {
+        string list = await SessionTargets.DescribeAsync(context, CancellationToken.None).ConfigureAwait(false);
+        return list.Length == 0 ? Loc["BridgeNoSessions"] : Loc.F("BridgeSessions", list);
+    }
+
+    private async Task<string> BindAsync(BridgeConversation conversation, string argument)
+    {
+        if (argument.Length == 0)
+        {
+            return Loc["BridgeBindUsage"];
+        }
+        if (await SessionTargets.ResolveAsync(context, argument, CancellationToken.None).ConfigureAwait(false) is not { } session)
+        {
+            return Loc.F("BridgeBindNotFound", argument);
+        }
+        conversation.BoundTarget = SessionTargets.Format(session);
+        // 绑定要过夜:存进设置里,VelaShell 重开、会话重连之后群里不用再绑一次
+        BridgeSettings settings = await bridgeStore.LoadAsync().ConfigureAwait(false);
+        settings.ChatBindings[conversation.ChatKey] = conversation.BoundTarget;
+        await bridgeStore.SaveAsync(settings).ConfigureAwait(false);
+        Settings.ChatBindings[conversation.ChatKey] = conversation.BoundTarget;
+        return Loc.F("BridgeBound", conversation.BoundTarget);
+    }
+
+    /// <summary>
+    /// <c>/mode</c>:换这个聊天的挡位。<b>默认只让往低了换。</b>
+    /// </summary>
+    /// <remarks>
+    /// 白名单里的任何人都能发 <c>/mode agent</c> 的话,设置页里那个"桥接默认只读"就形同虚设 ——
+    /// 拉高权限这件事应该在 VelaShell 里做,不该在群里做。要开放得去设置页勾
+    /// <see cref="BridgeSettings.AllowModeEscalation" />。
+    /// </remarks>
+    private string SetMode(BridgeConversation conversation, string argument)
+    {
+        ChatMode? requested;
+        switch (argument.Trim().ToLowerInvariant())
+        {
+            case "chat":
+                requested = ChatMode.Chat;
+                break;
+            case "plan":
+                requested = ChatMode.Plan;
+                break;
+            case "agent":
+                requested = ChatMode.Agent;
+                break;
+            case "" or "reset" or "default":
+                requested = null;
+                break;
+            default:
+                return Loc["BridgeModeUsage"];
+        }
+        if (requested is { } mode && Rank(mode) > Rank(Settings.Mode) && !Settings.AllowModeEscalation)
+        {
+            return Loc.F("BridgeModeLocked", Settings.Mode);
+        }
+        conversation.ModeOverride = requested;
+        return Loc.F("BridgeModeSet", conversation.ModeOverride ?? Settings.Mode);
+
+        static int Rank(ChatMode mode) => mode switch
+        {
+            ChatMode.Agent => 2,
+            ChatMode.Plan => 1,
+            _ => 0
+        };
+    }
+
+    private BridgeConversation GetOrCreate(ChannelConfig config, InboundMessage message)
+    {
+        lock (_sync)
+        {
+            if (_conversations.TryGetValue(message.ChatKey, out BridgeConversation? existing))
+            {
+                return existing;
+            }
+            var created = new BridgeConversation(message.ChannelId, message.ChatId)
+            {
+                ThreadId = message.ThreadId,
+                BoundTarget = Settings.ChatBindings.TryGetValue(message.ChatKey, out string? bound)
+                    ? bound
+                    : config.DefaultTarget
+            };
+            _conversations[message.ChatKey] = created;
+            return created;
+        }
+    }
+
+    private static bool IsChatAllowed(ChannelConfig config, InboundMessage message)
+        => config.AllowedChats.Contains(message.ChatId);
+
+    /// <summary>
+    /// 没授权的聊天回一次(且只回一次)带 id 的提示。
+    /// </summary>
+    /// <remarks>
+    /// 沉默是更"安全"的做法,但它把用户卡在第一步:群 id 在飞书/钉钉的界面上根本看不到,
+    /// 不回这一句,人就只能去翻日志。机器人已经在群里了,回一句并不多暴露什么。
+    /// </remarks>
+    private async Task NotifyUnauthorizedOnceAsync(InboundMessage message)
+    {
+        lock (_sync)
+        {
+            if (!_unauthorizedNotified.Add(message.ChatKey))
+            {
+                return;
+            }
+        }
+        context.Log.Info($"Bridge: chat {message.ChatId} is not in the allowlist (channel {message.ChannelId}).");
+        if (message.IsGroup && !message.MentionsBot)
+        {
+            return; // 群里没 @ 就别自说自话
+        }
+        await hub.SendAsync(message.ChannelId, new OutboundTarget(message.ChatId, message.ThreadId),
+            Loc.F("BridgeUnauthorized", message.ChatId), CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private static string Clip(string text, int max)
+        => text.Length <= max ? text : string.Concat(text.AsSpan(0, Math.Max(0, max - 1)), "…");
+
+    /// <summary>超长回复切段。尽量断在换行处,断不了才硬切。</summary>
+    private static List<string> Split(string text, int max)
+    {
+        if (text.Length <= max)
+        {
+            return [text];
+        }
+        var parts = new List<string>();
+        ReadOnlySpan<char> rest = text;
+        while (rest.Length > max)
+        {
+            int cut = rest[..max].LastIndexOf('\n');
+            if (cut < max / 2)
+            {
+                cut = max;
+            }
+            parts.Add(rest[..cut].ToString());
+            rest = rest[cut..].TrimStart('\n');
+        }
+        if (rest.Length > 0)
+        {
+            parts.Add(rest.ToString());
+        }
+        return parts;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ImApprovalBroker.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ImApprovalBroker.cs
@@ -1,0 +1,165 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 把审批搬到 IM 里:发一条"要不要放行",等有权限的人回一个字。
+/// </summary>
+/// <remarks>
+/// <b>为什么是文本而不是交互卡片。</b>四家平台的卡片回传各有各的坑 ——
+/// 飞书的 <c>card.action.trigger</c> 在长连接上并不总能收到(上游项目也挂着同样的 issue),
+/// 企微的卡片回调又得走公网。文本回复是唯一在四家都稳的通道,所以它是底线实现;
+/// 卡片按钮以后按渠道能力逐个加,加上了也只是把同一个 <see cref="Resolve" /> 换个触发方式。
+///
+/// <para>一个聊天同一时刻只会有一个待批项 —— 一个聊天的多轮本来就是串行的
+/// (见 <see cref="BridgeConversation.Gate" />),所以用聊天键做主键就够了。</para>
+/// </remarks>
+public sealed class ImApprovalBroker(ChannelHub hub, IPluginContext context)
+{
+    private sealed record Pending(
+        BridgeConversation Conversation,
+        ApprovalRequest Request,
+        TaskCompletionSource<bool> Completion,
+        List<string> Approvers);
+
+    private readonly Dictionary<string, Pending> _pending = [];
+    private readonly Lock _sync = new();
+
+    /// <summary>当前有没有人在等审批(设置页的状态用)。</summary>
+    public int PendingCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _pending.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 发一条审批请求到聊天里并等回复。超时按<b>拒绝</b>处理 ——
+    /// 没人应答时,不动手才是安全的那一侧。
+    /// </summary>
+    public async Task<bool> RequestAsync(BridgeConversation conversation, ChannelConfig config,
+        ApprovalRequest request, int timeoutSeconds, Loc loc, CancellationToken cancellationToken)
+    {
+        if (request.RepeatKey is { } key && conversation.AlwaysApproved.Contains(key))
+        {
+            return true;
+        }
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = new Pending(conversation, request, completion, Approvers(config));
+        lock (_sync)
+        {
+            // 上一条还悬着(理论上不会,一个聊天串行)——把它按拒绝收掉,免得回复对错了对象
+            if (_pending.TryGetValue(conversation.ChatKey, out Pending? stale))
+            {
+                stale.Completion.TrySetResult(false);
+            }
+            _pending[conversation.ChatKey] = pending;
+        }
+        string always = request.RepeatKey is null ? "" : loc["BridgeApprovalAlways"];
+        await hub.SendAsync(conversation.ChannelId, conversation.Reply,
+            loc.F("BridgeApprovalAsk", request.Kind, Trim(request.Detail), always, timeoutSeconds),
+            cancellationToken).ConfigureAwait(false);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 10, 3600)));
+        using CancellationTokenSource linked =
+            CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
+        using (linked.Token.Register(() => completion.TrySetResult(false)))
+        {
+            bool granted = await completion.Task.ConfigureAwait(false);
+            lock (_sync)
+            {
+                if (_pending.TryGetValue(conversation.ChatKey, out Pending? current) && current == pending)
+                {
+                    _pending.Remove(conversation.ChatKey);
+                }
+            }
+            if (!granted && timeout.IsCancellationRequested)
+            {
+                await hub.SendAsync(conversation.ChannelId, conversation.Reply, loc["BridgeApprovalTimedOut"],
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            return granted;
+        }
+    }
+
+    /// <summary>
+    /// 看这条消息是不是在回审批。是就地消化掉并返回 true(不再送去 agent)。
+    /// </summary>
+    public bool TryConsume(InboundMessage message, ChannelConfig config, Loc loc)
+    {
+        Pending? pending;
+        lock (_sync)
+        {
+            if (!_pending.TryGetValue(message.ChatKey, out pending))
+            {
+                return false;
+            }
+        }
+        if (ParseVerdict(message.Text) is not { } verdict)
+        {
+            return false; // 不是 y/n/a,当普通消息处理(可能是补充说明)
+        }
+        if (pending.Approvers.Count > 0 && !pending.Approvers.Contains(message.UserId))
+        {
+            // 不是审批人:告诉他一声,但**不消费** —— 他说的话仍然是给 agent 的
+            _ = hub.SendAsync(message.ChannelId, new OutboundTarget(message.ChatId, message.ThreadId),
+                loc["BridgeApprovalNotAllowed"], CancellationToken.None);
+            return true;
+        }
+        if (verdict == Verdict.Always && pending.Request.RepeatKey is { } key)
+        {
+            pending.Conversation.AlwaysApproved.Add(key);
+        }
+        Resolve(message.ChatKey, verdict != Verdict.Deny);
+        _ = hub.SendAsync(message.ChannelId, new OutboundTarget(message.ChatId, message.ThreadId),
+            verdict == Verdict.Deny ? loc["BridgeApprovalDenied"] : loc["BridgeApprovalGranted"],
+            CancellationToken.None);
+        context.Log.Info($"Bridge: {message.UserName} {(verdict == Verdict.Deny ? "denied" : "approved")} " +
+                         $"{pending.Request.Kind} in {message.ChatKey}.");
+        return true;
+    }
+
+    /// <summary>放行 / 拒绝一条待批项(卡片按钮以后也走这里)。</summary>
+    public void Resolve(string chatKey, bool granted)
+    {
+        lock (_sync)
+        {
+            if (_pending.Remove(chatKey, out Pending? pending))
+            {
+                pending.Completion.TrySetResult(granted);
+            }
+        }
+    }
+
+    /// <summary>丢掉某聊天的待批项(会话重置 / 渠道停掉时)。</summary>
+    public void Cancel(string chatKey) => Resolve(chatKey, false);
+
+    private enum Verdict
+    {
+        Allow,
+        Deny,
+        Always
+    }
+
+    private static Verdict? ParseVerdict(string text) => text.Trim().ToLowerInvariant() switch
+    {
+        "y" or "yes" or "ok" or "同意" or "批准" or "允许" or "放行" or "可以" => Verdict.Allow,
+        "n" or "no" or "拒绝" or "不" or "不行" or "算了" => Verdict.Deny,
+        "a" or "always" or "总是" or "以后都行" => Verdict.Always,
+        _ => null
+    };
+
+    /// <summary>谁能批:优先 <see cref="ChannelConfig.Approvers" />,没配就回落到能说话的人。</summary>
+    private static List<string> Approvers(ChannelConfig config)
+        => config.Approvers.Count > 0 ? config.Approvers : config.AllowedUsers;
+
+    /// <summary>审批详情发进 IM 前先截一刀 —— 一段几百行的文件内容不该刷屏。</summary>
+    private static string Trim(string detail)
+        => detail.Length <= 800 ? detail : string.Concat(detail.AsSpan(0, 800), "…");
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/PairingService.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/PairingService.cs
@@ -1,0 +1,182 @@
+using System.Security.Cryptography;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>一个敲过门但没被放行的聊天。</summary>
+/// <param name="ChannelId">来自哪个渠道实例。</param>
+/// <param name="ChatId">聊天 id。</param>
+/// <param name="IsGroup">是不是群聊。</param>
+/// <param name="UserName">最近一次是谁在说话(给设置页显示"是谁在敲门")。</param>
+/// <param name="FirstSeen">第一次敲门的时刻。</param>
+public readonly record struct PendingChat(
+    string ChannelId,
+    string ChatId,
+    bool IsGroup,
+    string UserName,
+    DateTimeOffset FirstSeen)
+{
+    /// <summary>会话键(与 <see cref="InboundMessage.ChatKey" /> 同构)。</summary>
+    public string ChatKey => $"{ChannelId}/{ChatId}";
+}
+
+/// <summary>
+/// 配对码与待放行聊天:把"授权一个群"这件事从电脑前挪到群里。
+/// </summary>
+/// <remarks>
+/// <b>为什么要有这个东西。</b>白名单本身没问题,难受的是拿到群 id 的过程 ——
+/// 群 id 在飞书/钉钉的界面上根本看不到,原来的路子是"加机器人进群 → 发一句 → 看它回的 id
+/// → 复制 → 回电脑粘进设置页 → 保存 → 重连"。人在手机上,电脑在工位上,这一趟很蠢。
+/// <para>
+/// 两条更短的路:① 设置页生成一个配对码,在群里发 <c>/pair 428913</c> 就完事;
+/// ② 敲过门的聊天会被记下来,设置页上一行一个「允许」按钮。
+/// </para>
+/// <para>
+/// <b>安全性没有让步。</b>配对码只决定"这个聊天能不能跟机器人说话",能不能动服务器仍旧由
+/// 挡位与审批管;码是一次性的、十分钟过期、猜错五次直接作废,而且它只能<b>加</b>白名单,
+/// 不能改挡位、不能绕审批。
+/// </para>
+/// <para>本实例由 <see cref="BridgeService" /> 持有,因此<b>跨渠道重载存活</b> ——
+/// 用户在设置页点保存导致桥接重建时,已经敲过的门不该跟着丢掉。</para>
+/// </remarks>
+public sealed class PairingService
+{
+    /// <summary>配对码的寿命。够走到手机跟前,又不至于挂一整天。</summary>
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(10);
+
+    /// <summary>猜错这么多次就作废。六位数字被暴力猜中的概率本就极低,这一条是兜底。</summary>
+    private const int MaxAttempts = 5;
+
+    /// <summary>待放行清单的上限:被一个陌生群刷屏时不该把内存吃掉。</summary>
+    private const int MaxPending = 50;
+
+    private readonly Dictionary<string, PendingChat> _pending = [];
+    private readonly Lock _sync = new();
+    private string? _code;
+    private DateTimeOffset _expiresAt;
+    private int _attempts;
+
+    /// <summary>当前有效的配对码;没有或已过期时为 <see langword="null" />。</summary>
+    public string? Code
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return Valid() ? _code : null;
+            }
+        }
+    }
+
+    /// <summary>当前配对码的失效时刻(没有码时为 <see cref="DateTimeOffset.MinValue" />)。</summary>
+    public DateTimeOffset ExpiresAt
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return Valid() ? _expiresAt : DateTimeOffset.MinValue;
+            }
+        }
+    }
+
+    /// <summary>发一个新的配对码(旧的立即作废)。</summary>
+    public string Issue()
+    {
+        lock (_sync)
+        {
+            // 随机数走密码学 RNG:配对码在有效期内是一个能把陌生群放进白名单的凭据,
+            // 用 Random 生成的话,知道种子规律的人就能猜。
+            _code = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
+            _expiresAt = DateTimeOffset.UtcNow + Lifetime;
+            _attempts = 0;
+            return _code;
+        }
+    }
+
+    /// <summary>作废当前配对码。</summary>
+    public void Revoke()
+    {
+        lock (_sync)
+        {
+            _code = null;
+            _expiresAt = DateTimeOffset.MinValue;
+            _attempts = 0;
+        }
+    }
+
+    /// <summary>
+    /// 核对并<b>用掉</b>一个配对码。对了返回 true,并且这个码立刻作废(一次性)。
+    /// </summary>
+    public bool TryRedeem(string presented)
+    {
+        lock (_sync)
+        {
+            if (!Valid())
+            {
+                return false;
+            }
+            if (!string.Equals(presented.Trim(), _code, StringComparison.Ordinal))
+            {
+                if (++_attempts >= MaxAttempts)
+                {
+                    _code = null;
+                    _expiresAt = DateTimeOffset.MinValue;
+                }
+                return false;
+            }
+            _code = null;
+            _expiresAt = DateTimeOffset.MinValue;
+            _attempts = 0;
+            return true;
+        }
+    }
+
+    /// <summary>记下一个敲过门的聊天(同一个聊天只记第一次,但显示名跟着最新一次更新)。</summary>
+    public void Remember(PendingChat chat)
+    {
+        lock (_sync)
+        {
+            if (_pending.TryGetValue(chat.ChatKey, out PendingChat existing))
+            {
+                _pending[chat.ChatKey] = existing with { UserName = chat.UserName };
+                return;
+            }
+            if (_pending.Count >= MaxPending)
+            {
+                // 满了就挤掉最早的那条 —— 用户关心的是刚才敲门的那个群
+                string oldest = _pending.OrderBy(kv => kv.Value.FirstSeen).First().Key;
+                _pending.Remove(oldest);
+            }
+            _pending[chat.ChatKey] = chat;
+        }
+    }
+
+    /// <summary>待放行清单(最近敲门的排在前面)。</summary>
+    public IReadOnlyList<PendingChat> Pending()
+    {
+        lock (_sync)
+        {
+            return [.. _pending.Values.OrderByDescending(c => c.FirstSeen)];
+        }
+    }
+
+    /// <summary>把一个聊天从待放行清单里去掉(放行了,或者用户点了忽略)。</summary>
+    public void Forget(string channelId, string chatId)
+    {
+        lock (_sync)
+        {
+            _pending.Remove($"{channelId}/{chatId}");
+        }
+    }
+
+    /// <summary>清空待放行清单。</summary>
+    public void Clear()
+    {
+        lock (_sync)
+        {
+            _pending.Clear();
+        }
+    }
+
+    private bool Valid() => _code is not null && DateTimeOffset.UtcNow < _expiresAt;
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/SessionTargets.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/SessionTargets.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 在"绑定的服务器"与宿主的会话 id 之间来回换。
+/// </summary>
+/// <remarks>
+/// <b>绑定存的是 <c>user@host:port</c>,不是 SessionId。</b>
+/// SessionId 是一次连接的不透明 id —— 用户断线重连、或者早上重开一次 VelaShell,它就换了;
+/// 存 id 的话群里的绑定第二天全部失效,而且失效得毫无提示。存"哪台机器",
+/// 每轮临时解析成当下那条活着的会话,才是能过夜的做法。
+/// </remarks>
+public static class SessionTargets
+{
+    /// <summary>把一条会话写成绑定用的目标串。</summary>
+    public static string Format(SessionInfo session) => $"{session.Username}@{session.Host}:{session.Port}";
+
+    /// <summary>
+    /// 找一条与 <paramref name="target" /> 对得上、且<b>已连上</b>的会话。
+    /// 目标串可以省略用户名与端口(<c>host</c> / <c>host:port</c> / <c>user@host</c> 都认)。
+    /// </summary>
+    public static async Task<SessionInfo?> ResolveAsync(
+        IPluginContext context, string target, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return null;
+        }
+        IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
+        (string? user, string host, int? port) = Parse(target);
+        foreach (SessionInfo session in sessions)
+        {
+            if (session.State != SessionState.Connected)
+            {
+                continue;
+            }
+            if (!string.Equals(session.Host, host, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (port is { } p && session.Port != p)
+            {
+                continue;
+            }
+            if (user is { } u && !string.Equals(session.Username, u, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            return session;
+        }
+        return null;
+    }
+
+    /// <summary>列出当前连上的会话,给 IM 里的 <c>/sessions</c> 用。</summary>
+    public static async Task<string> DescribeAsync(IPluginContext context, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
+        List<SessionInfo> connected = [.. sessions.Where(s => s.State == SessionState.Connected)];
+        if (connected.Count == 0)
+        {
+            return "";
+        }
+        var sb = new StringBuilder();
+        foreach (SessionInfo session in connected)
+        {
+            sb.Append("• ").AppendLine(Format(session));
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>拆 <c>[user@]host[:port]</c>。拆不出端口就返回 null(表示"不挑端口")。</summary>
+    private static (string? User, string Host, int? Port) Parse(string target)
+    {
+        string rest = target.Trim();
+        string? user = null;
+        int at = rest.LastIndexOf('@');
+        if (at >= 0)
+        {
+            user = rest[..at];
+            rest = rest[(at + 1)..];
+        }
+        int colon = rest.LastIndexOf(':');
+        // IPv6 字面量里冒号成堆,只有带方括号时才认最后那个冒号是端口分隔符
+        bool portish = colon > 0 && (rest.IndexOf(':') == colon || rest.StartsWith('['));
+        if (portish && int.TryParse(rest[(colon + 1)..], out int port))
+        {
+            return (user, rest[..colon].Trim('[', ']'), port);
+        }
+        return (user, rest.Trim('[', ']'), null);
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpEndpoint.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpEndpoint.cs
@@ -1,0 +1,401 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Interop;
+
+/// <summary>
+/// 把 VelaShell 的工具对外开成一个 MCP 服务端,让 Claude Code / Codex / Cursor
+/// 这类外部 agent 能连进来用。
+/// </summary>
+/// <remarks>
+/// <b>传输选的是 Streamable HTTP,不是 stdio。</b>stdio 的前提是"客户端能把服务端拉起来",
+/// 而 VelaShell 是一个已经开着的桌面程序 —— 外部 agent 拉不起它,也不该拉起第二个。
+/// HTTP 只需要用户在自己的 agent 配置里填一行地址。协议允许对一次 POST 直接回一个 JSON
+/// 响应(不必开 SSE 流),而 MCP 的请求-响应本来就都是一问一答,所以这里只实现 JSON 那条路。
+///
+/// <para><b>只绑 127.0.0.1,且必须带令牌。</b>本机监听不等于安全:同机任何进程,包括浏览器里的
+/// 网页,都能往本地端口发请求。令牌是这条路上唯一的门,见
+/// <see cref="McpServerSettingsStore.TokenAsync" />。</para>
+///
+/// <para>配置方法(Claude Code):
+/// <c>claude mcp add --transport http velashell http://127.0.0.1:8391/mcp --header "Authorization: Bearer &lt;令牌&gt;"</c>
+/// </para>
+/// </remarks>
+public sealed class McpEndpoint(IPluginContext context, McpServerSettingsStore store) : IAsyncDisposable
+{
+    /// <summary>本实现对齐的协议版本。客户端要更老的版本时按它要的回。</summary>
+    private const string ProtocolVersion = "2025-06-18";
+
+    /// <summary>一个外部会话闲置多久后丢掉。</summary>
+    private static readonly TimeSpan SessionIdleTimeout = TimeSpan.FromHours(2);
+
+    private readonly ConcurrentDictionary<string, McpToolHost> _sessions = new();
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
+
+    private HttpListener? _listener;
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+    private McpServerSettings _settings = new();
+    private string _token = "";
+
+    /// <summary>此刻在不在监听。</summary>
+    public bool IsRunning => _listener?.IsListening == true;
+
+    /// <summary>给设置页显示的接入地址(没开时为 null)。</summary>
+    public string? Url => IsRunning ? $"http://127.0.0.1:{_settings.Port}/mcp" : null;
+
+    /// <summary>读设置并把服务端调到该有的样子。</summary>
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _reloadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            McpServerSettings settings = await store.LoadAsync(cancellationToken).ConfigureAwait(false);
+            await StopCoreAsync().ConfigureAwait(false);
+            if (!settings.Enabled)
+            {
+                return;
+            }
+            _settings = settings;
+            _token = await store.TokenAsync(cancellationToken).ConfigureAwait(false);
+            var listener = new HttpListener();
+            // 只在回环上开。这里刻意不提供"绑 0.0.0.0"的选项 —— 把一个能在生产机上敲命令的
+            // 接口开到局域网上,不是一个应该由勾选框决定的事。
+            listener.Prefixes.Add($"http://127.0.0.1:{settings.Port}/");
+            listener.Start();
+            _listener = listener;
+            _cts = new CancellationTokenSource();
+            _loop = AcceptLoopAsync(listener, _cts.Token);
+            context.Log.Info($"MCP server listening on {Url} (mode {settings.Mode}, approval {settings.Approval}).");
+        }
+        catch (HttpListenerException ex)
+        {
+            context.Log.Error($"MCP server could not listen on port {_settings.Port}: {ex.Message}");
+            await StopCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
+    /// <summary>停掉服务端。</summary>
+    public async Task StopAsync()
+    {
+        await _reloadGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await StopCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
+    private async Task StopCoreAsync()
+    {
+        if (_cts is { } cts)
+        {
+            await cts.CancelAsync().ConfigureAwait(false);
+        }
+        _listener?.Close();
+        _listener = null;
+        if (_loop is { } loop)
+        {
+            try
+            {
+                await loop.ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or HttpListenerException or ObjectDisposedException)
+            {
+                // 关监听时的正常收摊
+            }
+        }
+        _loop = null;
+        _cts?.Dispose();
+        _cts = null;
+        _sessions.Clear();
+    }
+
+    private async Task AcceptLoopAsync(HttpListener listener, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested && listener.IsListening)
+        {
+            HttpListenerContext http;
+            try
+            {
+                http = await listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is HttpListenerException or ObjectDisposedException)
+            {
+                return; // 监听被关掉了
+            }
+            // 一次请求一个任务:tools/call 可能跑几十秒(一条远程命令),不能占着 accept 循环
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await HandleAsync(http, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    context.Log.Warn($"MCP server: request failed: {ex.Message}");
+                }
+                finally
+                {
+                    try
+                    {
+                        http.Response.Close();
+                    }
+                    catch (Exception)
+                    {
+                        // 客户端先断了
+                    }
+                }
+            }, cancellationToken);
+        }
+    }
+
+    private async Task HandleAsync(HttpListenerContext http, CancellationToken cancellationToken)
+    {
+        HttpListenerRequest request = http.Request;
+        HttpListenerResponse response = http.Response;
+        if (!Authorized(request))
+        {
+            response.StatusCode = 401;
+            response.AddHeader("WWW-Authenticate", "Bearer");
+            await WriteAsync(response, """{"error":"unauthorized"}""", cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        switch (request.HttpMethod)
+        {
+            case "DELETE":
+                if (SessionId(request) is { Length: > 0 } ending)
+                {
+                    _sessions.TryRemove(ending, out _);
+                }
+                response.StatusCode = 200;
+                return;
+
+            case "GET":
+                // 服务端不主动推消息,所以不开 SSE 流。协议允许这么回。
+                response.StatusCode = 405;
+                response.AddHeader("Allow", "POST, DELETE");
+                return;
+
+            case "POST":
+                break;
+
+            default:
+                response.StatusCode = 405;
+                return;
+        }
+
+        string body;
+        using (var reader = new StreamReader(request.InputStream, Encoding.UTF8))
+        {
+            body = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(body);
+        }
+        catch (JsonException ex)
+        {
+            response.StatusCode = 400;
+            await WriteAsync(response, Error(null, -32700, $"Parse error: {ex.Message}"), cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+        using (document)
+        {
+            JsonElement root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                // 批量请求:MCP 客户端极少用,不支持也要说清楚而不是静默失败
+                response.StatusCode = 400;
+                await WriteAsync(response, Error(null, -32600, "Batched requests are not supported."), cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+            }
+            await DispatchAsync(http, root, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DispatchAsync(HttpListenerContext http, JsonElement request, CancellationToken cancellationToken)
+    {
+        HttpListenerResponse response = http.Response;
+        string method = request.TryGetProperty("method", out JsonElement m) ? m.GetString() ?? "" : "";
+        JsonElement? id = request.TryGetProperty("id", out JsonElement idElement) ? idElement : null;
+        JsonElement parameters = request.TryGetProperty("params", out JsonElement p) ? p : default;
+
+        // 通知(没有 id)一律 202,没有响应体
+        if (id is null)
+        {
+            response.StatusCode = 202;
+            return;
+        }
+
+        switch (method)
+        {
+            case "initialize":
+            {
+                string sessionId = Guid.NewGuid().ToString("n");
+                var host = new McpToolHost(context, _settings);
+                await host.AutoSelectAsync(cancellationToken).ConfigureAwait(false);
+                _sessions[sessionId] = host;
+                EvictIdleSessions();
+                response.AddHeader("Mcp-Session-Id", sessionId);
+                string version = parameters.ValueKind == JsonValueKind.Object
+                                 && parameters.TryGetProperty("protocolVersion", out JsonElement requested)
+                    ? requested.GetString() ?? ProtocolVersion
+                    : ProtocolVersion;
+                await WriteAsync(response, Result(id.Value, new
+                {
+                    protocolVersion = version,
+                    capabilities = new { tools = new { listChanged = false } },
+                    serverInfo = new { name = "velashell", title = "VelaShell", version = context.PluginVersion },
+                    instructions = "Tools act on the SSH sessions the user has open in VelaShell. "
+                                   + "Call list_sessions first, then use_session to pick one. "
+                                   + host.Describe()
+                }), cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            case "ping":
+                await WriteAsync(response, Result(id.Value, new { }), cancellationToken).ConfigureAwait(false);
+                return;
+
+            case "tools/list":
+            {
+                if (Resolve(http) is not { } host)
+                {
+                    await WriteAsync(response, Error(id, -32001, "Unknown or expired session; call initialize first."),
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                object[] tools =
+                [
+                    .. host.Tools.Select(t => new
+                    {
+                        name = t.Name,
+                        description = t.Description,
+                        inputSchema = t.JsonSchema
+                    })
+                ];
+                await WriteAsync(response, Result(id.Value, new { tools }), cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            case "tools/call":
+            {
+                if (Resolve(http) is not { } host)
+                {
+                    await WriteAsync(response, Error(id, -32001, "Unknown or expired session; call initialize first."),
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                string name = parameters.ValueKind == JsonValueKind.Object
+                              && parameters.TryGetProperty("name", out JsonElement n)
+                    ? n.GetString() ?? ""
+                    : "";
+                var arguments = new Dictionary<string, object?>(StringComparer.Ordinal);
+                if (parameters.ValueKind == JsonValueKind.Object
+                    && parameters.TryGetProperty("arguments", out JsonElement args)
+                    && args.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (JsonProperty property in args.EnumerateObject())
+                    {
+                        arguments[property.Name] = property.Value;
+                    }
+                }
+                try
+                {
+                    string text = await host.CallAsync(name, arguments, cancellationToken).ConfigureAwait(false);
+                    await WriteAsync(response, Result(id.Value, new
+                    {
+                        content = new[] { new { type = "text", text } },
+                        isError = false
+                    }), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // 工具出错走 isError,不走 JSON-RPC 错误 —— 前者模型看得到并能改正,
+                    // 后者多数客户端会直接把整轮判失败。
+                    await WriteAsync(response, Result(id.Value, new
+                    {
+                        content = new[] { new { type = "text", text = ex.Message } },
+                        isError = true
+                    }), cancellationToken).ConfigureAwait(false);
+                }
+                return;
+            }
+
+            default:
+                await WriteAsync(response, Error(id, -32601, $"Method not found: {method}"), cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+        }
+    }
+
+    private McpToolHost? Resolve(HttpListenerContext http)
+        => SessionId(http.Request) is { Length: > 0 } id && _sessions.TryGetValue(id, out McpToolHost? host)
+            ? host
+            : null;
+
+    private void EvictIdleSessions()
+    {
+        DateTimeOffset cutoff = DateTimeOffset.UtcNow - SessionIdleTimeout;
+        foreach (KeyValuePair<string, McpToolHost> entry in _sessions)
+        {
+            if (entry.Value.LastActivity < cutoff)
+            {
+                _sessions.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+
+    private static string? SessionId(HttpListenerRequest request) => request.Headers["Mcp-Session-Id"];
+
+    /// <summary>令牌比对走定时安全比较 —— 本地端口谁都能敲,不给逐字节试探留缝。</summary>
+    private bool Authorized(HttpListenerRequest request)
+    {
+        string? header = request.Headers["Authorization"];
+        if (header is null || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        byte[] presented = Encoding.UTF8.GetBytes(header["Bearer ".Length..].Trim());
+        byte[] expected = Encoding.UTF8.GetBytes(_token);
+        return presented.Length == expected.Length && CryptographicOperations.FixedTimeEquals(presented, expected);
+    }
+
+    private static string Result(JsonElement id, object result)
+        => JsonSerializer.Serialize(new { jsonrpc = "2.0", id, result });
+
+    private static string Error(JsonElement? id, int code, string message)
+        => JsonSerializer.Serialize(new { jsonrpc = "2.0", id, error = new { code, message } });
+
+    private static async Task WriteAsync(HttpListenerResponse response, string payload,
+        CancellationToken cancellationToken)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(payload);
+        response.ContentType = "application/json";
+        response.ContentLength64 = bytes.Length;
+        await response.OutputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        _reloadGate.Dispose();
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpServerSettings.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpServerSettings.cs
@@ -1,0 +1,104 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Interop;
+
+/// <summary>
+/// 对外 MCP 服务端的设置:让 Claude Code / Codex / Cursor 这类外部 agent
+/// 反过来调用 VelaShell 的能力(枚举会话、读终端、跑命令、读写远端文件)。
+/// </summary>
+/// <remarks>
+/// <b>方向要分清。</b>插件本来就是 MCP <i>客户端</i>(见 <c>Agent/McpManager</c>) ——
+/// VelaShell 的 agent 去调别人的工具。这里是反过来:VelaShell 当<i>服务端</i>,
+/// 别人的 agent 来调 VelaShell 的工具。两套东西没有共用代码,只共用一个名字。
+/// </remarks>
+public sealed class McpServerSettings
+{
+    /// <summary>
+    /// 总开关。关着时不监听任何端口。<b>默认开</b>。
+    /// </summary>
+    /// <remarks>
+    /// 默认打开一个监听端口需要有理由,这里的理由是三条叠起来之后风险足够低,
+    /// 而"默认关"带来的代价(装完还得先去翻一页设置)恰恰是这个功能最没必要的门槛:
+    /// <list type="number">
+    /// <item>只绑 <c>127.0.0.1</c>,不提供绑其它地址的选项;</item>
+    /// <item>每个请求都必须带令牌,而令牌是随机生成、不可关闭的;</item>
+    /// <item>默认挡位是 <see cref="ChatMode.Plan" /> —— 外部 agent 开箱只能<b>看</b>,
+    /// 改任何东西都要用户显式把挡位或审批方式调开。</item>
+    /// </list>
+    /// 换句话说:默认开的是一个"只读、要令牌、只在本机"的接口。
+    /// </remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>监听端口(只绑 127.0.0.1)。</summary>
+    public int Port { get; set; } = 8391;
+
+    /// <summary>
+    /// 暴露哪一档工具。<b>默认计划档 = 只读</b> ——
+    /// 外部 agent 的行为不在用户眼皮底下,默认不该能改任何东西。
+    /// </summary>
+    public ChatMode Mode { get; set; } = ChatMode.Plan;
+
+    /// <summary>
+    /// 写操作的审批方式。<see cref="ApprovalMode.Ask" /> 在这条路上<b>等于拒绝</b> ——
+    /// 外部 agent 没有可以弹审批卡的界面(详见 <see cref="McpToolHost" />)。
+    /// </summary>
+    public ApprovalMode Approval { get; set; } = ApprovalMode.ReadOnlyAuto;
+
+    /// <summary>不暴露给外部 agent 的工具名,每行一条。</summary>
+    public string DisabledTools { get; set; } = "";
+
+    /// <summary>
+    /// 允许外部 agent 操作的服务器(<c>user@host:port</c>,每行一条;空 = 允许全部已连会话)。
+    /// </summary>
+    public string AllowedTargets { get; set; } = "";
+}
+
+/// <summary>MCP 服务端设置的读写。令牌走机密存储,不进明文配置。</summary>
+public sealed class McpServerSettingsStore(IPluginContext context)
+{
+    private const string SettingsKey = "mcp-server";
+    private const string TokenSecret = "mcp-server:token";
+
+    /// <summary>读取设置(没有则返回默认值)。</summary>
+    public async Task<McpServerSettings> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        JsonElement raw = await context.Storage.GetAsync<JsonElement>(SettingsKey, cancellationToken).ConfigureAwait(false);
+        return raw.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null
+            ? new McpServerSettings()
+            : raw.Deserialize<McpServerSettings>() ?? new McpServerSettings();
+    }
+
+    /// <summary>持久化设置。</summary>
+    public Task SaveAsync(McpServerSettings settings, CancellationToken cancellationToken = default)
+        => context.Storage.SetAsync(SettingsKey, settings, cancellationToken);
+
+    /// <summary>
+    /// 取访问令牌;<b>没有就现生成一个并存下</b>。
+    /// </summary>
+    /// <remarks>
+    /// 监听在 127.0.0.1 上并不等于安全:同一台机器上任何进程(包括浏览器里的页面)
+    /// 都能往本地端口发请求。令牌是这条路上唯一挡住"别的程序顺手调你的服务器"的东西,
+    /// 所以它不是可选项,也不该让用户自己想一个。
+    /// </remarks>
+    public async Task<string> TokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (await context.Secrets.GetAsync(TokenSecret, cancellationToken).ConfigureAwait(false) is { Length: > 0 } existing)
+        {
+            return existing;
+        }
+        string token = Convert.ToHexString(RandomNumberGenerator.GetBytes(24)).ToLowerInvariant();
+        await context.Secrets.SetAsync(TokenSecret, token, cancellationToken).ConfigureAwait(false);
+        return token;
+    }
+
+    /// <summary>换一个新令牌(设置页上的"重新生成")。</summary>
+    public async Task<string> RotateTokenAsync(CancellationToken cancellationToken = default)
+    {
+        string token = Convert.ToHexString(RandomNumberGenerator.GetBytes(24)).ToLowerInvariant();
+        await context.Secrets.SetAsync(TokenSecret, token, cancellationToken).ConfigureAwait(false);
+        return token;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
@@ -1,0 +1,142 @@
+using System.ComponentModel;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Interop;
+
+/// <summary>
+/// 一个外部 agent 连进来之后的会话状态:它选中了哪台服务器、能调哪些工具。
+/// </summary>
+/// <remarks>
+/// <b>工具直接复用 <see cref="AgentToolbox" />。</b>VelaShell 自己的 agent 用的就是那一套,
+/// 对外再抄一份只会让两边慢慢长歪。代价是工具签名里没有"服务器"这个参数
+/// (工具箱靠 <see cref="AgentToolbox.SessionIdProvider" /> 拿会话),所以这里补一个
+/// <c>use_session</c>:外部 agent 先 <c>list_sessions</c> 看有哪些,再 <c>use_session</c> 选一台。
+///
+/// <para><b>审批在这条路上没有界面。</b>外部 agent 跑在别的进程里,弹不出 VelaShell 的审批卡。
+/// 所以 <see cref="ApprovalMode.Ask" /> 在这里等于"一律拒绝"(工具箱在
+/// <c>ApprovalHandler</c> 为 null 时就是这个行为),用户要放开就得显式选
+/// 只读放行或绕过审批 —— 这是一个明摆着的选择,而不是一个悄悄的默认。</para>
+/// </remarks>
+internal sealed class McpToolHost
+{
+    private readonly IPluginContext _context;
+    private readonly McpServerSettings _settings;
+    private readonly AgentToolbox _toolbox;
+    private readonly List<string> _allowedTargets;
+    private string? _sessionId;
+    private string _target = "";
+
+    /// <summary>暴露给外部 agent 的工具(建好就不变)。</summary>
+    public IReadOnlyList<AIFunction> Tools { get; }
+
+    /// <summary>最后一次活动时刻(空闲会话回收看它)。</summary>
+    public DateTimeOffset LastActivity { get; set; } = DateTimeOffset.UtcNow;
+
+    public McpToolHost(IPluginContext context, McpServerSettings settings)
+    {
+        _context = context;
+        _settings = settings;
+        _allowedTargets =
+        [
+            .. settings.AllowedTargets.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        ];
+        _toolbox = new AgentToolbox(context)
+        {
+            SessionIdProvider = () => _sessionId,
+            Approval = settings.Approval,
+            DisabledTools = new HashSet<string>(
+                settings.DisabledTools.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase)
+            // ApprovalHandler 刻意不设:见类型注释
+        };
+        var tools = new List<AIFunction>
+        {
+            AIFunctionFactory.Create(UseSessionAsync, "use_session",
+                "Select which of the user's VelaShell SSH sessions the other tools act on. "
+                + "Call list_sessions first to see what is connected. "
+                + "Accepts user@host:port, host:port or host.")
+        };
+        tools.AddRange(_toolbox.CreateTools(settings.Mode).OfType<AIFunction>());
+        Tools = tools;
+    }
+
+    /// <summary>按名字调一个工具,返回给模型看的文本。</summary>
+    public async Task<string> CallAsync(string name, IDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        LastActivity = DateTimeOffset.UtcNow;
+        if (Tools.FirstOrDefault(t => string.Equals(t.Name, name, StringComparison.Ordinal)) is not { } tool)
+        {
+            throw new KeyNotFoundException($"Unknown tool: {name}");
+        }
+        object? result = await tool.InvokeAsync(new AIFunctionArguments(arguments), cancellationToken)
+            .ConfigureAwait(false);
+        return result?.ToString() ?? "";
+    }
+
+    /// <summary>
+    /// 选一台服务器。绑定的是<b>当下那条连接</b> —— 与桥接不同,MCP 会话本来就是短命的,
+    /// 没必要为它做"过夜后重新解析"。
+    /// </summary>
+    private async Task<string> UseSessionAsync(
+        [Description("Which session to use: user@host:port, host:port or just host.")] string target,
+        CancellationToken cancellationToken = default)
+    {
+        if (_allowedTargets.Count > 0
+            && !_allowedTargets.Any(a => string.Equals(a, target, StringComparison.OrdinalIgnoreCase)))
+        {
+            return $"'{target}' is not on the allowlist configured in VelaShell. "
+                   + $"Allowed: {string.Join(", ", _allowedTargets)}";
+        }
+        if (await SessionTargets.ResolveAsync(_context, target, cancellationToken).ConfigureAwait(false) is not { } session)
+        {
+            string list = await SessionTargets.DescribeAsync(_context, cancellationToken).ConfigureAwait(false);
+            return list.Length == 0
+                ? "No sessions are connected in VelaShell right now."
+                : $"No connected session matches '{target}'. Connected sessions:\n{list}";
+        }
+        _sessionId = session.SessionId;
+        _target = SessionTargets.Format(session);
+        return $"Now acting on {_target}.";
+    }
+
+    /// <summary>
+    /// 只有一台连着时,免掉 <c>use_session</c> 这一步。
+    /// </summary>
+    /// <remarks>
+    /// 纯粹是省事:外部 agent 一上来就 <c>run_command</c> 是很自然的写法,
+    /// 而"只有一台"时并不存在选错的风险。多于一台就老老实实让它自己选。
+    /// </remarks>
+    public async Task AutoSelectAsync(CancellationToken cancellationToken)
+    {
+        if (_sessionId is not null)
+        {
+            return;
+        }
+        IReadOnlyList<SessionInfo> sessions = await _context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
+        List<SessionInfo> connected = [.. sessions.Where(s => s.State == SessionState.Connected)];
+        if (connected.Count != 1)
+        {
+            return;
+        }
+        string only = SessionTargets.Format(connected[0]);
+        if (_allowedTargets.Count > 0
+            && !_allowedTargets.Any(a => string.Equals(a, only, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+        _sessionId = connected[0].SessionId;
+        _target = only;
+    }
+
+    /// <summary>给 <c>initialize</c> 的服务端说明里带一句"现在对着哪台机器"。</summary>
+    public string Describe()
+        => _target.Length > 0
+            ? $"VelaShell is acting on {_target}. Mode: {_settings.Mode}, approval: {_settings.Approval}."
+            : $"No session selected yet — call list_sessions, then use_session. Mode: {_settings.Mode}, approval: {_settings.Approval}.";
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml
@@ -1,0 +1,196 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="VelaShell.Plugin.Ai.Ui.CollaborationView">
+
+  <!-- 协作接入:两条方向相反的路合在一页。
+       上半页「IM 桥接」是往外接 —— 飞书 / 钉钉 / Telegram 里的人指使 VelaShell 的 agent;
+       下半页「对外 MCP 服务端」是往内接 —— Claude Code / Codex 这类外部 agent 调 VelaShell 的工具。
+       两者共用同一套安全观念(白名单、挡位、审批),摆在一页里才看得出这一点。
+       版式沿用模型配置页:节标题 + 描边卡片 + 末行操作。 -->
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://VelaShell.Plugin.Ai/Ui/AiTheme.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <UserControl.Styles>
+    <StyleInclude Source="avares://VelaShell.Plugin.Ai/Ui/DialogStyles.axaml" />
+  </UserControl.Styles>
+
+  <Border Background="{DynamicResource VelaBgTerminal}" CornerRadius="0,0,7,7">
+    <DockPanel>
+
+      <!-- 末行操作:保存并把两条服务按新配置重起 -->
+      <Border DockPanel.Dock="Bottom" Padding="24,12"
+              Background="{DynamicResource VelaBgSurface}"
+              BorderBrush="{DynamicResource VelaBorderPrimary}" BorderThickness="0,1,0,0"
+              CornerRadius="0,0,7,7">
+        <Grid ColumnDefinitions="*,Auto">
+          <TextBlock x:Name="StatusText" Classes="hint" VerticalAlignment="Center" TextWrapping="Wrap" />
+          <Button x:Name="SaveButton" Grid.Column="1" MinWidth="96" Classes="primary" />
+        </Grid>
+      </Border>
+
+      <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="24,18" Spacing="8">
+
+          <!-- ═══ IM 桥接 ═══ -->
+          <TextBlock x:Name="SectionBridgeTitle" Classes="section-title" />
+          <Border Classes="section">
+            <StackPanel Spacing="10">
+              <StackPanel>
+                <CheckBox x:Name="BridgeEnabledCheck" Classes="host" />
+                <TextBlock x:Name="BridgeEnabledHint" Classes="hint" />
+              </StackPanel>
+
+              <StackPanel x:Name="BridgeDetailPanel" Spacing="10">
+                <Grid ColumnDefinitions="*,12,*">
+                  <StackPanel>
+                    <TextBlock x:Name="BridgeModeLabel" Classes="label" />
+                    <ComboBox x:Name="BridgeModeCombo" HorizontalAlignment="Stretch" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="2">
+                    <TextBlock x:Name="BridgeApprovalLabel" Classes="label" />
+                    <ComboBox x:Name="BridgeApprovalCombo" HorizontalAlignment="Stretch" />
+                  </StackPanel>
+                </Grid>
+                <TextBlock x:Name="BridgeModeHint" Classes="hint" />
+
+                <!-- 桥接用哪个模型。原来只能默默跟着聊天面板当前选中的那个 ——
+                     结果是群里报一句 401,而人完全不知道那是哪个接入的密钥出了问题。 -->
+                <StackPanel>
+                  <TextBlock x:Name="BridgeModelLabel" Classes="label" />
+                  <ComboBox x:Name="BridgeModelCombo" HorizontalAlignment="Stretch" />
+                  <TextBlock x:Name="BridgeModelHint" Classes="hint" />
+                </StackPanel>
+
+                <StackPanel>
+                  <CheckBox x:Name="EscalationCheck" Classes="host" />
+                  <TextBlock x:Name="EscalationHint" Classes="hint" />
+                </StackPanel>
+
+                <Grid ColumnDefinitions="*,12,*,12,*">
+                  <StackPanel>
+                    <TextBlock x:Name="TurnTimeoutLabel" Classes="label" />
+                    <TextBox x:Name="TurnTimeoutBox" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="2">
+                    <TextBlock x:Name="ApprovalTimeoutLabel" Classes="label" />
+                    <TextBox x:Name="ApprovalTimeoutBox" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="4">
+                    <TextBlock x:Name="ConcurrencyLabel" Classes="label" />
+                    <TextBox x:Name="ConcurrencyBox" />
+                  </StackPanel>
+                </Grid>
+              </StackPanel>
+            </StackPanel>
+          </Border>
+
+          <!-- ═══ 渠道 ═══ -->
+          <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,6,0,0">
+            <TextBlock x:Name="SectionChannelsTitle" Classes="section-title" VerticalAlignment="Center" />
+            <ComboBox x:Name="AddKindCombo" Grid.Column="1" MinWidth="130" Margin="0,0,8,0" />
+            <Button x:Name="AddChannelButton" Grid.Column="2" MinWidth="72" Classes="host" />
+          </Grid>
+          <StackPanel x:Name="ChannelsPanel" Spacing="8" />
+          <TextBlock x:Name="NoChannelsHint" Classes="hint" />
+
+          <!-- ═══ 授权聊天 ═══
+               原来要人肉抄群 id:加机器人进群 → 发一句 → 看它回的 id → 复制 → 回电脑粘进白名单。
+               这一节把那趟路砍掉:要么在群里发 /pair <码>,要么在下面点一下「允许」。 -->
+          <TextBlock x:Name="SectionPairingTitle" Classes="section-title" Margin="0,10,0,0" />
+          <Border Classes="section">
+            <StackPanel Spacing="10">
+              <StackPanel>
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                  <TextBlock x:Name="PairCodeLabel" Classes="label" VerticalAlignment="Center" />
+                  <TextBlock x:Name="PairCodeText" Grid.Column="1" Margin="10,0,0,0"
+                             VerticalAlignment="Center"
+                             FontFamily="{DynamicResource VelaUiMonoFont}"
+                             FontSize="{DynamicResource VelaFontSize16}"
+                             Foreground="{DynamicResource VelaTextPrimary}" />
+                  <Button x:Name="IssuePairCodeButton" Grid.Column="2" MinWidth="96" Classes="host" />
+                </Grid>
+                <TextBlock x:Name="PairCodeHint" Classes="hint" TextWrapping="Wrap" />
+              </StackPanel>
+
+              <Border Classes="sep" />
+
+              <StackPanel>
+                <TextBlock x:Name="PendingLabel" Classes="label" />
+                <StackPanel x:Name="PendingPanel" Spacing="6" />
+                <TextBlock x:Name="NoPendingHint" Classes="hint" TextWrapping="Wrap" />
+              </StackPanel>
+            </StackPanel>
+          </Border>
+
+          <!-- ═══ 对外 MCP 服务端 ═══ -->
+          <TextBlock x:Name="SectionMcpTitle" Classes="section-title" Margin="0,10,0,0" />
+          <Border Classes="section">
+            <StackPanel Spacing="10">
+              <StackPanel>
+                <CheckBox x:Name="McpEnabledCheck" Classes="host" />
+                <TextBlock x:Name="McpEnabledHint" Classes="hint" />
+              </StackPanel>
+
+              <StackPanel x:Name="McpDetailPanel" Spacing="10">
+                <Grid ColumnDefinitions="*,12,*,12,*">
+                  <StackPanel>
+                    <TextBlock x:Name="McpPortLabel" Classes="label" />
+                    <TextBox x:Name="McpPortBox" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="2">
+                    <TextBlock x:Name="McpModeLabel" Classes="label" />
+                    <ComboBox x:Name="McpModeCombo" HorizontalAlignment="Stretch" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="4">
+                    <TextBlock x:Name="McpApprovalLabel" Classes="label" />
+                    <ComboBox x:Name="McpApprovalCombo" HorizontalAlignment="Stretch" />
+                  </StackPanel>
+                </Grid>
+                <TextBlock x:Name="McpApprovalHint" Classes="hint" />
+
+                <StackPanel>
+                  <TextBlock x:Name="McpTargetsLabel" Classes="label" />
+                  <TextBox x:Name="McpTargetsBox" AcceptsReturn="True" MinHeight="56" TextWrapping="NoWrap" />
+                  <TextBlock x:Name="McpTargetsHint" Classes="hint" />
+                </StackPanel>
+
+                <!-- 令牌与接入命令:这两行是用户唯一要复制走的东西,所以给按钮而不是让他手抄 -->
+                <StackPanel>
+                  <TextBlock x:Name="McpTokenLabel" Classes="label" />
+                  <Grid ColumnDefinitions="*,Auto,Auto">
+                    <TextBox x:Name="McpTokenBox" IsReadOnly="True" />
+                    <Button x:Name="CopyTokenButton" Grid.Column="1" Margin="8,0,0,0" MinWidth="64" Classes="host" />
+                    <Button x:Name="RotateTokenButton" Grid.Column="2" Margin="8,0,0,0" MinWidth="80" Classes="host" />
+                  </Grid>
+                  <TextBlock x:Name="McpTokenHint" Classes="hint" />
+                </StackPanel>
+
+                <!-- 复制键放在标题行上,文本框自己占满一行。
+                     **这里刻意用 NoWrap,别改成 Wrap。**外层 ScrollViewer 的竖滚动条是 Auto:
+                     会换行的文本一旦让内容高度正好卡在"要不要出滚动条"的边界上,出滚动条 → 可用宽度变窄
+                     → 文本重排变高 → 还是要滚动条 → 收回滚动条…… measure/arrange 就这么来回震荡,
+                     表现是窗口整个卡死(headless 测试里是一分钟超时,连异常都没有)。
+                     实测:同一个框内容为空时没事,填上接入命令(两行长串)就必挂。
+                     这里的内容本来就是给人整段复制走的,横向滚动完全够用。 -->
+                <StackPanel>
+                  <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+                    <TextBlock x:Name="McpCommandLabel" Classes="label" VerticalAlignment="Center" />
+                    <Button x:Name="CopyCommandButton" Grid.Column="1" MinWidth="64" Classes="host" />
+                  </Grid>
+                  <TextBox x:Name="McpCommandBox" IsReadOnly="True" TextWrapping="NoWrap" AcceptsReturn="True"
+                           MinHeight="64" FontFamily="{DynamicResource VelaUiMonoFont}" />
+                </StackPanel>
+              </StackPanel>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </ScrollViewer>
+    </DockPanel>
+  </Border>
+</UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
@@ -1,0 +1,803 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using QRCoder;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Interop;
+using VelaShell.PluginSdk;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// 「协作接入」设置页:IM 桥接(往外)与对外 MCP 服务端(往内)。
+/// </summary>
+/// <remarks>
+/// 渠道卡片是<b>代码建的</b>,不是 DataTemplate 绑上去的 —— 每种平台要填的字段不一样
+/// (Telegram 没有 AppId、只有飞书有国际版、只有企微要 AgentID),用模板就得靠一堆
+/// 转换器去藏字段,不如直接按平台建对应的那几行。
+/// </remarks>
+public partial class CollaborationView : UserControl
+{
+    private readonly IPluginContext _context;
+    private readonly BridgeSettingsStore _bridgeStore;
+    private readonly McpServerSettingsStore _mcpStore;
+    private readonly Loc _loc;
+    private readonly Func<Task> _restart;
+
+    private readonly BridgeService? _bridge;
+    private readonly DispatcherTimer _refresh;
+    private BridgeSettings _settings = new();
+    private McpServerSettings _mcp = new();
+    private readonly List<ChannelRow> _rows = [];
+    private string _token = "";
+
+    /// <summary>一张渠道卡片上那些要回读的控件。</summary>
+    private sealed class ChannelRow
+    {
+        public required ChannelConfig Config { get; init; }
+
+        public required CheckBox Enabled { get; init; }
+
+        public required TextBox Name { get; init; }
+
+        public TextBox? AppId { get; init; }
+
+        public TextBox? AgentId { get; init; }
+
+        public required TextBox Secret { get; init; }
+
+        /// <summary>企微回调用的 Token(与 <see cref="Secret" /> 是两样东西)。</summary>
+        public TextBox? CallbackToken { get; init; }
+
+        /// <summary>企微的 EncodingAESKey。</summary>
+        public TextBox? AesKey { get; init; }
+
+        /// <summary>企微回调监听的端口与路径。</summary>
+        public TextBox? Port { get; init; }
+
+        /// <inheritdoc cref="Port" />
+        public TextBox? Path { get; init; }
+
+        public CheckBox? International { get; init; }
+
+        public required TextBox Chats { get; init; }
+
+        public required TextBox Users { get; init; }
+
+        public required TextBox Approvers { get; init; }
+
+        public required TextBox Target { get; init; }
+
+        public bool Removed { get; set; }
+    }
+
+    /// <summary>由插件入口构造(UI 线程)。</summary>
+    /// <param name="context">插件上下文。</param>
+    /// <param name="loc">文案。</param>
+    /// <param name="restart">保存后按新配置重起桥接与 MCP 服务端。</param>
+    /// <param name="bridge">
+    /// 正在跑的桥接;为 null 表示还没起来(配对码与待放行清单那一节会说明原因)。
+    /// </param>
+    public CollaborationView(IPluginContext context, Loc loc, Func<Task> restart, BridgeService? bridge = null)
+    {
+        _context = context;
+        _loc = loc;
+        _restart = restart;
+        _bridge = bridge;
+        _bridgeStore = new BridgeSettingsStore(context);
+        _mcpStore = new McpServerSettingsStore(context);
+        InitializeComponent();
+        ApplyLoc();
+
+        IssuePairCodeButton.Click += (_, _) => IssuePairCode();
+        // 敲门是异步发生的(人在手机上操作),所以这一页开着时自己刷 ——
+        // 否则用户得关掉再打开才看得见刚才那个群
+        _refresh = new DispatcherTimer(TimeSpan.FromSeconds(3), DispatcherPriority.Background, (_, _) =>
+        {
+            RefreshPending();
+            RefreshPairCode();
+        });
+        _refresh.Start();
+        DetachedFromVisualTree += (_, _) => _refresh.Stop();
+
+        BridgeEnabledCheck.IsCheckedChanged += (_, _) => UpdateVisibility();
+        McpEnabledCheck.IsCheckedChanged += (_, _) => UpdateVisibility();
+        McpPortBox.TextChanged += (_, _) => UpdateCommandSample();
+        AddChannelButton.Click += (_, _) => AddChannel();
+        SaveButton.Click += (_, _) => _ = SaveAsync();
+        CopyTokenButton.Click += (_, _) => _ = _context.Clipboard.SetTextAsync(_token);
+        CopyCommandButton.Click += (_, _) => _ = _context.Clipboard.SetTextAsync(McpCommandBox.Text ?? "");
+        RotateTokenButton.Click += (_, _) => _ = RotateTokenAsync();
+
+        _ = LoadAsync();
+    }
+
+    /// <summary>语言切换时由面板调用。</summary>
+    public void ApplyLoc()
+    {
+        SectionBridgeTitle.Text = _loc["SecBridge"];
+        BridgeEnabledCheck.Content = _loc["BridgeEnabled"];
+        BridgeEnabledHint.Text = _loc["BridgeEnabledHint"];
+        BridgeModeLabel.Text = _loc["BridgeMode"];
+        BridgeApprovalLabel.Text = _loc["BridgeApproval"];
+        BridgeModeHint.Text = _loc["BridgeModeHint"];
+        EscalationCheck.Content = _loc["BridgeEscalation"];
+        EscalationHint.Text = _loc["BridgeEscalationHint"];
+        TurnTimeoutLabel.Text = _loc["BridgeTurnTimeout"];
+        ApprovalTimeoutLabel.Text = _loc["BridgeApprovalTimeout"];
+        ConcurrencyLabel.Text = _loc["BridgeConcurrency"];
+        BridgeModelLabel.Text = _loc["BridgeModel"];
+        BridgeModelHint.Text = _loc["BridgeModelHint"];
+
+        SectionChannelsTitle.Text = _loc["SecChannels"];
+        AddChannelButton.Content = _loc["ChannelAdd"];
+        NoChannelsHint.Text = _loc["ChannelNone"];
+
+        SectionPairingTitle.Text = _loc["SecPairing"];
+        PairCodeLabel.Text = _loc["PairCode"];
+        IssuePairCodeButton.Content = _loc["PairIssue"];
+        PairCodeHint.Text = _loc["PairHint"];
+        PendingLabel.Text = _loc["PairPending"];
+        NoPendingHint.Text = _loc["PairNoPending"];
+
+        SectionMcpTitle.Text = _loc["SecMcpServer"];
+        McpEnabledCheck.Content = _loc["McpServerEnabled"];
+        McpEnabledHint.Text = _loc["McpServerEnabledHint"];
+        McpPortLabel.Text = _loc["McpServerPort"];
+        McpModeLabel.Text = _loc["BridgeMode"];
+        McpApprovalLabel.Text = _loc["BridgeApproval"];
+        McpApprovalHint.Text = _loc["McpServerApprovalHint"];
+        McpTargetsLabel.Text = _loc["McpServerTargets"];
+        McpTargetsHint.Text = _loc["McpServerTargetsHint"];
+        McpTokenLabel.Text = _loc["McpServerToken"];
+        McpTokenHint.Text = _loc["McpServerTokenHint"];
+        McpCommandLabel.Text = _loc["McpServerCommand"];
+        CopyTokenButton.Content = _loc["Copy"];
+        CopyCommandButton.Content = _loc["Copy"];
+        RotateTokenButton.Content = _loc["McpServerRotate"];
+        SaveButton.Content = _loc["Save"];
+
+        FillModes(BridgeModeCombo);
+        FillModes(McpModeCombo);
+        FillApprovals(BridgeApprovalCombo);
+        FillApprovals(McpApprovalCombo);
+        FillKinds();
+    }
+
+    private void FillModes(ComboBox combo)
+    {
+        int selected = combo.SelectedIndex;
+        combo.ItemsSource = new[] { _loc["ModeChat"], _loc["ModePlan"], _loc["ModeAgent"] };
+        combo.SelectedIndex = selected < 0 ? 1 : selected;
+    }
+
+    private void FillApprovals(ComboBox combo)
+    {
+        int selected = combo.SelectedIndex;
+        combo.ItemsSource = new[] { _loc["ApprovalAsk"], _loc["ApprovalReadOnly"], _loc["ApprovalBypass"] };
+        combo.SelectedIndex = selected < 0 ? 0 : selected;
+    }
+
+    private void FillKinds()
+    {
+        int selected = AddKindCombo.SelectedIndex;
+        // 平台名带上拉丁写法:界面可以切到日/韩,而"钉钉"两个字对那边的用户不是可读的品牌名
+        AddKindCombo.ItemsSource = new[] { "飞书 / Lark", "钉钉 / DingTalk", "Telegram", "企业微信 / WeCom" };
+        AddKindCombo.SelectedIndex = selected < 0 ? 0 : selected;
+    }
+
+    /// <summary>可选的模型(下拉里第 0 项是"跟随聊天面板",所以下标要减一)。</summary>
+    private List<ResolvedModel> _models = [];
+
+    private async Task LoadAsync()
+    {
+        _settings = await _bridgeStore.LoadAsync();
+        _mcp = await _mcpStore.LoadAsync();
+        _token = await _mcpStore.TokenAsync();
+        await LoadModelsAsync();
+
+        BridgeEnabledCheck.IsChecked = _settings.Enabled;
+        BridgeModeCombo.SelectedIndex = (int)_settings.Mode;
+        BridgeApprovalCombo.SelectedIndex = (int)_settings.Approval;
+        EscalationCheck.IsChecked = _settings.AllowModeEscalation;
+        TurnTimeoutBox.Text = _settings.TurnTimeoutSeconds.ToString();
+        ApprovalTimeoutBox.Text = _settings.ApprovalTimeoutSeconds.ToString();
+        ConcurrencyBox.Text = _settings.MaxConcurrentTurns.ToString();
+
+        McpEnabledCheck.IsChecked = _mcp.Enabled;
+        McpPortBox.Text = _mcp.Port.ToString();
+        McpModeCombo.SelectedIndex = (int)_mcp.Mode;
+        McpApprovalCombo.SelectedIndex = (int)_mcp.Approval;
+        McpTargetsBox.Text = _mcp.AllowedTargets;
+        McpTokenBox.Text = _token;
+
+        await RebuildChannelsAsync();
+        UpdateVisibility();
+        UpdateCommandSample();
+        // 立刻刷一次,别让人对着空白等三秒 —— 定时器只负责"页面开着时后来又有人敲门"
+        RefreshPending();
+        RefreshPairCode();
+    }
+
+    /// <summary>
+    /// 把已配好的模型灌进下拉。第 0 项是"跟随聊天面板"。
+    /// </summary>
+    /// <remarks>
+    /// 一个模型都没配时只留第 0 项 —— 这时桥接跑起来会回一句"还没配置模型",
+    /// 比在下拉里摆一堆空条目诚实。
+    /// </remarks>
+    private async Task LoadModelsAsync()
+    {
+        AiSettings ai = await new AiSettingsStore(_context).LoadAsync();
+        _models = ai.ResolveModels();
+        List<string> items = [_loc["BridgeModelFollow"]];
+        items.AddRange(_models.Select(m => $"{m.ProviderName} / {m.Name}"));
+        BridgeModelCombo.ItemsSource = items;
+        int index = _settings.ModelId is { Length: > 0 } id
+            ? _models.FindIndex(m => m.Id == id) + 1
+            : 0;
+        BridgeModelCombo.SelectedIndex = Math.Max(0, index);
+    }
+
+    private async Task RebuildChannelsAsync()
+    {
+        _rows.Clear();
+        ChannelsPanel.Children.Clear();
+        foreach (ChannelConfig config in _settings.Channels)
+        {
+            string? secret = await _bridgeStore.GetSecretAsync(config.Id, "secret");
+            ChannelsPanel.Children.Add(BuildCard(config, secret ?? ""));
+        }
+        NoChannelsHint.IsVisible = _settings.Channels.Count == 0;
+    }
+
+    private Border BuildCard(ChannelConfig config, string secret)
+    {
+        var title = new TextBlock { Text = KindLabel(config.Kind), VerticalAlignment = VerticalAlignment.Center };
+        title.Classes.Add("section-title");
+        Button test = HostButton(_loc["ChannelTest"], 72);
+        Button remove = HostButton(_loc["ChannelRemove"], 72);
+        remove.Margin = new Thickness(8, 0, 0, 0);
+        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        header.Children.Add(title);
+        Grid.SetColumn(test, 1);
+        header.Children.Add(test);
+        Grid.SetColumn(remove, 2);
+        header.Children.Add(remove);
+
+        // 体检结果与「拉机器人进群」的二维码:平时不占版面,点了测试才出现
+        var testResult = new TextBlock { TextWrapping = TextWrapping.Wrap, IsVisible = false };
+        testResult.Classes.Add("hint");
+        var qr = new Image { MaxWidth = 168, MaxHeight = 168 };
+        // 二维码本身是黑白的(为了扫得动,不跟着主题反色),所以给它一圈 card 的描边与内边距,
+        // 让它像页面上的一块内容,而不是一张糊在深色卡片上的白纸。
+        var qrFrame = new Border
+        {
+            Child = qr,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(0, 6, 0, 0),
+            IsVisible = false
+        };
+        qrFrame.Classes.Add("card");
+        var qrHint = new TextBlock
+        {
+            Text = _loc["ChannelInviteHint"],
+            TextWrapping = TextWrapping.Wrap,
+            IsVisible = false
+        };
+        qrHint.Classes.Add("hint");
+
+        CheckBox enabled = HostCheckBox(_loc["ChannelEnabled"], config.Enabled);
+        TextBox name = Field(_loc["ChannelName"], config.DisplayName, out StackPanel namePanel);
+        TextBox? appId = null;
+        StackPanel? appIdPanel = null;
+        if (config.Kind != ChannelKind.Telegram)
+        {
+            appId = Field(AppIdLabel(config.Kind), config.AppId, out appIdPanel);
+        }
+        TextBox secretBox = Field(SecretLabel(config.Kind), secret, out StackPanel secretPanel);
+        secretBox.PasswordChar = '●';
+
+        TextBox? agentId = null, callbackToken = null, aesKey = null, port = null, path = null;
+        StackPanel? agentPanel = null, callbackPanel = null, aesPanel = null, endpointPanel = null;
+        if (config.Kind == ChannelKind.WeCom)
+        {
+            agentId = Field("AgentID", config.AgentId, out agentPanel);
+            callbackToken = Field(_loc["ChannelCallbackToken"], "", out callbackPanel);
+            callbackToken.PasswordChar = '●';
+            aesKey = Field("EncodingAESKey", "", out aesPanel);
+            aesKey.PasswordChar = '●';
+            // 端口与路径并排:它们合起来才是一个地址,分两行读着费劲
+            port = Field(_loc["ChannelWebhookPort"], config.WebhookPort.ToString(), out StackPanel portPanel);
+            path = Field(_loc["ChannelWebhookPath"], config.WebhookPath, out StackPanel pathPanel);
+            endpointPanel = new StackPanel();
+            var endpoint = new Grid { ColumnDefinitions = new ColumnDefinitions("*,12,2*") };
+            endpoint.Children.Add(portPanel);
+            Grid.SetColumn(pathPanel, 2);
+            endpoint.Children.Add(pathPanel);
+            var callbackHint = new TextBlock { Text = _loc["ChannelWeComCallbackHint"], TextWrapping = Avalonia.Media.TextWrapping.Wrap };
+            callbackHint.Classes.Add("hint");
+            endpointPanel.Children.Add(endpoint);
+            endpointPanel.Children.Add(callbackHint);
+        }
+        CheckBox? international = null;
+        if (config.Kind == ChannelKind.Feishu)
+        {
+            international = HostCheckBox(_loc["ChannelInternational"], config.International);
+        }
+
+        TextBox chats = Field(_loc["ChannelChats"], string.Join("\n", config.AllowedChats), out StackPanel chatsPanel, multiline: true);
+        var chatsHint = new TextBlock { Text = _loc["ChannelChatsHint"] };
+        chatsHint.Classes.Add("hint");
+        chatsPanel.Children.Add(chatsHint);
+        TextBox users = Field(_loc["ChannelUsers"], string.Join("\n", config.AllowedUsers), out StackPanel usersPanel, multiline: true);
+        TextBox approvers = Field(_loc["ChannelApprovers"], string.Join("\n", config.Approvers), out StackPanel approversPanel, multiline: true);
+        TextBox target = Field(_loc["ChannelTarget"], config.DefaultTarget, out StackPanel targetPanel);
+
+        var body = new StackPanel { Spacing = 10 };
+        body.Children.Add(header);
+        body.Children.Add(enabled);
+        body.Children.Add(namePanel);
+        if (appIdPanel is not null)
+        {
+            body.Children.Add(appIdPanel);
+        }
+        if (agentPanel is not null)
+        {
+            body.Children.Add(agentPanel);
+        }
+        body.Children.Add(secretPanel);
+        if (callbackPanel is not null)
+        {
+            body.Children.Add(callbackPanel);
+        }
+        if (aesPanel is not null)
+        {
+            body.Children.Add(aesPanel);
+        }
+        if (endpointPanel is not null)
+        {
+            body.Children.Add(endpointPanel);
+        }
+        if (international is not null)
+        {
+            body.Children.Add(international);
+        }
+        body.Children.Add(chatsPanel);
+        body.Children.Add(usersPanel);
+        body.Children.Add(approversPanel);
+        body.Children.Add(targetPanel);
+        body.Children.Add(testResult);
+        body.Children.Add(qrHint);
+        body.Children.Add(qrFrame);
+
+        var card = new Border { Child = body };
+        card.Classes.Add("section");
+
+        var row = new ChannelRow
+        {
+            Config = config,
+            Enabled = enabled,
+            Name = name,
+            AppId = appId,
+            AgentId = agentId,
+            Secret = secretBox,
+            CallbackToken = callbackToken,
+            AesKey = aesKey,
+            Port = port,
+            Path = path,
+            International = international,
+            Chats = chats,
+            Users = users,
+            Approvers = approvers,
+            Target = target
+        };
+        _rows.Add(row);
+        remove.Click += (_, _) =>
+        {
+            row.Removed = true;
+            ChannelsPanel.Children.Remove(card);
+            NoChannelsHint.IsVisible = _rows.All(r => r.Removed);
+        };
+        test.Click += (_, _) => _ = TestAsync(row, test, testResult, qr, qrFrame, qrHint);
+        return card;
+    }
+
+    /// <summary>
+    /// 拿框里<b>当前</b>填的东西去试一次连接(不保存)。
+    /// </summary>
+    /// <remarks>
+    /// 用界面上的值而不是 <see cref="ChannelRow.Config" /> 里那份 —— 用户改完密钥
+    /// 最想做的就是当场验一下,让他先保存再测,等于把"试错"这件事变成"改配置"。
+    /// </remarks>
+    private async Task TestAsync(ChannelRow row, Button button, TextBlock result, Image qr, Border qrFrame,
+        TextBlock qrHint)
+    {
+        button.IsEnabled = false;
+        result.IsVisible = true;
+        result.Text = _loc["ChannelTesting"];
+        qrFrame.IsVisible = false;
+        qrHint.IsVisible = false;
+        try
+        {
+            var probe = new ChannelConfig
+            {
+                Id = row.Config.Id,
+                Kind = row.Config.Kind,
+                AppId = (row.AppId?.Text ?? row.Config.AppId).Trim(),
+                AgentId = (row.AgentId?.Text ?? row.Config.AgentId).Trim(),
+                International = row.International?.IsChecked == true
+            };
+            ChannelProbeResult outcome = await ChannelProbe.TestAsync(probe,
+                (row.Secret.Text ?? "").Trim(), (row.AesKey?.Text ?? "").Trim(),
+                _context.Log, CancellationToken.None);
+            result.Text = (outcome.Ok ? "✓ " : "✗ ") + outcome.Summary;
+            if (outcome is { Ok: true, InviteUrl: { Length: > 0 } url })
+            {
+                qr.Source = RenderQr(url);
+                qrFrame.IsVisible = true;
+                qrHint.Text = _loc["ChannelInviteHint"];
+                qrHint.IsVisible = true;
+            }
+            else if (outcome.Ok && row.Config.Kind == ChannelKind.Feishu)
+            {
+                // 飞书没有"扫码加机器人进群"的链接(applink 那条是打开小程序用的,
+                // 纯机器人应用扫出来是"此页面无效")。所以这里不摆码,直接把手工步骤写出来。
+                qrHint.Text = _loc["ChannelAddBotFeishu"];
+                qrHint.IsVisible = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            result.Text = "✗ " + ex.Message;
+        }
+        finally
+        {
+            button.IsEnabled = true;
+        }
+    }
+
+    /// <summary>把一段链接画成二维码。</summary>
+    /// <remarks>
+    /// 走 <see cref="PngByteQRCode" /> 出 PNG 字节再交给 Avalonia —— QRCoder 另有几个
+    /// 直接出 <c>System.Drawing.Bitmap</c> 的类型,那条路在 Linux 上要 libgdiplus,
+    /// 而这是个跨三平台的桌面程序。
+    /// </remarks>
+    private static Bitmap RenderQr(string text)
+    {
+        using var generator = new QRCodeGenerator();
+        using QRCodeData data = generator.CreateQrCode(text, QRCodeGenerator.ECCLevel.M);
+        byte[] png = new PngByteQRCode(data).GetGraphic(6);
+        return new Bitmap(new MemoryStream(png));
+    }
+
+    /// <summary>
+    /// 建一个和这一页其余按钮同款的按钮。
+    /// </summary>
+    /// <remarks>
+    /// <b>必须挂宿主的 <c>VelaOutlineButtonTheme</c>。</b>不挂的话不只是"颜色不一样" ——
+    /// 那套主题里带着 <c>HorizontalContentAlignment="Center"</c>,不挂就是文字不居中
+    /// (实测,用户先看出来的)。见 <c>DESIGN.md</c> 与 <c>src/VelaShell/Themes/ButtonThemes.axaml</c>。
+    /// <para>
+    /// 用 <c>TryFindResource</c> 而不是 <c>FindResource</c>:这是<b>宿主</b>的资源,
+    /// headless 测试里没有宿主那套主题字典,取不到就退回默认外观,而不是把整页构造炸掉。
+    /// </para>
+    /// </remarks>
+    private static Button HostButton(string content, double minWidth)
+    {
+        var button = new Button { Content = content, MinWidth = minWidth };
+        button.Classes.Add("host");
+        return button;
+    }
+
+    /// <summary>
+    /// 建一个和 XAML 里那几个同款的勾选框。
+    /// </summary>
+    /// <remarks>
+    /// 字号与前景色要跟着一起给:<c>AiCheckBoxTheme</c> 只管勾选框那个方块的画法,
+    /// 旁边那行字仍旧用控件自己的 <c>FontSize</c> / <c>Foreground</c> ——
+    /// 只挂主题不给这两项,代码建的勾选框会比 XAML 里的大一号、而且颜色不跟主题走。
+    /// </remarks>
+    private static CheckBox HostCheckBox(string content, bool isChecked)
+    {
+        var box = new CheckBox { Content = content, IsChecked = isChecked };
+        box.Classes.Add("host");
+        return box;
+    }
+
+    /// <summary>一个"标签 + 输入框"的竖排。</summary>
+    private static TextBox Field(string label, string value, out StackPanel panel, bool multiline = false)
+    {
+        var caption = new TextBlock { Text = label };
+        caption.Classes.Add("label"); // 间距由 label 这一档自己给
+        var box = new TextBox { Text = value };
+        if (multiline)
+        {
+            box.AcceptsReturn = true;
+            box.MinHeight = 56;
+            box.TextWrapping = Avalonia.Media.TextWrapping.NoWrap;
+        }
+        panel = new StackPanel();
+        panel.Children.Add(caption);
+        panel.Children.Add(box);
+        return box;
+    }
+
+    private void AddChannel()
+    {
+        ChannelKind kind = AddKindCombo.SelectedIndex switch
+        {
+            1 => ChannelKind.DingTalk,
+            2 => ChannelKind.Telegram,
+            3 => ChannelKind.WeCom,
+            _ => ChannelKind.Feishu
+        };
+        if (kind == ChannelKind.WeCom)
+        {
+            // 加得出来,但要提醒一句它和另外三家不一样:它需要一个公网可达的入口
+            StatusText.Text = _loc["ChannelWeComHint"];
+        }
+        var config = new ChannelConfig { Kind = kind, DisplayName = KindLabel(kind) };
+        _settings.Channels.Add(config);
+        ChannelsPanel.Children.Add(BuildCard(config, ""));
+        NoChannelsHint.IsVisible = false;
+    }
+
+    private async Task RotateTokenAsync()
+    {
+        _token = await _mcpStore.RotateTokenAsync();
+        McpTokenBox.Text = _token;
+        UpdateCommandSample();
+        StatusText.Text = _loc["McpServerRotated"];
+    }
+
+    /// <summary>发一个新的配对码。</summary>
+    private void IssuePairCode()
+    {
+        if (_bridge is null)
+        {
+            StatusText.Text = _loc["PairNeedsBridge"];
+            return;
+        }
+        _bridge.Pairing.Issue();
+        RefreshPairCode();
+    }
+
+    /// <summary>刷新配对码那一行(含剩余时间;过期了就退回成"点一下生成")。</summary>
+    private void RefreshPairCode()
+    {
+        if (_bridge?.Pairing.Code is not { } code)
+        {
+            PairCodeText.Text = "—";
+            return;
+        }
+        TimeSpan left = _bridge.Pairing.ExpiresAt - DateTimeOffset.UtcNow;
+        PairCodeText.Text = left > TimeSpan.Zero
+            ? $"{code}    {_loc.F("PairExpiresIn", (int)left.TotalMinutes, left.Seconds)}"
+            : "—";
+    }
+
+    /// <summary>
+    /// 刷新"敲过门的聊天"清单。
+    /// </summary>
+    /// <remarks>
+    /// 整块重建而不是做增量比对:这个列表最多几十行,而且只在这一页开着时刷 ——
+    /// 为它写一套差异算法,省下的那点开销还不够读那段代码的时间。
+    /// </remarks>
+    private void RefreshPending()
+    {
+        IReadOnlyList<PendingChat> pending = _bridge?.Pairing.Pending() ?? [];
+        if (pending.Count == PendingPanel.Children.Count
+            && pending.Select(p => p.ChatKey).SequenceEqual(_shownPending))
+        {
+            return; // 没变就别重建,否则用户的鼠标悬停状态每三秒被抹一次
+        }
+        _shownPending = [.. pending.Select(p => p.ChatKey)];
+        PendingPanel.Children.Clear();
+        foreach (PendingChat chat in pending)
+        {
+            PendingPanel.Children.Add(BuildPendingRow(chat));
+        }
+        NoPendingHint.IsVisible = pending.Count == 0;
+    }
+
+    private List<string> _shownPending = [];
+
+    private Border BuildPendingRow(PendingChat chat)
+    {
+        string channel = _settings.Channels.FirstOrDefault(c => c.Id == chat.ChannelId)?.Label ?? chat.ChannelId;
+        var title = new TextBlock
+        {
+            Text = $"{channel} · {(chat.IsGroup ? _loc["PairGroup"] : _loc["PairDirect"])} · {chat.UserName}",
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        title.Classes.Add("body");
+        var id = new TextBlock { Text = chat.ChatId, VerticalAlignment = VerticalAlignment.Center };
+        id.Classes.Add("hint");
+        Button allow = HostButton(_loc["PairAllow"], 72);
+        Button ignore = HostButton(_loc["PairIgnore"], 72);
+        ignore.Margin = new Thickness(8, 0, 0, 0);
+
+        var text = new StackPanel();
+        text.Children.Add(title);
+        text.Children.Add(id);
+        var grid = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        grid.Children.Add(text);
+        Grid.SetColumn(allow, 1);
+        grid.Children.Add(allow);
+        Grid.SetColumn(ignore, 2);
+        grid.Children.Add(ignore);
+
+        var card = new Border { Child = grid };
+        card.Classes.Add("card"); // 内边距由 card 这一档自己给,别在这儿另写一套
+        allow.Click += (_, _) => _ = AllowPendingAsync(chat);
+        ignore.Click += (_, _) =>
+        {
+            _bridge?.Pairing.Forget(chat.ChannelId, chat.ChatId);
+            RefreshPending();
+        };
+        return card;
+    }
+
+    private async Task AllowPendingAsync(PendingChat chat)
+    {
+        if (_bridge is null)
+        {
+            return;
+        }
+        try
+        {
+            await _bridge.AllowAsync(chat);
+            // 白名单那个框里也要跟着出现,否则用户点了保存反而把刚放行的又抹掉了
+            if (_rows.Find(r => r.Config.Id == chat.ChannelId) is { } row
+                && !Lines(row.Chats.Text).Contains(chat.ChatId))
+            {
+                row.Chats.Text = string.Join("\n", Lines(row.Chats.Text).Append(chat.ChatId));
+            }
+            StatusText.Text = _loc.F("PairAllowed", chat.ChatId);
+            RefreshPending();
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error($"Allowing chat {chat.ChatKey} failed: {ex}");
+            StatusText.Text = $"{_loc["Error"]}: {ex.Message}";
+        }
+    }
+
+    private void UpdateVisibility()
+    {
+        BridgeDetailPanel.IsVisible = BridgeEnabledCheck.IsChecked == true;
+        McpDetailPanel.IsVisible = McpEnabledCheck.IsChecked == true;
+    }
+
+    /// <summary>把接入方式写成可以直接粘走的两段:Claude Code 的命令,以及通用的 mcp.json 片段。</summary>
+    private void UpdateCommandSample()
+    {
+        int port = int.TryParse(McpPortBox.Text, out int parsed) ? parsed : _mcp.Port;
+        string url = $"http://127.0.0.1:{port}/mcp";
+        // 两段:Claude Code 的一行命令,以及其它客户端通用的 mcp.json 片段。
+        // 大括号在插值字符串里要转义,索性用拼接写 —— 这段是要被原样复制走的,不能写错一个字符。
+        string json = "{\"mcpServers\":{\"velashell\":{\"type\":\"http\",\"url\":\"" + url
+                      + "\",\"headers\":{\"Authorization\":\"Bearer " + _token + "\"}}}}";
+        McpCommandBox.Text = $"claude mcp add --transport http velashell {url} --header \"Authorization: Bearer {_token}\""
+                             + Environment.NewLine + Environment.NewLine + json;
+    }
+
+    private async Task SaveAsync()
+    {
+        try
+        {
+            _settings.Enabled = BridgeEnabledCheck.IsChecked == true;
+            _settings.Mode = (ChatMode)Math.Max(0, BridgeModeCombo.SelectedIndex);
+            _settings.Approval = (ApprovalMode)Math.Max(0, BridgeApprovalCombo.SelectedIndex);
+            _settings.AllowModeEscalation = EscalationCheck.IsChecked == true;
+            _settings.TurnTimeoutSeconds = ParseInt(TurnTimeoutBox.Text, _settings.TurnTimeoutSeconds, 30, 3600);
+            _settings.ApprovalTimeoutSeconds = ParseInt(ApprovalTimeoutBox.Text, _settings.ApprovalTimeoutSeconds, 10, 3600);
+            _settings.MaxConcurrentTurns = ParseInt(ConcurrencyBox.Text, _settings.MaxConcurrentTurns, 1, 16);
+            // 第 0 项是"跟随聊天面板",落库时写 null
+            _settings.ModelId = BridgeModelCombo.SelectedIndex > 0
+                ? _models[BridgeModelCombo.SelectedIndex - 1].Id
+                : null;
+
+            var channels = new List<ChannelConfig>();
+            foreach (ChannelRow row in _rows)
+            {
+                if (row.Removed)
+                {
+                    // 渠道删掉了,它那几份机密也别留在库里
+                    foreach (string slot in (string[])["secret", "token", "aeskey"])
+                    {
+                        await _bridgeStore.SetSecretAsync(row.Config.Id, slot, null);
+                    }
+                    continue;
+                }
+                ChannelConfig config = row.Config;
+                config.Enabled = row.Enabled.IsChecked == true;
+                config.DisplayName = (row.Name.Text ?? "").Trim();
+                config.AppId = (row.AppId?.Text ?? config.AppId).Trim();
+                config.AgentId = (row.AgentId?.Text ?? config.AgentId).Trim();
+                config.International = row.International?.IsChecked == true;
+                config.AllowedChats = Lines(row.Chats.Text);
+                config.AllowedUsers = Lines(row.Users.Text);
+                config.Approvers = Lines(row.Approvers.Text);
+                config.DefaultTarget = (row.Target.Text ?? "").Trim();
+                if (row.Port is { } portBox)
+                {
+                    config.WebhookPort = ParseInt(portBox.Text, config.WebhookPort, 1024, 65535);
+                }
+                if (row.Path is { } pathBox)
+                {
+                    string value = (pathBox.Text ?? "").Trim();
+                    config.WebhookPath = value.StartsWith('/') ? value : "/" + value;
+                }
+                channels.Add(config);
+                await _bridgeStore.SetSecretAsync(config.Id, "secret", row.Secret.Text);
+                // 企微那两份机密只有填了才写:框里是空的通常意味着"这次没改",
+                // 而不是"把它清掉" —— 加载时也没有把它们回显出来。
+                if (row.CallbackToken is { Text.Length: > 0 } tokenBox)
+                {
+                    await _bridgeStore.SetSecretAsync(config.Id, "token", tokenBox.Text);
+                }
+                if (row.AesKey is { Text.Length: > 0 } aesBox)
+                {
+                    await _bridgeStore.SetSecretAsync(config.Id, "aeskey", aesBox.Text);
+                }
+            }
+            _settings.Channels = channels;
+            await _bridgeStore.SaveAsync(_settings);
+
+            _mcp.Enabled = McpEnabledCheck.IsChecked == true;
+            _mcp.Port = ParseInt(McpPortBox.Text, _mcp.Port, 1024, 65535);
+            _mcp.Mode = (ChatMode)Math.Max(0, McpModeCombo.SelectedIndex);
+            _mcp.Approval = (ApprovalMode)Math.Max(0, McpApprovalCombo.SelectedIndex);
+            _mcp.AllowedTargets = McpTargetsBox.Text ?? "";
+            await _mcpStore.SaveAsync(_mcp);
+
+            await _restart();
+            StatusText.Text = _loc["Saved"];
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Error($"Saving the collaboration settings failed: {ex}");
+            StatusText.Text = $"{_loc["Error"]}: {ex.Message}";
+        }
+    }
+
+    private static List<string> Lines(string? text) =>
+    [
+        .. (text ?? "").Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    ];
+
+    private static int ParseInt(string? text, int fallback, int min, int max)
+        => int.TryParse(text, out int value) ? Math.Clamp(value, min, max) : fallback;
+
+    /// <summary>平台名。带上拉丁写法 —— 界面可以切到日/韩,"钉钉"两个字对那边的用户不是可读的品牌名。</summary>
+    private static string KindLabel(ChannelKind kind) => kind switch
+    {
+        ChannelKind.Feishu => "飞书 / Lark",
+        ChannelKind.DingTalk => "钉钉 / DingTalk",
+        ChannelKind.Telegram => "Telegram",
+        _ => "企业微信 / WeCom"
+    };
+
+    private static string AppIdLabel(ChannelKind kind) => kind switch
+    {
+        ChannelKind.Feishu => "App ID",
+        ChannelKind.DingTalk => "Client ID (AppKey)",
+        _ => "CorpID"
+    };
+
+    private static string SecretLabel(ChannelKind kind) => kind switch
+    {
+        ChannelKind.Feishu => "App Secret",
+        ChannelKind.DingTalk => "Client Secret",
+        ChannelKind.Telegram => "Bot Token",
+        _ => "Secret"
+    };
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/DialogStyles.axaml
@@ -26,6 +26,46 @@
     <Setter Property="Margin" Value="0,3,0,0" />
     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
+  <!-- ═══ 按钮 ═══
+       用 class 而不是在每个按钮上写 Theme="{DynamicResource …}",原因有两条,都是踩出来的:
+
+       1. **`VelaAccentPillButtonTheme` 没有 `HorizontalContentAlignment` 这个 setter**
+          (`VelaOutlineButtonTheme` 有)。它只在模板里 TemplateBinding,而 ContentControl 的默认值
+          是 Stretch —— 于是纯文字内容被拉开、看起来就是"没居中"。宿主自己那几个 pill 按钮都塞了
+          带 VerticalAlignment 的 StackPanel 当内容,恰好把这一点盖住了,所以一直没暴露。
+          这里显式补上,不依赖那边哪天会不会加。
+
+       2. **代码里 new 出来的按钮不能用 `TryFindResource` 取主题**:资源查找要沿逻辑树往上走,
+          而那时控件还没被挂进树,一律取不到,结果是静默地不挂主题。写成 Style 就没这个问题 ——
+          样式是在控件<b>进树时</b>套上去的,DynamicResource 那时才解析。 -->
+  <Style Selector="Button.host">
+    <Setter Property="Theme" Value="{DynamicResource VelaOutlineButtonTheme}" />
+    <Setter Property="Height" Value="26" />
+    <Setter Property="Padding" Value="12,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+  </Style>
+  <Style Selector="Button.primary">
+    <Setter Property="Theme" Value="{DynamicResource VelaAccentPillButtonTheme}" />
+    <Setter Property="Height" Value="26" />
+    <Setter Property="Padding" Value="12,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+  </Style>
+  <!-- 勾选框同理:AiCheckBoxTheme 只管那个方块怎么画,旁边那行字用的是控件自己的字号与前景色。 -->
+  <Style Selector="CheckBox.host">
+    <Setter Property="Theme" Value="{DynamicResource AiCheckBoxTheme}" />
+    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+  </Style>
+
+  <!-- 卡片里的正文一行(比如待放行清单里"哪个渠道 · 群聊 · 谁在说话")。
+       在这之前这种行只能靠不写 class 蒙混过去 —— 那样拿到的是 Fluent 的默认前景色,
+       而不是这套令牌里的 Primary,换主题时它不跟着走。 -->
+  <Style Selector="TextBlock.body">
+    <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
+    <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+  </Style>
   <Style Selector="TextBlock.toolName">
     <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
     <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -402,6 +402,211 @@ public sealed class Loc(string locale)
         ["DotPassed"] = ["Test passed", "测试通过", "測試通過", "テスト成功", "테스트 통과"],
         ["DotFailed"] = ["Test failed", "测试失败", "測試失敗", "テスト失敗", "테스트 실패"],
         // 上下文占用条的悬停说明(条只给量感,数字仍在用量提示里)
-        ["MeterTip"] = ["Share of the context window taken by the last turn.", "上一轮占掉了多大比例的上下文窗口。", "上一輪佔掉了多大比例的上下文視窗。", "直近のターンがコンテキスト長のどれだけを占めたか。", "직전 턴이 컨텍스트 창을 얼마나 차지했는지."]
+        ["MeterTip"] = ["Share of the context window taken by the last turn.", "上一轮占掉了多大比例的上下文窗口。", "上一輪佔掉了多大比例的上下文視窗。", "直近のターンがコンテキスト長のどれだけを占めたか。", "직전 턴이 컨텍스트 창을 얼마나 차지했는지."],
+
+        // ── 协作接入设置页 ──
+        ["CmdCollaboration"] = ["AI: Collaboration (chat bridge & MCP server)", "AI: 协作接入(IM 桥接与 MCP 服务端)", "AI: 協作接入(IM 橋接與 MCP 伺服器)", "AI: 連携設定(チャット連携と MCP サーバー)", "AI: 협업 연동(채팅 브리지 및 MCP 서버)"],
+        ["Collaboration"] = ["Collaboration", "协作接入", "協作接入", "連携", "협업 연동"],
+        ["SecBridge"] = ["Chat bridge", "IM 桥接", "IM 橋接", "チャット連携", "채팅 브리지"],
+        ["BridgeEnabled"] = ["Let the team talk to this assistant from a chat app", "允许团队从 IM 里指使这个助手", "允許團隊從 IM 裡指使這個助手", "チャットアプリからこのアシスタントを使えるようにする", "채팅 앱에서 이 어시스턴트를 쓸 수 있게 합니다"],
+        ["BridgeEnabledHint"] = [
+            "Runs while VelaShell is running (minimise to tray to stay online). Tools act on the SSH sessions you already have open.",
+            "只在 VelaShell 开着时在线(可最小化到托盘)。工具作用于你已经连上的那些 SSH 会话。",
+            "只在 VelaShell 開著時在線(可最小化到系統匣)。工具作用於你已經連上的那些 SSH 工作階段。",
+            "VelaShell の起動中のみ動作します(トレイに最小化で常駐)。ツールは既に接続済みの SSH セッションに作用します。",
+            "VelaShell이 실행 중일 때만 동작합니다(트레이로 최소화하면 계속 온라인). 도구는 이미 연결된 SSH 세션에 작용합니다."
+        ],
+        ["BridgeMode"] = ["Mode", "挡位", "擋位", "モード", "모드"],
+        ["BridgeApproval"] = ["Approval", "审批方式", "審批方式", "承認方式", "승인 방식"],
+        ["BridgeModeHint"] = [
+            "Plan is read-only and is the safe default for a chat room. Approvals are asked in the chat: reply y or n.",
+            "计划档只读,是聊天场景下的安全默认。审批就问在聊天里 —— 回 y 或 n。",
+            "計劃檔唯讀,是聊天場景下的安全預設。審批就問在聊天裡 —— 回 y 或 n。",
+            "計画モードは読み取り専用で、チャット用の安全な既定値です。承認はチャット内で尋ねます(y / n で返答)。",
+            "계획 모드는 읽기 전용이며 채팅에 안전한 기본값입니다. 승인은 대화에서 y 또는 n으로 답하면 됩니다."
+        ],
+        ["BridgeEscalation"] = ["Allow /mode to raise the mode from chat", "允许在聊天里用 /mode 提高挡位", "允許在聊天裡用 /mode 提高擋位", "チャットの /mode でモードを引き上げることを許可", "대화의 /mode로 모드를 올리는 것을 허용"],
+        ["BridgeEscalationHint"] = [
+            "Off by default: anyone allowed to talk could otherwise turn the read-only bridge into one that runs commands.",
+            "默认关:否则任何能说话的人都能把只读的桥接变成能敲命令的。",
+            "預設關:否則任何能說話的人都能把唯讀的橋接變成能敲命令的。",
+            "既定はオフ:許可された誰もが読み取り専用の連携をコマンド実行可能にできてしまうためです。",
+            "기본값은 꺼짐: 그렇지 않으면 대화 허용된 누구나 읽기 전용 브리지를 명령 실행형으로 바꿀 수 있습니다."
+        ],
+        ["BridgeTurnTimeout"] = ["Turn timeout (s)", "单轮超时(秒)", "單輪逾時(秒)", "1 ターンのタイムアウト(秒)", "턴 제한 시간(초)"],
+        ["BridgeApprovalTimeout"] = ["Approval timeout (s)", "审批超时(秒)", "審批逾時(秒)", "承認のタイムアウト(秒)", "승인 제한 시간(초)"],
+        ["BridgeConcurrency"] = ["Concurrent turns", "并发轮次", "並發輪次", "同時実行ターン数", "동시 실행 턴 수"],
+        ["BridgeModel"] = ["Model", "模型", "模型", "モデル", "모델"],
+        ["BridgeModelFollow"] = ["Follow the chat panel", "跟随聊天面板", "跟隨聊天面板", "チャットパネルに従う", "채팅 패널을 따름"],
+        ["BridgeModelHint"] = [
+            "Pin one so a failure names the right provider — an \"unauthorised\" from the model looks nothing like one from the chat platform, but both land in the same chat message.",
+            "指定一个,出错时才知道该查哪家的密钥 —— 模型返回的「未授权」和 IM 平台返回的「未授权」是两回事,但在群里长得一模一样。",
+            "指定一個,出錯時才知道該查哪家的密鑰 —— 模型回傳的「未授權」和 IM 平台回傳的「未授權」是兩回事,但在群裡長得一模一樣。",
+            "モデルを固定しておくと、失敗時にどの接続を確認すべきか分かります。モデル側の「未認証」とチャット基盤側の「未認証」は別物ですが、チャットには同じように出ます。",
+            "모델을 고정해 두면 실패했을 때 어느 연결을 확인해야 할지 알 수 있습니다. 모델의 \"인증 실패\"와 채팅 플랫폼의 \"인증 실패\"는 다르지만 대화에는 똑같이 표시됩니다."
+        ],
+        ["ChannelAddBotFeishu"] = [
+            "Feishu has no link for this: in the Feishu client open the group → Settings → Group bots → Add bot, and search for your app name.",
+            "飞书没有对应的链接:在飞书客户端里打开群 → 设置 → 群机器人 → 添加机器人,搜你的应用名。",
+            "飛書沒有對應的連結:在飛書用戶端裡打開群 → 設定 → 群機器人 → 新增機器人,搜你的應用名。",
+            "Feishu には該当するリンクがありません。Feishu クライアントでグループを開き、設定 → グループボット → ボットを追加 から、アプリ名で検索してください。",
+            "Feishu에는 해당 링크가 없습니다. Feishu 클라이언트에서 그룹 → 설정 → 그룹 봇 → 봇 추가로 이동해 앱 이름으로 검색하세요."
+        ],
+        ["SecChannels"] = ["Channels", "渠道", "渠道", "チャンネル", "채널"],
+        ["ChannelAdd"] = ["Add", "添加", "新增", "追加", "추가"],
+        ["ChannelRemove"] = ["Remove", "移除", "移除", "削除", "제거"],
+        ["ChannelNone"] = ["No channels yet — pick a platform above and add one.", "还没有渠道 —— 在上面选一个平台添加。", "還沒有渠道 —— 在上面選一個平台新增。", "チャンネルがありません。上でプラットフォームを選んで追加してください。", "채널이 없습니다. 위에서 플랫폼을 선택해 추가하세요."],
+        ["ChannelEnabled"] = ["Enabled", "启用", "啟用", "有効", "사용"],
+        ["ChannelName"] = ["Display name", "显示名", "顯示名", "表示名", "표시 이름"],
+        ["ChannelInternational"] = ["International edition (larksuite.com)", "国际版(larksuite.com)", "國際版(larksuite.com)", "国際版(larksuite.com)", "국제판(larksuite.com)"],
+        ["ChannelChats"] = ["Allowed chats (one id per line)", "允许的聊天(每行一个 id)", "允許的聊天(每行一個 id)", "許可するチャット(1 行に 1 つの ID)", "허용할 대화(한 줄에 ID 하나)"],
+        ["ChannelChatsHint"] = [
+            "Empty means nobody is served. Message the bot once and its reply tells you the chat id.",
+            "留空 = 谁都不理。先在群里 @ 一下机器人,它会回一句告诉你这个群的 id。",
+            "留空 = 誰都不理。先在群裡 @ 一下機器人,它會回一句告訴你這個群的 id。",
+            "空欄なら誰にも応答しません。まずボットにメッセージを送ると、返信でチャット ID がわかります。",
+            "비워 두면 아무에게도 응답하지 않습니다. 봇에게 한 번 말을 걸면 답장에 대화 ID가 표시됩니다."
+        ],
+        ["ChannelUsers"] = ["Allowed users (blank = anyone in those chats)", "允许的用户(留空 = 白名单聊天里的任何人)", "允許的使用者(留空 = 白名單聊天裡的任何人)", "許可するユーザー(空欄 = 上記チャットの全員)", "허용할 사용자(비우면 해당 대화의 모든 사람)"],
+        ["ChannelApprovers"] = ["Approvers (blank = same as allowed users)", "审批人(留空 = 与允许的用户相同)", "審批人(留空 = 與允許的使用者相同)", "承認者(空欄 = 許可ユーザーと同じ)", "승인자(비우면 허용 사용자와 동일)"],
+        ["ChannelTarget"] = ["Default server (user@host:port)", "默认服务器(user@host:port)", "預設伺服器(user@host:port)", "既定のサーバー(user@host:port)", "기본 서버(user@host:port)"],
+        ["ChannelTest"] = ["Test", "测试", "測試", "テスト", "테스트"],
+        ["ChannelTesting"] = ["Testing…", "正在测试…", "正在測試…", "テスト中…", "테스트 중…"],
+        ["ChannelInviteHint"] = [
+            "Scan with your phone to add the bot to a group — no need to search for it by name.",
+            "手机扫这个码直接把机器人加进群 —— 不用在手机上按名字搜。",
+            "手機掃這個碼直接把機器人加進群 —— 不用在手機上按名字搜。",
+            "スマホでこのコードを読み取ると、ボットをそのままグループに追加できます(名前で検索する必要はありません)。",
+            "휴대폰으로 이 코드를 스캔하면 봇을 바로 그룹에 추가할 수 있습니다(이름으로 검색할 필요 없음)."
+        ],
+        // ── 授权聊天(配对码 / 一键放行)──
+        ["SecPairing"] = ["Authorising chats", "授权聊天", "授權聊天", "チャットの許可", "대화 허용"],
+        ["PairCode"] = ["Pairing code", "配对码", "配對碼", "ペアリングコード", "페어링 코드"],
+        ["PairIssue"] = ["Generate", "生成", "產生", "生成", "생성"],
+        ["PairExpiresIn"] = ["(expires in {0}m {1}s)", "({0} 分 {1} 秒后过期)", "({0} 分 {1} 秒後過期)", "(あと {0} 分 {1} 秒で失効)", "({0}분 {1}초 후 만료)"],
+        ["PairHint"] = [
+            "Generate a code, then send \"/pair <code>\" in the chat you want to authorise — no need to copy chat ids around. One use, ten minutes, five wrong tries and it dies. It only lets that chat talk to the bot; the mode and approval settings above still apply.",
+            "点生成拿一个码,然后在想授权的那个聊天里发「/pair 码」—— 不用再来回抄群 id。一次性、十分钟过期、猜错五次作废。它只决定「这个聊天能不能跟机器人说话」,能不能动服务器仍旧由上面的挡位与审批管。",
+            "點產生拿一個碼,然後在想授權的那個聊天裡發「/pair 碼」—— 不用再來回抄群 id。一次性、十分鐘過期、猜錯五次作廢。它只決定「這個聊天能不能跟機器人說話」,能不能動伺服器仍舊由上面的擋位與審批管。",
+            "コードを生成し、許可したいチャットで「/pair コード」と送るだけです(チャット ID を書き写す必要はありません)。1 回限り・10 分で失効・5 回間違えると無効。許可するのは「そのチャットがボットと話せる」ことだけで、サーバー操作は上のモードと承認方式に従います。",
+            "코드를 생성한 뒤 허용할 대화에서 \"/pair 코드\"를 보내세요(대화 ID를 옮겨 적을 필요 없음). 일회용, 10분 만료, 5회 틀리면 폐기됩니다. 허용되는 것은 \"그 대화가 봇과 대화할 수 있다\"는 것뿐이며 서버 조작은 위의 모드와 승인 방식을 따릅니다."
+        ],
+        ["PairNeedsBridge"] = [
+            "Turn the chat bridge on and save first — a pairing code is only useful while the bot is online.",
+            "先把 IM 桥接打开并保存 —— 机器人不在线的时候,配对码没有意义。",
+            "先把 IM 橋接打開並儲存 —— 機器人不在線的時候,配對碼沒有意義。",
+            "先にチャット連携を有効にして保存してください。ボットがオンラインでなければペアリングコードは意味がありません。",
+            "먼저 채팅 브리지를 켜고 저장하세요. 봇이 온라인이 아니면 페어링 코드는 의미가 없습니다."
+        ],
+        ["PairPending"] = ["Chats that tried to talk to the bot", "敲过门的聊天", "敲過門的聊天", "ボットに話しかけてきたチャット", "봇에게 말을 건 대화"],
+        ["PairNoPending"] = [
+            "Nothing yet. Add the bot to a group and say something — it will show up here.",
+            "还没有。把机器人加进群里说句话,它就会出现在这。",
+            "還沒有。把機器人加進群裡說句話,它就會出現在這。",
+            "まだありません。ボットをグループに追加して何か話しかけると、ここに出てきます。",
+            "아직 없습니다. 봇을 그룹에 추가하고 말을 걸면 여기에 나타납니다."
+        ],
+        ["PairAllow"] = ["Allow", "允许", "允許", "許可", "허용"],
+        ["PairIgnore"] = ["Ignore", "忽略", "忽略", "無視", "무시"],
+        ["PairGroup"] = ["group", "群聊", "群聊", "グループ", "그룹"],
+        ["PairDirect"] = ["direct", "单聊", "單聊", "個別", "개인"],
+        ["PairAllowed"] = ["{0} is now allowed.", "已放行 {0}。", "已放行 {0}。", "{0} を許可しました。", "{0}을(를) 허용했습니다."],
+        ["ChannelWeComHint"] = [
+            "WeCom is the odd one out: it can only push to a public callback URL, so this listener needs a tunnel or reverse proxy in front of it.",
+            "企业微信和另外三家不一样:它只能往一个公网回调地址推消息,所以这个监听口前面得有一条隧道或反向代理。",
+            "企業微信和另外三家不一樣:它只能往一個公網回呼位址推訊息,所以這個監聽埠前面得有一條隧道或反向代理。",
+            "WeCom だけは公開コールバック URL にしか送れないため、この待ち受けの前にトンネルかリバースプロキシが必要です。",
+            "WeCom만 예외입니다. 공개 콜백 URL로만 전송하므로 이 수신 포트 앞에 터널이나 리버스 프록시가 필요합니다."
+        ],
+        ["ChannelCallbackToken"] = ["Callback Token", "回调 Token", "回呼 Token", "コールバック Token", "콜백 Token"],
+        ["ChannelWebhookPort"] = ["Callback port (127.0.0.1)", "回调端口(127.0.0.1)", "回呼連接埠(127.0.0.1)", "コールバックポート(127.0.0.1)", "콜백 포트(127.0.0.1)"],
+        ["ChannelWebhookPath"] = ["Callback path", "回调路径", "回呼路徑", "コールバックパス", "콜백 경로"],
+        ["ChannelWeComCallbackHint"] = [
+            "Only 127.0.0.1 is bound. Point WeCom at a public HTTPS address and forward it here — VelaShell's own remote port forwarding (Session → Tunnels) can do that leg.",
+            "只绑 127.0.0.1。把企业微信的回调地址指向一个公网 HTTPS 入口,再转发到这里 —— 这一段可以直接用 VelaShell 自己的远程端口转发(会话 → 隧道)。",
+            "只綁 127.0.0.1。把企業微信的回呼位址指向一個公網 HTTPS 入口,再轉發到這裡 —— 這一段可以直接用 VelaShell 自己的遠端連接埠轉發(工作階段 → 隧道)。",
+            "127.0.0.1 のみにバインドします。WeCom には公開 HTTPS のアドレスを設定し、そこからここへ転送してください。この区間は VelaShell のリモートポート転送(セッション → トンネル)で賄えます。",
+            "127.0.0.1에만 바인딩합니다. WeCom에는 공개 HTTPS 주소를 설정하고 이곳으로 전달하세요. 이 구간은 VelaShell의 원격 포트 포워딩(세션 → 터널)으로 해결할 수 있습니다."
+        ],
+        // ── 对外 MCP 服务端 ──
+        ["SecMcpServer"] = ["MCP server (for other agents)", "对外 MCP 服务端(给别的 agent 用)", "對外 MCP 伺服器(給別的 agent 用)", "MCP サーバー(他のエージェント向け)", "MCP 서버(다른 에이전트용)"],
+        ["McpServerEnabled"] = ["Let Claude Code / Codex call VelaShell's tools", "让 Claude Code / Codex 调用 VelaShell 的工具", "讓 Claude Code / Codex 呼叫 VelaShell 的工具", "Claude Code / Codex から VelaShell のツールを呼べるようにする", "Claude Code / Codex가 VelaShell 도구를 호출하도록 허용"],
+        ["McpServerEnabledHint"] = [
+            "Listens on 127.0.0.1 only, and every request must carry the token below.",
+            "只监听 127.0.0.1,而且每个请求都必须带下面那个令牌。",
+            "只監聽 127.0.0.1,而且每個請求都必須帶下面那個權杖。",
+            "127.0.0.1 のみで待ち受け、すべてのリクエストに下のトークンが必要です。",
+            "127.0.0.1에서만 수신하며 모든 요청에 아래 토큰이 필요합니다."
+        ],
+        ["McpServerPort"] = ["Port", "端口", "連接埠", "ポート", "포트"],
+        ["McpServerApprovalHint"] = [
+            "An external agent has no window to show an approval card in, so \"ask every time\" refuses writes outright. Pick read-only auto or bypass to let it change things.",
+            "外部 agent 那边没有能弹审批卡的界面,所以「每次询问」在这条路上等于直接拒绝写操作。要让它能改东西,得选只读放行或绕过审批。",
+            "外部 agent 那邊沒有能彈審批卡的介面,所以「每次詢問」在這條路上等於直接拒絕寫操作。要讓它能改東西,得選唯讀放行或繞過審批。",
+            "外部エージェント側に承認カードを出す画面がないため、「毎回確認」は書き込みを即拒否します。変更を許すには読み取り自動許可かバイパスを選んでください。",
+            "외부 에이전트에는 승인 카드를 띄울 화면이 없어 \"매번 확인\"은 쓰기를 즉시 거부합니다. 변경을 허용하려면 읽기 전용 자동 또는 우회를 선택하세요."
+        ],
+        ["McpServerTargets"] = ["Allowed servers (one user@host:port per line; blank = all connected)", "允许操作的服务器(每行一个 user@host:port;留空 = 全部已连会话)", "允許操作的伺服器(每行一個 user@host:port;留空 = 全部已連工作階段)", "許可するサーバー(1 行に 1 つ user@host:port、空欄 = 接続中すべて)", "허용할 서버(한 줄에 user@host:port 하나, 비우면 연결된 전체)"],
+        ["McpServerTargetsHint"] = ["The external agent can only pick from this list.", "外部 agent 只能在这个名单里挑。", "外部 agent 只能在這個名單裡挑。", "外部エージェントはこの一覧からのみ選べます。", "외부 에이전트는 이 목록에서만 고를 수 있습니다."],
+        ["McpServerToken"] = ["Access token", "访问令牌", "存取權杖", "アクセストークン", "액세스 토큰"],
+        ["McpServerTokenHint"] = [
+            "Anything running on this machine can reach a local port — this token is the only thing that stops it.",
+            "本机上任何程序都能敲本地端口,拦住它们的只有这个令牌。",
+            "本機上任何程式都能敲本地連接埠,攔住它們的只有這個權杖。",
+            "ローカルポートはこの端末上のどのプログラムからも叩けます。それを止めるのはこのトークンだけです。",
+            "이 컴퓨터의 어떤 프로그램도 로컬 포트에 접근할 수 있습니다. 이를 막는 것은 이 토큰뿐입니다."
+        ],
+        ["McpServerCommand"] = ["How to connect", "接入方式", "接入方式", "接続方法", "연결 방법"],
+        ["McpServerRotate"] = ["Regenerate", "重新生成", "重新產生", "再生成", "재생성"],
+        ["McpServerRotated"] = ["New token generated — update your agent's config.", "已生成新令牌 —— 记得同步改你 agent 那边的配置。", "已產生新權杖 —— 記得同步改你 agent 那邊的設定。", "新しいトークンを生成しました。エージェント側の設定も更新してください。", "새 토큰을 생성했습니다. 에이전트 설정도 업데이트하세요."],
+
+        // ── IM 桥接:发进聊天里的那些话。跟随宿主语言,不跟随发消息的人 ──
+        ["BridgeThinking"] = ["Working on it…", "正在处理…", "正在處理…", "処理中…", "처리 중…"],
+        ["BridgeBusy"] = ["Still on the previous request — queued.", "上一条还没跑完,已排队。", "上一條還沒跑完,已排隊。", "前の依頼を処理中です。順番待ちに入れました。", "이전 요청을 처리 중입니다. 대기열에 넣었습니다."],
+        ["BridgeRunningTool"] = ["running {0}…", "正在调用 {0}…", "正在呼叫 {0}…", "{0} を実行中…", "{0} 실행 중…"],
+        ["BridgeFooter"] = ["— {0} · {1}s · {2} tool call(s)", "— {0} · {1}s · {2} 次工具调用", "— {0} · {1}s · {2} 次工具呼叫", "— {0} · {1}s · ツール {2} 回", "— {0} · {1}s · 도구 {2}회"],
+        ["BridgeNoModel"] = ["No AI model is configured in VelaShell yet.", "VelaShell 里还没配置模型。", "VelaShell 裡還沒設定模型。", "VelaShell にモデルが設定されていません。", "VelaShell에 모델이 설정되지 않았습니다."],
+        ["BridgeEmptyReply"] = ["(the model returned nothing)", "(模型没有返回内容)", "(模型沒有回傳內容)", "(モデルの応答が空でした)", "(모델이 아무것도 반환하지 않았습니다)"],
+        ["BridgeTurnFailed"] = ["Failed: {0}", "出错了:{0}", "出錯了:{0}", "失敗しました:{0}", "실패했습니다: {0}"],
+        ["BridgeTimeout"] = ["Timed out — stopped this turn.", "超时,已中止这一轮。", "逾時,已中止這一輪。", "タイムアウトしたため中断しました。", "시간이 초과되어 이번 턴을 중단했습니다."],
+        ["BridgeUnauthorized"] = [
+            "This chat is not authorised yet. Generate a pairing code in VelaShell (Collaboration) and send \"/pair <code>\" here — or allow it from that page. Chat id: {0}",
+            "这个聊天还没被授权。到 VelaShell 的「协作接入」生成配对码,在这里发「/pair 码」即可 —— 或者直接在那一页点允许。聊天 id:{0}",
+            "這個聊天還沒被授權。到 VelaShell 的「協作接入」產生配對碼,在這裡發「/pair 碼」即可 —— 或者直接在那一頁點允許。聊天 id:{0}",
+            "このチャットは未許可です。VelaShell の「連携」でペアリングコードを生成し、ここで「/pair コード」と送ってください(その画面から許可することもできます)。チャット ID:{0}",
+            "이 대화는 아직 허용되지 않았습니다. VelaShell의 「협업 연동」에서 페어링 코드를 생성한 뒤 여기서 \"/pair 코드\"를 보내세요(해당 화면에서 바로 허용할 수도 있습니다). 대화 ID: {0}"
+        ],
+        ["BridgePairUsage"] = ["Usage: /pair <code> — the code is in VelaShell under Collaboration.", "用法:/pair 码 —— 码在 VelaShell 的「协作接入」页里。", "用法:/pair 碼 —— 碼在 VelaShell 的「協作接入」頁裡。", "使い方:/pair コード —— コードは VelaShell の「連携」画面にあります。", "사용법: /pair 코드 — 코드는 VelaShell의 「협업 연동」 화면에 있습니다."],
+        ["BridgePairRejected"] = ["That code is not valid. Generate a fresh one in VelaShell.", "这个码不对。到 VelaShell 里重新生成一个。", "這個碼不對。到 VelaShell 裡重新產生一個。", "そのコードは使えません。VelaShell で新しく生成してください。", "이 코드는 사용할 수 없습니다. VelaShell에서 새로 생성하세요."],
+        ["BridgePaired"] = ["Paired — this chat can talk to me now. Try /help.", "配对成功,这个聊天现在可以跟我说话了。试试 /help。", "配對成功,這個聊天現在可以跟我說話了。試試 /help。", "ペアリングできました。このチャットから話しかけられます。/help を試してください。", "페어링에 성공했습니다. 이제 이 대화에서 말을 걸 수 있습니다. /help를 사용해 보세요."],
+        // ── 斜杠命令 ──
+        ["BridgeHelp"] = [
+            "/sessions — list connected servers\n/use <user@host:port> — bind this chat to one\n/mode chat|plan|agent — change the mode\n/new — start a fresh conversation\n/stop — stop the current turn\n/status — show what this chat is set to",
+            "/sessions — 列出已连上的服务器\n/use <user@host:port> — 把本聊天绑到某一台\n/mode chat|plan|agent — 换挡位\n/new — 开一段新对话\n/stop — 中止当前这一轮\n/status — 看本聊天的当前设定",
+            "/sessions — 列出已連上的伺服器\n/use <user@host:port> — 把本聊天綁到某一台\n/mode chat|plan|agent — 換擋位\n/new — 開一段新對話\n/stop — 中止目前這一輪\n/status — 看本聊天的目前設定",
+            "/sessions — 接続中のサーバー一覧\n/use <user@host:port> — このチャットを 1 台に紐付け\n/mode chat|plan|agent — モード変更\n/new — 会話をやり直す\n/stop — 実行中のターンを中止\n/status — このチャットの設定を表示",
+            "/sessions — 연결된 서버 목록\n/use <user@host:port> — 이 대화를 서버에 연결\n/mode chat|plan|agent — 모드 변경\n/new — 새 대화 시작\n/stop — 현재 턴 중단\n/status — 이 대화의 설정 보기"
+        ],
+        ["BridgeNewChat"] = ["Started a fresh conversation.", "已开一段新对话。", "已開一段新對話。", "会話をやり直しました。", "새 대화를 시작했습니다."],
+        ["BridgeStopped"] = ["Stopped the current turn.", "已中止当前这一轮。", "已中止目前這一輪。", "実行中のターンを中止しました。", "현재 턴을 중단했습니다."],
+        ["BridgeNothingRunning"] = ["Nothing is running.", "当前没有正在跑的轮次。", "目前沒有正在跑的輪次。", "実行中のターンはありません。", "실행 중인 턴이 없습니다."],
+        ["BridgeStatus"] = ["{0} · mode {1} · approval {2} · bound to {3} ({4})", "{0} · 挡位 {1} · 审批 {2} · 绑定 {3}({4})", "{0} · 擋位 {1} · 審批 {2} · 綁定 {3}({4})", "{0} · モード {1} · 承認 {2} · 接続先 {3}({4})", "{0} · 모드 {1} · 승인 {2} · 대상 {3}({4})"],
+        ["BridgeSessionOnline"] = ["connected", "在线", "在線", "接続中", "연결됨"],
+        ["BridgeSessionOffline"] = ["not connected right now", "当前未连接", "目前未連線", "現在未接続", "현재 연결 안 됨"],
+        ["BridgeNoSessions"] = ["No connected sessions. Connect to a server in VelaShell first.", "当前没有连上的会话。先在 VelaShell 里连一台。", "目前沒有連上的工作階段。先在 VelaShell 裡連一台。", "接続中のセッションがありません。まず VelaShell で接続してください。", "연결된 세션이 없습니다. 먼저 VelaShell에서 서버에 연결하세요."],
+        ["BridgeSessions"] = ["Connected sessions:\n{0}", "已连上的会话:\n{0}", "已連上的工作階段:\n{0}", "接続中のセッション:\n{0}", "연결된 세션:\n{0}"],
+        ["BridgeBound"] = ["Bound this chat to {0}.", "已把本聊天绑定到 {0}。", "已把本聊天綁定到 {0}。", "このチャットを {0} に紐付けました。", "이 대화를 {0}에 연결했습니다."],
+        ["BridgeBindUsage"] = ["Usage: /use user@host:port", "用法:/use user@host:port", "用法:/use user@host:port", "使い方:/use user@host:port", "사용법: /use user@host:port"],
+        ["BridgeBindNotFound"] = ["No connected session matches {0}. Try /sessions.", "没有连着的会话匹配 {0}。先看 /sessions。", "沒有連著的工作階段符合 {0}。先看 /sessions。", "{0} に一致する接続中のセッションがありません。/sessions を確認してください。", "{0}과(와) 일치하는 연결된 세션이 없습니다. /sessions를 확인하세요."],
+        ["BridgeModeSet"] = ["Mode is now {0}.", "挡位已切到 {0}。", "擋位已切到 {0}。", "モードを {0} にしました。", "모드를 {0}(으)로 변경했습니다."],
+        ["BridgeModeUsage"] = ["Usage: /mode chat|plan|agent (or /mode reset)", "用法:/mode chat|plan|agent(或 /mode reset)", "用法:/mode chat|plan|agent(或 /mode reset)", "使い方:/mode chat|plan|agent(または /mode reset)", "사용법: /mode chat|plan|agent (또는 /mode reset)"],
+        ["BridgeModeLocked"] = ["Raising the mode from chat is turned off. The bridge is fixed at {0} — change it in VelaShell.", "不允许在聊天里提高挡位。桥接固定为 {0},要改请到 VelaShell 里改。", "不允許在聊天裡提高擋位。橋接固定為 {0},要改請到 VelaShell 裡改。", "チャットからモードを上げることは無効です。ブリッジは {0} 固定です。VelaShell 側で変更してください。", "대화에서 모드를 올릴 수 없습니다. 브리지는 {0}으로 고정되어 있으며 VelaShell에서 변경하세요."],
+        // ── 审批 ──
+        ["BridgeApprovalAsk"] = ["⚠️ Approval needed — {0}\n{1}\n\nReply y to allow, n to refuse{2} ({3}s until it is refused automatically).", "⚠️ 需要审批 — {0}\n{1}\n\n回复 y 放行,n 拒绝{2}({3} 秒后自动拒绝)。", "⚠️ 需要審批 — {0}\n{1}\n\n回覆 y 放行,n 拒絕{2}({3} 秒後自動拒絕)。", "⚠️ 承認が必要です — {0}\n{1}\n\ny で許可、n で拒否{2}({3} 秒で自動的に拒否)。", "⚠️ 승인이 필요합니다 — {0}\n{1}\n\ny는 허용, n은 거부{2} ({3}초 후 자동 거부)."],
+        ["BridgeApprovalAlways"] = [", a to always allow it in this conversation", ",a 表示本次对话内总是放行", ",a 表示本次對話內總是放行", "、a でこの会話中は常に許可", ", a는 이 대화에서 항상 허용"],
+        ["BridgeApprovalGranted"] = ["Approved.", "已放行。", "已放行。", "承認しました。", "승인했습니다."],
+        ["BridgeApprovalDenied"] = ["Refused.", "已拒绝。", "已拒絕。", "拒否しました。", "거부했습니다."],
+        ["BridgeApprovalTimedOut"] = ["Nobody answered in time — refused.", "没人应答,按拒绝处理。", "沒人應答,按拒絕處理。", "応答がなかったため拒否しました。", "응답이 없어 거부했습니다."],
+        ["BridgeApprovalNotAllowed"] = ["You are not on the approver list for this bridge.", "你不在这个桥接的审批人名单里。", "你不在這個橋接的審批人名單裡。", "このブリッジの承認者リストに含まれていません。", "이 브리지의 승인자 목록에 없습니다."]
     };
 }

--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -58,6 +58,12 @@
     <PackageReference Include="LiveMarkdown.Avalonia.Math" Version="2.4.0" />
     <!-- SVG:给图片管线注册 SVG 解码器。用 Svg.Controls.Avalonia 后端(非 Skia,用户决策)。 -->
     <PackageReference Include="LiveMarkdown.Avalonia.Svg" Version="2.4.0" />
+    <!-- 二维码:协作接入页上「把机器人拉进群」的链接渲染成码,手机扫一下直接跳过去,
+         省掉在手机上搜应用名。用 PngByteQRCode 出字节流交给 Avalonia 的 Bitmap ——
+         不碰 System.Drawing,Linux/macOS 上不需要 libgdiplus。
+         (MIT,netstandard2.0,无传递依赖。自己写一个 QR 编码器要 Reed-Solomon 与掩码评分,
+         几百行且没有额外价值 —— 与自研 VT/ZMODEM 不同,这里没有需要拿捏的协议细节。) -->
+    <PackageReference Include="QRCoder" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/plugins/VelaShell.Plugin.Ai/plugin.json
+++ b/plugins/VelaShell.Plugin.Ai/plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "velashell.ai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "displayName": "AI Assistant",
   "description": "多提供商 AI 助手:内置供应商目录,支持订阅登录(OAuth 授权码+PKCE / 设备码)或自填 API Key;OpenAI / Anthropic / Grok / Ollama / 自定义中转站,流式对话、Agent 模式与自定义 MCP 服务器工具;会话存入时序库可随时翻回,输入框 ↑↓ 调历史、@ 引用服务器文件。",
   "publisher": "velashell",
@@ -8,8 +8,11 @@
   "apiLevel": 2,
   "license": "MIT",
   "homepage": "https://github.com/joesdu/VelaShell",
-  // 惰性激活:不打开 AI 功能就不装载程序集,启动零开销。
+  // 启动即激活。IM 桥接必须常驻 —— 飞书/钉钉那头的消息随时会来,不能等用户
+  // 点开 AI 面板才建连。代价是本插件不再惰性装载;换来的是 ActivateAsync 里只多
+  // 一次配置读取(桥接关着时立刻返回),而聊天面板依旧是首次触发命令才构造。
   "activationEvents": [
+    "onStartup",
     "onCommand:velashell.ai.chat",
     "onCommand:velashell.ai.chat-window",
     "onCommand:velashell.ai.explain-terminal"
@@ -18,7 +21,8 @@
     "commands": [
       { "id": "velashell.ai.chat", "title": "AI: Open Chat (Tab)", "category": "AI" },
       { "id": "velashell.ai.chat-window", "title": "AI: Open Chat (Window)", "category": "AI" },
-      { "id": "velashell.ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" }
+      { "id": "velashell.ai.explain-terminal", "title": "AI: Explain Terminal Output", "category": "AI" },
+      { "id": "velashell.ai.collaboration", "title": "AI: Collaboration (chat bridge & MCP server)", "category": "AI" }
     ]
   }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
@@ -1,0 +1,121 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Chat;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>无头 agent 回合里那些不需要真的调模型就能钉住的行为。</summary>
+[TestClass]
+public sealed class BridgeAgentRunnerTests
+{
+    private static readonly Loc English = new("en");
+
+    private static BridgeAgentRunner Create(TestPluginContext context)
+        => new(context, new AiSettingsStore(context), new ChatHistoryStore(context), new McpManager(context));
+
+    private static InboundMessage Message(string text = "hi")
+        => new("ch1", "chat-1", false, "u1", "Ann", text, "m1", true);
+
+    private static Task<bool> Deny(ApprovalRequest _) => Task.FromResult(false);
+
+    [TestMethod]
+    public async Task RunAsync_WithNoModelConfigured_SaysSoInsteadOfThrowing()
+    {
+        using var context = new TestPluginContext();
+        BridgeTurn turn = await Create(context).RunAsync(new BridgeConversation("ch1", "chat-1"),
+            new BridgeSettings(), Message(), Deny, English, null, CancellationToken.None);
+
+        Assert.AreEqual(English["BridgeNoModel"], turn.Text);
+        Assert.AreEqual("", turn.Model);
+    }
+
+    /// <summary>
+    /// AI 设置必须<b>每轮现读</b>,不能吃桥接启动时的那份快照。
+    /// </summary>
+    /// <remarks>
+    /// 这条是线上撞到的那个 bug 的形状:用户在设置窗口登录了订阅制供应商(OpenAI Codex),
+    /// 聊天面板立刻好用,而桥接手里那份 <c>AiProvider</c> 还是登录之前的形态
+    /// (<c>Auth</c> 仍是 ApiKey、没有 OAuth 配置),于是凭据解析走了"取 API Key"那条岔路,
+    /// 把一个空 Key 发了出去 —— 群里看到 401「Could not parse your authentication token」,
+    /// 而同一刻面板一切正常。
+    /// <para>
+    /// 用例做法:<b>先</b>造好 runner,<b>之后</b>才往库里写供应商。第一轮必须说"没配模型",
+    /// 第二轮必须已经看得见它 —— 报错里带的模型名就是证据(端点指向一个必然连不上的地址,
+    /// 所以第二轮一定失败,但失败的原因得是"连不上",不是"没模型")。
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public async Task RunAsync_RereadsTheAiSettingsEveryTurn()
+    {
+        using var context = new TestPluginContext();
+        var store = new AiSettingsStore(context);
+        BridgeAgentRunner runner = Create(context);
+        var conversation = new BridgeConversation("ch1", "chat-1");
+        var bridge = new BridgeSettings { Mode = ChatMode.Chat }; // 纯对话:不碰工具,免得牵进 MCP
+
+        BridgeTurn before = await runner.RunAsync(conversation, bridge, Message(), Deny, English, null,
+            CancellationToken.None);
+        Assert.AreEqual(English["BridgeNoModel"], before.Text, "with nothing configured it should say so");
+
+        // runner 造好之后才配上模型 —— 快照式实现在这一步之后仍然会说"没配模型"
+        await store.SaveAsync(new AiSettings
+        {
+            Providers =
+            [
+                new AiProvider
+                {
+                    Id = "p1",
+                    Name = "Local",
+                    // 127.0.0.1:1 上不会有人监听,于是这一轮必定连不上 —— 我们要的正是这个
+                    BaseUrl = "http://127.0.0.1:1/v1",
+                    DefaultProtocol = ChatProtocol.OpenAiChatCompletions,
+                    Models = [new AiModelConfig { Id = "m1", Model = "probe" }]
+                }
+            ],
+            ActiveModelId = "m1"
+        });
+
+        InvalidOperationException error = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => runner.RunAsync(conversation, bridge, Message(), Deny, English, null, CancellationToken.None));
+
+        // 报错里带着模型名 = 它确实读到了刚写进去的那份设置
+        StringAssert.Contains(error.Message, "Local / probe");
+    }
+
+    /// <summary>
+    /// 报错必须点名是<b>哪个模型</b>。
+    /// </summary>
+    /// <remarks>
+    /// 群里只看到一句 401 时,人第一反应是去查飞书的凭证 —— 而那条 401 来自模型服务商。
+    /// 两者差着十万八千里,不点名就得靠猜。
+    /// </remarks>
+    [TestMethod]
+    public async Task RunAsync_NamesTheModelWhenTheProviderRejectsTheCall()
+    {
+        using var context = new TestPluginContext();
+        await new AiSettingsStore(context).SaveAsync(new AiSettings
+        {
+            Providers =
+            [
+                new AiProvider
+                {
+                    Id = "p1",
+                    Name = "Acme",
+                    BaseUrl = "http://127.0.0.1:1/v1",
+                    DefaultProtocol = ChatProtocol.OpenAiChatCompletions,
+                    Models = [new AiModelConfig { Id = "m1", Model = "x", Name = "some-model" }]
+                }
+            ],
+            ActiveModelId = "m1"
+        });
+
+        InvalidOperationException error = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => Create(context).RunAsync(new BridgeConversation("ch1", "chat-1"),
+                new BridgeSettings { Mode = ChatMode.Chat }, Message(), Deny, English, null, CancellationToken.None));
+
+        StringAssert.StartsWith(error.Message, "Acme / some-model:");
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeEndpointQuirksTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeEndpointQuirksTests.cs
@@ -1,0 +1,137 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Chat;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 机器人这条路发出去的请求,得和聊天面板那条<b>守同样的端点规矩</b>。
+/// </summary>
+/// <remarks>
+/// 这是线上撞到的 bug 的形状:同一个订阅型供应商(ChatGPT 的 Codex 后端),
+/// 聊天面板里一切正常,飞书群里却每轮都 400
+/// <c>{"detail":"System messages are not allowed"}</c> ——
+/// 因为端点怪癖的处理只写在 <c>ChatPanelView</c> 里,而 <c>BridgeAgentRunner</c>
+/// 是<b>另一条发送路径</b>,它只调了 ApplyReasoning 就把请求发出去了。
+/// <para>
+/// 所以这里不去断言"某个方法被调用过"(那种测试改个实现就废),而是
+/// <b>让 runner 真的把请求发到本地假端点上,抓报文来看</b>。
+/// 以后再加第三条发送路径、或再加一条新怪癖,漏了就会在这儿红。
+/// </para>
+/// </remarks>
+[TestClass]
+[TestCategory("Plugins")]
+public sealed class BridgeEndpointQuirksTests
+{
+    private static readonly Loc English = new("en");
+
+    private static Task<bool> Deny(ApprovalRequest _) => Task.FromResult(false);
+
+    private static InboundMessage Message(string text = "服务器磁盘满了")
+        => new("ch1", "chat-1", false, "u1", "Ann", text, "m1", true);
+
+    /// <summary>照目录里 Codex 那条建供应商,只把端点换成本地假的。</summary>
+    private static AiProvider CodexPointedAt(string baseUrl)
+    {
+        AiProvider provider = ProviderCatalog.Find("openai-codex")!.CreateProvider();
+        provider.BaseUrl = baseUrl;
+        provider.Auth = AuthMethod.ApiKey; // 免得走登录那条路;要测的是<b>发出去的报文</b>
+        provider.OAuth = null;
+        return provider;
+    }
+
+    /// <summary>跑一个回合,把 runner 真正发出去的请求体抓回来。</summary>
+    private static async Task<string> WireBodyAsync(BridgeSettings bridge)
+    {
+        using var context = new TestPluginContext();
+        using var stub = new SseStub("", jsonContent: "{}");
+        var store = new AiSettingsStore(context);
+        AiProvider provider = CodexPointedAt(stub.BaseUrl);
+        await store.SaveAsync(new AiSettings
+        {
+            Providers = [provider],
+            ActiveModelId = provider.Models[0].Id
+        });
+
+        var runner = new BridgeAgentRunner(context, store, new ChatHistoryStore(context), new McpManager(context));
+        try
+        {
+            await runner.RunAsync(new BridgeConversation("ch1", "chat-1"), bridge, Message(),
+                Deny, English, null, CancellationToken.None);
+        }
+        catch (Exception)
+        {
+            // 假端点回的不是 Responses 报文,解析失败无所谓 —— 只关心发出去的是什么
+        }
+        return await stub.RequestBodyAsync.WaitAsync(TimeSpan.FromSeconds(15));
+    }
+
+    /// <summary>
+    /// Codex 后端<b>不收 system 角色</b>。系统提示词得改走 Responses 自己的
+    /// <c>instructions</c> 字段 —— 内容一个字不少,只是换了个位置。
+    /// </summary>
+    [TestMethod]
+    public async Task BridgeTurn_SendsNoSystemMessageToAnEndpointThatRefusesThem()
+    {
+        string body = await WireBodyAsync(new BridgeSettings());
+
+        Assert.DoesNotContain("\"system\"", body,
+            $"这一家会为此整轮 400,面板里却好好的 —— 实际报文:{body}");
+        Assert.Contains("\"instructions\"", body, "系统提示词不能就这么丢了,它该落在 instructions 上");
+    }
+
+    /// <summary>
+    /// 同一条路上的另一半:这一家不认的参数也得摘掉。
+    /// </summary>
+    /// <remarks>
+    /// 上一轮踩坑的记录是:先修好 system 消息,下一条请求换来
+    /// <c>{"detail":"Unsupported parameter: max_output_tokens"}</c> —— 它一次只肯告诉你一个。
+    /// 两半一起钉住,免得再来一轮一来一回。
+    /// </remarks>
+    [TestMethod]
+    public async Task BridgeTurn_DropsTheParametersThisEndpointRejects()
+    {
+        string body = await WireBodyAsync(new BridgeSettings());
+
+        Assert.DoesNotContain("max_output_tokens", body, $"目录里已写明这一家不认它。实际报文:{body}");
+        Assert.DoesNotContain("\"store\":true", body, "订阅型的私有后端不给第三方做服务端响应存储");
+    }
+
+    /// <summary>
+    /// Agent 模式也得守同样的规矩 —— 群里默认就是 Agent,只测纯对话等于没测。
+    /// </summary>
+    [TestMethod]
+    public async Task BridgeTurn_InAgentMode_StillHonoursTheEndpointQuirks()
+    {
+        string body = await WireBodyAsync(new BridgeSettings { Mode = ChatMode.Agent });
+
+        Assert.DoesNotContain("\"system\"", body, $"实际报文:{body}");
+        Assert.DoesNotContain("max_output_tokens", body, $"实际报文:{body}");
+    }
+
+    /// <summary>
+    /// 怪癖要<b>请求时从目录读</b>,不能吃建供应商时的快照。
+    /// </summary>
+    /// <remarks>
+    /// 这条上过一次当:规则曾被快照进用户保存的供应商里,于是新加的规则永远到不了
+    /// <b>已经连上的</b>用户那儿 —— 代码改了三轮,用户那边一直是同一句 400。
+    /// </remarks>
+    [TestMethod]
+    public void Quirks_AreReadFromTheCatalogue_NotFromWhateverGotSaved()
+    {
+        AiProvider stale = ProviderCatalog.Find("openai-codex")!.CreateProvider();
+        // 模拟一份"登录那天存下来的"旧配置:三项怪癖全是出厂默认
+        stale.AllowSystemMessages = true;
+        stale.StoreResponses = true;
+        stale.UnsupportedParameters = "";
+
+        EndpointQuirks quirks = EndpointQuirks.Of(stale);
+
+        Assert.IsFalse(quirks.AllowSystemMessages, "该以目录为准,而不是用户库里那份旧快照");
+        Assert.IsFalse(quirks.StoreResponses);
+        Assert.Contains("max_output_tokens", quirks.UnsupportedParameters);
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
@@ -1,0 +1,402 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Chat;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// IM 桥接的策略层:谁能说话、哪句话是命令、挡位能不能在群里被抬高。
+/// </summary>
+/// <remarks>
+/// 这里<b>一条模型请求都不发</b> —— 用例只走白名单与斜杠命令这两条不碰模型的路。
+/// 真正要挡住的也正是它们:放行判断错一次,后果是陌生人能在生产机上敲命令。
+/// </remarks>
+[TestClass]
+public sealed class BridgeRouterTests
+{
+    /// <summary>一个只记录发了什么的渠道。<c>RunAsync</c> 挂着不动,直到被停掉。</summary>
+    private sealed class FakeChannel(string id) : IMessageChannel
+    {
+        public List<string> Sent { get; } = [];
+
+        public string Id { get; } = id;
+
+        public ChannelKind Kind => ChannelKind.Telegram;
+
+        public string Label => "fake";
+
+        public ChannelCapabilities Capabilities => new(true, 4000);
+
+        public event Action? Connected;
+
+        public Task RunAsync(Func<InboundMessage, Task> onMessage, CancellationToken cancellationToken)
+        {
+            Connected?.Invoke();
+            return Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+
+        public Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
+        {
+            Sent.Add(text);
+            return Task.FromResult<string?>($"m{Sent.Count}");
+        }
+
+        public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
+        {
+            Sent.Add($"[edit {messageId}] {text}");
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class Harness : IAsyncDisposable
+    {
+        public TestPluginContext Context { get; } = new();
+
+        public FakeChannel Channel { get; } = new("ch1");
+
+        public ChannelHub Hub { get; }
+
+        public ConversationRouter Router { get; }
+
+        public BridgeSettingsStore Store { get; }
+
+        public BridgeSettings Settings { get; }
+
+        public PairingService Pairing { get; } = new();
+
+        public Harness(BridgeSettings? settings = null, ChannelConfig? channel = null)
+        {
+            Store = new BridgeSettingsStore(Context);
+            Hub = new ChannelHub(Context);
+            var runner = new BridgeAgentRunner(Context, new AiSettingsStore(Context),
+                new ChatHistoryStore(Context), new McpManager(Context));
+            Router = new ConversationRouter(Context, Hub, runner, new ImApprovalBroker(Hub, Context), Store, Pairing);
+            Settings = settings ?? new BridgeSettings
+            {
+                Enabled = true,
+                Channels = [channel ?? new ChannelConfig { Id = "ch1", AllowedChats = ["chat-1"] }]
+            };
+            Router.Apply(Settings, new Loc("en"));
+        }
+
+        /// <summary>
+        /// 起渠道。<b>顺带把设置落一次盘</b> —— 真实情形里渠道是用户在设置页存下来的,
+        /// 而放行走的是"读库—改—写"那条路,库里没有这个渠道就没地方写。
+        /// </summary>
+        public async Task StartAsync()
+        {
+            await Store.SaveAsync(Settings);
+            await Hub.StartAsync(Channel, Router.HandleAsync);
+        }
+
+        public Task SendAsync(string text, string chatId = "chat-1", bool isGroup = false, bool mentions = true)
+            => Router.HandleAsync(new InboundMessage("ch1", chatId, isGroup, "u1", "Ann", text, "m1", mentions));
+
+        public async ValueTask DisposeAsync()
+        {
+            await Hub.DisposeAsync();
+            Context.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 白名单之外的聊天不该被伺候,但要回一句带 id 的话 —— 群 id 在飞书/钉钉界面上看不到,
+    /// 不给这一句,用户根本没法完成配置。
+    /// </summary>
+    [TestMethod]
+    public async Task Message_FromUnlistedChat_IsRefusedWithItsId()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("hello", chatId: "chat-stranger");
+
+        Assert.AreEqual(1, harness.Channel.Sent.Count);
+        StringAssert.Contains(harness.Channel.Sent[0], "chat-stranger");
+        StringAssert.Contains(harness.Channel.Sent[0], "not authorised");
+    }
+
+    /// <summary>同一个陌生聊天只提示一次,不然它每说一句我们就刷一条。</summary>
+    [TestMethod]
+    public async Task Message_FromUnlistedChat_IsAnnouncedOnlyOnce()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("hello", chatId: "chat-stranger");
+        await harness.SendAsync("anyone there?", chatId: "chat-stranger");
+
+        Assert.AreEqual(1, harness.Channel.Sent.Count);
+    }
+
+    /// <summary>群里没 @ 就当没听见 —— 机器人不该插进同事之间的正常对话。</summary>
+    [TestMethod]
+    public async Task GroupMessage_WithoutMention_IsIgnored()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("we should restart nginx", isGroup: true, mentions: false);
+
+        Assert.AreEqual(0, harness.Channel.Sent.Count);
+    }
+
+    [TestMethod]
+    public async Task SlashSessions_ListsConnectedSessions()
+    {
+        await using var harness = new Harness();
+        harness.Context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        await harness.StartAsync();
+
+        await harness.SendAsync("/sessions");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "root@prod-1:22");
+    }
+
+    [TestMethod]
+    public async Task SlashUse_BindsTheChatAndRemembersIt()
+    {
+        await using var harness = new Harness();
+        harness.Context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        await harness.StartAsync();
+
+        await harness.SendAsync("/use root@prod-1:22");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "root@prod-1:22");
+        BridgeSettings stored = await harness.Store.LoadAsync();
+        Assert.AreEqual("root@prod-1:22", stored.ChatBindings["ch1/chat-1"]);
+    }
+
+    [TestMethod]
+    public async Task SlashUse_WithNoMatchingSession_SaysSo()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/use root@nowhere:22");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "No connected session matches");
+    }
+
+    /// <summary>
+    /// <b>这条是安全用例。</b>白名单里的任何人都能发 <c>/mode agent</c> 的话,
+    /// 设置页里那个"桥接默认只读"就形同虚设。
+    /// </summary>
+    [TestMethod]
+    public async Task SlashMode_CannotRaiseThePrivilegeByDefault()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/mode agent");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "turned off");
+    }
+
+    [TestMethod]
+    public async Task SlashMode_CanRaiseWhenTheOperatorAllowedIt()
+    {
+        var settings = new BridgeSettings
+        {
+            Enabled = true,
+            Mode = ChatMode.Plan,
+            AllowModeEscalation = true,
+            Channels = [new ChannelConfig { Id = "ch1", AllowedChats = ["chat-1"] }]
+        };
+        await using var harness = new Harness(settings);
+        await harness.StartAsync();
+
+        await harness.SendAsync("/mode agent");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "Agent");
+    }
+
+    /// <summary>往低了换永远允许 —— 收紧权限不该需要谁批准。</summary>
+    [TestMethod]
+    public async Task SlashMode_CanAlwaysLowerThePrivilege()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/mode chat");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "Chat");
+    }
+
+    [TestMethod]
+    public async Task SlashHelp_ListsTheCommands()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/help");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "/sessions");
+    }
+
+    /// <summary>用户白名单非空时,名单外的人说话一律不理(连提示都不给 —— 他不是配置者)。</summary>
+    [TestMethod]
+    public async Task Message_FromUnlistedUser_IsIgnored()
+    {
+        var settings = new BridgeSettings
+        {
+            Enabled = true,
+            Channels = [new ChannelConfig { Id = "ch1", AllowedChats = ["chat-1"], AllowedUsers = ["boss"] }]
+        };
+        await using var harness = new Harness(settings);
+        await harness.StartAsync();
+
+        await harness.SendAsync("/help");
+
+        Assert.AreEqual(0, harness.Channel.Sent.Count);
+    }
+
+    /// <summary>
+    /// 配对码把「抄群 id」那一趟整个干掉:在群里发一句就进白名单,而且过夜有效。
+    /// </summary>
+    [TestMethod]
+    public async Task SlashPair_WithAValidCode_AuthorisesTheChatAndPersistsIt()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+        string code = harness.Pairing.Issue();
+
+        await harness.SendAsync($"/pair {code}", chatId: "chat-new");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "Paired");
+        // 内存里立刻生效:紧接着的一句话不该再被当成陌生人
+        harness.Channel.Sent.Clear();
+        await harness.SendAsync("/help", chatId: "chat-new");
+        StringAssert.Contains(harness.Channel.Sent.Single(), "/sessions");
+        // 而且落了盘,重启之后还在
+        BridgeSettings stored = await harness.Store.LoadAsync();
+        CollectionAssert.Contains(stored.Channels.Single().AllowedChats, "chat-new");
+    }
+
+    [TestMethod]
+    public async Task SlashPair_WithAWrongCode_LeavesTheChatUnauthorised()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+        string code = harness.Pairing.Issue();
+        string wrong = code == "000000" ? "111111" : "000000";
+
+        await harness.SendAsync($"/pair {wrong}", chatId: "chat-new");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "not valid");
+        BridgeSettings stored = await harness.Store.LoadAsync();
+        // 白名单里仍旧只有一开始那条,陌生聊天没被放进去
+        CollectionAssert.DoesNotContain(stored.Channels.Single().AllowedChats, "chat-new");
+        Assert.AreEqual(1, stored.Channels.Single().AllowedChats.Count);
+    }
+
+    /// <summary>没生成过码的时候,任何 /pair 都不该放行。</summary>
+    [TestMethod]
+    public async Task SlashPair_WithNoCodeIssued_IsRefused()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/pair 123456", chatId: "chat-new");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "not valid");
+    }
+
+    [TestMethod]
+    public async Task SlashPair_WithoutACode_ExplainsHowToGetOne()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/pair", chatId: "chat-new");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "Usage");
+    }
+
+    /// <summary>敲过门的聊天要被记下来,设置页那个「允许」按钮才有东西可点。</summary>
+    [TestMethod]
+    public async Task UnlistedChat_IsRememberedForOneClickApproval()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+
+        await harness.SendAsync("hello", chatId: "chat-stranger");
+
+        PendingChat pending = harness.Pairing.Pending().Single();
+        Assert.AreEqual("chat-stranger", pending.ChatId);
+        Assert.AreEqual("Ann", pending.UserName);
+    }
+
+    /// <summary>放行之后就不该再挂在待放行清单里。</summary>
+    [TestMethod]
+    public async Task Pairing_ClearsTheChatFromThePendingList()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+        await harness.SendAsync("hello", chatId: "chat-new");
+        string code = harness.Pairing.Issue();
+
+        await harness.SendAsync($"/pair {code}", chatId: "chat-new");
+
+        Assert.AreEqual(0, harness.Pairing.Pending().Count);
+    }
+}
+
+/// <summary>绑定串与宿主会话之间的换算。</summary>
+[TestClass]
+public sealed class SessionTargetsTests
+{
+    [TestMethod]
+    public async Task Resolve_MatchesOnUserHostAndPort()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+
+        SessionInfo? session = await SessionTargets.ResolveAsync(context, "root@prod-1:22", CancellationToken.None);
+
+        Assert.IsNotNull(session);
+        Assert.AreEqual("prod-1", session.Host);
+    }
+
+    /// <summary>省掉用户名与端口也该认 —— 群里手打一个 host 是最自然的写法。</summary>
+    [TestMethod]
+    public async Task Resolve_AcceptsHostOnly()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+
+        Assert.IsNotNull(await SessionTargets.ResolveAsync(context, "prod-1", CancellationToken.None));
+        Assert.IsNotNull(await SessionTargets.ResolveAsync(context, "prod-1:22", CancellationToken.None));
+        Assert.IsNotNull(await SessionTargets.ResolveAsync(context, "root@prod-1", CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task Resolve_RejectsAWrongUserOrPort()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+
+        Assert.IsNull(await SessionTargets.ResolveAsync(context, "deploy@prod-1", CancellationToken.None));
+        Assert.IsNull(await SessionTargets.ResolveAsync(context, "prod-1:2222", CancellationToken.None));
+        Assert.IsNull(await SessionTargets.ResolveAsync(context, "", CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task Describe_ListsEveryConnectedSession()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        context.FakeSessions.AddConnected(host: "db-2", username: "deploy");
+
+        string text = await SessionTargets.DescribeAsync(context, CancellationToken.None);
+
+        StringAssert.Contains(text, "root@prod-1:22");
+        StringAssert.Contains(text, "deploy@db-2:22");
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
@@ -1,0 +1,359 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using QRCoder;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Interop;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 「协作接入」设置页的 headless 装载:XAML 真的装得起来,渠道卡片按平台长对字段,
+/// 保存后配置与机密都落到该去的地方。
+/// </summary>
+/// <remarks>
+/// 这一页有相当一部分控件是<b>代码建的</b>(渠道卡片),而 <c>FindResource</c>、
+/// 样式类名这类东西"编译得过、运行才炸" —— 只有真装载一次才拦得住。
+/// </remarks>
+[TestClass]
+[TestCategory("Plugins")]
+public sealed class CollaborationViewUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(CollaborationViewUiTests).Assembly);
+
+    private static void OnUi(Func<Task> body) =>
+        _session.Dispatch(async () =>
+        {
+            await body();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    private static async Task PumpAsync(int rounds = 25)
+    {
+        for (int i = 0; i < rounds; i++)
+        {
+            await Task.Delay(5);
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// 开窗、跑用例、<b>无论断言过不过都把窗关掉</b>。
+    /// </summary>
+    /// <remarks>
+    /// 漏关的话 headless 会话会一直等那个窗,一次断言失败就被报成一分钟的超时 ——
+    /// 而"超时"这三个字什么线索都不给。
+    /// </remarks>
+    private static async Task WithViewAsync(TestPluginContext context, Func<CollaborationView, Task> body,
+        BridgeService? bridge = null)
+    {
+        var view = new CollaborationView(context, new Loc("en"), () => Task.CompletedTask, bridge);
+        var window = new Window { Width = 860, Height = 780, Content = view };
+        window.Show();
+        await PumpAsync();
+        try
+        {
+            await body(view);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// 两条服务的<b>开箱默认值</b>:IM 桥接默认关,对外 MCP 服务端默认开。
+    /// </summary>
+    /// <remarks>
+    /// 不对称是有意的,不是漏改:
+    /// <list type="bullet">
+    /// <item>桥接要用户去开发者后台拿凭证、还要把机器人拉进群,没配之前开着也没有意义;</item>
+    /// <item>MCP 服务端只绑 127.0.0.1、强制带令牌、默认只读挡位,开箱可用的收益明显大于风险 ——
+    /// 让人为了给 Claude Code 接一下先去翻一页设置,是没必要的门槛。</item>
+    /// </list>
+    /// 这条用例把这个决定钉住:哪天有人顺手把默认值改了,得先来改这段注释。
+    /// </remarks>
+    [TestMethod]
+    public void View_DefaultsBridgeOffAndMcpServerOn()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            await WithViewAsync(context, view =>
+            {
+                Assert.IsFalse(view.FindControl<CheckBox>("BridgeEnabledCheck")!.IsChecked);
+                Assert.IsFalse(view.FindControl<StackPanel>("BridgeDetailPanel")!.IsVisible);
+
+                Assert.IsTrue(view.FindControl<CheckBox>("McpEnabledCheck")!.IsChecked);
+                Assert.IsTrue(view.FindControl<StackPanel>("McpDetailPanel")!.IsVisible);
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    /// <summary>默认开着,但默认只给只读工具 —— "开箱可用"不等于"开箱可写"。</summary>
+    [TestMethod]
+    public void McpServer_DefaultsToTheReadOnlyMode()
+        => Assert.AreEqual(ChatMode.Plan, new McpServerSettings().Mode);
+
+    /// <summary>
+    /// 页面上<b>每一个</b>按钮的文字都得是居中的 —— 含代码建的那些。
+    /// </summary>
+    /// <remarks>
+    /// 这条是用户报了两次的那个 bug 的直接复现:第一次我只给 XAML 里的按钮挂了主题,
+    /// 而 ① <c>VelaAccentPillButtonTheme</c> 根本没有 <c>HorizontalContentAlignment</c> 这个 setter,
+    /// ② 代码建的按钮用 <c>TryFindResource</c> 取主题、在没进树时一律落空。两处都还是左对齐。
+    /// <para>
+    /// 这条用例在 headless 里<b>成立</b>,因为 <c>DialogStyles</c> 里那个 setter 的值是字面量
+    /// <c>Center</c>,不依赖宿主的资源字典 —— 而只检查"XAML 里写没写 Theme="的文本级用例,
+    /// 上面两种情况一个都抓不到。
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void EveryButtonCentresItsLabel()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            await using var bridge = new BridgeService(context, new AiSettingsStore(context));
+            // 三条建按钮的路都要覆盖到:XAML、渠道卡片、待放行卡片
+            bridge.Pairing.Remember(new PendingChat("c1", "oc_abc", true, "Ann", DateTimeOffset.UtcNow));
+            var store = new BridgeSettingsStore(context);
+            await store.SaveAsync(new BridgeSettings
+            {
+                Enabled = true,
+                Channels = [new ChannelConfig { Id = "c1", Kind = ChannelKind.Feishu }]
+            });
+            await WithViewAsync(context, async view =>
+            {
+                await PumpAsync();
+                // CheckBox 继承自 ToggleButton : Button,但勾选框的文字本来就该左对齐 —— 排掉
+                Button[] buttons =
+                [
+                    .. view.GetLogicalDescendants().OfType<Button>().Where(b => b is not ToggleButton)
+                ];
+
+                Assert.IsTrue(buttons.Length >= 8, $"expected the whole page, only found {buttons.Length} buttons");
+                string[] offenders =
+                [
+                    .. buttons.Where(b => b.HorizontalContentAlignment != HorizontalAlignment.Center)
+                              .Select(b => $"{b.Name ?? "(code-built)"}:{b.Content}")
+                ];
+                Assert.AreEqual(0, offenders.Length,
+                    "these buttons render their label off-centre: " + string.Join(", ", offenders));
+            }, bridge);
+        });
+    }
+
+    /// <summary>接入方式那一栏是给人直接复制走的,端口改了它必须跟着变。</summary>
+    [TestMethod]
+    public void CommandSample_FollowsThePortAndCarriesTheToken()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            var store = new McpServerSettingsStore(context);
+            await store.SaveAsync(new McpServerSettings { Enabled = true, Port = 9123 });
+            string token = await store.TokenAsync();
+            await WithViewAsync(context, view =>
+            {
+                string sample = view.FindControl<TextBox>("McpCommandBox")!.Text ?? "";
+
+                StringAssert.Contains(sample, "http://127.0.0.1:9123/mcp");
+                StringAssert.Contains(sample, token);
+                StringAssert.Contains(sample, "claude mcp add --transport http");
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    /// <summary>已配好的渠道要回显出来,而且密钥是遮起来的。</summary>
+    [TestMethod]
+    public void ExistingChannel_IsRenderedWithItsSecretMasked()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            var store = new BridgeSettingsStore(context);
+            var channel = new ChannelConfig
+            {
+                Id = "c1",
+                Kind = ChannelKind.Feishu,
+                DisplayName = "Ops group",
+                AppId = "cli_abc",
+                AllowedChats = ["oc_1"]
+            };
+            await store.SaveAsync(new BridgeSettings { Enabled = true, Channels = [channel] });
+            await store.SetSecretAsync("c1", "secret", "s3cret");
+            await WithViewAsync(context, view =>
+            {
+                var panel = view.FindControl<StackPanel>("ChannelsPanel")!;
+                Assert.AreEqual(1, panel.Children.Count);
+                TextBox[] boxes = [.. panel.GetLogicalDescendants().OfType<TextBox>()];
+                Assert.IsTrue(boxes.Any(b => b.Text == "cli_abc"), "the App ID should be shown");
+                TextBox? secret = boxes.FirstOrDefault(b => b.Text == "s3cret");
+                Assert.IsNotNull(secret, "the stored secret should be loaded back");
+                Assert.AreEqual('●', secret.PasswordChar);
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    /// <summary>Telegram 只有一个令牌,不该给它摆一个 App ID 的框。</summary>
+    [TestMethod]
+    public void TelegramChannel_HasNoAppIdField()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            var store = new BridgeSettingsStore(context);
+            await store.SaveAsync(new BridgeSettings
+            {
+                Enabled = true,
+                Channels = [new ChannelConfig { Id = "c1", Kind = ChannelKind.Telegram }]
+            });
+            await WithViewAsync(context, view =>
+            {
+                string[] labels =
+                [
+                    .. view.FindControl<StackPanel>("ChannelsPanel")!
+                           .GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")
+                ];
+                CollectionAssert.Contains(labels, "Bot Token");
+                CollectionAssert.DoesNotContain(labels, "App ID");
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    /// <summary>点一下生成,配对码要真的显示出来 —— 它是整条"授权一个群"路径的起点。</summary>
+    [TestMethod]
+    public void PairCode_IsShownAfterGenerating()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            await using var bridge = new BridgeService(context, new AiSettingsStore(context));
+            await WithViewAsync(context, async view =>
+            {
+                view.FindControl<Button>("IssuePairCodeButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync();
+
+                string shown = view.FindControl<TextBlock>("PairCodeText")!.Text ?? "";
+                Assert.IsNotNull(bridge.Pairing.Code);
+                StringAssert.Contains(shown, bridge.Pairing.Code!);
+            }, bridge);
+        });
+    }
+
+    /// <summary>没开桥接时点生成,要说清楚为什么没用,而不是默默什么都不发生。</summary>
+    [TestMethod]
+    public void PairCode_WithoutARunningBridge_ExplainsWhy()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            await WithViewAsync(context, async view =>
+            {
+                view.FindControl<Button>("IssuePairCodeButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync();
+
+                StringAssert.Contains(view.FindControl<TextBlock>("StatusText")!.Text ?? "", "bridge on");
+            });
+        });
+    }
+
+    /// <summary>敲过门的聊天要长出一行带「允许」的卡片 —— 这就是那个一键放行。</summary>
+    [TestMethod]
+    public void PendingChat_RendersARowWithAnAllowButton()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            await using var bridge = new BridgeService(context, new AiSettingsStore(context));
+            bridge.Pairing.Remember(new PendingChat("ch1", "oc_abc", true, "Ann", DateTimeOffset.UtcNow));
+            await WithViewAsync(context, async view =>
+            {
+                await PumpAsync(); // 页面加载完就会刷一次,不必等定时器
+
+                var panel = view.FindControl<StackPanel>("PendingPanel")!;
+                Assert.AreEqual(1, panel.Children.Count);
+                string[] text = [.. panel.GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")];
+                CollectionAssert.Contains(text, "oc_abc");
+                Assert.IsTrue(text.Any(t => t.Contains("Ann")), "the row should say who knocked");
+                Assert.IsTrue(panel.GetLogicalDescendants().OfType<Button>().Any(b => (string?)b.Content == "Allow"));
+            }, bridge);
+        });
+    }
+
+    /// <summary>
+    /// 二维码真的画得出来。
+    /// </summary>
+    /// <remarks>
+    /// QRCoder 是这次新引的依赖,而且要经 PNG 字节转成 Avalonia 的 <see cref="Bitmap" /> ——
+    /// 这条路"编译得过、运行才炸"的可能性最高(比如挑了个要 System.Drawing 的重载),
+    /// 所以单独钉一条。
+    /// </remarks>
+    [TestMethod]
+    public void QrCode_RendersToABitmap()
+    {
+        OnUi(() =>
+        {
+            using var generator = new QRCodeGenerator();
+            using QRCodeData data = generator.CreateQrCode("https://t.me/example_bot?startgroup=true",
+                QRCodeGenerator.ECCLevel.M);
+            byte[] png = new PngByteQRCode(data).GetGraphic(6);
+
+            using var bitmap = new Bitmap(new MemoryStream(png));
+
+            Assert.IsTrue(bitmap.PixelSize.Width > 0 && bitmap.PixelSize.Height > 0);
+            return Task.CompletedTask;
+        });
+    }
+
+    [TestMethod]
+    public void Save_PersistsBothSettingsAndTheChannelSecret()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            var bridgeStore = new BridgeSettingsStore(context);
+            var mcpStore = new McpServerSettingsStore(context);
+            await bridgeStore.SaveAsync(new BridgeSettings
+            {
+                Channels = [new ChannelConfig { Id = "c1", Kind = ChannelKind.Feishu }]
+            });
+            await WithViewAsync(context, async view =>
+            {
+                view.FindControl<CheckBox>("BridgeEnabledCheck")!.IsChecked = true;
+                view.FindControl<CheckBox>("McpEnabledCheck")!.IsChecked = true;
+                view.FindControl<TextBox>("McpPortBox")!.Text = "9401";
+                var channels = view.FindControl<StackPanel>("ChannelsPanel")!;
+                TextBox[] boxes = [.. channels.GetLogicalDescendants().OfType<TextBox>()];
+                boxes.First(b => b.PasswordChar == '●').Text = "written-secret";
+                // 按钮的 Click 是直接挂的委托,所以走真的路由事件而不是反射调私有方法
+                view.FindControl<Button>("SaveButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync(40);
+            });
+
+            BridgeSettings bridge = await bridgeStore.LoadAsync();
+            McpServerSettings mcp = await mcpStore.LoadAsync();
+            Assert.IsTrue(bridge.Enabled);
+            Assert.IsTrue(mcp.Enabled);
+            Assert.AreEqual(9401, mcp.Port);
+            Assert.AreEqual("written-secret", await bridgeStore.GetSecretAsync("c1", "secret"));
+        });
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/FeishuApiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/FeishuApiTests.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>飞书 REST 调用里那些"字段名本身就是协议"的地方。</summary>
+[TestClass]
+public sealed class FeishuApiTests
+{
+    /// <summary>
+    /// 长连接接入点那条请求的字段名必须逐字是 <c>AppID</c> / <c>AppSecret</c>。
+    /// </summary>
+    /// <remarks>
+    /// <b>这是一条回归用例,不是防御性断言。</b>真实翻车过一次:
+    /// <c>PostAsJsonAsync</c> 默认用 <see cref="JsonSerializerDefaults.Web" />(camelCase),
+    /// 匿名对象写 <c>AppID</c> 发出去变成 <c>appID</c>,平台回
+    /// <c>{"code":9499,"msg":"Bad Request"}</c>。
+    /// <para>
+    /// 阴险之处在于同一个类里换令牌那条用的是 <c>app_id</c>(本来就小写开头),camelCase
+    /// 动不了它 —— 于是界面上显示的是"凭证 OK,但接入点被拒",没有人会想到是序列化。
+    /// 所以这里刻意<b>按 Web 默认值序列化</b>:用 <c>JsonSerializerOptions.Default</c> 测
+    /// 是测不出这个 bug 的,那正是当初漏掉它的原因。
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void EndpointRequest_KeepsItsPascalCaseFieldNames()
+    {
+        string json = JsonSerializer.Serialize(new FeishuApi.EndpointRequest("cli_x", "s3cret"),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        StringAssert.Contains(json, "\"AppID\"");
+        StringAssert.Contains(json, "\"AppSecret\"");
+        Assert.IsFalse(json.Contains("\"appID\"", StringComparison.Ordinal),
+            $"the camelCased name is what the platform rejects with code 9499; got {json}");
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/LocTableTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/LocTableTests.cs
@@ -1,0 +1,107 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using VelaShell.Plugin.Ai.Ui;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 插件自理的多语言表:每个键都必须齐五种语言。
+/// </summary>
+/// <remarks>
+/// <see cref="Loc" /> 按下标取值(<c>values[_index]</c>),少一项就是运行时的
+/// <see cref="IndexOutOfRangeException" /> —— 而且只有把界面切到日语或韩语才撞得到,
+/// 开发机上多半是中文,永远发现不了。宿主那边由 <c>LocalizedKeyUsageTests</c> 守着五份 resx,
+/// 插件这份表同样需要一个守门的。
+/// </remarks>
+[TestClass]
+public sealed class LocTableTests
+{
+    private static Dictionary<string, string[]> Table()
+    {
+        FieldInfo field = typeof(Loc).GetField("Table", BindingFlags.NonPublic | BindingFlags.Static)
+                          ?? throw new InvalidOperationException("Loc.Table is gone — update this test.");
+        return (Dictionary<string, string[]>)field.GetValue(null)!;
+    }
+
+    [TestMethod]
+    public void EveryKey_HasAllFiveLanguages()
+    {
+        List<string> broken =
+        [
+            .. Table().Where(entry => entry.Value.Length != 5)
+                      .Select(entry => $"{entry.Key} ({entry.Value.Length})")
+        ];
+
+        Assert.AreEqual(0, broken.Count,
+            $"These keys do not have exactly five translations: {string.Join(", ", broken)}");
+    }
+
+    [TestMethod]
+    public void NoTranslation_IsBlank()
+    {
+        List<string> blank =
+        [
+            .. Table().Where(entry => entry.Value.Any(string.IsNullOrWhiteSpace)).Select(entry => entry.Key)
+        ];
+
+        Assert.AreEqual(0, blank.Count, $"These keys have a blank translation: {string.Join(", ", blank)}");
+    }
+
+    /// <summary>取词真的跟着语言走(顺序 en / zh-Hans / zh-Hant / ja / ko)。</summary>
+    [TestMethod]
+    public void Lookup_FollowsTheLocale()
+    {
+        Assert.AreEqual("Copy", new Loc("en")["Copy"]);
+        Assert.AreNotEqual(new Loc("en")["BridgeThinking"], new Loc("zh-Hans")["BridgeThinking"]);
+        Assert.AreNotEqual(new Loc("ja")["BridgeThinking"], new Loc("ko")["BridgeThinking"]);
+    }
+
+    /// <summary>缺键时返回键名本身,而不是抛 —— 少一句文案不该让面板打不开。</summary>
+    [TestMethod]
+    public void MissingKey_ReturnsTheKey()
+        => Assert.AreEqual("NoSuchKeyHere", new Loc("en")["NoSuchKeyHere"]);
+
+    /// <summary>
+    /// 同一个键不许在表里出现两次。
+    /// </summary>
+    /// <remarks>
+    /// <b>这条只能按源码查,运行时查不出来。</b>表是用索引器 <c>["key"] = […]</c> 初始化的,
+    /// 重复键是<b>静默覆盖</b>(换成集合初始化器的 <c>Add</c> 才会抛),所以 <see cref="Table" />
+    /// 里根本看不出曾经有过两条。
+    /// <para>
+    /// 真事:设置页的「审批超时(秒)」标签与 IM 里那句「没人应答,按拒绝处理。」都叫
+    /// <c>BridgeApprovalTimeout</c>,后写的把前面盖掉 —— 于是输入框上方的标签变成了一整句话。
+    /// 编译、测试、启动全都正常,只有把界面渲染出来看才发现。
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void NoKeyIsDefinedTwice()
+    {
+        string source = LocSourcePath();
+        List<string> duplicates =
+        [
+            .. Regex.Matches(File.ReadAllText(source), @"^\s*\[""([A-Za-z0-9]+)""\]\s*=", RegexOptions.Multiline)
+                    .Select(m => m.Groups[1].Value)
+                    .GroupBy(k => k, StringComparer.Ordinal)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => $"{g.Key} (×{g.Count()})")
+        ];
+
+        Assert.AreEqual(0, duplicates.Count,
+            "these keys are defined more than once; the later one silently wins: " + string.Join(", ", duplicates));
+    }
+
+    /// <summary>从测试程序集往上找到 <c>Loc.cs</c>。找不到就失败 —— 跳过会被记成通过。</summary>
+    private static string LocSourcePath()
+    {
+        for (DirectoryInfo? dir = new(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+        {
+            string candidate = Path.Combine(dir.FullName, "plugins", "VelaShell.Plugin.Ai", "Ui", "Loc.cs");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        throw new InvalidOperationException($"Could not find Loc.cs above '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/McpEndpointTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/McpEndpointTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.Plugin.Ai.Interop;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 对外的 MCP 服务端:外部 agent(Claude Code / Codex)真的连得上、看得到工具、调得动。
+/// </summary>
+/// <remarks>
+/// 这几条用例走的是<b>真的 HTTP</b>,不是对着内部方法打桩 —— 这条路上最容易坏的恰恰是
+/// 协议层面的细节(鉴权头、会话头、JSON-RPC 信封),打桩全都测不到。
+/// </remarks>
+[TestClass]
+public sealed class McpEndpointTests
+{
+    /// <summary>找一个空闲端口。写死端口会让并行跑测试的机器互相打架。</summary>
+    private static int FreePort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        int port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    /// <summary>本机回环不该走代理 —— 宿主给 DefaultProxy 装过东西,测试里绕开它。</summary>
+    private static HttpClient CreateClient(int port, string? token)
+    {
+        var client = new HttpClient(new HttpClientHandler { UseProxy = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{port}/"),
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        if (token is not null)
+        {
+            client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+        }
+        return client;
+    }
+
+    private static async Task<(McpEndpoint Endpoint, int Port, string Token)> StartAsync(
+        TestPluginContext context, ChatMode mode = ChatMode.Plan)
+    {
+        var store = new McpServerSettingsStore(context);
+        int port = FreePort();
+        await store.SaveAsync(new McpServerSettings { Enabled = true, Port = port, Mode = mode });
+        string token = await store.TokenAsync();
+        var endpoint = new McpEndpoint(context, store);
+        await endpoint.ReloadAsync();
+        return (endpoint, port, token);
+    }
+
+    private static async Task<JsonDocument> RpcAsync(HttpClient client, object request, string? sessionId = null)
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Post, "mcp")
+        {
+            Content = JsonContent.Create(request)
+        };
+        if (sessionId is not null)
+        {
+            message.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+        }
+        using HttpResponseMessage response = await client.SendAsync(message);
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    [TestMethod]
+    public async Task Initialize_ReturnsSessionIdAndServerInfo()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context);
+        await using (endpoint)
+        {
+            Assert.IsTrue(endpoint.IsRunning);
+            using HttpClient client = CreateClient(port, token);
+
+            using var message = new HttpRequestMessage(HttpMethod.Post, "mcp")
+            {
+                Content = JsonContent.Create(new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new { protocolVersion = "2025-06-18", clientInfo = new { name = "test", version = "1" } }
+                })
+            };
+            using HttpResponseMessage response = await client.SendAsync(message);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.Headers.TryGetValues("Mcp-Session-Id", out IEnumerable<string>? ids));
+            Assert.IsFalse(string.IsNullOrEmpty(ids!.First()));
+            using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            JsonElement result = document.RootElement.GetProperty("result");
+            Assert.AreEqual("velashell", result.GetProperty("serverInfo").GetProperty("name").GetString());
+            Assert.AreEqual("2025-06-18", result.GetProperty("protocolVersion").GetString());
+        }
+    }
+
+    /// <summary>没有令牌就进不来。本机端口谁都能敲,这是唯一的门。</summary>
+    [TestMethod]
+    public async Task Request_WithoutToken_IsRejected()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string _) = await StartAsync(context);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token: null);
+
+            using HttpResponseMessage response = await client.PostAsJsonAsync("mcp",
+                new { jsonrpc = "2.0", id = 1, method = "initialize" });
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+
+    [TestMethod]
+    public async Task Request_WithWrongToken_IsRejected()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token + "x");
+
+            using HttpResponseMessage response = await client.PostAsJsonAsync("mcp",
+                new { jsonrpc = "2.0", id = 1, method = "initialize" });
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+
+    /// <summary>
+    /// 计划档只给只读工具 —— 外部 agent 默认不该能在生产机上敲命令。
+    /// </summary>
+    [TestMethod]
+    public async Task ToolsList_InPlanMode_ExposesOnlyReadOnlyTools()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token);
+            string sessionId = await InitializeAsync(client);
+
+            using JsonDocument document = await RpcAsync(client,
+                new { jsonrpc = "2.0", id = 2, method = "tools/list" }, sessionId);
+
+            string[] names =
+            [
+                .. document.RootElement.GetProperty("result").GetProperty("tools")
+                           .EnumerateArray().Select(t => t.GetProperty("name").GetString()!)
+            ];
+            CollectionAssert.Contains(names, "list_sessions");
+            CollectionAssert.Contains(names, "use_session");
+            CollectionAssert.DoesNotContain(names, "run_command");
+            CollectionAssert.DoesNotContain(names, "write_remote_file");
+        }
+    }
+
+    [TestMethod]
+    public async Task ToolsList_InAgentMode_ExposesWriteTools()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context, ChatMode.Agent);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token);
+            string sessionId = await InitializeAsync(client);
+
+            using JsonDocument document = await RpcAsync(client,
+                new { jsonrpc = "2.0", id = 2, method = "tools/list" }, sessionId);
+
+            string[] names =
+            [
+                .. document.RootElement.GetProperty("result").GetProperty("tools")
+                           .EnumerateArray().Select(t => t.GetProperty("name").GetString()!)
+            ];
+            CollectionAssert.Contains(names, "run_command");
+        }
+    }
+
+    [TestMethod]
+    public async Task ToolsCall_ListSessions_ReturnsTheHostsSessions()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token);
+            string sessionId = await InitializeAsync(client);
+
+            using JsonDocument document = await RpcAsync(client, new
+            {
+                jsonrpc = "2.0",
+                id = 3,
+                method = "tools/call",
+                @params = new { name = "list_sessions", arguments = new { } }
+            }, sessionId);
+
+            JsonElement result = document.RootElement.GetProperty("result");
+            Assert.IsFalse(result.GetProperty("isError").GetBoolean());
+            string text = result.GetProperty("content")[0].GetProperty("text").GetString()!;
+            StringAssert.Contains(text, "prod-1");
+        }
+    }
+
+    /// <summary>没走 initialize 就调工具,要给一个说得清的错,而不是空指针。</summary>
+    [TestMethod]
+    public async Task ToolsList_WithoutSession_ReportsAnError()
+    {
+        using var context = new TestPluginContext();
+        (McpEndpoint endpoint, int port, string token) = await StartAsync(context);
+        await using (endpoint)
+        {
+            using HttpClient client = CreateClient(port, token);
+
+            using JsonDocument document = await RpcAsync(client,
+                new { jsonrpc = "2.0", id = 9, method = "tools/list" });
+
+            Assert.AreEqual(-32001, document.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+        }
+    }
+
+    /// <summary>桥接与服务端都关着时,不该占任何端口。</summary>
+    [TestMethod]
+    public async Task Disabled_DoesNotListen()
+    {
+        using var context = new TestPluginContext();
+        var store = new McpServerSettingsStore(context);
+        await store.SaveAsync(new McpServerSettings { Enabled = false, Port = FreePort() });
+
+        await using var endpoint = new McpEndpoint(context, store);
+        await endpoint.ReloadAsync();
+
+        Assert.IsFalse(endpoint.IsRunning);
+        Assert.IsNull(endpoint.Url);
+    }
+
+    private static async Task<string> InitializeAsync(HttpClient client)
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Post, "mcp")
+        {
+            Content = JsonContent.Create(new { jsonrpc = "2.0", id = 1, method = "initialize" })
+        };
+        using HttpResponseMessage response = await client.SendAsync(message);
+        return response.Headers.GetValues("Mcp-Session-Id").First();
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
@@ -1,0 +1,115 @@
+using VelaShell.Plugin.Ai.Bridge;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 配对码本身:一次性、会过期、猜错有上限。
+/// </summary>
+/// <remarks>
+/// 这个码在有效期内能把一个陌生聊天放进白名单,所以它的三条边界都是安全边界,
+/// 不是"顺手加的便利功能"。
+/// </remarks>
+[TestClass]
+public sealed class PairingServiceTests
+{
+    [TestMethod]
+    public void Issue_ProducesASixDigitCode()
+    {
+        string code = new PairingService().Issue();
+
+        Assert.AreEqual(6, code.Length);
+        Assert.IsTrue(code.All(char.IsAsciiDigit), $"expected six digits, got '{code}'");
+    }
+
+    [TestMethod]
+    public void Redeem_AcceptsTheCodeExactlyOnce()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue();
+
+        Assert.IsTrue(pairing.TryRedeem(code));
+        Assert.IsFalse(pairing.TryRedeem(code), "a pairing code must not be reusable");
+        Assert.IsNull(pairing.Code);
+    }
+
+    [TestMethod]
+    public void Redeem_RejectsAWrongCode()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue();
+        string wrong = code == "000000" ? "111111" : "000000";
+
+        Assert.IsFalse(pairing.TryRedeem(wrong));
+        Assert.IsTrue(pairing.TryRedeem(code), "one wrong guess should not kill a valid code");
+    }
+
+    /// <summary>猜错够多次就作废 —— 六位数字挡得住随手试,挡不住脚本。</summary>
+    [TestMethod]
+    public void Redeem_KillsTheCodeAfterTooManyWrongGuesses()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue();
+        string wrong = code == "000000" ? "111111" : "000000";
+
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.IsFalse(pairing.TryRedeem(wrong));
+        }
+
+        Assert.IsNull(pairing.Code, "the code should be dead after five wrong guesses");
+        Assert.IsFalse(pairing.TryRedeem(code), "even the right code must not work once it has been burnt");
+    }
+
+    [TestMethod]
+    public void Redeem_FailsWhenNoCodeWasIssued()
+        => Assert.IsFalse(new PairingService().TryRedeem("123456"));
+
+    [TestMethod]
+    public void Issue_InvalidatesThePreviousCode()
+    {
+        var pairing = new PairingService();
+        string first = pairing.Issue();
+        pairing.Issue();
+
+        Assert.IsFalse(pairing.TryRedeem(first));
+    }
+
+    [TestMethod]
+    public void Revoke_DropsTheCode()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue();
+
+        pairing.Revoke();
+
+        Assert.IsNull(pairing.Code);
+        Assert.IsFalse(pairing.TryRedeem(code));
+    }
+
+    [TestMethod]
+    public void Pending_KeepsTheMostRecentFirstAndDeduplicates()
+    {
+        var pairing = new PairingService();
+        pairing.Remember(new PendingChat("ch1", "a", true, "Ann", DateTimeOffset.UtcNow.AddMinutes(-5)));
+        pairing.Remember(new PendingChat("ch1", "b", false, "Bob", DateTimeOffset.UtcNow));
+        // 同一个聊天再敲一次:不新增一行,但显示名跟上最新的那个人
+        pairing.Remember(new PendingChat("ch1", "a", true, "Cara", DateTimeOffset.UtcNow));
+
+        IReadOnlyList<PendingChat> pending = pairing.Pending();
+
+        Assert.AreEqual(2, pending.Count);
+        Assert.AreEqual("b", pending[0].ChatId);
+        Assert.AreEqual("Cara", pending.Single(p => p.ChatId == "a").UserName);
+    }
+
+    [TestMethod]
+    public void Forget_RemovesOneChat()
+    {
+        var pairing = new PairingService();
+        pairing.Remember(new PendingChat("ch1", "a", true, "Ann", DateTimeOffset.UtcNow));
+
+        pairing.Forget("ch1", "a");
+
+        Assert.AreEqual(0, pairing.Pending().Count);
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/Pbbp2Tests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/Pbbp2Tests.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using VelaShell.Plugin.Ai.Bridge.Channels.Feishu;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 飞书长连接的帧编解码。
+/// </summary>
+/// <remarks>
+/// 这套 protobuf 是<b>手写</b>的(见 <see cref="Pbbp2" /> 的注释),没有生成器兜底,
+/// 所以字段号、线格式与跳过未知字段这三件事必须有回归保护 —— 错一个字节的表现是
+/// "连上了但一条消息都收不到",而那种故障在真机上极难定位。
+/// </remarks>
+[TestClass]
+public sealed class Pbbp2Tests
+{
+    [TestMethod]
+    public void Encode_ThenDecode_RoundTripsEveryField()
+    {
+        var frame = new Pbbp2.Frame
+        {
+            SeqId = 42,
+            LogId = 987654321,
+            Service = 7,
+            Method = Pbbp2.FrameTypeData,
+            PayloadEncoding = "gzip",
+            PayloadType = "json",
+            Payload = Encoding.UTF8.GetBytes("""{"hello":"世界"}"""),
+            LogIdNew = "log-new"
+        };
+        frame.SetHeader(Pbbp2.HeaderNames.Type, "event");
+        frame.SetHeader(Pbbp2.HeaderNames.MessageId, "msg-1");
+
+        Pbbp2.Frame decoded = Pbbp2.Decode(Pbbp2.Encode(frame));
+
+        Assert.AreEqual(42ul, decoded.SeqId);
+        Assert.AreEqual(987654321ul, decoded.LogId);
+        Assert.AreEqual(7, decoded.Service);
+        Assert.AreEqual(Pbbp2.FrameTypeData, decoded.Method);
+        Assert.AreEqual("gzip", decoded.PayloadEncoding);
+        Assert.AreEqual("json", decoded.PayloadType);
+        Assert.AreEqual("""{"hello":"世界"}""", Encoding.UTF8.GetString(decoded.Payload));
+        Assert.AreEqual("log-new", decoded.LogIdNew);
+        Assert.AreEqual("event", decoded.Header(Pbbp2.HeaderNames.Type));
+        Assert.AreEqual("msg-1", decoded.Header(Pbbp2.HeaderNames.MessageId));
+    }
+
+    /// <summary>varint 是变长的,所以大于一个字节的值必须单独验一遍。</summary>
+    [TestMethod]
+    public void Encode_HandlesMultiByteVarints()
+    {
+        var frame = new Pbbp2.Frame { SeqId = ulong.MaxValue, LogId = 300, Service = 128, Method = 1 };
+
+        Pbbp2.Frame decoded = Pbbp2.Decode(Pbbp2.Encode(frame));
+
+        Assert.AreEqual(ulong.MaxValue, decoded.SeqId);
+        Assert.AreEqual(300ul, decoded.LogId);
+        Assert.AreEqual(128, decoded.Service);
+    }
+
+    /// <summary>ping 帧只有类型与服务号,别的字段一个都不该占位。</summary>
+    [TestMethod]
+    public void PingFrame_CarriesOnlyTypeAndService()
+    {
+        var ping = new Pbbp2.Frame { Method = Pbbp2.FrameTypeControl, Service = 3 };
+        ping.SetHeader(Pbbp2.HeaderNames.Type, "ping");
+
+        Pbbp2.Frame decoded = Pbbp2.Decode(Pbbp2.Encode(ping));
+
+        Assert.AreEqual(Pbbp2.FrameTypeControl, decoded.Method);
+        Assert.AreEqual("ping", decoded.Header(Pbbp2.HeaderNames.Type));
+        Assert.AreEqual(0, decoded.Payload.Length);
+        Assert.AreEqual(1, decoded.Headers.Count);
+    }
+
+    /// <summary>同名头只留最后一份 —— 应答帧会重复设 biz_rt,不能越堆越多。</summary>
+    [TestMethod]
+    public void SetHeader_ReplacesInsteadOfAppending()
+    {
+        var frame = new Pbbp2.Frame();
+        frame.SetHeader(Pbbp2.HeaderNames.BizRt, "10");
+        frame.SetHeader(Pbbp2.HeaderNames.BizRt, "20");
+
+        Assert.AreEqual(1, frame.Headers.Count);
+        Assert.AreEqual("20", frame.Header(Pbbp2.HeaderNames.BizRt));
+    }
+
+    /// <summary>
+    /// 平台以后加字段时,解码不能崩 —— 未知字段按线格式跳过就好。
+    /// </summary>
+    [TestMethod]
+    public void Decode_SkipsUnknownFields()
+    {
+        byte[] known = Pbbp2.Encode(new Pbbp2.Frame { SeqId = 5, Method = Pbbp2.FrameTypeData });
+        // 手工追加两个未知字段:15 号(varint)与 16 号(长度前缀)。
+        // 16 号的 tag 是 130,超过一个字节,所以它本身也得按 varint 写成 0x82 0x01 ——
+        // 写成单字节的话解码器会把它当成"还有后续字节",整帧就歪了。
+        byte[] withUnknown =
+        [
+            .. known,
+            (15 << 3) | 0, 0x96, 0x01,          // 字段 15 = varint 150
+            0x82, 0x01, 3, 1, 2, 3              // 字段 16 = bytes {1,2,3}
+        ];
+
+        Pbbp2.Frame decoded = Pbbp2.Decode(withUnknown);
+
+        Assert.AreEqual(5ul, decoded.SeqId);
+        Assert.AreEqual(Pbbp2.FrameTypeData, decoded.Method);
+    }
+
+    /// <summary>截断的字节流要抛,不能读出一个"看起来还行"的半截帧。</summary>
+    [TestMethod]
+    public void Decode_ThrowsOnTruncatedInput()
+    {
+        byte[] full = Pbbp2.Encode(new Pbbp2.Frame
+        {
+            SeqId = 1,
+            Payload = Encoding.UTF8.GetBytes("0123456789")
+        });
+
+        byte[] truncated = full[..^4];
+
+        Assert.ThrowsExactly<InvalidDataException>(() => Pbbp2.Decode(truncated));
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/ThemeTokenUsageTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ThemeTokenUsageTests.cs
@@ -1,0 +1,155 @@
+using System.Text.RegularExpressions;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 插件界面必须真的落在软件自己那套主题上。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>为什么需要这道关。</b><c>{DynamicResource Xxx}</c> 拼错一个字母不会报错、不会抛异常 ——
+/// 它只是<b>什么都不做</b>,于是那条分隔线是隐形的、那段文字用的是 Fluent 默认前景色。
+/// 真事:协作接入页的保存栏写了 <c>VelaBorderSubtle</c>,而这套令牌里根本没有这个键
+/// (只有 <c>VelaBorderPrimary</c> / <c>VelaBorderSecondary</c>),那条线从落地起就没画出来过,
+/// 直到用户说"这个窗口没应用主题"才被发现。
+/// </para>
+/// <para>
+/// headless 用例挡不住这一类:测试进程里压根没装载宿主的令牌字典,所有键都解析不到,
+/// 拼对拼错看起来一模一样。所以这里按<b>文本</b>比对 —— 用的键必须能在仓库里找到定义。
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class ThemeTokenUsageTests
+{
+    /// <summary><c>{DynamicResource Key}</c> / <c>{StaticResource Key}</c>。</summary>
+    private static readonly Regex Used = new(@"\{(?:Dynamic|Static)Resource\s+([A-Za-z0-9._]+)\s*\}",
+        RegexOptions.Compiled);
+
+    /// <summary>XAML 里的 <c>x:Key="Key"</c>。</summary>
+    private static readonly Regex DefinedInXaml = new(@"x:Key=""([A-Za-z0-9._]+)""", RegexOptions.Compiled);
+
+    /// <summary>
+    /// C# 里运行时塞进去的键(如 <c>Resources["AiCopyTip"] = …</c>)。
+    /// </summary>
+    /// <remarks>
+    /// 本地化的提示文案就是这么给的:XAML 里引用一个键,构造时按当前语言把值填进
+    /// <c>Resources</c>。它们同样是"有定义"的键,漏算就会把好代码判成红。
+    /// </remarks>
+    private static readonly Regex DefinedInCode = new(@"Resources\[""([A-Za-z0-9._]+)""\]", RegexOptions.Compiled);
+
+    /// <summary>XML 注释。里面的示例代码不算引用。</summary>
+    private static readonly Regex Comments = new("<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>从测试程序集往上找到仓库根(带 <c>VelaShell.slnx</c> 的那一层)。</summary>
+    /// <remarks>
+    /// 找不到就<b>失败</b>而不是跳过:MSTest 把跳过记成通过,一条永远"绿"的守门用例
+    /// 比没有这条用例更糟 —— 它会让人以为这一类问题已经被挡住了。
+    /// </remarks>
+    private static DirectoryInfo RepositoryRoot()
+    {
+        for (DirectoryInfo? dir = new(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "VelaShell.slnx")))
+            {
+                return dir;
+            }
+        }
+        throw new InvalidOperationException(
+            $"Could not find VelaShell.slnx above '{AppContext.BaseDirectory}'; this test must run from the repository.");
+    }
+
+    private static HashSet<string> DefinedKeys(DirectoryInfo root)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string directory in (string[])["src", "plugins"])
+        {
+            string path = Path.Combine(root.FullName, directory);
+            if (!Directory.Exists(path))
+            {
+                continue;
+            }
+            foreach (string file in Directory.EnumerateFiles(path, "*.axaml", SearchOption.AllDirectories))
+            {
+                foreach (Match match in DefinedInXaml.Matches(File.ReadAllText(file)))
+                {
+                    keys.Add(match.Groups[1].Value);
+                }
+            }
+            foreach (string file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                foreach (Match match in DefinedInCode.Matches(File.ReadAllText(file)))
+                {
+                    keys.Add(match.Groups[1].Value);
+                }
+            }
+        }
+        return keys;
+    }
+
+    [TestMethod]
+    public void EveryResourceKeyUsedByThePluginIsDefinedSomewhere()
+    {
+        DirectoryInfo root = RepositoryRoot();
+        HashSet<string> defined = DefinedKeys(root);
+        Assert.IsTrue(defined.Count > 50, $"only found {defined.Count} defined keys — the scan is probably looking in the wrong place");
+
+        string ui = Path.Combine(root.FullName, "plugins", "VelaShell.Plugin.Ai", "Ui");
+        List<string> missing = [];
+        foreach (string file in Directory.EnumerateFiles(ui, "*.axaml"))
+        {
+            string text = Comments.Replace(File.ReadAllText(file), "");
+            foreach (Match match in Used.Matches(text))
+            {
+                if (!defined.Contains(match.Groups[1].Value))
+                {
+                    missing.Add($"{Path.GetFileName(file)}: {match.Groups[1].Value}");
+                }
+            }
+        }
+
+        Assert.AreEqual(0, missing.Count,
+            "these resource keys resolve to nothing at runtime (no error, just no styling): "
+            + string.Join(", ", missing.Distinct()));
+    }
+
+    /// <summary>
+    /// 协作接入页的每个 <c>&lt;Button&gt;</c> / <c>&lt;CheckBox&gt;</c> 都必须带上样式表里那个 class。
+    /// </summary>
+    /// <remarks>
+    /// <b>不要退回"每个按钮自己写 <c>Theme=</c>"那种写法。</b>两条都是踩出来的:
+    /// <list type="number">
+    /// <item>
+    /// <c>VelaAccentPillButtonTheme</c> <b>没有</b> <c>HorizontalContentAlignment</c> 这个 setter,
+    /// 只挂主题不补这一项,纯文字内容会被 Stretch 拉开 —— 看起来就是"文字没居中"。
+    /// class 那条路在样式表里显式补上了。
+    /// </item>
+    /// <item>
+    /// 代码里 new 出来的控件<b>不能</b>用 <c>TryFindResource</c> 取主题:那时它还没进逻辑树,
+    /// 资源查找一律落空,而且是静默落空。写成 class,样式在进树时才套,DynamicResource 那时才解析。
+    /// </item>
+    /// </list>
+    /// </remarks>
+    [TestMethod]
+    public void EveryButtonAndCheckBoxOnTheCollaborationPageCarriesItsClass()
+    {
+        string file = Path.Combine(RepositoryRoot().FullName,
+            "plugins", "VelaShell.Plugin.Ai", "Ui", "CollaborationView.axaml");
+        string text = Comments.Replace(File.ReadAllText(file), "");
+
+        List<string> bare =
+        [
+            .. Regex.Matches(text, @"<(?:Button|CheckBox)\b[^>]*>", RegexOptions.Singleline)
+                    .Select(m => m.Value)
+                    .Where(e => !Regex.IsMatch(e, @"Classes=""(host|primary)"""))
+                    .Select(e => Regex.Replace(e, @"\s+", " ").Trim())
+        ];
+
+        Assert.AreEqual(0, bare.Count,
+            "these controls carry no host class, so they fall back to the default look "
+            + "(and their labels are not centred): " + string.Join(" | ", bare));
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/WeComCryptoTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/WeComCryptoTests.cs
@@ -1,0 +1,131 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using VelaShell.Plugin.Ai.Bridge.Channels.WeCom;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 企业微信回调的签名与加解密。
+/// </summary>
+/// <remarks>
+/// <b>这是一道安全边界:</b>验签是唯一能证明"这条回调真的来自企业微信"的东西,
+/// 而解密的报文布局(16 随机 + 4 字节大端长度 + 正文 + corpid、按 32 字节补位)
+/// 写错一个常数,表现就是"配置回调地址时一直提示失败",从日志里根本看不出是哪一步。
+/// </remarks>
+[TestClass]
+public sealed class WeComCryptoTests
+{
+    /// <summary>
+    /// 43 个字符的 EncodingAESKey(Base64 字母表),补一个 "=" 后解出来正好 32 字节。
+    /// </summary>
+    /// <remarks>
+    /// 末位刻意用 "E":补一个 "=" 之后最后一组只有 3 个字符,.NET 9 起会校验那一组的
+    /// 尾部空位必须为 0,末位换成 "G" 这类低两位非零的字符会被判成非法 Base64。
+    /// 企业微信自己生成的 key 天然满足这一点。
+    /// </remarks>
+    private const string SampleKey = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFE";
+
+    [TestMethod]
+    public void ParseKey_Yields32Bytes()
+        => Assert.AreEqual(32, WeComCrypto.ParseKey(SampleKey).Length);
+
+    [TestMethod]
+    public void ParseKey_RejectsAKeyOfTheWrongLength()
+        => Assert.ThrowsExactly<ArgumentException>(() => WeComCrypto.ParseKey("tooshort"));
+
+    [TestMethod]
+    public void EncryptThenDecrypt_RoundTrips()
+    {
+        byte[] key = WeComCrypto.ParseKey(SampleKey);
+        const string message = "<xml><Content>重启一下 nginx</Content></xml>";
+
+        string cipher = WeComCrypto.Encrypt(key, message, "ww1234567890");
+        (string plain, string receiveId) = WeComCrypto.Decrypt(key, cipher);
+
+        Assert.AreEqual(message, plain);
+        Assert.AreEqual("ww1234567890", receiveId);
+    }
+
+    /// <summary>
+    /// 独立按官方文档的布局拼一段明文,验证解密读的是同一套常数
+    /// (而不是"我加密怎么写、我解密就怎么读"的自圆其说)。
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_ReadsTheDocumentedLayout()
+    {
+        byte[] key = WeComCrypto.ParseKey(SampleKey);
+        byte[] text = Encoding.UTF8.GetBytes("hello 世界");
+        byte[] corp = Encoding.UTF8.GetBytes("wwCORP");
+        var body = new byte[16 + 4 + text.Length + corp.Length];
+        RandomNumberGenerator.Fill(body.AsSpan(0, 16));
+        BinaryPrimitives.WriteInt32BigEndian(body.AsSpan(16, 4), text.Length);
+        text.CopyTo(body, 20);
+        corp.CopyTo(body, 20 + text.Length);
+        // 补位块是 32 而不是 AES 的 16
+        int pad = 32 - (body.Length % 32);
+        var padded = new byte[body.Length + pad];
+        body.CopyTo(padded, 0);
+        padded.AsSpan(body.Length).Fill((byte)pad);
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.None;
+        string cipher = Convert.ToBase64String(aes.EncryptCbc(padded, key.AsSpan(0, 16).ToArray(), PaddingMode.None));
+
+        (string plain, string receiveId) = WeComCrypto.Decrypt(key, cipher);
+
+        Assert.AreEqual("hello 世界", plain);
+        Assert.AreEqual("wwCORP", receiveId);
+    }
+
+    /// <summary>
+    /// 长度不是分组整数倍的密文要抛,不能吐出半截明文。
+    /// </summary>
+    /// <remarks>
+    /// 刻意不测"翻转一个字节":那样解出来的补位字节是随机的,大多数时候确实会被挡住,
+    /// 但偶尔会撞上一个合法值 —— 一个偶尔红一次的用例比没有还糟。
+    /// 真正挡住篡改的是验签(见 <see cref="WeComCrypto.Verify" />),不是解密。
+    /// </remarks>
+    [TestMethod]
+    public void Decrypt_ThrowsOnAMalformedPayload()
+    {
+        byte[] key = WeComCrypto.ParseKey(SampleKey);
+        string malformed = Convert.ToBase64String(new byte[20]); // 20 不是 16 的整数倍
+
+        Assert.ThrowsExactly<CryptographicException>(() => WeComCrypto.Decrypt(key, malformed));
+    }
+
+    /// <summary>签名是把四个串<b>排序</b>后再拼,所以参数顺序不影响结果。</summary>
+    [TestMethod]
+    public void Sign_IsOrderIndependent()
+    {
+        string a = WeComCrypto.Sign("tok", "1700000000", "nonce1", "cipher");
+        string b = WeComCrypto.Sign("cipher", "nonce1", "tok", "1700000000");
+
+        Assert.AreEqual(a, b);
+    }
+
+    /// <summary>算法钉死在 SHA1(排序后拼接)的十六进制小写上。</summary>
+    [TestMethod]
+    public void Sign_IsSha1OfTheSortedConcatenation()
+    {
+        string[] parts = ["tok", "1700000000", "nonce1", "cipher"];
+        Array.Sort(parts, StringComparer.Ordinal);
+        string expected = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(string.Concat(parts))))
+                                 .ToLowerInvariant();
+
+        Assert.AreEqual(expected, WeComCrypto.Sign("tok", "1700000000", "nonce1", "cipher"));
+    }
+
+    [TestMethod]
+    public void Verify_AcceptsTheRealSignatureAndRejectsEverythingElse()
+    {
+        string signature = WeComCrypto.Sign("tok", "1700000000", "nonce1", "cipher");
+
+        Assert.IsTrue(WeComCrypto.Verify("tok", "1700000000", "nonce1", "cipher", signature));
+        Assert.IsFalse(WeComCrypto.Verify("tok", "1700000000", "nonce1", "cipher", signature[..^1] + "0"));
+        Assert.IsFalse(WeComCrypto.Verify("other-token", "1700000000", "nonce1", "cipher", signature));
+        Assert.IsFalse(WeComCrypto.Verify("tok", "1700000000", "nonce1", "cipher", ""));
+    }
+}


### PR DESCRIPTION
让 VelaShell 的 agent 能被**团队从 IM 里指使**,也能**被别的 agent 调用**。两件事一起做,
因为它们是同一个能力的两个方向,而且共用同一套安全观念(白名单、挡位、审批)。

- **往外**:飞书 / 钉钉 / Telegram / 企微里 @ 机器人 → agent 在已连上的 SSH 会话上干活 → 回帖到群里
- **往内**:Claude Code / Codex 这类外部 agent 把 VelaShell 当 MCP 服务端调,用的就是 `AgentToolbox` 里那套工具

全部落在 `plugins/VelaShell.Plugin.Ai/`(新增 `Bridge/` 与 `Interop/`)。**AI 插件因此改为 `onStartup` 激活** ——
桥接必须常驻,不能等用户点开面板才建连;两条服务都关着时 `ActivateAsync` 只多读一次配置就返回。

## 四个渠道,四种入站传输

| 渠道 | 入站 | 要公网 | 能改已发消息 |
| --- | --- | --- | --- |
| 飞书 / Lark | 官方长连接(WebSocket + pbbp2 帧) | 否 | 能(流式改同一条) |
| 钉钉 | Stream 模式(WebSocket + JSON) | 否 | 不能 |
| Telegram | Bot API 长轮询 | 否 | 能 |
| 企业微信 | 公网回调(本机 HTTP 监听) | **是** | 不能 |

抽象是 `IMessageChannel`:只管收发、"跑到断为止";重连退避统一在 `ChannelHub`。
四家刻意各选一种传输,把抽象压到位。

**飞书的帧格式官方文档没公开**,照官方 Go SDK 的 `ws/pbbp2.pb.go` 手写编解码
(varint + 长度前缀两种线格式、十一个字段),不引 protobuf 运行时。
企微的 `WXBizMsgCrypt` 同样自己实现(AES-256-CBC、**32 字节**补位、SHA1 排序签名),验签走定时安全比较。

企微只绑 `127.0.0.1`,不提供绑 0.0.0.0 的选项 —— 把一个能在生产机上敲命令的回调口开到公网,
不该是一个勾选框能决定的事。要让它够得着,用一条反向隧道转发过来即可(VelaShell 自己就有远程端口转发)。

## 安全默认

- **白名单为空 = 谁都不理**。群 id 在飞书/钉钉界面上看不到,所以第一次被 @ 时回一句(且只回一句)带 id 的提示 —— 沉默更"安全",但会把用户卡在第一步
- **桥接默认计划档(只读)**,比聊天面板保守一档:面板前面坐着人,IM 那头的人可能在地铁上
- **`/mode` 默认只能往低了调**。白名单里任何人都能 `/mode agent` 的话,设置页那个"只读"就形同虚设;要放开得去设置页勾 `AllowModeEscalation`
- **审批走文本回复**(`y`/`n`/`a`)而不是交互卡片:四家的卡片回传各有各的坑(飞书的 `card.action.trigger` 在长连接上并不总能收到),文本是唯一都稳的通道。审批人可与"能说话的人"分开配
- 会话绑定存 `user@host:port` 而**不是 SessionId** —— 后者断线重连就换一个,存它的话群里的绑定过夜就失效

## 配置流程:不用抄群 id

原来要人肉跑一趟:加机器人进群 → 发一句 → 看它回的 id → 复制 → 回电脑粘进白名单 → 保存 → 重连。现在两条路:

1. **配对码**:设置页生成六位码,在要授权的聊天里发 `/pair 428913`。一次性、十分钟过期、猜错五次作废,
   随机数走 `RandomNumberGenerator`;它**只能加白名单**,动不了挡位与审批
2. **一键放行**:敲过门的聊天会被记下来,设置页一行一个「允许」按钮

另有 **[测试] 按钮**,拿界面上当前填的值当场验(不保存)。飞书那条多走一步:换到令牌之后再问一次
长连接接入点 —— 接飞书最常见的两种翻车是「事件订阅没改成长连接」与「改完没发布版本」,
这两种情况下密钥完全正确却一条消息都收不到。

## 对外 MCP 服务端

`Interop/McpEndpoint`:**Streamable HTTP 而不是 stdio** —— stdio 的前提是客户端能把服务端拉起来,
而 VelaShell 是一个已经开着的桌面程序。只绑 `127.0.0.1`,**每个请求必须带令牌**(随机生成、不可关闭):
本机端口同机任何进程(包括浏览器里的网页)都能敲。

工具直接由 `AgentToolbox` 产出(零重复),外加一个 `use_session` 让外部 agent 挑机器
(工具箱靠 `SessionIdProvider` 拿会话,签名里没有这个参数)。

**审批在这条路上没有界面**,所以 `ApprovalMode.Ask` 等于一律拒绝写操作 —— 要放开得由用户显式选
只读放行或绕过审批,是个明摆着的选择而不是悄悄的默认。

这一条**默认开**:三条叠起来风险足够低(只绑回环 + 强制令牌 + 默认只读挡位),
而"默认关"带来的"装完还得先翻一页设置"是没必要的门槛。

## 已知限制(需要 SDK 新契约)

`ISessionsApi` 只有 `ListAsync` / `GetAsync`,**开不了新会话**,所以两条路上的 agent 都只能操作
用户已经连上的机器。SDK 侧的契约已另开 PR:**VelaShellLabs/velashell-plugin-sdk#10**
(`ListSavedAsync` / `OpenAsync` / `CloseAsync`,含权限闸门与拒绝语义)。那边发版后可以去掉这条限制。

## 测试

新增 11 个测试文件。除了各协议自身,还有三条**守门用例**,都是这次真踩出来的:

- `ThemeTokenUsageTests` —— 插件 XAML 引用的资源键必须都有定义。`{DynamicResource Xxx}` 拼错不会报错、
  只是什么都不做:协作页曾写了一个根本不存在的 `VelaBorderSubtle`,那条分隔线从落地起就没画出来过
- `EveryButtonCentresItsLabel` —— 页面上每个按钮的文字必须居中。`VelaAccentPillButtonTheme` **没有**
  `HorizontalContentAlignment` 这个 setter(Outline 那个有),而代码 `new` 出来的控件用
  `TryFindResource` 取主题会在没进树时静默落空 —— 两处都表现为"文字左对齐"
- `NoKeyIsDefinedTwice` —— `Loc` 表用索引器初始化,**重名键是静默覆盖**。曾把「审批超时(秒)」这个
  标签盖成了一整句 IM 提示,编译测试启动全正常,只有把界面渲染出来才看得见

`VelaShell.Plugin.Ai.Tests` **473 条全绿**,全仓 `dotnet build` 无警告。

> ⚠️ 全仓 `dotnet test` 有 **1 条失败,与本 PR 无关**:`ShortcutCatalogTests.Doc_ListsEveryCatalogEntry`
> 找 `docs/快捷键参考.md`,而按 `AGENTS.md` 文档已经搬去 velashell-docs,`origin/main` 上也没有这个目录 ——
> 是搬文档时漏改的陈旧用例。本 PR 只动了 `plugins/` `tests/` `plan.md`,没碰 `src/`。要的话我可以单开一个 PR 修它。

## 待办(不在本 PR 内)

- [x] velashell-docs 同步:`{zh,en}/plugins/协作接入.md`(渠道配置步骤、安全模型、MCP 接入方式)+ STATUS 登记
- [x] SDK 发版后接上"自己打开已保存会话"的能力

🤖 Generated with [Claude Code](https://claude.com/claude-code)
