### PR TITLE
优化长连接优雅关闭，提升停机健壮性

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
@@ -160,13 +160,9 @@ public sealed class ChannelHub(IPluginContext context) : IAsyncDisposable
             {
                 break;
             }
-            try
+            if (!await ChannelShutdown.DelayAsync(backoff, token).ConfigureAwait(false))
             {
-                await Task.Delay(backoff, token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
+                break; // 退避期间被停掉
             }
             backoff = backoff >= MaxBackoff ? MaxBackoff : backoff * 2;
         }

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelShutdown.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelShutdown.cs
@@ -1,0 +1,87 @@
+using System.Net.WebSockets;
+
+namespace VelaShell.Plugin.Ai.Bridge;
+
+/// <summary>
+/// 长连接渠道收摊时的共用动作。
+/// </summary>
+/// <remarks>
+/// 这里的每一个方法都在做同一件事:<b>别拿异常当收摊的通知</b>。
+///
+/// <para>把宿主的取消令牌直接交给 <c>ClientWebSocket.ReceiveAsync</c> 看着省事,代价却不小:
+/// 取消一次挂起的接收,库内走的是 <c>Abort</c> —— 底层 TCP 直接掐断,于是一次退出要连锁抛出
+/// 套接字 <c>IOException</c>、TLS 层 <c>IOException</c>、<c>HttpClient</c> 的
+/// <c>TaskCanceledException</c>,最后才轮到我们自己这层。对端看到的也不是"它下线了",
+/// 而是"连接莫名其妙断了"。</para>
+///
+/// <para>正确的收法是发一个 Close 帧,让读循环从对端的 Close 应答里自然返回 —— 零异常,
+/// 且平台侧能干净地摘掉这条长连接。对端不应答时才 <c>Abort</c> 兜底,不为一个已经失联的
+/// 服务端无限等下去。</para>
+/// </remarks>
+internal static class ChannelShutdown
+{
+    /// <summary>优雅关闭的宽限:发 Close 帧、以及等对端回 Close 各给这么多时间。</summary>
+    private static readonly TimeSpan CloseGrace = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// 可取消的等待:等满返回 true,被取消返回 false —— 不抛。
+    /// </summary>
+    /// <remarks>
+    /// 与 <c>PluginManager.DelayObservedAsync</c> 同一个套路:经 <c>ContinueWith</c> 观察取消。
+    /// 直接 <c>await Task.Delay(delay, token)</c> 会在每次停机时给调试输出添一条
+    /// <c>TaskCanceledException</c>,而调用方要的信息只是一个"要不要接着跑"的布尔值。
+    /// </remarks>
+    public static async Task<bool> DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        var wait = Task.Delay(delay, cancellationToken);
+        await wait.ContinueWith(static _ => { }, CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default).ConfigureAwait(false);
+        return !wait.IsCanceled;
+    }
+
+    /// <summary>
+    /// 等到任务结束、或等到令牌取消,先到先返回;两条路都不抛。
+    /// </summary>
+    /// <remarks>
+    /// 任务本身出的错留给调用方之后 <c>await</c> 时去接 —— 这里只回答"该收摊了吗"。
+    /// </remarks>
+    public static async Task WhenCompletedOrCancelledAsync(Task task, CancellationToken cancellationToken)
+    {
+        if (task.IsCompleted || !cancellationToken.CanBeCanceled)
+        {
+            return;
+        }
+        var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using CancellationTokenRegistration registration = cancellationToken.UnsafeRegister(
+            static state => ((TaskCompletionSource)state!).TrySetResult(), cancelled);
+        await Task.WhenAny(task, cancelled.Task).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 优雅关闭一条 WebSocket:发 Close 帧,等读循环收到对端的 Close 应答后自行返回。
+    /// </summary>
+    /// <param name="socket">要关的连接。</param>
+    /// <param name="receiveLoop">还挂在这条连接上的读循环。</param>
+    public static async Task CloseAsync(ClientWebSocket socket, Task receiveLoop)
+    {
+        try
+        {
+            if (socket.State == WebSocketState.Open)
+            {
+                using var deadline = new CancellationTokenSource(CloseGrace);
+                await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, deadline.Token)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is WebSocketException or OperationCanceledException or ObjectDisposedException)
+        {
+            // 对端已经不在了,Close 帧发不出去 —— 直接走下面的 Abort 兜底。
+        }
+        if (await Task.WhenAny(receiveLoop, Task.Delay(CloseGrace)).ConfigureAwait(false) != receiveLoop)
+        {
+            // 对端不回 Close。退出不能因此挂住,只能掐断 —— 这是唯一一条会制造收摊异常的路,
+            // 也只有在平台确实失联时才会走到。
+            socket.Abort();
+        }
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
@@ -64,6 +64,38 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
         Connected?.Invoke();
         context.Log.Info($"Bridge: {Label} connected to DingTalk stream.");
 
+        // 读循环刻意**不**接宿主的取消令牌:取消一次挂起的 ReceiveAsync,ClientWebSocket
+        // 走的是 Abort,整条 TLS/TCP 栈会连锁抛异常,平台侧看到的也是一条莫名断掉的长连接。
+        // 停机改走 Close 帧(见 ChannelShutdown.CloseAsync),读循环从对端的 Close 应答里
+        // 正常返回;只有对端不应答时才由那里 Abort 兜底。
+        using var stop = new CancellationTokenSource();
+        Task receive = ReceiveLoopAsync(socket, onMessage, stop.Token);
+        try
+        {
+            await ChannelShutdown.WhenCompletedOrCancelledAsync(receive, cancellationToken).ConfigureAwait(false);
+            if (!receive.IsCompleted)
+            {
+                await ChannelShutdown.CloseAsync(socket, receive).ConfigureAwait(false);
+            }
+            try
+            {
+                await receive.ConfigureAwait(false);
+            }
+            catch (Exception) when (cancellationToken.IsCancellationRequested)
+            {
+                // 优雅关闭超时后被 Abort 掐断的读取。停机路径,不算故障。
+            }
+        }
+        finally
+        {
+            await stop.CancelAsync().ConfigureAwait(false);
+            _socket = null;
+        }
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, Func<InboundMessage, Task> onMessage,
+        CancellationToken cancellationToken)
+    {
         byte[] buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
         try
         {
@@ -95,7 +127,6 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
-            _socket = null;
         }
     }
 

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
@@ -79,24 +79,41 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
         Connected?.Invoke();
         context.Log.Info($"Bridge: {Label} connected to Feishu (service {_serviceId}, ping every {pingSeconds}s).");
 
-        using var pings = new CancellationTokenSource();
-        using CancellationTokenSource linked =
-            CancellationTokenSource.CreateLinkedTokenSource(pings.Token, cancellationToken);
-        Task pingLoop = PingLoopAsync(socket, pingSeconds, linked.Token);
+        // 读循环刻意**不**接宿主的取消令牌:取消一次挂起的 ReceiveAsync,ClientWebSocket
+        // 走的是 Abort,整条 TLS/TCP 栈会连锁抛异常,平台侧看到的也是一条莫名断掉的长连接。
+        // 停机改走 Close 帧(见 ChannelShutdown.CloseAsync),读循环从对端的 Close 应答里
+        // 正常返回;只有对端不应答时才由那里 Abort 兜底。
+        using var stop = new CancellationTokenSource();
+        Task receive = ReceiveLoopAsync(socket, onMessage, stop.Token);
+        Task pingLoop = PingLoopAsync(socket, pingSeconds, stop.Token);
         try
         {
-            await ReceiveLoopAsync(socket, onMessage, cancellationToken).ConfigureAwait(false);
+            await ChannelShutdown.WhenCompletedOrCancelledAsync(receive, cancellationToken).ConfigureAwait(false);
+            if (!receive.IsCompleted)
+            {
+                await ChannelShutdown.CloseAsync(socket, receive).ConfigureAwait(false);
+            }
+            try
+            {
+                await receive.ConfigureAwait(false);
+            }
+            catch (Exception) when (cancellationToken.IsCancellationRequested)
+            {
+                // 优雅关闭超时后被 Abort 掐断的读取。停机路径,不算故障。
+            }
         }
         finally
         {
-            await pings.CancelAsync().ConfigureAwait(false);
+            await stop.CancelAsync().ConfigureAwait(false);
             try
             {
                 await pingLoop.ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException
+                                           or WebSocketException
+                                           or ObjectDisposedException)
             {
-                // 收摊时的正常取消
+                // 收摊时撞上正在关闭的连接
             }
             _socket = null;
         }
@@ -188,9 +205,10 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
     private async Task PingLoopAsync(ClientWebSocket socket, int pingSeconds, CancellationToken cancellationToken)
     {
         TimeSpan interval = TimeSpan.FromSeconds(Math.Clamp(pingSeconds, 10, 600));
-        while (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
+        // 等待走不抛的那条路:停机时这里被取消是常态,不该每次都在调试输出里留一条异常。
+        while (socket.State == WebSocketState.Open
+               && await ChannelShutdown.DelayAsync(interval, cancellationToken).ConfigureAwait(false))
         {
-            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
             var ping = new Pbbp2.Frame { Method = Pbbp2.FrameTypeControl, Service = _serviceId };
             ping.SetHeader(Pbbp2.HeaderNames.Type, "ping");
             await SendFrameAsync(socket, ping, cancellationToken).ConfigureAwait(false);

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
@@ -69,6 +69,13 @@ internal sealed class WeComChannel(
         context.Log.Info(
             $"Bridge: {Label} listening for WeCom callbacks on http://127.0.0.1:{config.WebhookPort}{config.WebhookPath} " +
             "(put a tunnel or reverse proxy in front of it).");
+        // 停机靠关监听来唤醒 accept,而不是 WaitAsync(token)。后者只是**放弃等待**:
+        // GetContextAsync 那个任务还挂在监听上,随后 finally 里的 Close 会让它以
+        // HttpListenerException 收场 —— 一个没人观察的任务异常;而 WaitAsync 自己抛出的
+        // TaskCanceledException 又不在下面的 catch 里,得一路穿到 ChannelHub 才被吃掉。
+        // 关监听则让 accept 自己以 HttpListenerException 返回,正好落进已有的分支。
+        await using CancellationTokenRegistration stopping =
+            cancellationToken.Register(static state => ((HttpListener)state!).Close(), listener);
         try
         {
             while (listener.IsListening && !cancellationToken.IsCancellationRequested)
@@ -76,7 +83,7 @@ internal sealed class WeComChannel(
                 HttpListenerContext http;
                 try
                 {
-                    http = await listener.GetContextAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+                    http = await listener.GetContextAsync().ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is HttpListenerException or ObjectDisposedException)
                 {

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -23,6 +23,7 @@ using VelaShell.PluginSdk.Ui;
 using VelaShell.Presentation.DependencyInjection;
 using VelaShell.Presentation.ViewModels;
 using VelaShell.Services;
+using VelaShell.Terminal;
 using VelaShell.ViewModels;
 using VelaShell.Views;
 
@@ -303,6 +304,7 @@ public class App : Application
                 _launchChannel?.Dispose();
                 _trayIconService?.Dispose();
                 ExternalEditSessionManager.CleanupAll();
+                CloseTerminalBridgesOnExit(viewModel);
                 DisposeServicesOnExit();
             };
         }
@@ -428,6 +430,46 @@ public class App : Application
                 // 自动推送失败静默,手动同步可见错误。
             }
         });
+    }
+
+    /// <summary>
+    /// 退出时先把还开着的终端标签拆掉,再去释放容器。
+    /// </summary>
+    /// <remarks>
+    /// 关标签这条路上,<see cref="SshTerminalBridge.Dispose" /> 是按顺序来的:先释放 shell 流
+    /// (挂起的读取以"通道关闭"醒来,包装层吞成 EOF),再取消令牌、等读写循环收摊。退出时却
+    /// 谁也没走这一步 —— 容器一释放,<c>SshConnectionService</c> 直接把底下的 <c>SshClient</c>
+    /// 全 Dispose 掉,而读循环还挂在各自的通道上。于是每个开着的标签都要在退出时炸出一串
+    /// <c>SshChannelClosedException</c> / <c>IOException</c>,远端看到的也不是一次干净的通道
+    /// 关闭,而是连接被直接掐断。
+    /// <para>
+    /// 这里补上那一步:并发拆桥(每个 <c>Dispose</c> 内部最多等 3 秒),整体再压一个 2 秒的
+    /// 总预算 —— 退出路径绝不为一条无响应的连接挂住。超时未拆完的部分随进程退出由系统回收,
+    /// 与改动前的行为一致。
+    /// </para>
+    /// </remarks>
+    private static void CloseTerminalBridgesOnExit(MainWindowViewModel viewModel)
+    {
+        SshTerminalBridge[] bridges =
+        [
+            .. viewModel.TabBar.Tabs
+                .OfType<TerminalTabViewModel>()
+                .Select(tab => tab.Bridge)
+                .OfType<SshTerminalBridge>()
+        ];
+        if (bridges.Length == 0)
+        {
+            return;
+        }
+        try
+        {
+            Task.WhenAll([.. bridges.Select(bridge => Task.Run(bridge.Dispose))])
+                .Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // 尽力关闭:绝不阻塞或中断退出路径。
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

统一引入 ChannelShutdown 工具类，优化 DingTalk、Feishu、WeCom 等长连接渠道的关闭流程。新增 DelayAsync、WhenCompletedOrCancelledAsync、CloseAsync 等方法，避免取消令牌直接中断连接。各渠道读循环和 PingLoop 均采用更优雅的关闭方式，异常处理更细致。App.axaml.cs 支持应用退出时并发优雅关闭所有 SSH 终端桥，整体提升停机/退出时的健壮性和异常容忍度。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
