### PR TITLE
chore: 补齐 Avalonia 12.1.2 漏改的一处,并把 PluginSdk 抬到 2.0.2

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -24,7 +24,7 @@
          PrivateAssets=all + ExcludeAssets=runtime:编译期能看见类型,输出目录里不留 dll ——
          装载时它必须与宿主是同一份程序集,复制过去就成了两份类型。
          版本须与 src/Directory.Packages.props 里宿主引的那一条一致。 -->
-    <PackageReference Include="VelaShell.PluginSdk" Version="2.0.1" PrivateAssets="all" ExcludeAssets="runtime">
+    <PackageReference Include="VelaShell.PluginSdk" Version="2.0.2" PrivateAssets="all" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- 仅编译期引用 Avalonia,运行时由装载方共享同一套(版本须与宿主一致)。 -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
          (VelaShellLabs/velashell-plugins)里,版本由那边的中央包管理登记,别再加回来。
          本仓库 plugins/ 下的自建插件(AI)不走中央包版本管理
          (根目录没有 Directory.Packages.props),依赖版本写在各自的 csproj 里。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.1" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.2" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <!-- 构建期工具:SourceLink(见 src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <!-- 插件契约与测试替身,由插件工具链仓库(joesdu/velashell-plugin-toolchain)
          发布到 nuget.org。 -->
-    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.1" />
-    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="2.0.1" />
-    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="VelaShell.PluginSdk" Version="2.0.2" />
+    <PackageVersion Include="VelaShell.PluginSdk.Testing" Version="2.0.2" />
+    <PackageVersion Include="Avalonia" Version="12.1.2" />
     <PackageVersion Include="Avalonia.Headless" Version="12.1.2" />
     <!-- 真实光栅化后端。headless 平台默认 UseHeadlessDrawing=true(绘制是空操作,
          CaptureRenderedFrame 返回 null),因此终端的字形绘制路径在测试里一个像素都验不到 ——


### PR DESCRIPTION
配套 VelaShellLabs/velashell-plugin-sdk#11。

## 1. `tests/Directory.Packages.props` 里 Avalonia 本体漏改了

187a91e(依赖包版本升级:VelaShell.PluginSdk 及 Avalonia)把 Avalonia 从 12.1.1 升到 12.1.2 时,**这一行漏了**:

```diff
-    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia" Version="12.1.2" />
```

同文件的 `Avalonia.Headless` / `Avalonia.Skia` / `Avalonia.Themes.Fluent` 都已经是 12.1.2,只有它还停在 12.1.1。中央包管理下这一条决定测试宿主(扮演插件装载方)提供的**运行时**程序集版本 —— 与 Headless 不同版就是跨 ALC 的类型对不上。

## 2. `VelaShell.PluginSdk` 2.0.1 → 2.0.2

2.0.1 导出的 `$(VelaSdkPinnedAvaloniaVersion)` 还是 **12.1.1**,而宿主现在引 12.1.2 —— `src/Directory.Build.targets` 的 `VerifyAvaloniaMatchesSdk` 现在就会以 **VELA1000** 报红。2.0.2 是承载 12.1.2 版本锁的那一版。

三处一起抬:

- `src/Directory.Packages.props` → `VelaShell.PluginSdk`
- `tests/Directory.Packages.props` → `VelaShell.PluginSdk` + `VelaShell.PluginSdk.Testing`
- `plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj` → `VelaShell.PluginSdk`(必须与宿主是同一份程序集)

## 有意没改的

- **`ReactiveUI.Avalonia` 留在 12.1.1** —— 上游最新就是 12.1.1,nuget.org 上没有 12.1.2。
- `Avalonia.AvaloniaEdit` 留在 12.0.0(走自己的版本线)。
- `tests/.../HostRegistryTests.cs` 里的 `AvaloniaVersion = "12.1.1"` 是注册表往返用例的合成夹具值,与真实 Avalonia 版本无关,不动。

## ⚠️ 合并前提

**`VelaShell.PluginSdk` 2.0.2 必须已经推上 nuget.org**(velashell-plugin-sdk#11)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbA4MRa7iimxtU99YcZ71f
