### PR TITLE
完善 Linux 包分发体系，支持 AppImage/deb/rpm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,14 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Packaging scripts and rpm specs must keep LF endings: they are consumed on
+# CI's Linux runners, where a CRLF shebang fails with
+# "bad interpreter: /usr/bin/env^M" and rpmbuild reads the trailing carriage
+# return into every spec field.
+###############################################################################
+*.sh      text eol=lf
+*.spec    text eol=lf
+*.spec.in text eol=lf
+AppRun    text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@
 # 三平台原生 runner 构建 self-contained 产物,统一附加到该 Release:
 #   Windows x64/arm64 → zip
 #   macOS   x64/arm64 → tar.gz + dmg(未签名/未公证;Unix 可执行位在原生 runner 上保留)
-#   Linux   x64/arm64 → tar.gz
+#   Linux   x64/arm64 → tar.gz + AppImage + deb + rpm(后三者均未签名;四种格式全部在同一台
+#                       x64 runner 上交叉打包出 amd64/arm64 两份,理由见各自的打包脚本:
+#                       build/appimage/ 与 build/linux-packages/)
 # 随包分发的插件(plugins/<目录名>/,目录名 = id 把点换成短横,原因见 macOS job 的签名一步)
 # **只有本仓库 plugins/ 下自建的那些**(当前是 AI 插件 velashell.ai),随 publish 一起构建、
 # 由 src/VelaShell/VelaShell.csproj 的 AddVelaPluginsToPublish 登记入包。
@@ -28,6 +30,9 @@
 #            就是 tar.gz 的扁平布局,应用在 bundle 内运行时更新器的应用目录即
 #            Contents/MacOS,后续自更新照常工作(Info.plist/图标不随更新变,可接受)。
 #   因此 dmg 绝不能写进 latest.json 的 assets;二者布局必须保持一致。
+# Linux 一共四种产物,分工同理:只有 tar.gz 是更新器资产、进 latest.json;AppImage / deb / rpm
+# 都是给人下载安装的。后三者装完之后应用目录要么是只读 squashfs 挂载点、要么归 root,
+# 应用内更新器的可写探测会自动把关于页降级成"发现新版本,请手动下载",无需为它们加任何判定。
 # 另生成两份元数据:
 #   SHA256SUMS.txt — 全部产物的校验和(人工核对用)
 #   latest.json    — 应用内自更新清单(版本号/标签/各 RID 产物名+sha256+大小);
@@ -259,7 +264,16 @@ jobs:
         run: echo "$SNK_B64" | openssl base64 -A -d > src/VelaShell.snk
         env:
           SNK_B64: ${{ secrets.STRONG_NAME_KEY }}
-      - name: Publish (linux-x64 / linux-arm64)
+      # rpm:Debian 系上装个 rpmbuild 就能产出 rpm 包,不必再养一台 rpm 发行版的 runner。
+      # imagemagick:仓库只有一张 1024×1024 的源图,而 hicolor 主题不认这个尺寸,
+      #             deb/rpm 里的图标必须现降采样成标准档位(见 Stage-Payload.sh)。
+      # 显式装而不是赌 runner 镜像自带:两者在 ubuntu 镜像的历次改版里都进出过。
+      - name: Install packaging tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm imagemagick
+      - name: Publish & package (linux-x64 / linux-arm64 → tar.gz + AppImage + deb + rpm)
         run: |
           set -euo pipefail
           version="${TAG_NAME#v}"
@@ -270,7 +284,22 @@ jobs:
               -p:Version="$version" -p:SelfContained=true -p:DebugType=None --nologo
             # 两个可执行体:主程序,以及隔离插件的宿主进程(由主程序按需拉起)。
             chmod +x "out/$name/VelaShell" "out/$name/VelaShell.PluginHost"
+            # tar.gz:应用内更新器的资产,扁平布局不可改(latest.json 只登记它)。
             tar -czf "dist/$name.tar.gz" -C "out/$name" .
+            # AppImage:人类下载资产,与 macOS 的 dmg 同一定位 —— 单文件、免安装、双击即跑。
+            # 同样**不进 latest.json**:更新器只会原地解包 zip/tar.gz;何况 AppImage 运行时应用
+            # 目录是只读的 squashfs 挂载点,换版无从谈起(可写探测会自动降级成"请手动下载")。
+            build/appimage/Build-AppImage.sh "out/$name" "$rid" "$version" dist
+            # deb / rpm:发行版原生包,装进 /opt/velashell 并登记到菜单与 PATH。
+            # 两者装进系统的文件是同一棵树(build/linux-packages/Stage-Payload.sh),只是外壳不同。
+            # 命名刻意跟随各自发行版的惯例(velashell_1.2.3_amd64.deb / velashell-1.2.3-1.x86_64.rpm)
+            # 而不是本仓库的 VelaShell-<版本>-<RID>:这两个文件名是给 dpkg/rpm 和仓库工具解析的,
+            # 改成自定义样式会让它们认不出包名/版本/架构。同样不进 latest.json(装完目录归 root,
+            # 更新交给包管理器)。
+            build/linux-packages/Build-Deb.sh "out/$name" "$rid" "$version" dist
+            build/linux-packages/Build-Rpm.sh "out/$name" "$rid" "$version" dist
+            # 打完就回收:一份发布目录 200 MB 上下,两个 RID 之间不留全量副本。
+            rm -rf "out/$name"
           done
         env:
           TAG_NAME: ${{ github.event.release.tag_name || inputs.tag }}

--- a/README.en.md
+++ b/README.en.md
@@ -135,7 +135,7 @@ Together, VelaShell means **"a terminal as your sail, riding the signal winds to
 | Platform | Architecture | Status |
 |----------|--------------|--------|
 | Windows 10 / 11 | x64 / arm64 | ✅ Fully supported (portable zip, in-app updates; also on Microsoft Store as MSIX) |
-| Linux | x64 / arm64 | ✅ Fully supported (portable tar.gz) |
+| Linux | x64 / arm64 | ✅ Fully supported (portable tar.gz, single-file `.AppImage`, native `.deb` / `.rpm`) |
 | macOS | x64 / arm64 | ✅ Fully supported (tar.gz + drag-install `.dmg`, unsigned/not notarised) |
 
 Releases are **self-contained**, so no .NET runtime is required on the target machine. [`scripts/publish-all.ps1`](scripts/publish-all.ps1) produces every platform package in one go — see [Build & release](#-build--release).
@@ -211,7 +211,7 @@ docker compose -f docker-compose.test.yml up -d
 pwsh scripts/publish-all.ps1
 ```
 
-Artifacts cover Windows x64/arm64 (portable zip) plus macOS and Linux x64/arm64 (tar.gz), all self-contained — unpack anywhere and run, no .NET required. Each package carries the isolated-plugin host process `VelaShell.PluginHost` plus a `plugins/` directory holding only the in-house AI plugin (Redis / S3 / Telnet have not been preinstalled since 2026-08-22 — users install them from the marketplace on demand). The macOS `.dmg` drag-install image is produced only on CI's macOS runner (`hdiutil`/`iconutil`/`codesign` are macOS-only tools); **the updater always consumes the tar.gz**, while the dmg exists purely for manual installation.
+Artifacts cover Windows x64/arm64 (portable zip) plus macOS and Linux x64/arm64 (tar.gz), all self-contained — unpack anywhere and run, no .NET required. Each package carries the isolated-plugin host process `VelaShell.PluginHost` plus a `plugins/` directory holding only the in-house AI plugin (Redis / S3 / Telnet have not been preinstalled since 2026-08-22 — users install them from the marketplace on demand). The macOS `.dmg` drag-install image is produced only on CI's macOS runner (`hdiutil`/`iconutil`/`codesign` are macOS-only tools); Beyond the tar.gz, Linux ships three more: a single-file `.AppImage` (`chmod +x` and double-click — see `build/appimage/README.md`) plus native `.deb` / `.rpm` packages (installed into `/opt/velashell`, registering a menu entry and `/usr/bin/velashell` — see `build/linux-packages/README.md`), one of each per architecture, all cross-built on the same x64 runner. **The updater always consumes the tar.gz**; the dmg, AppImage, deb and rpm exist purely for manual download and installation — once installed their application directory is not writable, so the About page degrades to "download it manually".
 
 > Microsoft Store (MSIX) installs are updated by the Store, so in-app update actions are hidden there. The Store build lives under the read-only `WindowsApps` directory and its data folder is redirected to a package-private location, so **its settings, sessions and keys are separate from the portable build's**.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ VelaShell 是一个使用 .NET 11 与 Avalonia 构建的桌面终端应用，支
 | 平台 | 架构 | 状态 |
 |------|------|------|
 | Windows 10 / 11 | x64 / arm64 | ✅ 完整支持（便携 zip，应用内自动更新；另有 Microsoft Store MSIX） |
-| Linux | x64 / arm64 | ✅ 完整支持（便携 tar.gz） |
+| Linux | x64 / arm64 | ✅ 完整支持（便携 tar.gz、`.AppImage` 单文件免安装包、`.deb` / `.rpm` 发行版原生包） |
 | macOS | x64 / arm64 | ✅ 完整支持（tar.gz + `.dmg` 拖装包，未签名/未公证） |
 
 发布方式为 **Self-contained**，目标机器无需预装 .NET Runtime。跨平台发布由 [`scripts/publish-all.ps1`](scripts/publish-all.ps1) 一键产出，详见[发布](#-构建与发布)。
@@ -211,7 +211,7 @@ docker compose -f docker-compose.test.yml up -d
 pwsh scripts/publish-all.ps1
 ```
 
-产物覆盖 Windows x64/arm64（便携 zip）、macOS 与 Linux x64/arm64（tar.gz），全部为含运行时的自包含发布，解压到任意目录即可运行，无需预装 .NET。包内除主程序外还带着隔离插件的宿主进程 `VelaShell.PluginHost`，以及只放着自建 AI 插件的 `plugins/` 目录（Redis / S3 / Telnet 自 2026-08-22 起不再预装，改由用户从插件商店按需安装）。macOS 的 `.dmg` 拖装包只在 CI 的 macOS runner 上生成（`hdiutil`/`iconutil`/`codesign` 是 macOS 独有工具）；**自动更新永远只取 tar.gz**，dmg 仅供人工安装。
+产物覆盖 Windows x64/arm64（便携 zip）、macOS 与 Linux x64/arm64（tar.gz），全部为含运行时的自包含发布，解压到任意目录即可运行，无需预装 .NET。包内除主程序外还带着隔离插件的宿主进程 `VelaShell.PluginHost`，以及只放着自建 AI 插件的 `plugins/` 目录（Redis / S3 / Telnet 自 2026-08-22 起不再预装，改由用户从插件商店按需安装）。macOS 的 `.dmg` 拖装包只在 CI 的 macOS runner 上生成（`hdiutil`/`iconutil`/`codesign` 是 macOS 独有工具）；Linux 除 tar.gz 外另出三份：`.AppImage` 单文件免安装包（`chmod +x` 后双击即跑，见 `build/appimage/README.md`），以及 `.deb` / `.rpm` 发行版原生包（装进 `/opt/velashell`，登记菜单项与 `/usr/bin/velashell`，见 `build/linux-packages/README.md`）—— 两种架构各一份，全部在同一台 x64 runner 上交叉打出。**自动更新永远只取 tar.gz**；dmg、AppImage、deb、rpm 都仅供人工下载安装，装完后应用目录不可写，关于页会自动降级成"请手动下载"。
 
 > 从 Microsoft Store 安装的版本（MSIX）更新由商店接管，应用内的更新操作会自动隐藏。商店版装在只读的 `WindowsApps` 下，数据目录被系统重定向到包私有位置，因此**与便携版的配置、会话、密钥互不相通**。
 

--- a/build/appimage/AppRun
+++ b/build/appimage/AppRun
@@ -1,0 +1,8 @@
+#!/bin/sh
+# AppImage 的入口:运行时整个包被挂到一个每次都不同的临时挂载点(/tmp/.mount_XXXX),
+# 绝对路径无从写死,只能由这个脚本按自身位置解析出真正的可执行体。
+# 布局与 tar.gz 完全一致(扁平的发布目录整个搬进 usr/bin),因此应用侧对
+# AppContext.BaseDirectory 的一切假设 —— plugins/ 目录、随包的 VelaShell.PluginHost —— 照旧成立。
+set -eu
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE/usr/bin/VelaShell" "$@"

--- a/build/appimage/Build-AppImage.sh
+++ b/build/appimage/Build-AppImage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# 把一份已经发布好的 Linux self-contained 目录打成 AppImage(免安装、免解压、双击即跑的单文件)。
+#
+#   用法:build/appimage/Build-AppImage.sh <发布目录> <RID> <版本号> <输出目录>
+#   例:  build/appimage/Build-AppImage.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+#
+# 与 macOS 的 dmg 同属"给人用"的安装资产:布局上就是 tar.gz 那份扁平发布目录整个搬进
+# AppDir/usr/bin,再由 AppRun 按挂载点相对定位启动 —— 应用侧看到的 BaseDirectory 结构不变。
+# **它不进 latest.json**:应用内更新器只认识 zip/tar.gz 的原地解包换版;何况 AppImage 跑起来时
+# 应用目录是只读的 squashfs 挂载点,UpdateService 的可写探测会自动把关于页降级成"请手动下载"。
+#
+# 三处刻意的选择,改之前先读:
+#   · appimagetool 取 AppImage/appimagetool 的 **1.9.1**(打了 tag 的固定版本)。不要回头去用
+#     AppImageKit 13 —— 那个仓库已归档,发布资产在上游被统一改名成 obsolete-*,老地址现在是 404。
+#   · runtime 用 --runtime-file 显式指定 type2-runtime 的 continuous 版(静态链接 fuse3)。
+#     不给这个参数 appimagetool 也会自己去下同一个文件,但显式下载才有重试、才看得见失败原因。
+#     绝不能用 AppImageKit 时代的旧 runtime:它依赖 libfuse2,而 Ubuntu 22.04 起默认不装,
+#     用户双击只会得到一句 dlopen(): error loading libfuse.so.2。
+#   · appimagetool 本身是个 AppImage,这里 --appimage-extract 解开再跑解出来的 AppRun。
+#     解包这条路不碰 FUSE(不需要 /dev/fuse,也不需要 libfuse2),在容器/精简 runner 上行为确定;
+#     且必须跑 AppRun 而不是里面的 usr/bin/appimagetool —— 前者会把自带的 mksquashfs 与
+#     desktop-file-validate 加进 PATH,后者找不到它们会直接 die。
+#     (还需要系统自带的 file 命令,GitHub 的 ubuntu 镜像与各主流发行版默认都有。)
+#   交叉打包没问题:mksquashfs 与"runtime + squashfs 拼接"都与目标架构无关,x64 机器上照样
+#   产出 aarch64 的 AppImage,不需要 arm64 runner —— runtime 按 $arch 下对的那份即可。
+set -euo pipefail
+
+publish_dir=${1:?用法: Build-AppImage.sh <发布目录> <RID> <版本号> <输出目录>}
+rid=${2:?缺少 RID}
+version=${3:?缺少版本号}
+out_dir=${4:?缺少输出目录}
+
+# AppImage 用的是 uname -m 的架构名,不是 .NET 的 RID。
+case "$rid" in
+  linux-x64) arch=x86_64 ;;
+  linux-arm64) arch=aarch64 ;;
+  *)
+    echo "Build-AppImage: 不支持的 RID '$rid'(只接受 linux-x64 / linux-arm64)" >&2
+    exit 1
+    ;;
+esac
+
+appimagetool_version=1.9.1
+appimagetool_url="https://github.com/AppImage/appimagetool/releases/download/$appimagetool_version/appimagetool-x86_64.AppImage"
+runtime_url="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-$arch"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+publish_dir="$(cd "$publish_dir" && pwd)"
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# 取工具:appimagetool 解包备用,runtime 按目标架构单独下。
+tools="$work/tools"
+mkdir -p "$tools"
+curl -fsSL --retry 3 --retry-all-errors -o "$tools/appimagetool.AppImage" "$appimagetool_url"
+curl -fsSL --retry 3 --retry-all-errors -o "$tools/runtime-$arch" "$runtime_url"
+chmod +x "$tools/appimagetool.AppImage"
+(cd "$tools" && ./appimagetool.AppImage --appimage-extract >/dev/null)
+
+# 搭 AppDir。
+appdir="$work/AppDir"
+mkdir -p "$appdir/usr/bin" "$appdir/usr/share/applications"
+cp -a "$publish_dir/." "$appdir/usr/bin/"
+# 两个可执行体:主程序,以及隔离插件的宿主进程(由主程序按需拉起)。
+chmod +x "$appdir/usr/bin/VelaShell" "$appdir/usr/bin/VelaShell.PluginHost"
+install -m 0755 "$script_dir/AppRun" "$appdir/AppRun"
+
+# 桌面入口沿用仓库里那份唯一的 .desktop(装进 /opt 的版本),只把 Exec 换成包内相对名字 ——
+# AppImage 实际由 AppRun 启动,Exec 只是给桌面集成工具看的标识,写死绝对路径反而是错的。
+desktop="$appdir/VelaShell.desktop"
+sed 's|^Exec=.*|Exec=VelaShell|' "$repo_root/src/VelaShell/VelaShell.desktop" > "$desktop"
+cp "$desktop" "$appdir/usr/share/applications/VelaShell.desktop"
+
+# 图标:Icon=velashell,同名文件必须躺在 AppDir 根;.DirIcon 是桌面集成读缩略图的固定入口
+# (不建也行,appimagetool 会照着 Icon= 自己补一个软链,这里直接给,少一层不确定)。
+# 直接用 1024×1024 的源图不缩放 —— 缩放要额外拉 ImageMagick,而各桌面环境本就会自行降采样。
+cp "$repo_root/src/VelaShell/Assets/velashell.png" "$appdir/velashell.png"
+ln -sf velashell.png "$appdir/.DirIcon"
+
+output="$out_dir/VelaShell-$version-$rid.AppImage"
+# --no-appstream:仓库没有 AppStream 元数据,不该因为没装 appstreamcli 就让打包失败。
+# ARCH:AppDir 里全是 .NET 的产物,让 appimagetool 自己猜架构既慢又可能猜错,直接告诉它。
+ARCH="$arch" "$tools/squashfs-root/AppRun" \
+  --no-appstream \
+  --runtime-file "$tools/runtime-$arch" \
+  "$appdir" "$output"
+chmod +x "$output"
+echo "Build-AppImage: 已生成 $output"

--- a/build/appimage/README.md
+++ b/build/appimage/README.md
@@ -1,0 +1,67 @@
+# Linux AppImage 打包
+
+AppImage 是 Linux 上的"下载即用"单文件格式:一个可执行文件里塞着完整的 squashfs 镜像,
+`chmod +x` 后双击就跑,不装、不解压、不碰系统目录。它与 tar.gz 是**同一份发布产物的两种容器**,
+定位等同 macOS 的 `.dmg` —— 给人手动安装用的那份。
+
+## 打包
+
+```bash
+# 先按发布流水线的方式产出 self-contained 目录
+dotnet publish src/VelaShell/VelaShell.csproj -c Release -r linux-x64 \
+  -o out/VelaShell-1.2.3-linux-x64 -p:Version=1.2.3 -p:SelfContained=true
+# 再把它装进 AppImage
+build/appimage/Build-AppImage.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+```
+
+产出 `dist/VelaShell-<版本>-<RID>.AppImage`。CI 里由 `release.yml` 的 `build-linux`
+任务在打完 tar.gz 之后顺手跑一遍,两个 RID 各出一份,随 Release 一起发布。
+
+**只需要 x64 runner。** mksquashfs 与"runtime + squashfs 拼接"都与目标架构无关,
+按 `$arch` 下对应的 runtime 就能在 x64 上产出 aarch64 的 AppImage,无需 arm64 runner。
+
+宿主机上只额外要一个系统自带的 `file` 命令;`mksquashfs` 与 `desktop-file-validate`
+由 appimagetool 自带(见下)。
+
+## AppDir 布局
+
+```
+AppDir/
+├── AppRun                     # 入口:按自身位置定位 usr/bin/VelaShell 并 exec
+├── VelaShell.desktop          # 由 src/VelaShell/VelaShell.desktop 改写 Exec 生成
+├── velashell.png              # Icon= 指向的同名图标,必须在根目录
+├── .DirIcon -> velashell.png  # 桌面集成读缩略图的固定入口
+└── usr/
+    ├── bin/                   # tar.gz 那份扁平发布目录,原样整个搬进来
+    └── share/applications/    # 桌面集成安装时读的那份 .desktop
+```
+
+`usr/bin` 与 tar.gz 的布局逐字节一致,所以应用侧对 `AppContext.BaseDirectory` 的一切假设
+—— `plugins/` 目录、随包的 `VelaShell.PluginHost` —— 在 AppImage 里照旧成立。
+
+## 三个不能想当然的选择
+
+**appimagetool 取 `AppImage/appimagetool` 的 1.9.1,不是 AppImageKit 13。**
+AppImageKit 仓库已归档,上游把 13 的发布资产统一改名成了 `obsolete-*`,
+网上到处能搜到的 `.../AppImageKit/releases/download/13/appimagetool-x86_64.AppImage` 现在是 404。
+
+**runtime 必须是 type2-runtime 的 continuous 版。** AppImageKit 时代的旧 runtime 依赖
+`libfuse.so.2`,而 Ubuntu 22.04 起默认不装 libfuse2,用户双击只会得到一句
+`dlopen(): error loading libfuse.so.2`。新 runtime 静态链接 fuse3,裸系统上也能跑。
+脚本用 `--runtime-file` 显式下载指定 —— 不给这个参数 appimagetool 也会自己去下同一个文件,
+但显式下载才有重试、才看得见失败原因。
+
+**appimagetool 解包后再跑,且跑的是 `squashfs-root/AppRun`。** 它自己也是个 AppImage,
+`--appimage-extract` 这条路不碰 FUSE(既不要 `/dev/fuse` 也不要 libfuse2),在容器和精简
+runner 上行为确定;而必须走 AppRun 而不是里面的 `usr/bin/appimagetool`,是因为前者会把自带的
+`mksquashfs` 与 `desktop-file-validate` 加进 `PATH`,后者找不到它们会直接 die。
+
+## 自更新
+
+AppImage **不进 `latest.json`**,理由和 dmg 一样、但更硬:
+
+* 应用内更新器是"原地换版"(按相对路径把新版解进应用目录),只认识 zip/tar.gz;
+* AppImage 运行时应用目录是**只读的 squashfs 挂载点**,想换也换不动。
+
+`UpdateService.CanSelfUpdate` 会通过写探测发现这一点(`UpdateApplier.IsApplicationDirectoryWritable`),
+自动把关于页降级成"发现新版本,请手动下载",不会走到必然失败的换版流程 —— 无需为 AppImage 加任何判定。

--- a/build/linux-packages/Build-Deb.sh
+++ b/build/linux-packages/Build-Deb.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# 把一份已发布的 Linux self-contained 目录打成 .deb(Debian / Ubuntu 系)。
+#
+#   用法:build/linux-packages/Build-Deb.sh <发布目录> <RID> <版本号> <输出目录>
+#   例:  build/linux-packages/Build-Deb.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+#
+# 安装树由 Stage-Payload.sh 铺(与 rpm 共用),这里只负责套上 DEBIAN/control 再压包。
+# 需要 dpkg-deb(Debian 系自带;别的发行版 apt/dnf 装 dpkg 即可)。
+#
+# **不进 latest.json**:装进 /opt/velashell 后目录归 root,应用内更新器的写探测必然失败,
+# 关于页会自动降级成"发现新版本,请手动下载" —— 系统包本就该由包管理器更新,这是对的行为。
+set -euo pipefail
+
+publish_dir=${1:?用法: Build-Deb.sh <发布目录> <RID> <版本号> <输出目录>}
+rid=${2:?缺少 RID}
+version=${3:?缺少版本号}
+out_dir=${4:?缺少输出目录}
+
+# Debian 的架构名,不是 .NET 的 RID,也不是 uname -m。
+case "$rid" in
+  linux-x64) arch=amd64 ;;
+  linux-arm64) arch=arm64 ;;
+  *)
+    echo "Build-Deb: 不支持的 RID '$rid'(只接受 linux-x64 / linux-arm64)" >&2
+    exit 1
+    ;;
+esac
+
+command -v dpkg-deb >/dev/null 2>&1 || { echo "Build-Deb: 缺少 dpkg-deb" >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+publish_dir="$(cd "$publish_dir" && pwd)"
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# 预发布版号里的第一个 '-' 必须换成 '~'。Debian 把 '-' 之后的部分当作 debian_revision,
+# 于是 1.2.0-preview.1 会被判定为**比** 1.2.0 更新(有 revision > 无 revision),预发布反而盖过正式版;
+# 而 '~' 排在"空"之前,1.2.0~preview.1 < 1.2.0,才是想要的顺序。rpm 侧同理。
+# 反斜杠不能省:替换串会先做波浪号展开,写成 ${version/-/~} 的话 ~ 会变成 $HOME。
+pkgversion="${version/-/\~}"
+
+root="$work/root"
+"$script_dir/Stage-Payload.sh" "$publish_dir" "$root"
+
+installed_size="$(du -sk "$root" | cut -f1)"
+
+mkdir -p "$root/DEBIAN"
+# 依赖分两档,刻意的:
+#   Depends   —— 只放十几年没改过名、各版本都在的那些。写错一个包名就是"装不上",
+#                比"装上了但缺库"更糟。
+#   Recommends —— ICU 与 OpenSSL 放这里。.NET 确实要它们(未开 InvariantGlobalization),
+#                但 Debian/Ubuntu 每换一代就改一次 soname 包名(libicu67→70→71→72→74→76,
+#                libssl1.1→libssl3→libssl3t64),写成硬依赖必然在某个发行版上把包卡死。
+#                apt 默认会装 Recommends,直接 dpkg -i 的用户则至少不会被拦下。
+#                **新发行版出了新的 libicuNN / libsslN,补在这一行。**
+cat > "$root/DEBIAN/control" <<CONTROL
+Package: velashell
+Version: $pkgversion
+Architecture: $arch
+Maintainer: joesdu <dannymaximo369@gmail.com>
+Installed-Size: $installed_size
+Section: net
+Priority: optional
+Homepage: https://github.com/joesdu/VelaShell
+Depends: libc6, libgcc-s1 | libgcc1, libstdc++6, zlib1g, libfontconfig1, libx11-6, libice6, libsm6
+Recommends: libicu76 | libicu74 | libicu72 | libicu71 | libicu70 | libicu67, libssl3t64 | libssl3 | libssl1.1
+Description: Cross-platform SSH terminal client
+ VelaShell is a self-drawn, plugin-based SSH terminal client built on Avalonia:
+ tabbed sessions, split panes with drag-and-drop docking, SFTP, port forwarding
+ and an extensible plugin system.
+ .
+ This package bundles the .NET runtime, so no system-wide .NET is required.
+CONTROL
+
+output="$out_dir/velashell_${pkgversion}_${arch}.deb"
+# --root-owner-group:产物里的文件一律记为 root:root。不加的话记的是打包机上的 uid/gid
+# (CI runner 是 1001),装到用户机器上就成了一堆归属错乱的文件。
+# 压缩用默认的 xz:zstd 更快,但只有较新的 dpkg 读得动,对"下载即装"的分发资产不划算。
+dpkg-deb --root-owner-group --build "$root" "$output"
+echo "Build-Deb: 已生成 $output"

--- a/build/linux-packages/Build-Rpm.sh
+++ b/build/linux-packages/Build-Rpm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 把一份已发布的 Linux self-contained 目录打成 .rpm(Fedora / RHEL / openSUSE 系)。
+#
+#   用法:build/linux-packages/Build-Rpm.sh <发布目录> <RID> <版本号> <输出目录>
+#   例:  build/linux-packages/Build-Rpm.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+#
+# 安装树由 Stage-Payload.sh 铺(与 deb 共用),这里只负责填 spec 再交给 rpmbuild。
+# 需要 rpmbuild(Debian 系 apt install rpm 即可,不必真的换到 rpm 发行版上)。
+#
+# 交叉打包没问题:--target 只是把包的架构标记改掉,而我们本来就不编译任何东西,
+# x64 机器上照样产出 aarch64 的 rpm。
+#
+# **不进 latest.json**:装进 /opt/velashell 后目录归 root,应用内更新器的写探测必然失败,
+# 关于页会自动降级成"发现新版本,请手动下载" —— 系统包本就该由包管理器更新,这是对的行为。
+set -euo pipefail
+
+publish_dir=${1:?用法: Build-Rpm.sh <发布目录> <RID> <版本号> <输出目录>}
+rid=${2:?缺少 RID}
+version=${3:?缺少版本号}
+out_dir=${4:?缺少输出目录}
+
+# rpm 的架构名(= uname -m),不是 .NET 的 RID,也不是 Debian 那套 amd64/arm64。
+case "$rid" in
+  linux-x64) arch=x86_64 ;;
+  linux-arm64) arch=aarch64 ;;
+  *)
+    echo "Build-Rpm: 不支持的 RID '$rid'(只接受 linux-x64 / linux-arm64)" >&2
+    exit 1
+    ;;
+esac
+
+command -v rpmbuild >/dev/null 2>&1 || { echo "Build-Rpm: 缺少 rpmbuild(apt install rpm)" >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+publish_dir="$(cd "$publish_dir" && pwd)"
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# rpm 的 Version 字段里根本不允许出现 '-'(那是 Version-Release 的分隔符),预发布号必须换成 '~';
+# '~' 同时带来正确的排序:1.2.0~preview.1 < 1.2.0。与 deb 侧的处理一致。
+# 反斜杠不能省:替换串会先做波浪号展开,写成 ${version/-/~} 的话 ~ 会变成 $HOME。
+pkgversion="${version/-/\~}"
+
+"$script_dir/Stage-Payload.sh" "$publish_dir" "$work/root"
+
+spec="$work/velashell.spec"
+sed "s|@VERSION@|$pkgversion|g" "$script_dir/velashell.spec.in" > "$spec"
+
+topdir="$work/rpmbuild"
+mkdir -p "$topdir"
+rpmbuild -bb \
+  --target "$arch" \
+  --define "_topdir $topdir" \
+  --define "_sourcedir $work" \
+  --quiet \
+  "$spec"
+
+built="$topdir/RPMS/$arch/velashell-$pkgversion-1.$arch.rpm"
+[ -f "$built" ] || { echo "Build-Rpm: 没找到预期的产物 $built" >&2; exit 1; }
+mv "$built" "$out_dir/"
+echo "Build-Rpm: 已生成 $out_dir/$(basename "$built")"

--- a/build/linux-packages/README.md
+++ b/build/linux-packages/README.md
@@ -1,0 +1,92 @@
+# Linux 发行版原生包(deb / rpm)
+
+给"装进系统"的那批用户:`apt install ./velashell_*.deb` 或 `dnf install ./velashell-*.rpm`,
+装完出现在应用菜单里,终端里敲 `velashell` 也能起。
+免安装的单文件 AppImage 是另一条路,在 [`build/appimage/`](../appimage/README.md) ——
+它和这两个包共享不了任何东西(布局不同、受众不同),所以刻意分开放。
+
+## 打包
+
+```bash
+# 先按发布流水线的方式产出 self-contained 目录
+dotnet publish src/VelaShell/VelaShell.csproj -c Release -r linux-x64 \
+  -o out/VelaShell-1.2.3-linux-x64 -p:Version=1.2.3 -p:SelfContained=true
+# 再分别套壳
+build/linux-packages/Build-Deb.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+build/linux-packages/Build-Rpm.sh out/VelaShell-1.2.3-linux-x64 linux-x64 1.2.3 dist
+```
+
+需要 `dpkg-deb`(Debian 系自带)、`rpmbuild`(`apt install rpm`)与 `imagemagick`。
+CI 里由 `release.yml` 的 `build-linux` 任务自动跑,两个 RID 各出一份 deb 与一份 rpm。
+
+**只需要 x64 runner。** 这两步都不编译任何东西,只是把已有产物换个外壳:
+deb 的架构写在 `control` 里,rpm 的架构由 `rpmbuild --target` 指定,x64 上照样产出 arm64/aarch64 包。
+
+## 安装布局
+
+`Stage-Payload.sh` 铺的这棵树 deb 与 rpm **完全共用**,两边只有外壳不同:
+
+| 路径 | 内容 |
+|---|---|
+| `/opt/velashell/` | 整个自包含发布目录(与 tar.gz 内容一致) |
+| `/usr/bin/velashell` | → `/opt/velashell/VelaShell` 的软链 |
+| `/usr/share/applications/velashell.desktop` | 菜单项 |
+| `/usr/share/icons/hicolor/<N>x<N>/apps/velashell.png` | 7 档尺寸的图标 |
+| `/usr/share/doc/velashell/copyright` | AGPL 全文 |
+
+装进 `/opt` 是 FHS 给"发行版仓库之外的整包软件"留的位置,而
+`src/VelaShell/VelaShell.desktop` 的 `Exec` 从一开始写的就是 `/opt/velashell/VelaShell` ——
+那份 .desktop 正是为这条路径准备的,这里原样装进去(AppImage 才需要改写 `Exec`)。
+
+**图标必须现降采样。** 仓库里只有一张 1024×1024 的源图,而 hicolor 主题的 `index.theme`
+根本没有 1024 这一档,直接装进去等于没装(图标查找会跳过未声明的尺寸)。
+
+## 命名
+
+刻意跟随各自发行版的惯例,而不是本仓库其它资产的 `VelaShell-<版本>-<RID>`:
+
+```
+velashell_1.2.3_amd64.deb        velashell-1.2.3-1.x86_64.rpm
+velashell_1.2.3_arm64.deb        velashell-1.2.3-1.aarch64.rpm
+```
+
+这两个文件名是给 `dpkg`/`rpm` 和各类仓库工具解析的(包名、版本、架构都从里面读),
+改成自定义样式会让它们认不出来。
+
+**预发布版号里的第一个 `-` 会换成 `~`**,`1.2.0-preview.1` → `1.2.0~preview.1`。两个理由:
+
+* rpm 的 `Version` 字段里 `-` 是非法字符(那是 `Version-Release` 的分隔符);
+* deb 会把 `-` 之后的部分当成 `debian_revision`,于是 `1.2.0-preview.1` 被判定为**比**
+  `1.2.0` 更新 —— 预发布反而盖过正式版。`~` 排在"空"之前,顺序才对。
+
+脚本里写的是 `${version/-/\~}`,**反斜杠不能省**:替换串会先做波浪号展开,裸 `~` 会变成 `$HOME`。
+
+## 依赖
+
+分档是刻意的,底线是"宁可装上之后缺库报错,也不要根本装不上":
+
+* **deb `Depends`** 只放十几年没改过名、各版本都在的那些(`libc6`、`libstdc++6`、
+  `libfontconfig1`、`libx11-6` …)。写错一个包名就是装不上。
+* **deb `Recommends`** 放 ICU 与 OpenSSL。.NET 确实要它们(没开 `InvariantGlobalization`),
+  但 Debian/Ubuntu 每换一代就改一次 soname 包名(`libicu67`→`70`→`71`→`72`→`74`→`76`,
+  `libssl1.1`→`libssl3`→`libssl3t64`),写成硬依赖必然在某个发行版上把包卡死。
+  apt 默认会装 Recommends,直接 `dpkg -i` 的用户至少不会被拦下。
+  **新发行版出了新的 `libicuNN` / `libsslN`,补进 `Build-Deb.sh` 的那一行。**
+* **rpm 干脆不写 `Requires`**,并且 `AutoReqProv: no`。rpm 系各发行版的包名彼此不同
+  (Fedora 的 `libX11` 在 openSUSE 叫 `libX11-6`),写死任何一套都会在另一套上炸;
+  需要什么库改在 `%description` 里说明。
+
+`AutoReqProv: no` 还有个更硬的理由:开着的话 rpmbuild 会去扫 `/opt/velashell` 里几百个
+随运行时带的 `.so`,把它们统统登记成本包的 `Provides`(别的包可能就解析到我们的私有副本上),
+同时按精确 soname 生成一堆装不上的 `Requires`。
+
+同理,spec 里把 rpm 默认的构建后处理全关了(`__os_install_post`、`debug_package`、
+`_build_id_links`):我们打的是**已经编译好的**产物,让它去 strip 二进制、抽 debuginfo,
+轻则白费时间重则弄坏产物。
+
+## 自更新
+
+deb / rpm **不进 `latest.json`**,和 AppImage、dmg 一样:装进 `/opt/velashell` 后目录归 root,
+`UpdateApplier.IsApplicationDirectoryWritable()` 的写探测必然失败,
+`UpdateService.CanSelfUpdate` 随之为 false,关于页自动降级成"发现新版本,请手动下载"。
+系统包本就该由包管理器更新 —— 这是对的行为,不需要为它们加任何判定。

--- a/build/linux-packages/Stage-Payload.sh
+++ b/build/linux-packages/Stage-Payload.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# 把一份已发布的 Linux self-contained 目录铺成 deb / rpm 共用的 FHS 安装树。
+#
+#   用法:build/linux-packages/Stage-Payload.sh <发布目录> <目标根目录>
+#
+# deb 与 rpm 的差别只在"外壳"(控制信息 + 打包命令),装进系统的文件是**逐字节相同**的一棵树,
+# 所以这一步抽出来共用 —— 两边各铺一遍迟早会长歪。
+#
+#   /opt/velashell/                     整个自包含发布目录(与 tar.gz 内容一致)
+#   /usr/bin/velashell                  → /opt/velashell/VelaShell 的软链,让命令行直接可用
+#   /usr/share/applications/velashell.desktop
+#   /usr/share/icons/hicolor/<N>x<N>/apps/velashell.png
+#   /usr/share/doc/velashell/copyright  AGPL 全文(Debian 策略要求,rpm 侧一并带上)
+#
+# 装进 /opt 而不是 /usr/lib/velashell:这是 FHS 给"发行版仓库之外的整包软件"留的位置,
+# 而 src/VelaShell/VelaShell.desktop 里的 Exec 从一开始写的就是 /opt/velashell/VelaShell ——
+# 那份 .desktop 正是为这条路径准备的,这里原样装进去,不像 AppImage 那样需要改写 Exec。
+set -euo pipefail
+
+publish_dir=${1:?用法: Stage-Payload.sh <发布目录> <目标根目录>}
+root=${2:?缺少目标根目录}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+# ImageMagick 7 是 magick,6 才是 convert;两个都没有就直说,别让包里少个图标还打得出来。
+if command -v magick >/dev/null 2>&1; then
+  im=(magick)
+elif command -v convert >/dev/null 2>&1; then
+  im=(convert)
+else
+  echo "Stage-Payload: 需要 ImageMagick 生成各尺寸图标(apt install imagemagick)" >&2
+  exit 1
+fi
+
+mkdir -p "$root/opt/velashell" "$root/usr/bin" \
+  "$root/usr/share/applications" "$root/usr/share/doc/velashell"
+cp -a "$publish_dir/." "$root/opt/velashell/"
+# 两个可执行体:主程序,以及隔离插件的宿主进程(由主程序按需拉起)。
+chmod +x "$root/opt/velashell/VelaShell" "$root/opt/velashell/VelaShell.PluginHost"
+
+# 绝对路径的软链:deb 与 rpm 都原样保留软链,装好后 `velashell` 直接可在终端里敲。
+ln -sfn /opt/velashell/VelaShell "$root/usr/bin/velashell"
+
+# .desktop 原样装(Exec 已是 /opt/velashell/VelaShell);文件名按包名小写,与 Icon=velashell 对应。
+cp "$repo_root/src/VelaShell/VelaShell.desktop" "$root/usr/share/applications/velashell.desktop"
+
+# 图标只有一张 1024×1024 的源图,而 hicolor 主题的 index.theme 里根本没有 1024 这一档 ——
+# 直接装进去等于没装(图标查找会跳过未声明的尺寸),必须降采样成标准档位。
+for size in 16 32 48 64 128 256 512; do
+  dir="$root/usr/share/icons/hicolor/${size}x${size}/apps"
+  mkdir -p "$dir"
+  "${im[@]}" "$repo_root/src/VelaShell/Assets/velashell.png" \
+    -resize "${size}x${size}" "$dir/velashell.png"
+done
+
+cp "$repo_root/LICENSE" "$root/usr/share/doc/velashell/copyright"
+
+# 目录 755、普通文件 644,可执行位只留给真正要跑的那些 —— dpkg-deb --root-owner-group 只管
+# 属主不管权限位,而 dotnet publish 出来的产物权限并不统一(有 600 的,装进系统就成了 root 专属)。
+find "$root" -type d -exec chmod 0755 {} +
+find "$root" -type f -exec chmod 0644 {} +
+chmod 0755 "$root/opt/velashell/VelaShell" "$root/opt/velashell/VelaShell.PluginHost"
+# createdump 之类随运行时带的辅助可执行体也要保住可执行位。
+find "$root/opt/velashell" -maxdepth 1 -type f -name 'createdump' -exec chmod 0755 {} +

--- a/build/linux-packages/velashell.spec.in
+++ b/build/linux-packages/velashell.spec.in
@@ -1,0 +1,55 @@
+# rpm 打包描述。由 Build-Rpm.sh 填掉 @VERSION@ 后交给 rpmbuild,不要直接 rpmbuild 这个 .in。
+#
+# 这里打的是**已经编译好的自包含产物**,不是从源码构建,所以把 rpm 默认的那套"构建后处理"
+# 全关掉,否则它会去 strip 我们的二进制、抽 debuginfo、改文件属性,轻则白费时间重则弄坏产物。
+%global __os_install_post %{nil}
+%global debug_package     %{nil}
+%define _build_id_links   none
+
+Name:           velashell
+Version:        @VERSION@
+Release:        1
+Summary:        Cross-platform SSH terminal client
+License:        AGPL-3.0-or-later
+URL:            https://github.com/joesdu/VelaShell
+
+# 必须关掉自动依赖分析:开着的话 rpmbuild 会去扫 /opt/velashell 里几百个随运行时带的 .so,
+# 把它们统统登记成本包的 Provides(于是别的包可能解析到我们的私有副本上),
+# 同时按精确 soname 生成一堆 Requires(libssl.so.3 之类),换个发行版就装不上。
+# 需要的系统库改在 %description 里说明:少数几个 dlopen 依赖装不上不该拦住整个安装,
+# 而 rpm 系各发行版的包名各不相同(Fedora 的 libX11 在 openSUSE 叫 libX11-6),
+# 写死任何一套都会在另一套上炸。
+AutoReqProv:    no
+
+%description
+VelaShell is a self-drawn, plugin-based SSH terminal client built on Avalonia:
+tabbed sessions, split panes with drag-and-drop docking, SFTP, port forwarding
+and an extensible plugin system.
+
+This package bundles the .NET runtime, so no system-wide .NET is required.
+It does rely on a few libraries that virtually every desktop install already
+has: glibc, libstdc++, zlib, fontconfig, libX11/libICE/libSM, OpenSSL and ICU.
+
+%prep
+# 无源码可解压 —— 产物是外面 dotnet publish 好之后铺进 _sourcedir/root 的。
+
+%build
+# 无编译步骤,同上。
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a %{_sourcedir}/root/. %{buildroot}/
+
+%files
+# 显式 root:root:rpmbuild 记的是 buildroot 里文件的实际属主,而 CI 上是以普通用户跑的。
+# 权限位保持 Stage-Payload.sh 铺好的样子(第一个 '-')。
+%defattr(-,root,root,-)
+/opt/velashell
+/usr/bin/velashell
+/usr/share/applications/velashell.desktop
+/usr/share/icons/hicolor/*/apps/velashell.png
+/usr/share/doc/velashell
+
+%changelog
+# 变更记录在 GitHub Release 里,不在这儿维护第二份。


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

新增 AppImage、deb、rpm 自动构建与发布，完善 CI 流程，统一产物分发与文档说明。打包脚本支持多架构与预发布处理，遵循 FHS 规范，自动生成菜单项和软链。gitattributes 保证 LF 行尾，避免 shebang 失效。应用内更新器仅识别 tar.gz，系统包交由包管理器或手动更新。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #346

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [x] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
