### PR TITLE
插件支持按已保存配置开 SSH 会话能力

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1050,6 +1050,9 @@ Ollama 走它的 OpenAI 兼容层。回应认三种形状:`{"data":[…]}`、裸
 操作"用户已经连上的机器";没有连上的,只能回一句让人去 VelaShell 里连。要让它自己按保存的
 配置连一台,得给 SDK 加契约(按 AGENTS.md 走 velashell-plugin-sdk 的发版流程)。
 
+> **已解(宿主侧,2026-09-03)**:SDK 2.0.2 补上了 `ListSavedAsync` / `OpenAsync` / `CloseAsync`,
+> 宿主实现见第 35 节。AI 插件的 `AgentToolbox` 尚未接上,所以本节描述的现象暂时还在。
+
 ### 六、踩到的坑
 
 **`TextWrapping="Wrap"` 的多行 TextBox + 竖滚动条 Auto = 布局死循环。**外层 ScrollViewer 的
@@ -1304,3 +1307,69 @@ IM 那条改名 `BridgeApprovalTimedOut`。
 另有一条钉住"报错必须点名哪个模型"。
 
 `VelaShell.Plugin.Ai.Tests` 469 条全绿。
+
+## 35. 2026-09-03 插件能按已保存配置自己连一台机器(SDK 2.0.2 的宿主侧落地)
+
+第 33 节 §5 记的那条"已知限制"到期了:SDK 2.0.2 给 `ISessionsApi` 补上了
+`ListSavedAsync` / `OpenAsync` / `CloseAsync`,宿主这边三个 `ISessionsApi` 实现
+(`SessionsCapability`、`PluginManager.EmptySessionsApi`、PluginHost 的 `RpcSessions`)
+一起 `CS0535` —— 这不是要绕过的障碍,是该动手实现的信号。
+
+### 一、闸门全部焊在宿主这一侧
+
+"插件能自己连机器"是一次实打实的权限扩张,所以契约里的每一条约束都在
+`SessionsCapability` 里有对应的代码,而不是留给实现自觉:
+
+- **只能开已保存的配置**。参数是配置 id,不是主机名端口 —— 连哪些机器由用户先在
+  会话树里定下来。列表还刻意只报 `ConnectionType.SSH` 的那些:SFTP / FTP / 插件协议
+  开不出 `SessionInfo` 来,列出去只是发一个注定失败的 id。
+- **凭据一个字节不经过插件**。`IPluginSessionOpener` 传的是宿主自己查出来的
+  `SessionProfile`,插件那边自始至终只有一个不透明 id。
+- **宿主可以拒绝**,且拒绝与失败是两种结局:`PluginPermissionDeniedException`
+  (用户说了不,重试没有意义)vs `PluginSessionOpenException`(放行了但没连上,
+  换个时间可能就好了)。合成一个异常,插件就只能靠读消息文本去猜。
+- **`Reason` 原样进确认框**,空理由直接判成插件的编码错误 —— 一个没有理由的确认框
+  只是一个让人盲点的按钮。
+- **只关得掉自己开的**。归属账本按插件计;**复用**拿到的那条(用户自己开的标签页)
+  不进账本,`CloseAsync` 对它一律拒绝。一个能挂断别人正在用的终端的接口,不该存在。
+
+### 二、为什么走 `TryConnectProfileAsync` 而不是直接 `ConnectAsync`
+
+直接调连接服务也能连上,但连出来的是一条**用户在界面上看不见**的会话:没有标签页,
+关不掉,断了也没人知道。用户点"同意"时期待的是屏幕上多出一台机器,而不是后台多了一条
+自己无从察觉的 SSH。顺带,凭据弹窗、跳板链、主机指纹确认、连接历史与审计全都在那条路上,
+复用它等于这些一件都没漏。代价是这件事只能在 UI 层做,于是 Infrastructure 侧只留一个
+`IPluginSessionOpener`(与 `IPluginPermissionPrompt` / `ITerminalResolver` 同一体例),
+`HostSessionOpener` 在 `VelaShell` 工程里实现;headless 宿主不挂它,于是开会话一律拒绝 ——
+**没人可问不等于可以自己放行**。
+
+### 三、授权闸拆成两本账
+
+`PluginPermissionGate` 原本只管终端回写。开会话另起一本(落库另一个文档,内存另一套):
+合成一本就意味着"允许它替我敲一行命令"顺带把"允许它自己连生产机"也批了 ——
+这两件事的分量差得远,用户在确认框上点的也不是同一个"是"。管理页的"撤销"仍是一刀切,
+两本一起清。确认框复用 `PluginPermissionDialog`(换标题/图标,预览框里放理由),
+四选一不变。
+
+### 四、超时按"人要看一眼再点"给
+
+`RpcSessions.OpenAsync` 用 5 分钟而不是普通能力调用的 30 秒。按 30 秒给的话,
+用户还没抬头看见确认框,插件那边就已经把请求判死了 —— 而宿主这边的连接照开不误,
+于是留下一条谁都不认领的会话。
+
+### 五、验收
+
+`SessionsCapabilityTests`(闸门语义:未知 id / 无 opener 即拒 / 拒绝与失败分型 /
+空理由前置拒 / 理由原样透传 / 复用不再问 / 只关得掉自己开的 / 幂等 / 跨插件不许关)、
+`SessionRoutingTests`(隔离模式真管道往返:listSaved → open → close,以及**拒绝要以
+`PluginPermissionDeniedException` 的身份到达插件那一侧** —— 跨进程只剩一个错误码,
+码丢了"用户说了不"就退化成一个笼统的调用失败,插件于是换个姿势再试一次)、
+`PluginPermissionGateTests` 新增两本账互不串门与撤销一刀切。
+`dotnet build VelaShell.slnx` 无警告;Infrastructure 147 条、Core 416 条、
+Presentation 55 条、VelaShell.Tests 963 条通过。
+
+**已知遗留**:`ShortcutCatalogTests.Doc_ListsEveryCatalogEntry` 读的是
+`docs/快捷键参考.md`,而文档已在 `f0f492a` 搬去 velashell-docs —— 与本次改动无关的既存失败。
+
+**待办**:AI 插件的 `AgentToolbox` 还没长出对应的工具,所以 IM 桥接与对外 MCP
+暂时仍只操作用户已经连上的机器。宿主这一层已经备好。

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -3744,6 +3744,8 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="PluginPerm_AllowSession"><value>今回の起動中は許可</value></data>
   <data name="PluginPerm_AllowAlways"><value>常に許可</value></data>
   <data name="PluginPerm_Deny"><value>拒否</value></data>
+  <data name="PluginPermSession_Title"><value>接続要求</value></data>
+  <data name="PluginPermSession_Message"><value>プラグイン「{0}」が {1} への接続を要求しています。プラグインが示した理由:</value></data>
   <data name="PluginManager_Install"><value>.vpx をインストール…</value></data>
   <data name="PluginManager_Uninstall"><value>アンインストール</value></data>
   <data name="PluginManager_Reload"><value>再読み込み</value></data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -3744,6 +3744,8 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="PluginPerm_AllowSession"><value>이번 세션 허용</value></data>
   <data name="PluginPerm_AllowAlways"><value>항상 허용</value></data>
   <data name="PluginPerm_Deny"><value>거부</value></data>
+  <data name="PluginPermSession_Title"><value>연결 요청</value></data>
+  <data name="PluginPermSession_Message"><value>플러그인 "{0}"이(가) {1}에 연결하려고 합니다. 플러그인이 밝힌 이유:</value></data>
   <data name="PluginManager_Install"><value>.vpx 설치…</value></data>
   <data name="PluginManager_Uninstall"><value>제거</value></data>
   <data name="PluginManager_Reload"><value>다시 로드</value></data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -3745,6 +3745,8 @@ Overwrite it?</value>
   <data name="PluginPerm_AllowSession"><value>Allow this session</value></data>
   <data name="PluginPerm_AllowAlways"><value>Always allow</value></data>
   <data name="PluginPerm_Deny"><value>Deny</value></data>
+  <data name="PluginPermSession_Title"><value>Connection request</value></data>
+  <data name="PluginPermSession_Message"><value>Plugin "{0}" wants to open a connection to {1}. Its stated reason:</value></data>
   <data name="PluginManager_Install"><value>Install .vpx…</value></data>
   <data name="PluginManager_Uninstall"><value>Uninstall</value></data>
   <data name="PluginManager_Reload"><value>Reload</value></data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -3919,6 +3919,12 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="PluginPerm_Deny" xml:space="preserve">
     <value>拒绝</value>
   </data>
+  <data name="PluginPermSession_Title" xml:space="preserve">
+    <value>连接请求</value>
+  </data>
+  <data name="PluginPermSession_Message" xml:space="preserve">
+    <value>插件“{0}”请求连接 {1}。它给出的理由:</value>
+  </data>
   <data name="PluginManager_Install" xml:space="preserve">
     <value>安装 .vpx…</value>
   </data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -3919,6 +3919,12 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="PluginPerm_Deny" xml:space="preserve">
     <value>拒絕</value>
   </data>
+  <data name="PluginPermSession_Title" xml:space="preserve">
+    <value>連線請求</value>
+  </data>
+  <data name="PluginPermSession_Message" xml:space="preserve">
+    <value>外掛「{0}」請求連線 {1}。它給出的理由:</value>
+  </data>
   <data name="PluginManager_Install" xml:space="preserve">
     <value>安裝 .vpx…</value>
   </data>

--- a/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/PluginServiceCollectionExtensions.cs
@@ -63,6 +63,11 @@ public static class PluginServiceCollectionExtensions
                 TrustRepository = sp.GetRequiredService<PluginTrustRepository>(),
                 HostVersion = hostVersion,
                 Connections = sp.GetService<ISshConnectionService>(),
+                // 已保存配置 + 开会话的实现:插件"自己按保存的配置连一台"这条路
+                // (蓝图 §Sessions)所需的两块。后者由 UI 层注册,headless 宿主没有,
+                // 于是开会话一律拒绝。
+                SessionProfiles = sp.GetService<Core.Data.ISessionRepository>(),
+                SessionOpener = sp.GetService<IPluginSessionOpener>(),
                 Sftp = sp.GetService<ISftpService>(),
                 Theme = sp.GetService<IThemeService>(),
                 Localization = sp.GetService<ILocalizationService>(),

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/SessionsCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/SessionsCapability.cs
@@ -1,12 +1,35 @@
+using System.Collections.Concurrent;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Core.Ssh;
+using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Sessions;
 
 namespace VelaShell.Infrastructure.Plugins.Capabilities;
 
-/// <summary><see cref="ISessionsApi" /> 的桥接实现:宿主会话列表的脱敏投影,不含任何凭据。</summary>
-internal sealed class SessionsCapability(ISshConnectionService connections) : ISessionsApi
+/// <summary>
+/// <see cref="ISessionsApi" /> 的桥接实现:宿主会话列表的脱敏投影,不含任何凭据;
+/// 以及「请求宿主打开一条已保存会话」的宿主侧闸门。
+/// </summary>
+/// <remarks>
+/// 开会话是一次实打实的权限扩张,闸门全部焊在这一侧(契约见 <see cref="ISessionsApi" />):
+/// <list type="bullet">
+/// <item>只能开**已保存的配置** —— 连哪些机器由用户先在宿主里定下来,插件给不出主机名端口。</item>
+/// <item>凭据一个字节不经过插件:这里拿到的是 <see cref="SessionProfile" />,插件那边只有一个不透明 id。</item>
+/// <item>宿主可以拒绝,且拒绝是契约的一部分(<see cref="PluginPermissionDeniedException" />)。</item>
+/// <item>只关得掉**本插件自己开的**会话 —— 一个能挂断别人正在用的终端的接口,不该存在。</item>
+/// </list>
+/// 每插件一个实例(<see cref="_openedByThisPlugin" /> 是按插件计的归属账本)。
+/// </remarks>
+internal sealed class SessionsCapability(
+    string pluginId,
+    ISshConnectionService connections,
+    ISessionRepository? profiles = null,
+    IPluginSessionOpener? opener = null) : ISessionsApi
 {
+    /// <summary>本插件经 <see cref="OpenAsync" /> 真正开出来的会话 id(复用到的**不算**)。</summary>
+    private readonly ConcurrentDictionary<Guid, byte> _openedByThisPlugin = new();
+
     /// <summary>把宿主会话对象投影为对插件安全的 DTO(仅连接元数据)。</summary>
     internal static SessionInfo Map(SshSession session) => new(
         session.SessionId.ToString(),
@@ -36,4 +59,122 @@ internal sealed class SessionsCapability(ISshConnectionService connections) : IS
             : null;
         return Task.FromResult(result);
     }
+
+    /// <summary>
+    /// 已保存配置的脱敏快照。只报 SSH 配置:其余协议(SFTP / FTP / 插件协议)
+    /// <see cref="OpenAsync" /> 根本开不出 <see cref="SessionInfo" /> 来,
+    /// 列出去只会让插件拿到一个注定失败的 id。
+    /// </summary>
+    public async Task<IReadOnlyList<SavedSessionInfo>> ListSavedAsync(CancellationToken cancellationToken = default)
+    {
+        if (profiles is null)
+        {
+            return [];
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        List<SessionProfile> saved = await profiles.GetAllSessionsAsync().ConfigureAwait(false);
+        List<ServerGroup> groups = await profiles.GetAllGroupsAsync().ConfigureAwait(false);
+        var groupNames = groups.GroupBy(g => g.Id).ToDictionary(g => g.Key, g => g.First().Name);
+        return
+        [
+            .. saved.Where(p => p.ConnectionType == ConnectionType.SSH)
+                    .Select(p => new SavedSessionInfo(
+                        p.Id.ToString(),
+                        string.IsNullOrWhiteSpace(p.Name) ? p.Host : p.Name,
+                        p.Host,
+                        p.Port,
+                        p.Username,
+                        p.GroupId is { } groupId && groupNames.TryGetValue(groupId, out string? name) ? name : null))
+        ];
+    }
+
+    public async Task<SessionInfo> OpenAsync(string savedSessionId, SessionOpenOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        // 理由是给用户看的,不是给日志看的:空理由等于把确认框变成一个只能盲点的按钮。
+        // 与其让用户面对一句空白,不如在这里就把这次调用判成插件的编码错误。
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Reason);
+        if (profiles is null || !Guid.TryParse(savedSessionId, out Guid profileId)
+            || await profiles.GetSessionAsync(profileId).ConfigureAwait(false) is not { } profile)
+        {
+            throw new PluginSessionNotFoundException(savedSessionId,
+                $"No saved session configuration with id '{savedSessionId}'.");
+        }
+        if (profile.ConnectionType != ConnectionType.SSH)
+        {
+            throw new PluginSessionOpenException(savedSessionId,
+                $"Saved session '{savedSessionId}' is not an SSH configuration.");
+        }
+        // 复用:这条配置已经有连着的会话时默认直接给回去。它**不进**归属账本 ——
+        // 用户自己开的那个标签页不归插件管,CloseAsync 关不掉它(契约如此)。
+        if (options.ReuseConnected && FindConnected(profile) is { } existing)
+        {
+            return Map(existing);
+        }
+        if (opener is null)
+        {
+            // 没有界面可问 = 不放行。绝不静默授权(与终端回写授权闸同一条纪律)。
+            throw new PluginPermissionDeniedException(
+                $"This host cannot ask the user to confirm opening sessions; plugin '{pluginId}' was denied.");
+        }
+        PluginSessionOpenResult result;
+        try
+        {
+            result = await opener.OpenAsync(pluginId, profile, options.Reason, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new PluginSessionOpenException(savedSessionId, ex.Message, ex);
+        }
+        switch (result.Outcome)
+        {
+            case PluginSessionOpenOutcome.Denied:
+                throw new PluginPermissionDeniedException(result.Error ?? "The user denied the request.");
+            case PluginSessionOpenOutcome.Opened when connections.GetSession(result.SessionId) is { } opened:
+                _openedByThisPlugin[result.SessionId] = 0;
+                return Map(opened);
+            default:
+                throw new PluginSessionOpenException(savedSessionId,
+                    result.Error ?? "The host could not open the session.");
+        }
+    }
+
+    public async Task CloseAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(sessionId, out Guid id) || !_openedByThisPlugin.ContainsKey(id))
+        {
+            throw new PluginPermissionDeniedException(
+                $"Session '{sessionId}' was not opened by plugin '{pluginId}'.");
+        }
+        // 幂等:用户先手动关了不算错。归属登记随之撤销 —— 会话 id 不复用,留着只是让账本长胖。
+        _openedByThisPlugin.TryRemove(id, out _);
+        if (connections.GetSession(id) is null)
+        {
+            return;
+        }
+        if (opener is not null)
+        {
+            await opener.CloseAsync(id, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        await connections.DisconnectAsync(id, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>找一条与该配置对得上的、已连上的会话。</summary>
+    /// <remarks>
+    /// 用户名为空的配置(留到连接时再问)只按主机 + 端口配对:拿空串去比对
+    /// 一条都配不上,于是每次都新开一条,“复用”形同虚设。
+    /// </remarks>
+    private SshSession? FindConnected(SessionProfile profile) =>
+        connections.Sessions.FirstOrDefault(s =>
+            s.Status == SessionStatus.Connected
+            && string.Equals(s.ConnectionInfo.Host, profile.Host, StringComparison.OrdinalIgnoreCase)
+            && s.ConnectionInfo.Port == profile.Port
+            && (string.IsNullOrWhiteSpace(profile.Username)
+                || string.Equals(s.ConnectionInfo.Username, profile.Username, StringComparison.Ordinal)));
 }

--- a/src/VelaShell.Infrastructure/Plugins/IPluginSessionOpener.cs
+++ b/src/VelaShell.Infrastructure/Plugins/IPluginSessionOpener.cs
@@ -1,0 +1,71 @@
+using VelaShell.Core.Models;
+
+namespace VelaShell.Infrastructure.Plugins;
+
+/// <summary>一次「请求宿主打开已保存会话」的结局。</summary>
+public enum PluginSessionOpenOutcome
+{
+    /// <summary>连上了。</summary>
+    Opened,
+
+    /// <summary>用户拒绝(确认框上点了「拒绝」,或在凭据弹窗上取消)。</summary>
+    Denied,
+
+    /// <summary>放行了,但没连上(网络不通、认证失败、指纹不符……)。</summary>
+    Failed
+}
+
+/// <summary>
+/// 打开结果。<see cref="Denied" /> 与 <see cref="Failed" /> 刻意分开:
+/// 前者重试没有意义(用户已经说了不),后者换个时间再来可能就好了 ——
+/// 插件对这两种情况的处置完全不同,合成一个"失败"就只能靠读消息文本去猜。
+/// </summary>
+/// <param name="Outcome">结局。</param>
+/// <param name="SessionId">连上的会话 id;仅 <see cref="PluginSessionOpenOutcome.Opened" /> 时有意义。</param>
+/// <param name="Error">失败/拒绝的说明(给日志与插件看,不必给不受信的一方转发)。</param>
+public sealed record PluginSessionOpenResult(PluginSessionOpenOutcome Outcome, Guid SessionId = default, string? Error = null)
+{
+    /// <summary>连上了。</summary>
+    public static PluginSessionOpenResult Opened(Guid sessionId) => new(PluginSessionOpenOutcome.Opened, sessionId);
+
+    /// <summary>用户拒绝。</summary>
+    public static PluginSessionOpenResult Denied(string reason) => new(PluginSessionOpenOutcome.Denied, default, reason);
+
+    /// <summary>放行了但没连上。</summary>
+    public static PluginSessionOpenResult Failed(string reason) => new(PluginSessionOpenOutcome.Failed, default, reason);
+}
+
+/// <summary>
+/// 「按已保存配置开一条会话」的宿主 SPI(由 UI 层实现)。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 这件事为什么不能留在 Infrastructure 里自己做完:它中间夹着两个**必须有人**的环节 ——
+/// 给用户看理由的确认框,以及配置没记密码时的凭据弹窗。两者都在 UI 层,
+/// 而 Infrastructure 不引用 Avalonia。所以这里只留一个契约,实现挂在
+/// <see cref="PluginManagerOptions.SessionOpener" /> 上;无界面的宿主(headless 测试)不挂,
+/// 于是 <c>ISessionsApi.OpenAsync</c> 一律拒绝 —— 没人可问不等于可以自己放行。
+/// </para>
+/// <para>
+/// 凭据一个字节都不经过插件:这个契约里传的是宿主自己查出来的
+/// <see cref="SessionProfile" />,插件那边只有一个不透明 id。
+/// </para>
+/// </remarks>
+public interface IPluginSessionOpener
+{
+    /// <summary>
+    /// 征得用户同意后连上 <paramref name="profile" />,并在宿主界面上开出对应的标签页。
+    /// </summary>
+    /// <param name="pluginId">发起请求的插件 id(确认框上显示的那个)。</param>
+    /// <param name="profile">要连的已保存配置。</param>
+    /// <param name="reason">插件给的理由,<b>原样显示给用户</b>。</param>
+    /// <param name="cancellationToken">取消。</param>
+    /// <returns>结局;实现不应为"用户拒绝"或"连不上"抛异常 —— 那是两种正常结果。</returns>
+    Task<PluginSessionOpenResult> OpenAsync(string pluginId, SessionProfile profile, string reason,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 关掉一条会话连同它的标签页。会话已经不在了不算错(幂等)。
+    /// </summary>
+    Task CloseAsync(Guid sessionId, CancellationToken cancellationToken);
+}

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginCapabilityRouter.cs
@@ -122,6 +122,20 @@ internal sealed class PluginCapabilityRouter : IDisposable
                 return await _context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
             case PluginRpc.SessionsGet:
                 return await _context.Sessions.GetAsync(Get<SessionRef>(payload).SessionId, cancellationToken).ConfigureAwait(false);
+            case PluginRpc.SessionsListSaved:
+                return await _context.Sessions.ListSavedAsync(cancellationToken).ConfigureAwait(false);
+            case PluginRpc.SessionsOpen:
+                {
+                    // 这一条可以很慢:中间夹着一个给用户看的确认框,还有真正的建连。
+                    // 插件侧的超时按"人要看一眼再点"给(见 RpcSessions.OpenTimeout),
+                    // 宿主这边不另设死线 —— 提前判死只会留下一条谁都不认领的连接。
+                    SessionOpenRequest request = Get<SessionOpenRequest>(payload);
+                    return await _context.Sessions.OpenAsync(request.SavedSessionId,
+                        new(request.Reason, request.ReuseConnected), cancellationToken).ConfigureAwait(false);
+                }
+            case PluginRpc.SessionsClose:
+                await _context.Sessions.CloseAsync(Get<SessionRef>(payload).SessionId, cancellationToken).ConfigureAwait(false);
+                return null;
             case PluginRpc.ExecRun:
                 {
                     ExecRunRequest request = Get<ExecRunRequest>(payload);

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1950,8 +1950,9 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
                       ?? new JsonFilePluginStorage(dataDirectory),
             // 时序只有 SonnetDB 后端能提供(文件退化实现没有意义):无 DB 的宿主一律报不可用。
             TimeSeries = options.DataStore?.CreateTimeSeries(manifest.Id) ?? new UnavailableTimeSeries(),
+            // 会话能力按插件分实例:开出来的会话记在实例里,CloseAsync 据此判"这条是不是你开的"。
             Sessions = options.Connections is { } connections
-                ? new SessionsCapability(connections)
+                ? new SessionsCapability(manifest.Id, connections, options.SessionProfiles, options.SessionOpener)
                 : new EmptySessionsApi(),
             RemoteFs = options is { Sftp: { } sftp, Connections: { } conn }
                 ? new RemoteFsCapability(sftp, conn)
@@ -2522,6 +2523,20 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
 
         public Task<SessionInfo?> GetAsync(string sessionId, CancellationToken cancellationToken = default)
             => Task.FromResult<SessionInfo?>(null);
+
+        public Task<IReadOnlyList<SavedSessionInfo>> ListSavedAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<SavedSessionInfo>>([]);
+
+        // 没有连接服务的宿主既问不了用户、也连不了机器。报"拒绝"而不是"能力不可用":
+        // 契约里拒绝是插件必须处理的一种正常结局,而 InvalidOperationException 不是。
+        public Task<SessionInfo> OpenAsync(string savedSessionId, SessionOpenOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromException<SessionInfo>(
+                new PluginPermissionDeniedException("This host cannot open sessions."));
+
+        public Task CloseAsync(string sessionId, CancellationToken cancellationToken = default)
+            => Task.FromException(new PluginPermissionDeniedException(
+                $"Session '{sessionId}' was not opened by this plugin."));
     }
 
     private sealed class UnavailableRemoteFs : IRemoteFsApi

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -95,6 +95,18 @@ public sealed class PluginManagerOptions
     /// <summary>SSH 连接服务(会话/远程执行能力与会话事件的来源)。</summary>
     public ISshConnectionService? Connections { get; init; }
 
+    /// <summary>
+    /// 已保存连接配置的仓储(<c>ISessionsApi.ListSavedAsync</c> 与
+    /// <c>OpenAsync</c> 的 id 解析)。缺席时已保存列表为空、开会话一律报"找不到这条配置"。
+    /// </summary>
+    public Core.Data.ISessionRepository? SessionProfiles { get; init; }
+
+    /// <summary>
+    /// 「按已保存配置开一条会话」的实现(由 UI 层提供:确认框 + 凭据弹窗 + 开标签页)。
+    /// 缺席时 <c>ISessionsApi.OpenAsync</c> 一律拒绝 —— 没人可问不等于可以自己放行。
+    /// </summary>
+    public IPluginSessionOpener? SessionOpener { get; init; }
+
     /// <summary>SFTP 服务(远程文件能力的来源)。</summary>
     public ISftpService? Sftp { get; init; }
 

--- a/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
@@ -24,72 +24,148 @@ public interface IPluginPermissionPrompt
     /// <summary>请求用户裁决一次终端回写。</summary>
     Task<PluginPermissionDecision> RequestTerminalWriteAsync(string pluginId, string sessionLabel, string inputPreview,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 请求用户裁决一次「按已保存配置开会话」。
+    /// </summary>
+    /// <param name="pluginId">发起请求的插件 id。</param>
+    /// <param name="target">要连的那台机器(会话树上的名字 + user@host:port)。</param>
+    /// <param name="reason">插件给的理由,<b>原样显示</b> —— 用户是照着它决定点不点同意的。</param>
+    /// <param name="cancellationToken">取消。</param>
+    Task<PluginPermissionDecision> RequestSessionOpenAsync(string pluginId, string target, string reason,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
-/// 终端回写的授权闸(蓝图 06 的最小可用形态):
+/// 敏感能力的授权闸(蓝图 06 的最小可用形态):
 /// 始终允许 → SonnetDB 持久化(按插件);本次运行允许 → 内存;仅本次 → 放行一次;
 /// 拒绝 → 本次拒绝。同插件的并发请求串行化,不弹对话框风暴。无提示器的宿主一律拒绝。
 /// </summary>
+/// <remarks>
+/// 两类能力(终端回写 / 开会话)各记各的账:落库分两个文档,内存也分两套。
+/// 合成一本账就意味着"允许它替我敲一行命令"顺带把"允许它自己连生产机"也批了 ——
+/// 这两件事的分量差得远,用户在确认框上点的也不是同一个"是"。
+/// </remarks>
 public sealed class PluginPermissionGate(IAppDataStore? store, IPluginPermissionPrompt? prompt)
 {
     private const string Collection = "app_config";
-    private const string DocumentId = "plugin_terminal_write_permissions";
 
     private sealed record PermissionsDoc(List<string> AlwaysAllow);
 
-    private readonly HashSet<string> _sessionAllowed = [with(StringComparer.Ordinal)];
+    /// <summary>一类能力的授权账本(持久 + 本次运行)。</summary>
+    private sealed class Grants(string documentId)
+    {
+        public string DocumentId { get; } = documentId;
+        public HashSet<string> SessionAllowed { get; } = new(StringComparer.Ordinal);
+        public HashSet<string>? AlwaysAllowed { get; set; }
+    }
+
+    /// <summary>终端回写。文档 id 是历史名字,不改 —— 改了等于把用户已有的授权丢掉。</summary>
+    private readonly Grants _terminalWrite = new("plugin_terminal_write_permissions");
+
+    /// <summary>按已保存配置开会话。</summary>
+    private readonly Grants _sessionOpen = new("plugin_session_open_permissions");
+
     private readonly SemaphoreSlim _promptGate = new(1, 1);
-    private HashSet<string>? _alwaysAllowed;
 
     /// <summary>是否放行本次终端回写;必要时弹授权对话框。</summary>
-    public async Task<bool> CheckTerminalWriteAsync(string pluginId, string sessionLabel, string inputPreview,
+    public Task<bool> CheckTerminalWriteAsync(string pluginId, string sessionLabel, string inputPreview,
         CancellationToken cancellationToken)
+        => CheckAsync(_terminalWrite, pluginId,
+            ct => prompt!.RequestTerminalWriteAsync(pluginId, sessionLabel, inputPreview, ct), cancellationToken);
+
+    /// <summary>
+    /// 是否放行本次「按已保存配置开会话」;必要时弹授权对话框。
+    /// </summary>
+    /// <remarks>
+    /// 授权按插件计,而不是按 (插件, 机器) 计:后者更精确,但也意味着一个 IM 桥接插件
+    /// 要为运维手上每一台机器各弹一次框 —— 用户会在第三台上开始盲点。分寸取在
+    /// "这个插件可以替我连机器"这一层,想收回就去插件管理页撤销。
+    /// </remarks>
+    public Task<bool> CheckSessionOpenAsync(string pluginId, string target, string reason,
+        CancellationToken cancellationToken)
+        => CheckAsync(_sessionOpen, pluginId,
+            ct => prompt!.RequestSessionOpenAsync(pluginId, target, reason, ct), cancellationToken);
+
+    /// <summary>撤销某插件的**全部**授权(持久 + 会话内),插件管理页使用。</summary>
+    public async Task RevokeAsync(string pluginId, CancellationToken cancellationToken = default)
     {
-        if (await IsAlwaysAllowedAsync(pluginId, cancellationToken).ConfigureAwait(false))
+        foreach (Grants grants in Ledgers)
         {
-            return true;
+            lock (grants.SessionAllowed)
+            {
+                grants.SessionAllowed.Remove(pluginId);
+            }
+            HashSet<string> always = await LoadAlwaysAsync(grants, cancellationToken).ConfigureAwait(false);
+            if (always.Remove(pluginId) && store is not null)
+            {
+                await store.UpsertAsync(Collection, grants.DocumentId, new PermissionsDoc([.. always]), cancellationToken)
+                           .ConfigureAwait(false);
+            }
         }
-        lock (_sessionAllowed)
+    }
+
+    /// <summary>某插件当前是否持有**任何**授权(持久或会话内、任一类能力),插件管理页展示用。</summary>
+    public async Task<bool> HasGrantAsync(string pluginId, CancellationToken cancellationToken = default)
+    {
+        foreach (Grants grants in Ledgers)
         {
-            if (_sessionAllowed.Contains(pluginId))
+            if (await IsAlwaysAllowedAsync(grants, pluginId, cancellationToken).ConfigureAwait(false))
             {
                 return true;
             }
+            lock (grants.SessionAllowed)
+            {
+                if (grants.SessionAllowed.Contains(pluginId))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private IEnumerable<Grants> Ledgers
+    {
+        get
+        {
+            yield return _terminalWrite;
+            yield return _sessionOpen;
+        }
+    }
+
+    private async Task<bool> CheckAsync(Grants grants, string pluginId,
+        Func<CancellationToken, Task<PluginPermissionDecision>> ask, CancellationToken cancellationToken)
+    {
+        if (await IsGrantedAsync(grants, pluginId, cancellationToken).ConfigureAwait(false))
+        {
+            return true;
         }
         if (prompt is null)
         {
             return false; // 无 UI 可问 = 不放行(绝不静默授权)
         }
-        // 串行化提问:并发写入只弹一个框;等待期间别人拿到的授权对后续请求同样生效。
+        // 串行化提问:并发请求只弹一个框;等待期间别人拿到的授权对后续请求同样生效。
         await _promptGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (await IsAlwaysAllowedAsync(pluginId, cancellationToken).ConfigureAwait(false))
+            if (await IsGrantedAsync(grants, pluginId, cancellationToken).ConfigureAwait(false))
             {
                 return true;
             }
-            lock (_sessionAllowed)
-            {
-                if (_sessionAllowed.Contains(pluginId))
-                {
-                    return true;
-                }
-            }
-            PluginPermissionDecision decision = await prompt
-                .RequestTerminalWriteAsync(pluginId, sessionLabel, inputPreview, cancellationToken).ConfigureAwait(false);
+            PluginPermissionDecision decision = await ask(cancellationToken).ConfigureAwait(false);
             switch (decision)
             {
                 case PluginPermissionDecision.AllowOnce:
                     return true;
                 case PluginPermissionDecision.AllowSession:
-                    lock (_sessionAllowed)
+                    lock (grants.SessionAllowed)
                     {
-                        _sessionAllowed.Add(pluginId);
+                        grants.SessionAllowed.Add(pluginId);
                     }
                     return true;
                 case PluginPermissionDecision.AllowAlways:
-                    await PersistAlwaysAsync(pluginId, cancellationToken).ConfigureAwait(false);
+                    await PersistAlwaysAsync(grants, pluginId, cancellationToken).ConfigureAwait(false);
                     return true;
                 default:
                     return false;
@@ -101,55 +177,41 @@ public sealed class PluginPermissionGate(IAppDataStore? store, IPluginPermission
         }
     }
 
-    /// <summary>撤销某插件的授权(持久 + 会话内),插件管理页使用。</summary>
-    public async Task RevokeAsync(string pluginId, CancellationToken cancellationToken = default)
+    private async Task<bool> IsGrantedAsync(Grants grants, string pluginId, CancellationToken cancellationToken)
     {
-        lock (_sessionAllowed)
-        {
-            _sessionAllowed.Remove(pluginId);
-        }
-        HashSet<string> always = await LoadAlwaysAsync(cancellationToken).ConfigureAwait(false);
-        if (always.Remove(pluginId) && store is not null)
-        {
-            await store.UpsertAsync(Collection, DocumentId, new PermissionsDoc([.. always]), cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>某插件当前是否持有任何回写授权(持久或会话内),插件管理页展示用。</summary>
-    public async Task<bool> HasGrantAsync(string pluginId, CancellationToken cancellationToken = default)
-    {
-        if (await IsAlwaysAllowedAsync(pluginId, cancellationToken).ConfigureAwait(false))
+        if (await IsAlwaysAllowedAsync(grants, pluginId, cancellationToken).ConfigureAwait(false))
         {
             return true;
         }
-        lock (_sessionAllowed)
+        lock (grants.SessionAllowed)
         {
-            return _sessionAllowed.Contains(pluginId);
+            return grants.SessionAllowed.Contains(pluginId);
         }
     }
 
-    private async Task<bool> IsAlwaysAllowedAsync(string pluginId, CancellationToken cancellationToken) =>
-        (await LoadAlwaysAsync(cancellationToken).ConfigureAwait(false)).Contains(pluginId);
+    private async Task<bool> IsAlwaysAllowedAsync(Grants grants, string pluginId, CancellationToken cancellationToken) =>
+        (await LoadAlwaysAsync(grants, cancellationToken).ConfigureAwait(false)).Contains(pluginId);
 
-    private async Task<HashSet<string>> LoadAlwaysAsync(CancellationToken cancellationToken)
+    private async Task<HashSet<string>> LoadAlwaysAsync(Grants grants, CancellationToken cancellationToken)
     {
-        if (_alwaysAllowed is not null)
+        if (grants.AlwaysAllowed is not null)
         {
-            return _alwaysAllowed;
+            return grants.AlwaysAllowed;
         }
         PermissionsDoc? doc = store is null
             ? null
-            : await store.GetAsync<PermissionsDoc>(Collection, DocumentId, cancellationToken).ConfigureAwait(false);
-        return _alwaysAllowed = new(doc?.AlwaysAllow ?? [], StringComparer.Ordinal);
+            : await store.GetAsync<PermissionsDoc>(Collection, grants.DocumentId, cancellationToken).ConfigureAwait(false);
+        return grants.AlwaysAllowed = new(doc?.AlwaysAllow ?? [], StringComparer.Ordinal);
     }
 
-    private async Task PersistAlwaysAsync(string pluginId, CancellationToken cancellationToken)
+    private async Task PersistAlwaysAsync(Grants grants, string pluginId, CancellationToken cancellationToken)
     {
-        HashSet<string> always = await LoadAlwaysAsync(cancellationToken).ConfigureAwait(false);
+        HashSet<string> always = await LoadAlwaysAsync(grants, cancellationToken).ConfigureAwait(false);
         always.Add(pluginId);
         if (store is not null)
         {
-            await store.UpsertAsync(Collection, DocumentId, new PermissionsDoc([.. always]), cancellationToken).ConfigureAwait(false);
+            await store.UpsertAsync(Collection, grants.DocumentId, new PermissionsDoc([.. always]), cancellationToken)
+                       .ConfigureAwait(false);
         }
     }
 }

--- a/src/VelaShell.PluginHost/RemoteCapabilities.cs
+++ b/src/VelaShell.PluginHost/RemoteCapabilities.cs
@@ -38,12 +38,39 @@ internal sealed class RpcSessions(RpcConnection rpc) : ISessionsApi
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// 打开会话的超时。<b>不能用上面那 30 秒</b>:这一条中间夹着一个给用户看的确认框,
+    /// 后面还有真正的建连(带跳板链时更慢)。按普通能力调用的档位给,结果是用户还没抬头
+    /// 看见确认框,插件这边就已经把请求判死了 —— 而宿主那边的连接照开不误,
+    /// 于是留下一条谁都不认领的会话。所以按"人要看一眼再点"来给。
+    /// </summary>
+    private static readonly TimeSpan OpenTimeout = TimeSpan.FromMinutes(5);
+
     public async Task<IReadOnlyList<SessionInfo>> ListAsync(CancellationToken cancellationToken = default)
         => await rpc.RequestAsync<SessionInfo[]>(PluginRpc.SessionsList, null, Timeout, cancellationToken)
                .ConfigureAwait(false) ?? [];
 
     public Task<SessionInfo?> GetAsync(string sessionId, CancellationToken cancellationToken = default)
         => rpc.RequestAsync<SessionInfo?>(PluginRpc.SessionsGet, new SessionRef(sessionId), Timeout, cancellationToken);
+
+    public async Task<IReadOnlyList<SavedSessionInfo>> ListSavedAsync(CancellationToken cancellationToken = default)
+        => await rpc.RequestAsync<SavedSessionInfo[]>(PluginRpc.SessionsListSaved, null, Timeout, cancellationToken)
+               .ConfigureAwait(false) ?? [];
+
+    public async Task<SessionInfo> OpenAsync(string savedSessionId, SessionOpenOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        // 宿主的拒绝(permission-denied)与连不上(session-open-failed)在应答里各有错误码,
+        // RpcConnection 还原成对应异常抛出 —— 这里不需要也不应该把它们抹平。
+        return await rpc.RequestAsync<SessionInfo>(PluginRpc.SessionsOpen,
+                   new SessionOpenRequest(savedSessionId, options.Reason, options.ReuseConnected),
+                   OpenTimeout, cancellationToken).ConfigureAwait(false)
+               ?? throw new PluginSessionOpenException(savedSessionId, "The host returned no session.");
+    }
+
+    public Task CloseAsync(string sessionId, CancellationToken cancellationToken = default)
+        => rpc.RequestAsync<object>(PluginRpc.SessionsClose, new SessionRef(sessionId), Timeout, cancellationToken);
 }
 
 /// <summary>远程执行能力的 RPC 代理(超时随选项放宽,留 15s 往返余量)。</summary>

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -90,6 +90,14 @@ public class App : Application
             .AddSingleton(sp => new Infrastructure.Plugins.PluginPermissionGate(
                 sp.GetService<IAppDataStore>(),
                 sp.GetService<Infrastructure.Plugins.IPluginPermissionPrompt>()))
+            // 插件「按已保存配置开一条会话」能力:授权闸 → 宿主既有连接流程 → 一个真实的标签页。
+            // 没有它,插件只能操作用户此刻已经连着的机器 —— 值班的人昨晚关了那个标签页,
+            // IM 桥接就只能回一句"你先去连一台"。
+            .AddSingleton<Infrastructure.Plugins.IPluginSessionOpener>(sp =>
+                new Services.Plugins.HostSessionOpener(
+                    () => sp.GetService<MainWindowViewModel>(),
+                    sp.GetRequiredService<Core.Ssh.ISshConnectionService>(),
+                    sp.GetRequiredService<Infrastructure.Plugins.PluginPermissionGate>()))
             // 插件终端能力:读取/搜索终端缓冲 + 授权回写(经主窗口视图模型解析会话仿真器)。
             .AddSingleton<Func<string, IPluginLogger, PluginSdk.Terminal.ITerminalApi>>(sp =>
                 (pluginId, log) => new Services.Plugins.HostTerminal(pluginId, log,

--- a/src/VelaShell/Services/Plugins/DialogPermissionPrompt.cs
+++ b/src/VelaShell/Services/Plugins/DialogPermissionPrompt.cs
@@ -9,4 +9,8 @@ internal sealed class DialogPermissionPrompt : IPluginPermissionPrompt
     public Task<PluginPermissionDecision> RequestTerminalWriteAsync(string pluginId, string sessionLabel,
         string inputPreview, CancellationToken cancellationToken)
         => PluginPermissionDialog.AskAsync(pluginId, sessionLabel, inputPreview);
+
+    public Task<PluginPermissionDecision> RequestSessionOpenAsync(string pluginId, string target, string reason,
+        CancellationToken cancellationToken)
+        => PluginPermissionDialog.AskSessionOpenAsync(pluginId, target, reason);
 }

--- a/src/VelaShell/Services/Plugins/HostSessionOpener.cs
+++ b/src/VelaShell/Services/Plugins/HostSessionOpener.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using Avalonia.Threading;
+using VelaShell.Core.Models;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Plugins;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Services.Plugins;
+
+/// <summary>
+/// <see cref="IPluginSessionOpener" /> 的宿主实现:授权闸 → 宿主既有的连接流程 → 一个真实的标签页。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>为什么走 <see cref="MainWindowViewModel.TryConnectProfileAsync" /> 而不是直接
+/// <see cref="ISshConnectionService.ConnectAsync" />。</b>后者能连上,但连出来的是一条
+/// 用户在界面上看不见的会话:没有标签页,关不掉,断了也没人知道。插件替人连的机器
+/// 尤其不该是隐形的 —— 用户点了"同意",他期待的是屏幕上多出一台机器,
+/// 而不是后台多了一条自己无从察觉的 SSH。顺带,凭据弹窗、跳板链、主机指纹确认、
+/// 连接历史与审计也都在那条路上,复用它等于这些一件都没漏。
+/// </para>
+/// <para>
+/// 授权闸在连接之前:先问人,再动网络。反过来的话,用户点"拒绝"时机器早就连上了。
+/// </para>
+/// </remarks>
+internal sealed class HostSessionOpener(
+    Func<MainWindowViewModel?> viewModel,
+    ISshConnectionService connections,
+    PluginPermissionGate gate) : IPluginSessionOpener
+{
+    public async Task<PluginSessionOpenResult> OpenAsync(string pluginId, SessionProfile profile, string reason,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        if (viewModel() is not { } vm)
+        {
+            // 主窗口还没建起来(启动早期的惰性激活)。这不是拒绝,过一会儿再来就行。
+            return PluginSessionOpenResult.Failed("The main window is not ready yet.");
+        }
+        bool allowed = await gate.CheckSessionOpenAsync(pluginId, Describe(profile), reason, cancellationToken)
+                                 .ConfigureAwait(false);
+        if (!allowed)
+        {
+            return PluginSessionOpenResult.Denied($"The user denied opening a session for plugin '{pluginId}'.");
+        }
+        return await Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            TerminalTabViewModel? tab = await vm.TryConnectProfileAsync(profile, cancellationToken);
+            if (tab is { ConnectionStatus: SessionStatus.Connected } connected && connected.SessionId != Guid.Empty)
+            {
+                return PluginSessionOpenResult.Opened(connected.SessionId);
+            }
+            // TryConnectProfileAsync 从不让连接异常逃逸 —— 失败原因落在 LastConnectionError 上,
+            // 而用户在凭据弹窗上取消时它被显式清空。这是此处区分"没连上"与"人不同意"的依据。
+            string? error = vm.LastConnectionError;
+            return string.IsNullOrWhiteSpace(error)
+                ? PluginSessionOpenResult.Denied("The user cancelled the credential prompt.")
+                : PluginSessionOpenResult.Failed(error);
+        });
+    }
+
+    public async Task CloseAsync(Guid sessionId, CancellationToken cancellationToken)
+    {
+        bool closed = await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (viewModel() is not { } vm)
+            {
+                return false;
+            }
+            TerminalTabViewModel? tab = vm.TabBar.Tabs.OfType<TerminalTabViewModel>()
+                                          .FirstOrDefault(t => t.SessionId == sessionId);
+            if (tab is null)
+            {
+                return false;
+            }
+            // 用户语义的关闭:标签、停靠文档、会话日志与底层传输一并拆掉,SSH 会话随之断开。
+            vm.CloseTerminalTab(tab);
+            return true;
+        });
+        if (!closed)
+        {
+            // 没有对应标签(用户先手动关了,或会话根本不是标签页开的):直接拆连接。
+            // DisconnectAsync 本身幂等,会话已不在时是空操作。
+            await connections.DisconnectAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>确认框上的那台机器:会话树上的名字 + <c>user@host:port</c>。</summary>
+    /// <remarks>
+    /// 名字与地址都要给。只给名字("生产 3 号")的话,用户没法确认插件要连的是不是
+    /// 他以为的那台;只给地址则要用户自己把 IP 翻译回机器 —— 确认框上多花的这一秒,
+    /// 换的是他真的看懂了自己在同意什么。
+    /// </remarks>
+    private static string Describe(SessionProfile profile)
+    {
+        string address = string.IsNullOrWhiteSpace(profile.Username)
+            ? string.Create(CultureInfo.InvariantCulture, $"{profile.Host}:{profile.Port}")
+            : string.Create(CultureInfo.InvariantCulture, $"{profile.Username}@{profile.Host}:{profile.Port}");
+        return string.IsNullOrWhiteSpace(profile.Name) ? address : $"{profile.Name} ({address})";
+    }
+}

--- a/src/VelaShell/Views/PluginPermissionDialog.axaml
+++ b/src/VelaShell/Views/PluginPermissionDialog.axaml
@@ -11,8 +11,11 @@
         Background="Transparent"
         WindowStartupLocation="CenterOwner">
 
-  <!-- 终端回写授权弹窗。规格与 MessageDialog 一致:bg-surface 卡片 + 圆角 8 + 阴影;
-       四种选择:仅本次 / 本次运行 / 始终 / 拒绝(蓝图 06 的最小授权流)。 -->
+  <!-- 插件敏感能力授权弹窗(终端回写 / 按已保存配置开会话)。
+       规格与 MessageDialog 一致:bg-surface 卡片 + 圆角 8 + 阴影;
+       四种选择:仅本次 / 本次运行 / 始终 / 拒绝(蓝图 06 的最小授权流)。
+       标题、正文、预览框与图标由 code-behind 按能力填 —— 两种请求的骨架完全一样,
+       各写一个窗口只会让两边的按钮排布慢慢长歪。 -->
 
   <Window.Styles>
     <Style Selector="Button.dlg-outline">
@@ -63,7 +66,7 @@
               BorderBrush="{DynamicResource VelaBorderPrimary}"
               BorderThickness="0,0,0,1">
         <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-          <pc:LucideIcon Width="15" Height="15" Data="{StaticResource Icon.terminal}"
+          <pc:LucideIcon x:Name="HeaderIcon" Width="15" Height="15" Data="{StaticResource Icon.terminal}"
                          Foreground="{DynamicResource VelaWarning}" VerticalAlignment="Center" />
           <TextBlock x:Name="TitleText"
                      Foreground="{DynamicResource VelaTextPrimary}"

--- a/src/VelaShell/Views/PluginPermissionDialog.axaml.cs
+++ b/src/VelaShell/Views/PluginPermissionDialog.axaml.cs
@@ -9,38 +9,62 @@ using VelaShell.Infrastructure.Plugins;
 namespace VelaShell.Views;
 
 /// <summary>
-/// 终端回写授权弹窗:展示插件、目标终端与内容预览,给出
+/// 插件敏感能力的授权弹窗:展示插件、目标与内容预览,给出
 /// 仅本次 / 本次运行 / 始终 / 拒绝 四种选择(蓝图 06 的最小授权流)。
+/// 两种请求共用这一个窗口:终端回写(预览 = 要敲进去的那行)与
+/// 按已保存配置开会话(预览 = 插件给的理由)。
 /// </summary>
 public partial class PluginPermissionDialog : Window
 {
     /// <summary>设计器构造。</summary>
     public PluginPermissionDialog() => InitializeComponent();
 
-    private PluginPermissionDialog(string pluginId, string sessionLabel, string inputPreview) : this()
+    private PluginPermissionDialog(string title, string message, string preview, string iconKey) : this()
     {
-        TitleText.Text = Strings.Get("PluginPerm_Title");
-        MessageText.Text = Strings.Format("PluginPerm_Message", pluginId, sessionLabel);
-        PreviewText.Text = inputPreview;
+        TitleText.Text = title;
+        MessageText.Text = message;
+        PreviewText.Text = preview;
+        if (Avalonia.Application.Current?.TryFindResource(iconKey, out object? icon) == true
+            && icon is Avalonia.Media.Geometry geometry)
+        {
+            HeaderIcon.Data = geometry;
+        }
         OnceButton.Content = Strings.Get("PluginPerm_AllowOnce");
         SessionButton.Content = Strings.Get("PluginPerm_AllowSession");
         AlwaysButton.Content = Strings.Get("PluginPerm_AllowAlways");
         DenyButton.Content = Strings.Get("PluginPerm_Deny");
     }
 
-    /// <summary>在主窗口上模态弹出,返回用户裁决(取消/关闭 = 拒绝)。</summary>
-    public static async Task<PluginPermissionDecision> AskAsync(string pluginId, string sessionLabel, string inputPreview)
+    /// <summary>终端回写:在主窗口上模态弹出,返回用户裁决(取消/关闭 = 拒绝)。</summary>
+    public static Task<PluginPermissionDecision> AskAsync(string pluginId, string sessionLabel, string inputPreview)
+        => ShowAsync(Strings.Get("PluginPerm_Title"),
+            Strings.Format("PluginPerm_Message", pluginId, sessionLabel), inputPreview, "Icon.terminal");
+
+    /// <summary>
+    /// 按已保存配置开会话:同一个窗口,预览框里放插件给的<b>理由</b>。
+    /// </summary>
+    /// <remarks>
+    /// 理由原样显示,一个字都不改写 —— 用户就是照着它决定点不点同意的。
+    /// 插件写成"插件需要连接"这种废话,后果由它自己承担:确认框会照实显示,
+    /// 而不是由宿主替它补一句像样的说明。
+    /// </remarks>
+    public static Task<PluginPermissionDecision> AskSessionOpenAsync(string pluginId, string target, string reason)
+        => ShowAsync(Strings.Get("PluginPermSession_Title"),
+            Strings.Format("PluginPermSession_Message", pluginId, target), reason, "Icon.plug");
+
+    private static async Task<PluginPermissionDecision> ShowAsync(string title, string message, string preview,
+        string iconKey)
     {
         if (!Dispatcher.UIThread.CheckAccess())
         {
-            return await Dispatcher.UIThread.InvokeAsync(() => AskAsync(pluginId, sessionLabel, inputPreview));
+            return await Dispatcher.UIThread.InvokeAsync(() => ShowAsync(title, message, preview, iconKey));
         }
         if ((Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
             ?.MainWindow is not { } owner)
         {
             return PluginPermissionDecision.Deny;
         }
-        var dialog = new PluginPermissionDialog(pluginId, sessionLabel, inputPreview);
+        var dialog = new PluginPermissionDialog(title, message, preview, iconKey);
         return await dialog.ShowDialog<PluginPermissionDecision>(owner);
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginPermissionGateTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginPermissionGateTests.cs
@@ -35,10 +35,19 @@ public class PluginPermissionGateTests
     {
         public int Calls { get; private set; }
 
+        public int SessionOpenCalls { get; private set; }
+
         public Task<PluginPermissionDecision> RequestTerminalWriteAsync(string pluginId, string sessionLabel,
             string inputPreview, CancellationToken cancellationToken)
         {
             Calls++;
+            return Task.FromResult(decision);
+        }
+
+        public Task<PluginPermissionDecision> RequestSessionOpenAsync(string pluginId, string target, string reason,
+            CancellationToken cancellationToken)
+        {
+            SessionOpenCalls++;
             return Task.FromResult(decision);
         }
     }
@@ -106,5 +115,43 @@ public class PluginPermissionGateTests
     {
         var gate = new PluginPermissionGate(new MemoryStore(), prompt: null);
         Assert.IsFalse(await gate.CheckTerminalWriteAsync("acme.p", "prod", "ls", default));
+        Assert.IsFalse(await gate.CheckSessionOpenAsync("acme.p", "prod (root@10.0.0.1:22)", "机器人要看 nginx 日志", default));
+    }
+
+    /// <summary>
+    /// 两类能力各记各的账。合成一本的话,“允许它替我敲一行命令”会顺带把
+    /// “允许它自己连生产机”也批了 —— 用户在确认框上点的从来不是同一个“是”。
+    /// </summary>
+    [TestMethod]
+    public async Task TerminalWriteGrant_DoesNotCarryOverToOpeningSessions()
+    {
+        var prompt = new ScriptedPrompt(PluginPermissionDecision.AllowAlways);
+        var gate = new PluginPermissionGate(new MemoryStore(), prompt);
+
+        Assert.IsTrue(await gate.CheckTerminalWriteAsync("acme.p", "prod", "ls", default));
+        Assert.AreEqual(0, prompt.SessionOpenCalls);
+
+        Assert.IsTrue(await gate.CheckSessionOpenAsync("acme.p", "prod (root@10.0.0.1:22)", "查磁盘", default));
+        Assert.AreEqual(1, prompt.SessionOpenCalls, "开会话是另一件事,必须另问一次");
+    }
+
+    [TestMethod]
+    public async Task SessionOpen_AllowAlways_PersistsAndIsRevokedTogether()
+    {
+        var store = new MemoryStore();
+        var prompt = new ScriptedPrompt(PluginPermissionDecision.AllowAlways);
+        var gate = new PluginPermissionGate(store, prompt);
+        Assert.IsTrue(await gate.CheckSessionOpenAsync("acme.p", "prod", "查磁盘", default));
+
+        var afterRestart = new PluginPermissionGate(store, prompt);
+        Assert.IsTrue(await afterRestart.CheckSessionOpenAsync("acme.p", "prod", "查磁盘", default));
+        Assert.AreEqual(1, prompt.SessionOpenCalls, "始终允许已持久,不再问");
+        Assert.IsTrue(await afterRestart.HasGrantAsync("acme.p"), "管理页要看得见这条授权");
+
+        // 管理页的“撤销”是一刀切:两类账本一起清,不留一半。
+        await afterRestart.RevokeAsync("acme.p");
+        Assert.IsFalse(await afterRestart.HasGrantAsync("acme.p"));
+        Assert.IsTrue(await afterRestart.CheckSessionOpenAsync("acme.p", "prod", "查磁盘", default));
+        Assert.AreEqual(2, prompt.SessionOpenCalls);
     }
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
@@ -1,0 +1,217 @@
+using System.IO.Pipes;
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Plugins;
+using VelaShell.Infrastructure.Plugins.Capabilities;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Rpc;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Infrastructure.Tests.Plugins;
+
+/// <summary>
+/// 「开会话」在隔离模式下的 RPC 链路:已保存列表 → 请求打开 → 关闭,
+/// 以及宿主的拒绝要以 <see cref="PluginPermissionDeniedException" /> 的身份到达插件那一侧。
+/// </summary>
+/// <remarks>
+/// 后一条是这组用例真正的看点。跨进程时异常只剩一个错误码加一句话,
+/// 错误码要是丢了,"用户说了不"就会变成一个笼统的调用失败 ——
+/// 插件于是换个姿势再试一次,而这正是契约明令禁止的。
+/// </remarks>
+[TestClass]
+[TestCategory("Plugins")]
+public class SessionRoutingTests
+{
+    private sealed class StubOpener(PluginSessionOpenResult result, List<SshSession> sessions) : IPluginSessionOpener
+    {
+        public List<Guid> Closed { get; } = [];
+
+        public Task<PluginSessionOpenResult> OpenAsync(string pluginId, SessionProfile profile, string reason,
+            CancellationToken cancellationToken)
+        {
+            if (result.Outcome == PluginSessionOpenOutcome.Opened)
+            {
+                sessions.Add(new()
+                {
+                    SessionId = result.SessionId,
+                    ConnectionInfo = new()
+                    {
+                        Host = profile.Host,
+                        Port = profile.Port,
+                        Username = profile.Username,
+                        AuthMethod = AuthMethod.Password
+                    },
+                    Status = SessionStatus.Connected,
+                    ConnectedAt = DateTime.UtcNow
+                });
+            }
+            return Task.FromResult(result);
+        }
+
+        public Task CloseAsync(Guid sessionId, CancellationToken cancellationToken)
+        {
+            Closed.Add(sessionId);
+            sessions.RemoveAll(s => s.SessionId == sessionId);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>建起一对管道 + 路由,插件那侧是一个裸 <see cref="RpcConnection" />。</summary>
+    private static async Task<(RpcConnection Plugin, IAsyncDisposable Cleanup)> ConnectAsync(ISessionsApi sessions)
+    {
+        string name = $"velashell-test-{Guid.NewGuid():N}";
+        var serverPipe = new NamedPipeServerStream(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var clientPipe = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.Asynchronous);
+        Task wait = serverPipe.WaitForConnectionAsync();
+        await clientPipe.ConnectAsync(5000);
+        await wait;
+
+        string dataDir = Path.Combine(Path.GetTempPath(), "velashell-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        var context = new PluginContext
+        {
+            PluginId = "acme.sessions",
+            PluginVersion = "1.0.0",
+            DataDirectory = dataDir,
+            Host = new TestHostInfo(),
+            Log = new CollectingLogger(),
+            Storage = new InMemoryStorage(),
+            TimeSeries = new InMemoryTimeSeries(),
+            Sessions = sessions,
+            RemoteFs = new FakeRemoteFs(),
+            RemoteExec = new FakeRemoteExec(),
+            RemoteTunnel = new FakeRemoteTunnel(),
+            TerminalView = new FakeTerminalViewApi(),
+            Commands = new RecordingCommands(),
+            Events = new PluginEventHub(new CollectingLogger(), null, null, null),
+            Theme = new StaticHostTheme(),
+            Ui = new FakeUi(),
+            Secrets = new FakeSecrets(),
+            Clipboard = new FakeClipboard(),
+            Terminal = new FakeTerminal(),
+            Protocols = new UnavailableProtocols(),
+            Workspaces = new UnavailableWorkspaces(),
+            Shutdown = CancellationToken.None
+        };
+        var hostConnection = new RpcConnection(serverPipe);
+        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        hostConnection.SetRequestHandler(router.HandleRequestAsync);
+        hostConnection.SetNotificationHandler(router.HandleNotification);
+        hostConnection.Start();
+
+        var pluginConnection = new RpcConnection(clientPipe);
+        pluginConnection.SetRequestHandler((_, _, _) => Task.FromResult<object?>(null));
+        pluginConnection.Start();
+        await pluginConnection.RequestAsync<HandshakeResponse>(PluginRpc.Handshake,
+            new HandshakeRequest("token", "acme.sessions", "1.0.0", [VelaPluginApi.Level]), TimeSpan.FromSeconds(5));
+        return (pluginConnection, new Cleanup(pluginConnection, hostConnection, router, dataDir));
+    }
+
+    private sealed class Cleanup(RpcConnection plugin, RpcConnection host,
+        Infrastructure.Plugins.Isolated.PluginCapabilityRouter router, string dataDir) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await plugin.DisposeAsync();
+            await host.DisposeAsync();
+            router.Dispose();
+            try
+            {
+                Directory.Delete(dataDir, true);
+            }
+            catch (IOException)
+            {
+                // 临时目录清不掉不影响断言。
+            }
+        }
+    }
+
+    private static (SessionsCapability Capability, SessionProfile Profile, List<SshSession> Sessions, StubOpener Opener)
+        NewCapability(PluginSessionOpenResult result)
+    {
+        SessionProfile profile = new()
+        {
+            Name = "prod-1", Host = "10.0.0.1", Port = 22, Username = "root", ConnectionType = ConnectionType.SSH
+        };
+        List<SshSession> sessions = [];
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.Sessions.Returns(_ => sessions);
+        connections.GetSession(Arg.Any<Guid>()).Returns(call => sessions.Find(s => s.SessionId == call.Arg<Guid>()));
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(new List<SessionProfile> { profile }));
+        repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+        repository.GetSessionAsync(Arg.Any<Guid>())
+                  .Returns(call => Task.FromResult(call.Arg<Guid>() == profile.Id ? profile : null));
+        var opener = new StubOpener(result, sessions);
+        return (new("acme.sessions", connections, repository, opener), profile, sessions, opener);
+    }
+
+    [TestMethod]
+    public async Task ListSaved_Open_Close_RoundTripOverRpc()
+    {
+        var opened = Guid.NewGuid();
+        (SessionsCapability capability, SessionProfile profile, List<SshSession> sessions, StubOpener opener) =
+            NewCapability(PluginSessionOpenResult.Opened(opened));
+        (RpcConnection plugin, IAsyncDisposable cleanup) = await ConnectAsync(capability);
+        await using (cleanup)
+        {
+            SavedSessionInfo[]? saved = await plugin.RequestAsync<SavedSessionInfo[]>(
+                PluginRpc.SessionsListSaved, null, TimeSpan.FromSeconds(5));
+            Assert.AreEqual(profile.Id.ToString(), saved!.Single().SavedSessionId);
+
+            SessionInfo? session = await plugin.RequestAsync<SessionInfo>(PluginRpc.SessionsOpen,
+                new SessionOpenRequest(profile.Id.ToString(), "查磁盘", true), TimeSpan.FromSeconds(5));
+            Assert.AreEqual(opened.ToString(), session!.SessionId);
+            Assert.AreEqual(SessionState.Connected, session.State);
+            Assert.AreEqual(1, sessions.Count);
+
+            await plugin.RequestAsync<object>(PluginRpc.SessionsClose,
+                new SessionRef(session.SessionId), TimeSpan.FromSeconds(5));
+            CollectionAssert.AreEqual(new[] { opened }, opener.Closed);
+        }
+    }
+
+    [TestMethod]
+    public async Task Open_UserDenied_ArrivesAsPermissionDeniedOnThePluginSide()
+    {
+        (SessionsCapability capability, SessionProfile profile, _, _) =
+            NewCapability(PluginSessionOpenResult.Denied("用户点了拒绝"));
+        (RpcConnection plugin, IAsyncDisposable cleanup) = await ConnectAsync(capability);
+        await using (cleanup)
+        {
+            await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(
+                () => plugin.RequestAsync<SessionInfo>(PluginRpc.SessionsOpen,
+                    new SessionOpenRequest(profile.Id.ToString(), "查磁盘", true), TimeSpan.FromSeconds(5)));
+        }
+    }
+
+    [TestMethod]
+    public async Task Open_ConnectFailure_ArrivesAsSessionOpenFailureNotAsDenial()
+    {
+        (SessionsCapability capability, SessionProfile profile, _, _) =
+            NewCapability(PluginSessionOpenResult.Failed("Connection timed out"));
+        (RpcConnection plugin, IAsyncDisposable cleanup) = await ConnectAsync(capability);
+        await using (cleanup)
+        {
+            await Assert.ThrowsExactlyAsync<PluginSessionOpenException>(
+                () => plugin.RequestAsync<SessionInfo>(PluginRpc.SessionsOpen,
+                    new SessionOpenRequest(profile.Id.ToString(), "查磁盘", true), TimeSpan.FromSeconds(5)));
+        }
+    }
+
+    [TestMethod]
+    public async Task Close_SessionThisPluginNeverOpened_IsRefusedAcrossTheWire()
+    {
+        (SessionsCapability capability, _, _, _) = NewCapability(PluginSessionOpenResult.Opened(Guid.NewGuid()));
+        (RpcConnection plugin, IAsyncDisposable cleanup) = await ConnectAsync(capability);
+        await using (cleanup)
+        {
+            await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(
+                () => plugin.RequestAsync<object>(PluginRpc.SessionsClose,
+                    new SessionRef(Guid.NewGuid().ToString()), TimeSpan.FromSeconds(5)));
+        }
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SessionsCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SessionsCapabilityTests.cs
@@ -1,0 +1,299 @@
+using NSubstitute;
+using VelaShell.Core.Data;
+using VelaShell.Core.Models;
+using VelaShell.Core.Ssh;
+using VelaShell.Infrastructure.Plugins;
+using VelaShell.Infrastructure.Plugins.Capabilities;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Infrastructure.Tests.Plugins;
+
+/// <summary>
+/// 会话能力里"开会话"那一半。它是一次实打实的权限扩张,所以这里验的不是
+/// "能不能连上"(那是连接服务的事),而是<b>闸门有没有关严</b>:
+/// 只能开已保存的配置、宿主能拒、拒绝与连不上是两种结局、只关得掉自己开的那条。
+/// </summary>
+[TestClass]
+[TestCategory("Plugins")]
+public class SessionsCapabilityTests
+{
+    /// <summary>脚本化的开会话实现:按剧本给结局,并把连上的会话塞进连接服务。</summary>
+    private sealed class ScriptedOpener(PluginSessionOpenResult result, List<SshSession> sessions) : IPluginSessionOpener
+    {
+        public int Calls { get; private set; }
+
+        public string? LastReason { get; private set; }
+
+        public List<Guid> Closed { get; } = [];
+
+        public Task<PluginSessionOpenResult> OpenAsync(string pluginId, SessionProfile profile, string reason,
+            CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastReason = reason;
+            if (result.Outcome == PluginSessionOpenOutcome.Opened)
+            {
+                sessions.Add(NewSession(result.SessionId, profile.Host, profile.Port, profile.Username));
+            }
+            return Task.FromResult(result);
+        }
+
+        public Task CloseAsync(Guid sessionId, CancellationToken cancellationToken)
+        {
+            Closed.Add(sessionId);
+            sessions.RemoveAll(s => s.SessionId == sessionId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static SshSession NewSession(Guid id, string host, int port, string user) => new()
+    {
+        SessionId = id,
+        ConnectionInfo = new() { Host = host, Port = port, Username = user, AuthMethod = AuthMethod.Password },
+        Status = SessionStatus.Connected,
+        ConnectedAt = DateTime.UtcNow
+    };
+
+    private static SessionProfile NewProfile(string name = "prod-1", string host = "10.0.0.1", string user = "root") =>
+        new() { Name = name, Host = host, Port = 22, Username = user, ConnectionType = ConnectionType.SSH };
+
+    /// <summary>连接服务替身:会话表是一个可变列表,连上/断开直接改它。</summary>
+    private static ISshConnectionService NewConnections(List<SshSession> sessions)
+    {
+        ISshConnectionService connections = Substitute.For<ISshConnectionService>();
+        connections.Sessions.Returns(_ => sessions);
+        connections.GetSession(Arg.Any<Guid>())
+                   .Returns(call => sessions.Find(s => s.SessionId == call.Arg<Guid>()));
+        connections.DisconnectAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                   .Returns(call =>
+                   {
+                       sessions.RemoveAll(s => s.SessionId == call.Arg<Guid>());
+                       return Task.CompletedTask;
+                   });
+        return connections;
+    }
+
+    private static ISessionRepository NewRepository(params SessionProfile[] profiles)
+    {
+        ISessionRepository repository = Substitute.For<ISessionRepository>();
+        repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(profiles.ToList()));
+        repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+        repository.GetSessionAsync(Arg.Any<Guid>())
+                  .Returns(call => Task.FromResult(Array.Find(profiles, p => p.Id == call.Arg<Guid>())));
+        return repository;
+    }
+
+    [TestMethod]
+    public async Task ListSavedAsync_ReportsConfigsThatAreNotConnected_WithoutCredentials()
+    {
+        SessionProfile profile = NewProfile();
+        profile.Password = "hunter2";
+        var group = new ServerGroup { Name = "生产" };
+        profile.GroupId = group.Id;
+        ISessionRepository repository = NewRepository(profile);
+        repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup> { group }));
+        var capability = new SessionsCapability("acme.p", NewConnections([]), repository);
+
+        IReadOnlyList<SavedSessionInfo> saved = await capability.ListSavedAsync();
+
+        // 一条都没连着,但它们照样要报出来 —— 这正是 ListAsync 给不了的那部分。
+        SavedSessionInfo only = saved.Single();
+        Assert.AreEqual(profile.Id.ToString(), only.SavedSessionId);
+        Assert.AreEqual("prod-1", only.Name);
+        Assert.AreEqual("生产", only.Group);
+        Assert.AreEqual(22, only.Port);
+    }
+
+    /// <summary>
+    /// 非 SSH 的配置(SFTP / FTP / 插件协议)不进列表:<c>OpenAsync</c> 开不出
+    /// <see cref="SessionInfo" /> 来,列出去只是发一个注定失败的 id。
+    /// </summary>
+    [TestMethod]
+    public async Task ListSavedAsync_SkipsProfilesThatCannotBeOpenedAsSshSessions()
+    {
+        SessionProfile ssh = NewProfile();
+        SessionProfile ftp = NewProfile("nas", "10.0.0.9", "ftp");
+        ftp.ConnectionType = ConnectionType.FTP;
+        var capability = new SessionsCapability("acme.p", NewConnections([]), NewRepository(ssh, ftp));
+
+        IReadOnlyList<SavedSessionInfo> saved = await capability.ListSavedAsync();
+
+        Assert.AreEqual(1, saved.Count);
+        Assert.AreEqual(ssh.Id.ToString(), saved[0].SavedSessionId);
+    }
+
+    [TestMethod]
+    public async Task OpenAsync_UnknownSavedSession_ThrowsSessionNotFound()
+    {
+        var capability = new SessionsCapability("acme.p", NewConnections([]), NewRepository());
+        await Assert.ThrowsExactlyAsync<PluginSessionNotFoundException>(
+            () => capability.OpenAsync(Guid.NewGuid().ToString(), new("查磁盘")));
+    }
+
+    /// <summary>没有开会话实现(headless / 无界面宿主)= 没人可问 = 拒绝,绝不静默放行。</summary>
+    [TestMethod]
+    public async Task OpenAsync_WithoutOpener_IsDeniedRatherThanSilentlyAllowed()
+    {
+        SessionProfile profile = NewProfile();
+        var capability = new SessionsCapability("acme.p", NewConnections([]), NewRepository(profile));
+        await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(
+            () => capability.OpenAsync(profile.Id.ToString(), new("查磁盘")));
+    }
+
+    [TestMethod]
+    public async Task OpenAsync_UserDenied_ThrowsPermissionDenied_NotOpenFailure()
+    {
+        SessionProfile profile = NewProfile();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Denied("用户点了拒绝"), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        // "不让你连"与"没连上"处置不同:前者重试没有意义,合成一个异常就只能靠读文本去猜。
+        await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(
+            () => capability.OpenAsync(profile.Id.ToString(), new("查磁盘")));
+    }
+
+    [TestMethod]
+    public async Task OpenAsync_ConnectFailed_ThrowsSessionOpenException()
+    {
+        SessionProfile profile = NewProfile();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Failed("Connection timed out"), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        await Assert.ThrowsExactlyAsync<PluginSessionOpenException>(
+            () => capability.OpenAsync(profile.Id.ToString(), new("查磁盘")));
+    }
+
+    /// <summary>理由是给用户看的:空理由等于把确认框变成一个只能盲点的按钮。</summary>
+    [TestMethod]
+    public async Task OpenAsync_BlankReason_IsRejectedBeforeAnyoneIsAsked()
+    {
+        SessionProfile profile = NewProfile();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(Guid.NewGuid()), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => capability.OpenAsync(profile.Id.ToString(), new("   ")));
+        Assert.AreEqual(0, opener.Calls);
+    }
+
+    [TestMethod]
+    public async Task OpenAsync_PassesTheReasonThroughUnchanged()
+    {
+        SessionProfile profile = NewProfile();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(Guid.NewGuid()), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        const string reason = "AI 助手:飞书群 运维值班 里 张三 要求查看 nginx 日志";
+        SessionInfo opened = await capability.OpenAsync(profile.Id.ToString(), new(reason));
+
+        Assert.AreEqual(reason, opener.LastReason, "理由必须原样送到确认框,不许宿主改写");
+        Assert.AreEqual(SessionState.Connected, opened.State);
+        Assert.AreEqual("10.0.0.1", opened.Host);
+    }
+
+    /// <summary>已经连着的同一台机器默认复用,不再开第二条(也就不再弹第二个确认框)。</summary>
+    [TestMethod]
+    public async Task OpenAsync_ReuseConnected_ReturnsTheExistingSessionWithoutAsking()
+    {
+        SessionProfile profile = NewProfile();
+        var existing = Guid.NewGuid();
+        List<SshSession> sessions = [NewSession(existing, profile.Host, profile.Port, profile.Username)];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(Guid.NewGuid()), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        SessionInfo reused = await capability.OpenAsync(profile.Id.ToString(), new("查磁盘"));
+
+        Assert.AreEqual(existing.ToString(), reused.SessionId);
+        Assert.AreEqual(0, opener.Calls);
+    }
+
+    [TestMethod]
+    public async Task OpenAsync_ReuseDisabled_OpensASecondSession()
+    {
+        SessionProfile profile = NewProfile();
+        List<SshSession> sessions = [NewSession(Guid.NewGuid(), profile.Host, profile.Port, profile.Username)];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(Guid.NewGuid()), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        await capability.OpenAsync(profile.Id.ToString(), new("查磁盘", ReuseConnected: false));
+
+        Assert.AreEqual(1, opener.Calls);
+        Assert.AreEqual(2, sessions.Count);
+    }
+
+    [TestMethod]
+    public async Task CloseAsync_ClosesWhatThisPluginOpened()
+    {
+        SessionProfile profile = NewProfile();
+        var opened = Guid.NewGuid();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(opened), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        SessionInfo session = await capability.OpenAsync(profile.Id.ToString(), new("查磁盘"));
+        await capability.CloseAsync(session.SessionId);
+
+        CollectionAssert.AreEqual(new[] { opened }, opener.Closed);
+    }
+
+    /// <summary>
+    /// 用户自己开的会话不归插件管 —— 一个能挂断别人正在用的终端的接口,不该存在。
+    /// 复用拿到的那条同样如此:它是用户的,不是插件开的。
+    /// </summary>
+    [TestMethod]
+    public async Task CloseAsync_RefusesSessionsThisPluginDidNotOpen()
+    {
+        SessionProfile profile = NewProfile();
+        var users = Guid.NewGuid();
+        List<SshSession> sessions = [NewSession(users, profile.Host, profile.Port, profile.Username)];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(Guid.NewGuid()), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        SessionInfo reused = await capability.OpenAsync(profile.Id.ToString(), new("查磁盘"));
+        Assert.AreEqual(users.ToString(), reused.SessionId);
+
+        await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(() => capability.CloseAsync(reused.SessionId));
+        Assert.IsEmpty(opener.Closed);
+        Assert.AreEqual(1, sessions.Count, "用户的会话必须原封不动");
+    }
+
+    /// <summary>会话已经不在了(用户先手动关了)不算错:此方法幂等。</summary>
+    [TestMethod]
+    public async Task CloseAsync_IsIdempotentWhenTheSessionIsAlreadyGone()
+    {
+        SessionProfile profile = NewProfile();
+        var opened = Guid.NewGuid();
+        List<SshSession> sessions = [];
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(opened), sessions);
+        var capability = new SessionsCapability("acme.p", NewConnections(sessions), NewRepository(profile), opener);
+
+        SessionInfo session = await capability.OpenAsync(profile.Id.ToString(), new("查磁盘"));
+        sessions.Clear(); // 用户手动关掉了那个标签页
+        await capability.CloseAsync(session.SessionId);
+
+        Assert.IsEmpty(opener.Closed, "会话都没了,不必再劳烦界面层");
+    }
+
+    /// <summary>另一个插件开的会话,同样关不掉 —— 归属账本是按插件计的。</summary>
+    [TestMethod]
+    public async Task CloseAsync_RefusesSessionsOpenedByAnotherPlugin()
+    {
+        SessionProfile profile = NewProfile();
+        var opened = Guid.NewGuid();
+        List<SshSession> sessions = [];
+        ISshConnectionService connections = NewConnections(sessions);
+        ISessionRepository repository = NewRepository(profile);
+        var opener = new ScriptedOpener(PluginSessionOpenResult.Opened(opened), sessions);
+
+        var first = new SessionsCapability("acme.first", connections, repository, opener);
+        var second = new SessionsCapability("acme.second", connections, repository, opener);
+
+        SessionInfo session = await first.OpenAsync(profile.Id.ToString(), new("查磁盘"));
+        await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(() => second.CloseAsync(session.SessionId));
+    }
+}

--- a/tests/VelaShell.Tests/Views/PluginPermissionDialogTests.cs
+++ b/tests/VelaShell.Tests/Views/PluginPermissionDialogTests.cs
@@ -28,14 +28,18 @@ public sealed class PluginPermissionDialogTests
             // 私有的带参构造会给 TitleText/MessageText/… 赋文本;字段没被 XAML 填充就 NRE。
             ConstructorInfo ctor = typeof(PluginPermissionDialog).GetConstructor(
                 BindingFlags.NonPublic | BindingFlags.Instance, null,
-                [typeof(string), typeof(string), typeof(string)], null)!;
-            object dialog = ctor.Invoke(["acme.plugin", "prod-1", "echo hi"]);
+                [typeof(string), typeof(string), typeof(string), typeof(string)], null)!;
+            object dialog = ctor.Invoke(["Terminal write request", "acme.plugin → prod-1", "echo hi", "Icon.terminal"]);
 
             // 命名控件应已由编译器生成的填充逻辑绑定(非 null),且带上了文案。
             var title = (TextBlock)typeof(PluginPermissionDialog)
                 .GetField("TitleText", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(dialog)!;
             Assert.IsNotNull(title);
             Assert.IsFalse(string.IsNullOrEmpty(title.Text));
+
+            // 开会话那一版换的是图标 —— 它也是个 x:Name 控件,同样会因填充缺失而 NRE。
+            Assert.IsNotNull(typeof(PluginPermissionDialog)
+                .GetField("HeaderIcon", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(dialog));
 
             ((Window)dialog).Close();
         }, CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

实现插件安全请求宿主新建/关闭 SSH 会话，完善 ISessionsApi、授权机制与 UI 交互，确保凭据隔离与用户可控。支持多账本授权、动态弹窗、依赖注入与隔离模式。补充多场景测试，详细注释设计约束与异常处理。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
