### PR TITLE
会话范围授权:IM 群与外部 agent 只能碰授权范围内的机器

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
@@ -76,6 +76,24 @@ public sealed class AgentToolbox(IPluginContext context)
     /// <summary>用户在"配置工具"里取消勾选的内置工具名(不暴露给模型)。</summary>
     public IReadOnlySet<string> DisabledTools { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// 这次调用能碰哪些机器。<b><see langword="null" /> = 不限制</b>。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// null 是聊天面板那条路的取值,而且必须一直是:人就坐在屏幕前,每个危险操作还要点一次
+    /// 审批卡,再叠一层范围只会把用户自己拦住 —— 一套把作者也拦住的权限设计,
+    /// 结局是被整个关掉。收紧只发生在<b>被委托的那些身份</b>上:IM 里的群,以及外部 agent。
+    /// </para>
+    /// <para>
+    /// <b>它挡的是九个收 <c>session_id</c> 的工具,不只是"默认目标"。</b>
+    /// 把范围做成"绑定哪台机器"是拦不住的:每个工具都能显式传 id,传了就绕开默认值。
+    /// 所以闸设在 <see cref="ResolveAsync" />(单目标)、<see cref="RunOnSessionsAsync" />(多目标)
+    /// 与两个列表工具上,而不是设在提示词里。
+    /// </para>
+    /// </remarks>
+    public ISessionScope? Scope { get; set; }
+
     /// <summary>网络检索设置(SearXNG 地址、私网闸、截断上限)。由聊天面板每轮推过来。</summary>
     public WebSearchOptions WebSearch { get; set; } = new();
 
@@ -232,10 +250,12 @@ public sealed class AgentToolbox(IPluginContext context)
 
     private async Task<string> ListSessionsAsync(CancellationToken cancellationToken)
     {
-        IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<SessionInfo> sessions =
+            await InScopeAsync(await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         if (sessions.Count == 0)
         {
-            return "No sessions. " + NoSession;
+            return Scope is null ? "No sessions. " + NoSession : OutOfScopeEmpty;
         }
         // 与 ResolveAsync 同一套优先级:界面选中的 > 自己开出来的。标错默认目标比不标更糟。
         string? selected = SessionIdProvider?.Invoke() ?? _openedSessionId;
@@ -266,10 +286,16 @@ public sealed class AgentToolbox(IPluginContext context)
     /// </remarks>
     private async Task<string> ListSavedSessionsAsync(CancellationToken cancellationToken)
     {
-        IReadOnlyList<SavedSessionInfo> saved = await context.Sessions.ListSavedAsync(cancellationToken).ConfigureAwait(false);
-        if (saved.Count == 0)
+        IReadOnlyList<SavedSessionInfo> all = await context.Sessions.ListSavedAsync(cancellationToken).ConfigureAwait(false);
+        if (all.Count == 0)
         {
             return "The user has no saved connection configurations in VelaShell.";
+        }
+        // 范围外的配置连名字都不该出现:分组名本身就在泄露"这台机器归谁管"
+        IReadOnlyList<SavedSessionInfo> saved = await InScopeAsync(all, cancellationToken).ConfigureAwait(false);
+        if (saved.Count == 0)
+        {
+            return OutOfScopeEmpty;
         }
         IReadOnlyList<SessionInfo> live = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
         var sb = new StringBuilder();
@@ -531,6 +557,12 @@ public sealed class AgentToolbox(IPluginContext context)
             {
                 return $"No such session: {raw}. Call list_sessions to see the available ids.";
             }
+            // 单目标的闸在 ResolveAsync 上,而这个工具收的是一个 id 数组、根本不经过那里 ——
+            // 批量执行是范围最容易漏掉的一处:漏了就等于给了整批的后门。
+            if (!await AllowedAsync(info, cancellationToken).ConfigureAwait(false))
+            {
+                return OutOfScope;
+            }
             targets.Add(info);
         }
         // 审批摘要里把目标主机全列出来:批量执行最该让用户看清的就是"打到哪几台"
@@ -616,6 +648,11 @@ public sealed class AgentToolbox(IPluginContext context)
         if (saved.FirstOrDefault(s => string.Equals(s.SavedSessionId, wanted, StringComparison.Ordinal)) is not { } target)
         {
             return $"No such saved session: {wanted}. Call list_saved_sessions to see the available ids.";
+        }
+        // 范围要在审批之前挡:越界的请求根本不该走到"惊动用户点头"那一步
+        if (Scope is { } scope && !await scope.AllowsSavedAsync(target, cancellationToken).ConfigureAwait(false))
+        {
+            return OutOfScope;
         }
         // 审批卡上要看得见连的是哪一台,以及模型给宿主的那句理由 ——
         // 用户在这里点头之后,同一句话还会出现在宿主的确认框上,两处对得上才不显得可疑。
@@ -1104,6 +1141,25 @@ public sealed class AgentToolbox(IPluginContext context)
             : NoSessionMessage;
 
     /// <summary>
+    /// 目标在 <see cref="Scope" /> 之外时给模型的话。
+    /// </summary>
+    /// <remarks>
+    /// <b>刻意不说范围外有什么。</b>一句"这台不在范围内,范围内的是 A、B、C"会把拒绝消息本身
+    /// 变成一个枚举接口 —— 试一个 id 就能问出一份清单。说清"越界了、别换个 id 再试、
+    /// 去告诉用户",够模型正确收场,也够用户知道该去哪儿改。
+    /// </remarks>
+    private const string OutOfScope =
+        "That machine is outside the scope this conversation is authorized for. "
+        + "Do NOT retry with a different session id. Tell the user which machine you needed and that "
+        + "the authorization for this conversation would have to be widened in VelaShell's collaboration settings.";
+
+    /// <summary>范围内一台都没有时的说法(与"用户一台都没连"要分开,否则用户会去连一台然后发现还是不行)。</summary>
+    private const string OutOfScopeEmpty =
+        "No machines are within the scope this conversation is authorized for. "
+        + "Tell the user: the authorization for this conversation would have to be widened in "
+        + "VelaShell's collaboration settings.";
+
+    /// <summary>
     /// 解出这次调用该落在哪个会话上:显式传了就用那个(先核实存在),否则用界面上选中的那个,
     /// 再没有就用本轮 <c>open_session</c> 自己开出来的那条。
     /// </summary>
@@ -1114,6 +1170,11 @@ public sealed class AgentToolbox(IPluginContext context)
     /// <para>
     /// 兜底那一档的位置是刻意的:排在选中项<b>之后</b>。理由见 <see cref="_openedSessionId" />。
     /// </para>
+    /// <para>
+    /// <b>三条路都要过 <see cref="Scope" /> 那一关</b>,包括默认目标 —— 不只是显式传进来的 id。
+    /// 默认目标来自 IM 里的 <c>/use</c> 或 MCP 的 <c>use_session</c>,它们各自也在挡范围;
+    /// 但用户可能在授权之后把那台机器移出了分组,而绑定还留着。闸口只有一个才守得住。
+    /// </para>
     /// </remarks>
     private async Task<(string? Id, string? Error)> ResolveAsync(string? sessionId, CancellationToken cancellationToken)
     {
@@ -1121,12 +1182,21 @@ public sealed class AgentToolbox(IPluginContext context)
         {
             string wanted = sessionId.Trim();
             SessionInfo? info = await context.Sessions.GetAsync(wanted, cancellationToken).ConfigureAwait(false);
-            return info is null
-                ? (null, $"No such session: {wanted}. Call list_sessions to see the available ids.")
-                : (info.SessionId, null);
+            if (info is null)
+            {
+                return (null, $"No such session: {wanted}. Call list_sessions to see the available ids.");
+            }
+            return await AllowedAsync(info, cancellationToken).ConfigureAwait(false)
+                ? (info.SessionId, null)
+                : (null, OutOfScope);
         }
         if (SessionIdProvider?.Invoke() is { } current)
         {
+            SessionInfo? bound = await context.Sessions.GetAsync(current, cancellationToken).ConfigureAwait(false);
+            if (bound is not null && !await AllowedAsync(bound, cancellationToken).ConfigureAwait(false))
+            {
+                return (null, OutOfScope);
+            }
             return (current, null);
         }
         // 自己开的那条:用户手动关掉之后就不该再往它上面发东西,所以每次都核实一下还在不在。
@@ -1134,11 +1204,55 @@ public sealed class AgentToolbox(IPluginContext context)
         {
             if (await context.Sessions.GetAsync(opened, cancellationToken).ConfigureAwait(false) is { } live)
             {
-                return (live.SessionId, null);
+                return await AllowedAsync(live, cancellationToken).ConfigureAwait(false)
+                    ? (live.SessionId, null)
+                    : (null, OutOfScope);
             }
             _openedSessionId = null;
         }
         return (null, NoSession);
+    }
+
+    /// <summary>过 <see cref="Scope" /> 那一关;没有范围时一律放行。</summary>
+    private Task<bool> AllowedAsync(SessionInfo session, CancellationToken cancellationToken)
+        => Scope is { } scope ? scope.AllowsLiveAsync(session, cancellationToken) : Task.FromResult(true);
+
+    /// <summary>按范围筛活会话(没有范围时原样返回,不多跑一趟)。</summary>
+    private async Task<IReadOnlyList<SessionInfo>> InScopeAsync(
+        IReadOnlyList<SessionInfo> sessions, CancellationToken cancellationToken)
+    {
+        if (Scope is not { } scope)
+        {
+            return sessions;
+        }
+        var kept = new List<SessionInfo>();
+        foreach (SessionInfo session in sessions)
+        {
+            if (await scope.AllowsLiveAsync(session, cancellationToken).ConfigureAwait(false))
+            {
+                kept.Add(session);
+            }
+        }
+        return kept;
+    }
+
+    /// <summary>按范围筛已保存配置。</summary>
+    private async Task<IReadOnlyList<SavedSessionInfo>> InScopeAsync(
+        IReadOnlyList<SavedSessionInfo> saved, CancellationToken cancellationToken)
+    {
+        if (Scope is not { } scope)
+        {
+            return saved;
+        }
+        var kept = new List<SavedSessionInfo>();
+        foreach (SavedSessionInfo candidate in saved)
+        {
+            if (await scope.AllowsSavedAsync(candidate, cancellationToken).ConfigureAwait(false))
+            {
+                kept.Add(candidate);
+            }
+        }
+        return kept;
     }
 
     private static string Describe(RemoteFileEntry entry) => JsonSerializer.Serialize(new

--- a/plugins/VelaShell.Plugin.Ai/Agent/SessionScope.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/SessionScope.cs
@@ -1,0 +1,223 @@
+using System.Text.Json.Serialization;
+using VelaShell.PluginSdk;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Agent;
+
+/// <summary>范围的形状。</summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ScopeKind
+{
+    /// <summary>
+    /// 不限范围。<b>这是缺省值,而且是刻意的</b> ——
+    /// 反序列化一份没有这个字段的旧配置会落在这里,于是升级不改变任何人当前的行为。
+    /// </summary>
+    All,
+
+    /// <summary>只限于 <see cref="SessionScope.Groups" /> 与 <see cref="SessionScope.SavedIds" /> 的并集。</summary>
+    Limited
+}
+
+/// <summary>
+/// 一份授权能碰哪些机器。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>范围是"这个房间"的属性,不是"这个人"的属性。</b>群要收紧是因为群里的人数会在你不知情时
+/// 增长;单聊、聊天面板、本机 MCP 都不存在这个问题,所以它们默认 <see cref="ScopeKind.All" />。
+/// 一套把作者自己也拦住的权限设计,结局是被整个关掉,回到零防护。
+/// </para>
+/// <para>
+/// <b><see cref="ScopeKind.Limited" /> 且两个列表都空 = 一台都不给。</b>空列表最自然的读法是
+/// "什么都没选",而权限的默认值一旦读错方向,错的方向是放开。要不限范围就明写
+/// <see cref="ScopeKind.All" /> —— 它不是一个"放行全部"的过滤器,而是<b>压根没有过滤器</b>
+/// (见 <see cref="Resolve" />)。
+/// </para>
+/// </remarks>
+public sealed class SessionScope
+{
+    /// <summary>形状。</summary>
+    public ScopeKind Kind { get; set; } = ScopeKind.All;
+
+    /// <summary>允许的分组名(会话树上那些分组的名字,大小写不敏感)。</summary>
+    public List<string> Groups { get; set; } = [];
+
+    /// <summary>额外单独放行的已保存会话 id(<c>SavedSessionInfo.SavedSessionId</c>)。</summary>
+    public List<string> SavedIds { get; set; } = [];
+
+    /// <summary>不限范围?</summary>
+    [JsonIgnore]
+    public bool IsUnrestricted => Kind == ScopeKind.All;
+
+    /// <summary>
+    /// 把这份配置变成运行期的闸门。<b>不限范围时返回 <see langword="null" /></b> ——
+    /// 于是"全部"与"没有范围这回事"走的是同一条代码路径,不存在一个可能写错的放行分支。
+    /// </summary>
+    public ISessionScope? Resolve(IPluginContext context)
+        => IsUnrestricted ? null : new SavedSessionScope(context, this);
+
+    /// <summary>拷一份(设置页编辑时不该改到正在生效的那一份)。</summary>
+    public SessionScope Clone() => new() { Kind = Kind, Groups = [.. Groups], SavedIds = [.. SavedIds] };
+}
+
+/// <summary>
+/// 运行期的会话闸门:一台机器在不在这次授权的范围里。
+/// </summary>
+/// <remarks>
+/// <b>它是工具箱上的一个钩子,不是提示词里的一句话。</b>写进系统提示的"你只能碰生产组"
+/// 是一条建议,模型可以忽略、可以被用户的下一句话劝服;写在这里的是每次工具调用都要过的闸。
+/// </remarks>
+public interface ISessionScope
+{
+    /// <summary>这条活着的会话在范围内吗?</summary>
+    Task<bool> AllowsLiveAsync(SessionInfo session, CancellationToken cancellationToken);
+
+    /// <summary>这条已保存的配置在范围内吗?</summary>
+    Task<bool> AllowsSavedAsync(SavedSessionInfo saved, CancellationToken cancellationToken);
+
+    /// <summary>范围的一句人话描述(给 <c>/status</c> 用)。</summary>
+    string Describe();
+}
+
+/// <summary>
+/// 按"已保存的连接配置"判定范围:分组名 + 单独放行的配置 id。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>活会话怎么判。</b>会话本身不带分组(<c>SessionInfo</c> 只有主机、端口、用户名),
+/// 所以要先把它映射回一条已保存的配置,再看那条配置在不在范围里:
+/// 对上了且在范围内 → 放行;对上了但不在范围内 → 拒绝;
+/// <b>一条都对不上</b>(用户在终端里手敲 <c>ssh</c> 连出去的临时会话)→ <b>也拒绝</b>。
+/// </para>
+/// <para>
+/// 最后那一档是<b>失败关闭</b>,也是这套设计里最容易写反的一处:一条不在会话树里的机器,
+/// 恰恰是没人替它定过范围的那种,把它当成"不受管辖所以放行",等于给任何手敲的连接开了后门。
+/// 代价是受限的群碰不到临时会话 —— 这是对的,而你自己那条路本来就不受限
+/// (见 <see cref="SessionScope" />)。
+/// </para>
+/// <para>
+/// 已保存列表缓存几秒:一轮里工具会被调很多次,每次都去问宿主既慢又没必要;
+/// 而用户刚在会话树里挪了一台机器,几秒之内生效也够快了。
+/// </para>
+/// </remarks>
+public sealed class SavedSessionScope(IPluginContext context, SessionScope scope) : ISessionScope
+{
+    private static readonly TimeSpan CacheLife = TimeSpan.FromSeconds(5);
+
+    private readonly HashSet<string> _groups = new(scope.Groups, StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _savedIds = new(scope.SavedIds, StringComparer.Ordinal);
+    private readonly Lock _sync = new();
+    private IReadOnlyList<SavedSessionInfo>? _cached;
+    private DateTimeOffset _cachedAt;
+
+    /// <inheritdoc />
+    public async Task<bool> AllowsLiveAsync(SessionInfo session, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        IReadOnlyList<SavedSessionInfo> saved = await SavedAsync(cancellationToken).ConfigureAwait(false);
+        // 对不上任何一条已保存配置时循环自然走完 → false,即失败关闭(理由见类型注释)
+        return saved.Any(candidate => Matches(candidate, session) && Allows(candidate));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> AllowsSavedAsync(SavedSessionInfo saved, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(saved);
+        return Task.FromResult(Allows(saved));
+    }
+
+    /// <inheritdoc />
+    public string Describe()
+    {
+        List<string> parts = [];
+        if (scope.Groups.Count > 0)
+        {
+            parts.Add(string.Join(", ", scope.Groups));
+        }
+        if (_savedIds.Count > 0)
+        {
+            parts.Add($"+{_savedIds.Count}");
+        }
+        return parts.Count == 0 ? "—" : string.Join(" ", parts);
+    }
+
+    /// <summary>一条活会话与一条已保存配置是不是同一台机器。</summary>
+    /// <remarks>
+    /// 与 <c>AgentToolbox</c> 标注"这条配置已经连着了"用的是同一套规则:主机不分大小写、
+    /// 端口必须相等、已保存配置没填用户名(留到连接时再问)就不比用户名。
+    /// </remarks>
+    internal static bool Matches(SavedSessionInfo saved, SessionInfo session)
+        => string.Equals(saved.Host, session.Host, StringComparison.OrdinalIgnoreCase)
+           && saved.Port == session.Port
+           && (saved.Username.Length == 0 || string.Equals(saved.Username, session.Username, StringComparison.Ordinal));
+
+    private bool Allows(SavedSessionInfo saved)
+        => _savedIds.Contains(saved.SavedSessionId)
+           || (saved.Group is { Length: > 0 } group && _groups.Contains(group));
+
+    private async Task<IReadOnlyList<SavedSessionInfo>> SavedAsync(CancellationToken cancellationToken)
+    {
+        lock (_sync)
+        {
+            if (_cached is { } fresh && DateTimeOffset.UtcNow - _cachedAt < CacheLife)
+            {
+                return fresh;
+            }
+        }
+        IReadOnlyList<SavedSessionInfo> loaded =
+            await context.Sessions.ListSavedAsync(cancellationToken).ConfigureAwait(false);
+        lock (_sync)
+        {
+            _cached = loaded;
+            _cachedAt = DateTimeOffset.UtcNow;
+        }
+        return loaded;
+    }
+}
+
+/// <summary>
+/// 按 <c>user@host:port</c> 清单判定范围(对外 MCP 设置页上那个"允许操作的服务器")。
+/// </summary>
+/// <remarks>
+/// <b>这一条原来是句空话。</b>它只挡 <c>use_session</c>,而工具箱里九个工具都收可选的
+/// <c>session_id</c> —— 外部 agent 只要 <c>list_sessions</c> 拿到 id 直接传,清单形同虚设。
+/// 做成 <see cref="ISessionScope" /> 之后它作用在每一次工具调用上,界面上写的那句话才是真的。
+/// <para>
+/// 清单为空仍然是"允许全部",默认值不动:MCP 的边界是回环地址 + 令牌 + 只读挡位,
+/// 把用户自己机器上的 agent 一起收紧挡不住任何攻击者,只挡得住用户自己。
+/// </para>
+/// </remarks>
+public sealed class TargetListScope : ISessionScope
+{
+    private readonly List<string> _targets;
+
+    /// <param name="targets">每行一条 <c>user@host:port</c>;空行忽略。</param>
+    public TargetListScope(IEnumerable<string> targets)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+        _targets = [.. targets.Select(t => t.Trim()).Where(t => t.Length > 0)];
+    }
+
+    /// <summary>清单为空(= 不限范围,此时根本不该建这个对象)。</summary>
+    public bool IsEmpty => _targets.Count == 0;
+
+    /// <inheritdoc />
+    public Task<bool> AllowsLiveAsync(SessionInfo session, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        return Task.FromResult(Contains($"{session.Username}@{session.Host}:{session.Port}"));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> AllowsSavedAsync(SavedSessionInfo saved, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(saved);
+        return Task.FromResult(Contains($"{saved.Username}@{saved.Host}:{saved.Port}"));
+    }
+
+    /// <inheritdoc />
+    public string Describe() => _targets.Count == 0 ? "—" : string.Join(", ", _targets);
+
+    private bool Contains(string target)
+        => _targets.Any(t => string.Equals(t, target, StringComparison.OrdinalIgnoreCase));
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
@@ -41,6 +41,17 @@ public sealed class BridgeAgentRunner(
     /// 跑一轮。<paramref name="progress" /> 每拿到一批增量就被调一次(参数是<b>累计</b>文本),
     /// 由调用方决定是改同一条消息还是攒到最后再发。
     /// </summary>
+    /// <param name="conversation">这个聊天的状态(上下文、绑定的机器、正在跑的那一轮)。</param>
+    /// <param name="bridge">桥接的全局设置。</param>
+    /// <param name="message">触发这一轮的那条消息。</param>
+    /// <param name="approve">危险操作的审批回调。</param>
+    /// <param name="loc">界面语言。</param>
+    /// <param name="progress">增量回调(参数是<b>累计</b>文本)。</param>
+    /// <param name="grant">
+    /// 这个聊天的授权(范围 / 挡位 / 审批)。<see langword="null" /> = 完全跟随全局且不限范围 ——
+    /// 这也是升级前那些聊天的取值,所以老配置的行为逐字不变。
+    /// </param>
+    /// <param name="cancellationToken">取消。</param>
     public async Task<BridgeTurn> RunAsync(
         BridgeConversation conversation,
         BridgeSettings bridge,
@@ -48,6 +59,7 @@ public sealed class BridgeAgentRunner(
         Func<ApprovalRequest, Task<bool>> approve,
         Loc loc,
         Action<string>? progress,
+        ChatGrant? grant,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(conversation);
@@ -70,19 +82,25 @@ public sealed class BridgeAgentRunner(
         {
             return new BridgeTurn(loc["BridgeNoModel"], "", TimeSpan.Zero, 0);
         }
-        ChatMode mode = conversation.ModeOverride ?? bridge.Mode;
+        ChatMode mode = conversation.ModeOverride ?? grant?.Mode ?? bridge.Mode;
+        ApprovalMode approval = grant?.Approval ?? bridge.Approval;
+        // 不限范围时这里是 null,于是"全部"与"没有范围这回事"走同一条路(见 SessionScope.Resolve)
+        ISessionScope? scope = grant?.Scope.Resolve(context);
 
         // 目标服务器在**回合开始时**解析一次:工具箱要的是同步的 id 提供者,
         // 而"这一轮在哪台机器上干活"本来就不该跑到一半换人。
+        // 带上范围:授权之后用户可能把这台机器移出了分组,而绑定还留着。
         SessionInfo? session = conversation.BoundTarget.Length > 0
-            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, cancellationToken).ConfigureAwait(false)
+            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, cancellationToken, scope)
+                .ConfigureAwait(false)
             : null;
 
         var toolbox = new AgentToolbox(context)
         {
             SessionIdProvider = () => session?.SessionId,
             ApprovalHandler = approve,
-            Approval = bridge.Approval,
+            Approval = approval,
+            Scope = scope,
             DisabledTools = new HashSet<string>(
                 (ai.DisabledBuiltinTools ?? "").Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
                 StringComparer.OrdinalIgnoreCase),
@@ -108,7 +126,7 @@ public sealed class BridgeAgentRunner(
                             && NativeWebSearch.IsSupported(model.Protocol);
         if (mode != ChatMode.Chat)
         {
-            mcp.Approval = bridge.Approval;
+            mcp.Approval = approval;
             mcp.ApprovalHandler = approve;
             IList<AITool> tools = toolbox.CreateTools(mode, nativeSearch);
             if (mode == ChatMode.Agent && ai.McpServers.Any(s => s.Enabled))

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
@@ -99,19 +99,34 @@ public sealed class BridgeService(IPluginContext context, AiSettingsStore aiStor
     /// 桥接正开着就走路由器那条路(内存 + 落盘,立刻生效);没开着就只落盘 ——
     /// 用户完全可能先在设置页把门开好,再去打开桥接。
     /// </remarks>
-    public async Task AllowAsync(PendingChat chat, CancellationToken cancellationToken = default)
+    /// <param name="chat">敲过门的那个聊天。</param>
+    /// <param name="grant">
+    /// 给它的授权。<see langword="null" /> = 不限范围、挡位审批跟随全局。
+    /// <b>单聊传 null 是对的</b>:它只有一个对端,而且是用户逐个放行的;
+    /// 群则应当由设置页先问一句范围再传进来(见 <see cref="ChatGrant" />)。
+    /// </param>
+    /// <param name="cancellationToken">取消。</param>
+    public async Task AllowAsync(PendingChat chat, ChatGrant? grant = null,
+        CancellationToken cancellationToken = default)
     {
+        ChatGrant resolved = (grant ?? new ChatGrant()).Clone();
+        resolved.ChatId = chat.ChatId;
+        resolved.IsGroup = chat.IsGroup;
+        if (resolved.Label.Length == 0)
+        {
+            resolved.Label = chat.UserName;
+        }
         if (_router is { } router
             && router.Settings.Channels.FirstOrDefault(c => c.Id == chat.ChannelId) is { } live)
         {
-            await router.AllowChatAsync(live, chat.ChatId).ConfigureAwait(false);
+            await router.AllowChatAsync(live, resolved).ConfigureAwait(false);
             return;
         }
         BridgeSettings stored = await _bridgeStore.LoadAsync(cancellationToken).ConfigureAwait(false);
         if (stored.Channels.FirstOrDefault(c => c.Id == chat.ChannelId) is { } config
-            && !config.AllowedChats.Contains(chat.ChatId))
+            && config.GrantFor(chat.ChatId) is null)
         {
-            config.AllowedChats.Add(chat.ChatId);
+            config.Grants.Add(resolved);
             await _bridgeStore.SaveAsync(stored, cancellationToken).ConfigureAwait(false);
         }
         Pairing.Forget(chat.ChannelId, chat.ChatId);

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using VelaShell.Plugin.Ai.Agent;
 using VelaShell.Plugin.Ai.Configuration;
 using VelaShell.PluginSdk;
 
@@ -25,6 +26,54 @@ public enum ChannelKind
 
     /// <summary>企业微信:只有回调 URL 一条路,需要公网可达的入口(见 WeCom 渠道的说明)。</summary>
     WeCom
+}
+
+/// <summary>
+/// 一份给某个聊天的授权:能碰哪些机器、在哪一档挡位上、写操作怎么审批。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>范围是"这个房间"的属性,不是"这个人"的属性。</b>把机器人拉进一个群,群里的人数
+/// 之后还会增长,而你不会每次都收到通知 —— 所以群要收紧。单聊只有一个对端、还是你逐个
+/// 放行的,它的默认值是不限范围(<see cref="ScopeKind.All" />);聊天面板压根不经过这里。
+/// </para>
+/// <para>
+/// <b>挡位与审批也下放到这一层</b>,不然"只读群"和"运维群"没法共存 ——
+/// 那几乎是提出范围需求之后的下一个需求。<see langword="null" /> = 跟随
+/// <see cref="BridgeSettings.Mode" /> / <see cref="BridgeSettings.Approval" /> 的全局值,
+/// 也是升级后既有聊天的取值,所以行为逐字不变。
+/// </para>
+/// </remarks>
+public sealed class ChatGrant
+{
+    /// <summary>被授权的聊天 id(群 id 或单聊会话 id)。</summary>
+    public string ChatId { get; set; } = "";
+
+    /// <summary>是群聊(设置页据此提示"群里的人数会变")。</summary>
+    public bool IsGroup { get; set; }
+
+    /// <summary>显示名(配对时记下的,纯粹给设置页看;认不出来就留空)。</summary>
+    public string Label { get; set; } = "";
+
+    /// <summary>能碰哪些机器。</summary>
+    public SessionScope Scope { get; set; } = new();
+
+    /// <summary>这个聊天的挡位(<see langword="null" /> = 跟随全局)。</summary>
+    public ChatMode? Mode { get; set; }
+
+    /// <summary>这个聊天的审批方式(<see langword="null" /> = 跟随全局)。</summary>
+    public ApprovalMode? Approval { get; set; }
+
+    /// <summary>拷一份(设置页编辑时不该改到正在生效的那一份)。</summary>
+    public ChatGrant Clone() => new()
+    {
+        ChatId = ChatId,
+        IsGroup = IsGroup,
+        Label = Label,
+        Scope = Scope.Clone(),
+        Mode = Mode,
+        Approval = Approval
+    };
 }
 
 /// <summary>一个已配置的渠道。</summary>
@@ -66,7 +115,15 @@ public sealed class ChannelConfig
     /// 允许对话的群 / 单聊 id 白名单。<b>空 = 一个都不放行</b> ——
     /// 这是安全默认:一个能在生产机上敲命令的机器人,不该因为被拉进某个群就开始听话。
     /// </summary>
+    /// <remarks>
+    /// <b>这一份现在是 <see cref="Grants" /> 的派生镜像</b>,由 <see cref="NormalizeGrants" />
+    /// 重算,不再单独维护。留着它是为了两件事:把升级前的白名单折算成授权,
+    /// 以及万一用户换回旧版本,白名单还在。判断"能不能说话"一律走 <see cref="GrantFor" />。
+    /// </remarks>
     public List<string> AllowedChats { get; set; } = [];
+
+    /// <summary>每个聊天各自的授权(范围 / 挡位 / 审批)。</summary>
+    public List<ChatGrant> Grants { get; set; } = [];
 
     /// <summary>允许对话的用户 id 白名单(空 = 白名单群里的任何人都可以)。</summary>
     public List<string> AllowedUsers { get; set; } = [];
@@ -82,6 +139,33 @@ public sealed class ChannelConfig
 
     /// <summary>平台名(显示名为空时的回落)。</summary>
     public string Label => DisplayName.Length > 0 ? DisplayName : Kind.ToString();
+
+    /// <summary>这个聊天的授权;没有就是没被放行。</summary>
+    public ChatGrant? GrantFor(string chatId)
+        => Grants.FirstOrDefault(g => string.Equals(g.ChatId, chatId, StringComparison.Ordinal));
+
+    /// <summary>
+    /// 把升级前的 <see cref="AllowedChats" /> 折算成授权,并让它重新成为 <see cref="Grants" /> 的镜像。
+    /// </summary>
+    /// <remarks>
+    /// 折算出来的授权是 <see cref="ScopeKind.All" /> + 挡位审批跟随全局,
+    /// 也就是<b>与升级前逐字相同的行为</b>。收紧是用户自己的决定,不该由一次升级替他做。
+    /// <para>
+    /// 读写两头都调:读的时候把老配置补上,写的时候把镜像刷新 ——
+    /// 一个派生字段只要有一头没算,它就会开始撒谎。
+    /// </para>
+    /// </remarks>
+    public void NormalizeGrants()
+    {
+        foreach (string chatId in AllowedChats)
+        {
+            if (chatId.Length > 0 && GrantFor(chatId) is null)
+            {
+                Grants.Add(new ChatGrant { ChatId = chatId });
+            }
+        }
+        AllowedChats = [.. Grants.Select(g => g.ChatId).Where(id => id.Length > 0).Distinct(StringComparer.Ordinal)];
+    }
 }
 
 /// <summary>IM 桥接的设置。</summary>
@@ -160,12 +244,22 @@ public sealed class BridgeSettingsStore(IPluginContext context)
         {
             return new BridgeSettings();
         }
-        return raw.Deserialize<BridgeSettings>() ?? new BridgeSettings();
+        return Normalize(raw.Deserialize<BridgeSettings>() ?? new BridgeSettings());
     }
 
     /// <summary>持久化设置。</summary>
     public Task SaveAsync(BridgeSettings settings, CancellationToken cancellationToken = default)
-        => context.Storage.SetAsync(SettingsKey, settings, cancellationToken);
+        => context.Storage.SetAsync(SettingsKey, Normalize(settings), cancellationToken);
+
+    /// <summary>把每个渠道的授权补齐 / 刷新镜像(见 <see cref="ChannelConfig.NormalizeGrants" />)。</summary>
+    private static BridgeSettings Normalize(BridgeSettings settings)
+    {
+        foreach (ChannelConfig channel in settings.Channels)
+        {
+            channel.NormalizeGrants();
+        }
+        return settings;
+    }
 
     /// <summary>读某渠道的机密(未配置返回 null)。</summary>
     public Task<string?> GetSecretAsync(string channelId, string slot, CancellationToken cancellationToken = default)

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
@@ -43,6 +43,14 @@ public sealed class ConversationRouter(
     /// </remarks>
     public void Apply(BridgeSettings bridge, Loc loc)
     {
+        ArgumentNullException.ThrowIfNull(bridge);
+        // 授权在这里再折算一次。存储那一层已经折算过,但这里是**唯一**真正判"能不能说话"的地方,
+        // 而设置可以不经过存储直接送进来(测试、以及将来任何别的调用方)——
+        // 少了这一句,一份只填了 AllowedChats 的设置会静默地谁都不放行。
+        foreach (ChannelConfig channel in bridge.Channels)
+        {
+            channel.NormalizeGrants();
+        }
         Settings = bridge;
         Loc = loc;
         int limit = Math.Clamp(bridge.MaxConcurrentTurns, 1, 16);
@@ -58,7 +66,7 @@ public sealed class ConversationRouter(
         {
             return;
         }
-        if (!IsChatAllowed(config, message))
+        if (config.GrantFor(message.ChatId) is not { } grant)
         {
             // 配对码要在白名单之前处理 —— 它存在的全部意义就是"我还不在白名单里,请把我加进去"
             if (await TryPairAsync(config, message).ConfigureAwait(false))
@@ -88,7 +96,7 @@ public sealed class ConversationRouter(
         BridgeConversation conversation = GetOrCreate(config, message);
         conversation.LastActivity = DateTimeOffset.UtcNow;
         string text = message.Text.Trim();
-        if (text.StartsWith('/') && await TryCommandAsync(conversation, config, message, text).ConfigureAwait(false))
+        if (text.StartsWith('/') && await TryCommandAsync(conversation, config, grant, message, text).ConfigureAwait(false))
         {
             return;
         }
@@ -96,7 +104,7 @@ public sealed class ConversationRouter(
         {
             return;
         }
-        await RunTurnAsync(conversation, config, message).ConfigureAwait(false);
+        await RunTurnAsync(conversation, config, grant, message).ConfigureAwait(false);
     }
 
     /// <summary>丢掉闲置太久的会话上下文(由 <see cref="BridgeService" /> 定时调)。</summary>
@@ -134,7 +142,13 @@ public sealed class ConversationRouter(
     /// <remarks>
     /// <b>这里刻意不要求群里先 @ 机器人。</b>此刻它还不在白名单里,而"要不要理你"这一关就在
     /// 前面 —— 再叠一条"先 @ 我"等于把配对本身也挡在门外。配对码本身足够窄:一次性、
-    /// 十分钟过期、猜错五次作废,而且只能把聊天加进白名单,动不了挡位与审批。
+    /// 十分钟过期、猜错五次作废。
+    /// <para>
+    /// <b>配对码携带的是一份具体的授权,而不是一张通行证。</b>从前的顺序是"先放进来,
+    /// 再去设置页收紧",这在权限上是反的:从放行到收紧之间那个群拥有全部权限,
+    /// 而人往往就忘了第二步。现在范围在<b>发码时</b>就定死,群里的人从第一秒起
+    /// 就只看得见范围内的机器。
+    /// </para>
     /// </remarks>
     private async Task<bool> TryPairAsync(ChannelConfig config, InboundMessage message)
     {
@@ -151,7 +165,7 @@ public sealed class ConversationRouter(
                 .ConfigureAwait(false);
             return true;
         }
-        if (!pairing.TryRedeem(code))
+        if (!pairing.TryRedeem(code, out ChatGrant? template))
         {
             // 只记日志,不在群里说"码错了还是过期了" —— 那等于告诉试探的人他离对还有多远
             context.Log.Warn($"Bridge: a wrong or expired pairing code was presented in {message.ChatKey}.");
@@ -159,10 +173,17 @@ public sealed class ConversationRouter(
                 .ConfigureAwait(false);
             return true;
         }
-        await AllowChatAsync(config, message.ChatId).ConfigureAwait(false);
-        context.Log.Info($"Bridge: {message.ChatKey} was paired by {message.UserName}.");
-        await hub.SendAsync(message.ChannelId, target, Loc["BridgePaired"], CancellationToken.None)
-            .ConfigureAwait(false);
+        ChatGrant grant = (template ?? new ChatGrant()).Clone();
+        grant.ChatId = message.ChatId;
+        grant.IsGroup = message.IsGroup;
+        await AllowChatAsync(config, grant).ConfigureAwait(false);
+        context.Log.Info($"Bridge: {message.ChatKey} was paired by {message.UserName} " +
+                         $"(scope: {DescribeScope(grant)}).");
+        await hub.SendAsync(message.ChannelId, target,
+            grant.Scope.IsUnrestricted
+                ? Loc["BridgePaired"]
+                : Loc.F("BridgePairedScoped", DescribeScope(grant)),
+            CancellationToken.None).ConfigureAwait(false);
         return true;
     }
 
@@ -174,19 +195,24 @@ public sealed class ConversationRouter(
     /// 落盘走"读—改—写"而不是把内存那份整个盖上去 —— 设置页可能正开着,
     /// 用它内存里的快照覆盖会把用户刚改的别的字段抹掉。
     /// </remarks>
-    public async Task AllowChatAsync(ChannelConfig config, string chatId)
+    public async Task AllowChatAsync(ChannelConfig config, ChatGrant grant)
     {
         ArgumentNullException.ThrowIfNull(config);
-        if (!config.AllowedChats.Contains(chatId))
+        ArgumentNullException.ThrowIfNull(grant);
+        string chatId = grant.ChatId;
+        if (config.GrantFor(chatId) is null)
         {
-            config.AllowedChats.Add(chatId);
+            config.Grants.Add(grant);
         }
+        config.NormalizeGrants();
         BridgeSettings stored = await bridgeStore.LoadAsync().ConfigureAwait(false);
         if (stored.Channels.FirstOrDefault(c => c.Id == config.Id) is { } persisted)
         {
-            if (!persisted.AllowedChats.Contains(chatId))
+            if (persisted.GrantFor(chatId) is null)
             {
-                persisted.AllowedChats.Add(chatId);
+                // 落盘的是**另一份**对象:内存里那份归正在跑的路由器,
+                // 两边共享同一个实例的话,设置页保存时的编辑会串到运行中的授权上。
+                persisted.Grants.Add(grant.Clone());
                 await bridgeStore.SaveAsync(stored).ConfigureAwait(false);
             }
         }
@@ -205,7 +231,8 @@ public sealed class ConversationRouter(
         }
     }
 
-    private async Task RunTurnAsync(BridgeConversation conversation, ChannelConfig config, InboundMessage message)
+    private async Task RunTurnAsync(BridgeConversation conversation, ChannelConfig config, ChatGrant grant,
+        InboundMessage message)
     {
         // 同一个聊天串行:后来的排队,而不是插进上一轮的工具循环中间
         bool queued = conversation.Gate.CurrentCount == 0;
@@ -247,7 +274,7 @@ public sealed class ConversationRouter(
                 conversation, Settings, message,
                 request => approvals.RequestAsync(conversation, config, request,
                     Settings.ApprovalTimeoutSeconds, Loc, turn.Token),
-                Loc, OnProgress, turn.Token).ConfigureAwait(false);
+                Loc, OnProgress, grant, turn.Token).ConfigureAwait(false);
 
             await DeliverAsync(conversation, placeholder, Compose(result), turn.Token).ConfigureAwait(false);
         }
@@ -296,7 +323,7 @@ public sealed class ConversationRouter(
             : $"{turn.Text}\n\n{Loc.F("BridgeFooter", turn.Model, turn.Elapsed.TotalSeconds.ToString("0.0"), turn.ToolCalls)}";
 
     private async Task<bool> TryCommandAsync(BridgeConversation conversation, ChannelConfig config,
-        InboundMessage message, string text)
+        ChatGrant grant, InboundMessage message, string text)
     {
         string[] parts = text.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         string command = parts[0].ToLowerInvariant();
@@ -306,10 +333,10 @@ public sealed class ConversationRouter(
             "/help" or "/?" => Loc["BridgeHelp"],
             "/new" or "/reset" => Reset(conversation),
             "/stop" => Stop(conversation),
-            "/status" => await StatusAsync(conversation, config).ConfigureAwait(false),
-            "/sessions" => await ListSessionsAsync().ConfigureAwait(false),
-            "/use" => await BindAsync(conversation, argument).ConfigureAwait(false),
-            "/mode" => SetMode(conversation, argument),
+            "/status" => await StatusAsync(conversation, config, grant).ConfigureAwait(false),
+            "/sessions" => await ListSessionsAsync(grant).ConfigureAwait(false),
+            "/use" => await BindAsync(conversation, grant, argument).ConfigureAwait(false),
+            "/mode" => SetMode(conversation, grant, argument),
             _ => null
         };
         if (reply is null)
@@ -338,30 +365,46 @@ public sealed class ConversationRouter(
         return Loc["BridgeStopped"];
     }
 
-    private async Task<string> StatusAsync(BridgeConversation conversation, ChannelConfig config)
+    /// <summary><c>/status</c>:把这个聊天<b>实际</b>生效的那几个值报出来,包括范围。</summary>
+    /// <remarks>
+    /// 报的是授权算完之后的值,不是全局设置里的值 —— 一个只读群里显示"Agent 模式"
+    /// 比不显示更糟,人会照着它去下命令,然后对着一句拒绝发懵。
+    /// </remarks>
+    private async Task<string> StatusAsync(BridgeConversation conversation, ChannelConfig config, ChatGrant grant)
     {
-        ChatMode mode = conversation.ModeOverride ?? Settings.Mode;
+        ChatMode mode = conversation.ModeOverride ?? grant.Mode ?? Settings.Mode;
+        ApprovalMode approval = grant.Approval ?? Settings.Approval;
+        ISessionScope? scope = grant.Scope.Resolve(context);
         string target = conversation.BoundTarget.Length > 0 ? conversation.BoundTarget : "—";
         SessionInfo? session = conversation.BoundTarget.Length > 0
-            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, CancellationToken.None).ConfigureAwait(false)
+            ? await SessionTargets.ResolveAsync(context, conversation.BoundTarget, CancellationToken.None, scope)
+                .ConfigureAwait(false)
             : null;
-        return Loc.F("BridgeStatus", config.Label, mode, Settings.Approval, target,
-            session is null ? Loc["BridgeSessionOffline"] : Loc["BridgeSessionOnline"]);
+        return Loc.F("BridgeStatus", config.Label, mode, approval, target,
+                   session is null ? Loc["BridgeSessionOffline"] : Loc["BridgeSessionOnline"])
+               + "\n" + Loc.F("BridgeStatusScope", DescribeScope(grant));
     }
 
-    private async Task<string> ListSessionsAsync()
+    private async Task<string> ListSessionsAsync(ChatGrant grant)
     {
-        string list = await SessionTargets.DescribeAsync(context, CancellationToken.None).ConfigureAwait(false);
+        string list = await SessionTargets
+            .DescribeAsync(context, CancellationToken.None, grant.Scope.Resolve(context)).ConfigureAwait(false);
         return list.Length == 0 ? Loc["BridgeNoSessions"] : Loc.F("BridgeSessions", list);
     }
 
-    private async Task<string> BindAsync(BridgeConversation conversation, string argument)
+    /// <summary><c>/use</c>:把这个聊天绑到一台机器上。范围外的当作<b>不存在</b>。</summary>
+    /// <remarks>
+    /// 回的是同一句"没找到",而不是"找到了但不给你" —— 后者会把这条命令变成探测接口:
+    /// 试一个主机名就能问出它在不在用户的机器列表里。日志里记全,群里说一半。
+    /// </remarks>
+    private async Task<string> BindAsync(BridgeConversation conversation, ChatGrant grant, string argument)
     {
         if (argument.Length == 0)
         {
             return Loc["BridgeBindUsage"];
         }
-        if (await SessionTargets.ResolveAsync(context, argument, CancellationToken.None).ConfigureAwait(false) is not { } session)
+        if (await SessionTargets.ResolveAsync(context, argument, CancellationToken.None, grant.Scope.Resolve(context))
+                .ConfigureAwait(false) is not { } session)
         {
             return Loc.F("BridgeBindNotFound", argument);
         }
@@ -382,7 +425,7 @@ public sealed class ConversationRouter(
     /// 拉高权限这件事应该在 VelaShell 里做,不该在群里做。要开放得去设置页勾
     /// <see cref="BridgeSettings.AllowModeEscalation" />。
     /// </remarks>
-    private string SetMode(BridgeConversation conversation, string argument)
+    private string SetMode(BridgeConversation conversation, ChatGrant grant, string argument)
     {
         ChatMode? requested;
         switch (argument.Trim().ToLowerInvariant())
@@ -402,12 +445,15 @@ public sealed class ConversationRouter(
             default:
                 return Loc["BridgeModeUsage"];
         }
-        if (requested is { } mode && Rank(mode) > Rank(Settings.Mode) && !Settings.AllowModeEscalation)
+        // 天花板是**这个聊天**的挡位,不是全局的:一个被设成只读的群,不该因为全局是 Agent
+        // 就能用一句 /mode agent 把自己抬回去。
+        ChatMode ceiling = grant.Mode ?? Settings.Mode;
+        if (requested is { } mode && Rank(mode) > Rank(ceiling) && !Settings.AllowModeEscalation)
         {
-            return Loc.F("BridgeModeLocked", Settings.Mode);
+            return Loc.F("BridgeModeLocked", ceiling);
         }
         conversation.ModeOverride = requested;
-        return Loc.F("BridgeModeSet", conversation.ModeOverride ?? Settings.Mode);
+        return Loc.F("BridgeModeSet", conversation.ModeOverride ?? ceiling);
 
         static int Rank(ChatMode mode) => mode switch
         {
@@ -437,9 +483,6 @@ public sealed class ConversationRouter(
         }
     }
 
-    private static bool IsChatAllowed(ChannelConfig config, InboundMessage message)
-        => config.AllowedChats.Contains(message.ChatId);
-
     /// <summary>
     /// 没授权的聊天回一次(且只回一次)带 id 的提示。
     /// </summary>
@@ -464,6 +507,10 @@ public sealed class ConversationRouter(
         await hub.SendAsync(message.ChannelId, new OutboundTarget(message.ChatId, message.ThreadId),
             Loc.F("BridgeUnauthorized", message.ChatId), CancellationToken.None).ConfigureAwait(false);
     }
+
+    /// <summary>范围的一句人话(给 <c>/status</c> 与日志用)。</summary>
+    private string DescribeScope(ChatGrant grant)
+        => grant.Scope.Resolve(context) is { } scope ? scope.Describe() : Loc["BridgeScopeAll"];
 
     private static string Clip(string text, int max)
         => text.Length <= max ? text : string.Concat(text.AsSpan(0, Math.Max(0, max - 1)), "…");

--- a/plugins/VelaShell.Plugin.Ai/Bridge/PairingService.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/PairingService.cs
@@ -31,9 +31,10 @@ public readonly record struct PendingChat(
 /// ② 敲过门的聊天会被记下来,设置页上一行一个「允许」按钮。
 /// </para>
 /// <para>
-/// <b>安全性没有让步。</b>配对码只决定"这个聊天能不能跟机器人说话",能不能动服务器仍旧由
-/// 挡位与审批管;码是一次性的、十分钟过期、猜错五次直接作废,而且它只能<b>加</b>白名单,
-/// 不能改挡位、不能绕审批。
+/// <b>安全性没有让步,而且比从前更紧。</b>码是一次性的、十分钟过期、猜错五次直接作废;
+/// 更重要的是它现在<b>携带一份具体的授权</b>(范围 / 挡位 / 审批,见 <see cref="ChatGrant" />)
+/// 而不是一张通行证 —— 发码时就把范围定死,不再存在"先全开、回头去设置页收紧"的窗口,
+/// 而那个窗口正是人最容易忘掉第二步的地方。它仍然只能<b>加</b>授权,改不了别人的。
 /// </para>
 /// <para>本实例由 <see cref="BridgeService" /> 持有,因此<b>跨渠道重载存活</b> ——
 /// 用户在设置页点保存导致桥接重建时,已经敲过的门不该跟着丢掉。</para>
@@ -52,6 +53,7 @@ public sealed class PairingService
     private readonly Dictionary<string, PendingChat> _pending = [];
     private readonly Lock _sync = new();
     private string? _code;
+    private ChatGrant? _template;
     private DateTimeOffset _expiresAt;
     private int _attempts;
 
@@ -79,11 +81,28 @@ public sealed class PairingService
         }
     }
 
+    /// <summary>当前配对码携带的授权模板(没有码时为 <see langword="null" />)。</summary>
+    public ChatGrant? Template
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return Valid() ? _template : null;
+            }
+        }
+    }
+
     /// <summary>发一个新的配对码(旧的立即作废)。</summary>
-    public string Issue()
+    /// <param name="template">
+    /// 这个码兑现之后建出来的授权。<see langword="null" /> = 不限范围、挡位审批跟随全局。
+    /// 给群的码应当带一份收紧过的模板;给自己单聊的码不带,那条路本来就不该受限。
+    /// </param>
+    public string Issue(ChatGrant? template = null)
     {
         lock (_sync)
         {
+            _template = template?.Clone();
             // 随机数走密码学 RNG:配对码在有效期内是一个能把陌生群放进白名单的凭据,
             // 用 Random 生成的话,知道种子规律的人就能猜。
             _code = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
@@ -99,6 +118,7 @@ public sealed class PairingService
         lock (_sync)
         {
             _code = null;
+            _template = null;
             _expiresAt = DateTimeOffset.MinValue;
             _attempts = 0;
         }
@@ -107,10 +127,16 @@ public sealed class PairingService
     /// <summary>
     /// 核对并<b>用掉</b>一个配对码。对了返回 true,并且这个码立刻作废(一次性)。
     /// </summary>
-    public bool TryRedeem(string presented)
+    /// <param name="presented">群里发过来的那串数字。</param>
+    /// <param name="template">
+    /// 成功时交回发码时选定的那份授权(可能是 <see langword="null" /> = 不限范围)。
+    /// 调用方负责填上 <see cref="ChatGrant.ChatId" /> 与 <see cref="ChatGrant.IsGroup" />。
+    /// </param>
+    public bool TryRedeem(string presented, out ChatGrant? template)
     {
         lock (_sync)
         {
+            template = null;
             if (!Valid())
             {
                 return false;
@@ -120,11 +146,14 @@ public sealed class PairingService
                 if (++_attempts >= MaxAttempts)
                 {
                     _code = null;
+                    _template = null;
                     _expiresAt = DateTimeOffset.MinValue;
                 }
                 return false;
             }
+            template = _template;
             _code = null;
+            _template = null;
             _expiresAt = DateTimeOffset.MinValue;
             _attempts = 0;
             return true;

--- a/plugins/VelaShell.Plugin.Ai/Bridge/SessionTargets.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/SessionTargets.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using VelaShell.Plugin.Ai.Agent;
 using VelaShell.PluginSdk;
 using VelaShell.PluginSdk.Sessions;
 
@@ -22,8 +23,16 @@ public static class SessionTargets
     /// 找一条与 <paramref name="target" /> 对得上、且<b>已连上</b>的会话。
     /// 目标串可以省略用户名与端口(<c>host</c> / <c>host:port</c> / <c>user@host</c> 都认)。
     /// </summary>
+    /// <param name="context">插件上下文。</param>
+    /// <param name="target"><c>[user@]host[:port]</c>。</param>
+    /// <param name="cancellationToken">取消。</param>
+    /// <param name="scope">
+    /// 范围闸门(<see langword="null" /> = 不限制)。范围外的会话在这里就当作<b>不存在</b>,
+    /// 而不是"找到了但不给" —— 后者会让 <c>/use 某台</c> 的回复变成一个探测接口:
+    /// 试一个主机名就能问出它在不在用户的机器列表里。
+    /// </param>
     public static async Task<SessionInfo?> ResolveAsync(
-        IPluginContext context, string target, CancellationToken cancellationToken)
+        IPluginContext context, string target, CancellationToken cancellationToken, ISessionScope? scope = null)
     {
         if (string.IsNullOrWhiteSpace(target))
         {
@@ -49,23 +58,30 @@ public static class SessionTargets
             {
                 continue;
             }
+            if (scope is not null && !await scope.AllowsLiveAsync(session, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
             return session;
         }
         return null;
     }
 
     /// <summary>列出当前连上的会话,给 IM 里的 <c>/sessions</c> 用。</summary>
-    public static async Task<string> DescribeAsync(IPluginContext context, CancellationToken cancellationToken)
+    /// <param name="context">插件上下文。</param>
+    /// <param name="cancellationToken">取消。</param>
+    /// <param name="scope">范围闸门(<see langword="null" /> = 不限制);范围外的不列出来。</param>
+    public static async Task<string> DescribeAsync(
+        IPluginContext context, CancellationToken cancellationToken, ISessionScope? scope = null)
     {
         IReadOnlyList<SessionInfo> sessions = await context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
-        List<SessionInfo> connected = [.. sessions.Where(s => s.State == SessionState.Connected)];
-        if (connected.Count == 0)
-        {
-            return "";
-        }
         var sb = new StringBuilder();
-        foreach (SessionInfo session in connected)
+        foreach (SessionInfo session in sessions.Where(s => s.State == SessionState.Connected))
         {
+            if (scope is not null && !await scope.AllowsLiveAsync(session, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
             sb.Append("• ").AppendLine(Format(session));
         }
         return sb.ToString().TrimEnd();

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpServerSettings.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpServerSettings.cs
@@ -51,8 +51,17 @@ public sealed class McpServerSettings
     public string DisabledTools { get; set; } = "";
 
     /// <summary>
-    /// 允许外部 agent 操作的服务器(<c>user@host:port</c>,每行一条;空 = 允许全部已连会话)。
+    /// 允许外部 agent 操作的服务器(<c>user@host:port</c>,每行一条;<b>空 = 允许全部</b>)。
     /// </summary>
+    /// <remarks>
+    /// <b>它作用在每一次工具调用上</b>,不只是 <c>use_session</c> ——
+    /// 工具箱里九个工具都收可选的 <c>session_id</c>,只挡"选哪台"等于没挡
+    /// (见 <see cref="McpToolHost" />)。
+    /// <para>
+    /// 空仍然是"允许全部",这是刻意的:这条路的边界是回环地址 + 令牌 + 只读挡位,
+    /// 顺手把用户自己机器上的 Claude Code / Codex 一起收紧,挡不住任何攻击者,只挡得住用户自己。
+    /// </para>
+    /// </remarks>
     public string AllowedTargets { get; set; } = "";
 }
 

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
@@ -21,6 +21,13 @@ namespace VelaShell.Plugin.Ai.Interop;
 /// 所以 <see cref="ApprovalMode.Ask" /> 在这里等于"一律拒绝"(工具箱在
 /// <c>ApprovalHandler</c> 为 null 时就是这个行为),用户要放开就得显式选
 /// 只读放行或绕过审批 —— 这是一个明摆着的选择,而不是一个悄悄的默认。</para>
+///
+/// <para><b><see cref="McpServerSettings.AllowedTargets" /> 从前只挡 <c>use_session</c>。</b>
+/// 那是一句空话:工具箱里九个工具都收可选的 <c>session_id</c>,外部 agent
+/// <c>list_sessions</c> 拿到 id 直接传就绕过去了。现在它变成
+/// <see cref="TargetListScope" /> 挂在 <see cref="AgentToolbox.Scope" /> 上,
+/// 每一次工具调用都要过。<b>默认值仍是空 = 不限范围</b> —— 这条路的边界是回环地址、
+/// 令牌与只读挡位,把用户自己机器上的 agent 一起收紧挡不住任何攻击者,只挡得住用户自己。</para>
 /// </remarks>
 internal sealed class McpToolHost
 {
@@ -28,6 +35,7 @@ internal sealed class McpToolHost
     private readonly McpServerSettings _settings;
     private readonly AgentToolbox _toolbox;
     private readonly List<string> _allowedTargets;
+    private readonly TargetListScope? _scope;
     private string? _sessionId;
     private string _target = "";
 
@@ -45,9 +53,11 @@ internal sealed class McpToolHost
         [
             .. settings.AllowedTargets.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         ];
+        _scope = _allowedTargets.Count > 0 ? new TargetListScope(_allowedTargets) : null;
         _toolbox = new AgentToolbox(context)
         {
             SessionIdProvider = () => _sessionId,
+            Scope = _scope,
             Approval = settings.Approval,
             DisabledTools = new HashSet<string>(
                 settings.DisabledTools.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
@@ -93,9 +103,9 @@ internal sealed class McpToolHost
             return $"'{target}' is not on the allowlist configured in VelaShell. "
                    + $"Allowed: {string.Join(", ", _allowedTargets)}";
         }
-        if (await SessionTargets.ResolveAsync(_context, target, cancellationToken).ConfigureAwait(false) is not { } session)
+        if (await SessionTargets.ResolveAsync(_context, target, cancellationToken, _scope).ConfigureAwait(false) is not { } session)
         {
-            string list = await SessionTargets.DescribeAsync(_context, cancellationToken).ConfigureAwait(false);
+            string list = await SessionTargets.DescribeAsync(_context, cancellationToken, _scope).ConfigureAwait(false);
             return list.Length == 0
                 ? "No sessions are connected in VelaShell right now."
                 : $"No connected session matches '{target}'. Connected sessions:\n{list}";
@@ -119,19 +129,23 @@ internal sealed class McpToolHost
             return;
         }
         IReadOnlyList<SessionInfo> sessions = await _context.Sessions.ListAsync(cancellationToken).ConfigureAwait(false);
-        List<SessionInfo> connected = [.. sessions.Where(s => s.State == SessionState.Connected)];
+        var connected = new List<SessionInfo>();
+        foreach (SessionInfo session in sessions.Where(s => s.State == SessionState.Connected))
+        {
+            // 数的是"允许操作的里面有几台",不是"一共连着几台" —— 否则用户连着两台、
+            // 清单里只写了一台时,本该没有歧义的那一台反而选不上。
+            if (_scope is not null && !await _scope.AllowsLiveAsync(session, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+            connected.Add(session);
+        }
         if (connected.Count != 1)
         {
             return;
         }
-        string only = SessionTargets.Format(connected[0]);
-        if (_allowedTargets.Count > 0
-            && !_allowedTargets.Any(a => string.Equals(a, only, StringComparison.OrdinalIgnoreCase)))
-        {
-            return;
-        }
         _sessionId = connected[0].SessionId;
-        _target = only;
+        _target = SessionTargets.Format(connected[0]);
     }
 
     /// <summary>给 <c>initialize</c> 的服务端说明里带一句"现在对着哪台机器"。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
@@ -1,0 +1,321 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk.Sessions;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+/// <summary>
+/// 「已授权的聊天」那一段:每个聊天各自的范围、挡位与审批。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 从前这里是一个多行文本框,一行一个聊天 id —— 那是"谁能说话"那一个轴。
+/// 但把机器人拉进群之后,群里的人数会在用户不知情时增长,而<b>能碰哪些机器</b>
+/// 与<b>能做到什么程度</b>是另外两个轴,它们过去只有一份全局值。
+/// </para>
+/// <para>
+/// <b>默认值按房间类型分,而不是一刀切。</b>群要求先选范围;单聊默认不限范围 ——
+/// 它只有一个对端,而且是用户逐个放行的。这一条不是宽松,是这套设计的红线:
+/// 一套把作者自己也拦住的权限设计,结局是被整个关掉,回到零防护。
+/// </para>
+/// </remarks>
+public partial class CollaborationView
+{
+    /// <summary>会话树里已保存的连接(建范围选择器时用;界面打开时取一次)。</summary>
+    private List<SavedSessionInfo> _saved = [];
+
+    /// <summary>一条授权在界面上的那几个控件。</summary>
+    private sealed class GrantRow
+    {
+        public required ChatGrant Grant { get; init; }
+
+        public required TextBox ChatId { get; init; }
+
+        public required ComboBox Scope { get; init; }
+
+        public required ComboBox Mode { get; init; }
+
+        public required ComboBox Approval { get; init; }
+
+        /// <summary>分组勾选框(键 = 分组名)。</summary>
+        public required Dictionary<string, CheckBox> Groups { get; init; }
+
+        /// <summary>单台勾选框(键 = 已保存会话 id)。</summary>
+        public required Dictionary<string, CheckBox> Machines { get; init; }
+
+        public bool Removed { get; set; }
+
+        /// <summary>把界面上填的东西读回一份授权(空聊天 id = 这一行没填完,丢掉)。</summary>
+        public ChatGrant? Harvest()
+        {
+            string chatId = (ChatId.Text ?? "").Trim();
+            if (Removed || chatId.Length == 0)
+            {
+                return null;
+            }
+            Grant.ChatId = chatId;
+            Grant.Scope = new SessionScope
+            {
+                Kind = Scope.SelectedIndex == 1 ? ScopeKind.Limited : ScopeKind.All,
+                Groups = [.. Groups.Where(g => g.Value.IsChecked == true).Select(g => g.Key)],
+                SavedIds = [.. Machines.Where(m => m.Value.IsChecked == true).Select(m => m.Key)]
+            };
+            // 第 0 项是"跟随全局",落库时写 null —— 存成具体值的话,用户以后改全局设置,
+            // 这些聊天会一动不动,而界面上看不出为什么。
+            Grant.Mode = Mode.SelectedIndex > 0 ? (ChatMode)(Mode.SelectedIndex - 1) : null;
+            Grant.Approval = Approval.SelectedIndex > 0 ? (ApprovalMode)(Approval.SelectedIndex - 1) : null;
+            return Grant;
+        }
+    }
+
+    /// <summary>整段「已授权的聊天」。</summary>
+    /// <param name="config">这个渠道。</param>
+    /// <param name="rows">建出来的行(调用方保存时从这里收割)。</param>
+    /// <param name="list">
+    /// 装着那些行的面板。设置页上那个「允许」按钮要往里再插一行 ——
+    /// 不插的话用户点完放行再点保存,反而把刚放行的又抹掉了。
+    /// </param>
+    private StackPanel BuildGrantsSection(ChannelConfig config, List<GrantRow> rows, out StackPanel list)
+    {
+        var caption = new TextBlock { Text = _loc["GrantsLabel"] };
+        caption.Classes.Add("label");
+        var hint = new TextBlock { Text = _loc["GrantsHint"], TextWrapping = TextWrapping.Wrap };
+        hint.Classes.Add("hint");
+
+        list = new StackPanel { Spacing = 8 };
+        var panel = new StackPanel();
+        panel.Children.Add(caption);
+        panel.Children.Add(hint);
+        panel.Children.Add(list);
+
+        config.NormalizeGrants();
+        StackPanel target = list;
+        foreach (ChatGrant grant in config.Grants)
+        {
+            target.Children.Add(BuildGrantRow(grant.Clone(), rows, target));
+        }
+
+        Button add = HostButton(_loc["GrantAdd"], 96);
+        add.HorizontalAlignment = HorizontalAlignment.Left;
+        add.Margin = new Thickness(0, 8, 0, 0);
+        add.Click += (_, _) => target.Children.Add(BuildGrantRow(new ChatGrant(), rows, target));
+        panel.Children.Add(add);
+        return panel;
+    }
+
+    /// <summary>往一个渠道的授权列表里补一行(设置页上那个「允许」按钮用)。</summary>
+    /// <remarks>
+    /// <b>单聊补出来的是"不限范围"。</b>它只有一个对端,而且是用户逐个放行的;
+    /// 群补出来的也是不限范围 —— 与放行前的行为一致,收紧留给用户自己在这一行上点。
+    /// 默认值不该由一次点击替用户做决定,但界面把范围摆在那一行上,他一眼就看得见。
+    /// </remarks>
+    private void AppendGrant(ChannelRow row, PendingChat chat)
+    {
+        if (row.Grants.Any(g => string.Equals((g.ChatId.Text ?? "").Trim(), chat.ChatId, StringComparison.Ordinal)))
+        {
+            return;
+        }
+        var grant = new ChatGrant { ChatId = chat.ChatId, IsGroup = chat.IsGroup, Label = chat.UserName };
+        row.GrantsList.Children.Add(BuildGrantRow(grant, row.Grants, row.GrantsList));
+    }
+
+    private Border BuildGrantRow(ChatGrant grant, List<GrantRow> rows, Panel list)
+    {
+        var chatId = new TextBox { Text = grant.ChatId, PlaceholderText = _loc["GrantChatId"] };
+        var kind = new TextBlock
+        {
+            Text = grant.ChatId.Length == 0 ? "" : _loc[grant.IsGroup ? "GrantIsGroup" : "GrantIsDirect"],
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 8, 0)
+        };
+        kind.Classes.Add("hint");
+        Button remove = HostButton(_loc["ChannelRemove"], 64);
+
+        var head = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        head.Children.Add(chatId);
+        Grid.SetColumn(kind, 1);
+        head.Children.Add(kind);
+        Grid.SetColumn(remove, 2);
+        head.Children.Add(remove);
+
+        var scope = new ComboBox { MinWidth = 190 };
+        scope.ItemsSource = new[] { _loc["ScopeAll"], _loc["ScopeLimited"] };
+        scope.SelectedIndex = grant.Scope.IsUnrestricted ? 0 : 1;
+
+        var mode = new ComboBox { MinWidth = 130 };
+        mode.ItemsSource = new[] { _loc["GrantFollowGlobal"], _loc["ModeChat"], _loc["ModePlan"], _loc["ModeAgent"] };
+        mode.SelectedIndex = grant.Mode is { } m ? (int)m + 1 : 0;
+
+        var approval = new ComboBox { MinWidth = 130 };
+        approval.ItemsSource = new[]
+        {
+            _loc["GrantFollowGlobal"], _loc["ApprovalAsk"], _loc["ApprovalReadOnly"], _loc["ApprovalBypass"]
+        };
+        approval.SelectedIndex = grant.Approval is { } a ? (int)a + 1 : 0;
+
+        var controls = new WrapPanel { ItemSpacing = 12, LineSpacing = 8, Margin = new Thickness(0, 8, 0, 0) };
+        controls.Children.Add(Labelled(_loc["ScopeLabel"], scope));
+        controls.Children.Add(Labelled(_loc["GrantMode"], mode));
+        controls.Children.Add(Labelled(_loc["GrantApproval"], approval));
+
+        StackPanel picker = BuildScopeChecklist(grant.Scope,
+            out Dictionary<string, CheckBox> groups, out Dictionary<string, CheckBox> machines, out TextBlock empty);
+
+        var body = new StackPanel();
+        body.Children.Add(head);
+        body.Children.Add(controls);
+        body.Children.Add(picker);
+        var card = new Border { Child = body };
+        card.Classes.Add("card");
+
+        var row = new GrantRow
+        {
+            Grant = grant,
+            ChatId = chatId,
+            Scope = scope,
+            Mode = mode,
+            Approval = approval,
+            Groups = groups,
+            Machines = machines
+        };
+        rows.Add(row);
+
+        void Sync()
+        {
+            bool limited = scope.SelectedIndex == 1;
+            picker.IsVisible = limited;
+            // 受限却一个都没勾 = 这个聊天碰不到任何机器。说出来 —— 这个方向读错了很难自己发现,
+            // 用户会以为是机器人坏了。
+            empty.IsVisible = limited && _saved.Count > 0
+                              && groups.Values.All(c => c.IsChecked != true)
+                              && machines.Values.All(c => c.IsChecked != true);
+        }
+
+        scope.SelectionChanged += (_, _) => Sync();
+        foreach (CheckBox check in groups.Values.Concat(machines.Values))
+        {
+            check.IsCheckedChanged += (_, _) => Sync();
+        }
+        remove.Click += (_, _) =>
+        {
+            row.Removed = true;
+            list.Children.Remove(card);
+        };
+        Sync();
+        return card;
+    }
+
+    /// <summary>
+    /// 范围选择器的下半截:分组与单台的勾选框。
+    /// </summary>
+    /// <remarks>
+    /// 勾选项来自会话树,不是让用户手打分组名 —— 打错一个字的后果是这份授权碰不到任何机器,
+    /// 而界面上看不出哪里错了。
+    /// </remarks>
+    private StackPanel BuildScopeChecklist(SessionScope scope,
+        out Dictionary<string, CheckBox> groups, out Dictionary<string, CheckBox> machines, out TextBlock empty)
+    {
+        groups = [];
+        machines = [];
+        var picker = new StackPanel { Spacing = 6, Margin = new Thickness(0, 8, 0, 0) };
+        empty = new TextBlock { Text = _loc["ScopeEmptyWarning"], TextWrapping = TextWrapping.Wrap };
+        empty.Classes.Add("hint");
+        if (_saved.Count == 0)
+        {
+            var none = new TextBlock { Text = _loc["ScopeNoSaved"], TextWrapping = TextWrapping.Wrap };
+            none.Classes.Add("hint");
+            picker.Children.Add(none);
+            picker.Children.Add(empty);
+            return picker;
+        }
+        List<string> groupNames =
+        [
+            .. _saved.Select(s => s.Group)
+                .Where(g => g is { Length: > 0 })
+                .Select(g => g!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g, StringComparer.CurrentCulture)
+        ];
+        if (groupNames.Count > 0)
+        {
+            var box = new WrapPanel { ItemSpacing = 14, LineSpacing = 4 };
+            foreach (string name in groupNames)
+            {
+                CheckBox check = HostCheckBox(name, scope.Groups.Contains(name, StringComparer.OrdinalIgnoreCase));
+                groups[name] = check;
+                box.Children.Add(check);
+            }
+            picker.Children.Add(Section(_loc["ScopeGroups"], box));
+        }
+        var machineBox = new WrapPanel { ItemSpacing = 14, LineSpacing = 4 };
+        foreach (SavedSessionInfo saved in _saved.OrderBy(s => s.Name, StringComparer.CurrentCulture))
+        {
+            CheckBox check = HostCheckBox($"{saved.Name} ({saved.Host})",
+                scope.SavedIds.Contains(saved.SavedSessionId, StringComparer.Ordinal));
+            machines[saved.SavedSessionId] = check;
+            machineBox.Children.Add(check);
+        }
+        picker.Children.Add(Section(_loc["ScopeMachines"], machineBox));
+        picker.Children.Add(empty);
+        return picker;
+    }
+
+    /// <summary>
+    /// 发给群的配对码那一段的范围选择器:整块面板 + 一个"现在勾了什么"的读取器。
+    /// </summary>
+    /// <remarks>
+    /// <b>范围在发码时就定死。</b>从前的顺序是"先放进来,再去设置页收紧" —— 那在权限上是反的:
+    /// 从放行到收紧之间那个群拥有全部权限,而人往往就忘了第二步。
+    /// </remarks>
+    private StackPanel BuildPairScopePicker(out Func<SessionScope> read)
+    {
+        StackPanel checklist = BuildScopeChecklist(new SessionScope { Kind = ScopeKind.Limited },
+            out Dictionary<string, CheckBox> groups, out Dictionary<string, CheckBox> machines, out TextBlock empty);
+        Dictionary<string, CheckBox> g = groups;
+        Dictionary<string, CheckBox> m = machines;
+
+        void Sync() => empty.IsVisible = _saved.Count > 0
+                                         && g.Values.All(c => c.IsChecked != true)
+                                         && m.Values.All(c => c.IsChecked != true);
+        foreach (CheckBox check in g.Values.Concat(m.Values))
+        {
+            check.IsCheckedChanged += (_, _) => Sync();
+        }
+        Sync();
+
+        read = () => new SessionScope
+        {
+            Kind = ScopeKind.Limited,
+            Groups = [.. g.Where(x => x.Value.IsChecked == true).Select(x => x.Key)],
+            SavedIds = [.. m.Where(x => x.Value.IsChecked == true).Select(x => x.Key)]
+        };
+        return checklist;
+    }
+
+    /// <summary>一个"小标题 + 控件"的竖排(下拉那几个用)。</summary>
+    private static StackPanel Labelled(string label, Control control)
+    {
+        var caption = new TextBlock { Text = label };
+        caption.Classes.Add("hint");
+        var panel = new StackPanel { Spacing = 2 };
+        panel.Children.Add(caption);
+        panel.Children.Add(control);
+        return panel;
+    }
+
+    /// <summary>范围选择器里的一小段(分组 / 单台)。</summary>
+    private static StackPanel Section(string label, Control content)
+    {
+        var caption = new TextBlock { Text = label };
+        caption.Classes.Add("hint");
+        var panel = new StackPanel { Spacing = 4 };
+        panel.Children.Add(caption);
+        panel.Children.Add(content);
+        return panel;
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml
@@ -113,9 +113,21 @@
                              FontFamily="{DynamicResource VelaUiMonoFont}"
                              FontSize="{DynamicResource VelaFontSize16}"
                              Foreground="{DynamicResource VelaTextPrimary}" />
-                  <Button x:Name="IssuePairCodeButton" Grid.Column="2" MinWidth="96" Classes="host" />
+                  <Button x:Name="IssuePairSelfButton" Grid.Column="2" MinWidth="96" Classes="host" />
                 </Grid>
                 <TextBlock x:Name="PairCodeHint" Classes="hint" TextWrapping="Wrap" />
+                <!-- 给群的码另起一段:它必须先选范围,而给自己单聊的那个不必 ——
+                     一套把作者自己也拦住的权限设计,结局是被整个关掉。 -->
+                <Border Classes="card" Margin="0,10,0,0">
+                  <StackPanel>
+                    <Grid ColumnDefinitions="*,Auto">
+                      <TextBlock x:Name="PairGroupLabel" Classes="label" VerticalAlignment="Center" />
+                      <Button x:Name="IssuePairGroupButton" Grid.Column="1" MinWidth="96" Classes="host" />
+                    </Grid>
+                    <StackPanel x:Name="PairScopePanel" />
+                    <TextBlock x:Name="PairScopeHint" Classes="hint" TextWrapping="Wrap" Margin="0,6,0,0" />
+                  </StackPanel>
+                </Border>
               </StackPanel>
 
               <Border Classes="sep" />

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using QRCoder;
+using VelaShell.Plugin.Ai.Agent;
 using VelaShell.Plugin.Ai.Bridge;
 using VelaShell.Plugin.Ai.Configuration;
 using VelaShell.Plugin.Ai.Interop;
@@ -66,7 +67,11 @@ public partial class CollaborationView : UserControl
 
         public CheckBox? International { get; init; }
 
-        public required TextBox Chats { get; init; }
+        /// <summary>这个渠道下每个聊天的授权(范围 / 挡位 / 审批)。</summary>
+        public required List<GrantRow> Grants { get; init; }
+
+        /// <summary>装着那些授权行的面板(「允许」按钮往里插新行)。</summary>
+        public required StackPanel GrantsList { get; init; }
 
         public required TextBox Users { get; init; }
 
@@ -95,7 +100,9 @@ public partial class CollaborationView : UserControl
         InitializeComponent();
         ApplyLoc();
 
-        IssuePairCodeButton.Click += (_, _) => IssuePairCode();
+        // 两个码:给自己的不限范围,给群的必须先勾范围。它们的默认值本来就该不一样。
+        IssuePairSelfButton.Click += (_, _) => IssuePairCode(null);
+        IssuePairGroupButton.Click += (_, _) => IssuePairCode(_pairScope?.Invoke());
         // 敲门是异步发生的(人在手机上操作),所以这一页开着时自己刷 ——
         // 否则用户得关掉再打开才看得见刚才那个群
         _refresh = new DispatcherTimer(TimeSpan.FromSeconds(3), DispatcherPriority.Background, (_, _) =>
@@ -141,8 +148,11 @@ public partial class CollaborationView : UserControl
 
         SectionPairingTitle.Text = _loc["SecPairing"];
         PairCodeLabel.Text = _loc["PairCode"];
-        IssuePairCodeButton.Content = _loc["PairIssue"];
+        IssuePairSelfButton.Content = _loc["PairForSelf"];
         PairCodeHint.Text = _loc["PairHint"];
+        PairGroupLabel.Text = _loc["PairForGroup"];
+        IssuePairGroupButton.Content = _loc["PairIssue"];
+        PairScopeHint.Text = _loc["PairScopeHint"];
         PendingLabel.Text = _loc["PairPending"];
         NoPendingHint.Text = _loc["PairNoPending"];
 
@@ -198,6 +208,9 @@ public partial class CollaborationView : UserControl
     private async Task LoadAsync()
     {
         _settings = await _bridgeStore.LoadAsync();
+        // 范围选择器要按会话树里的分组来勾。取一次就够:这一页开着的时候会话树很少在动,
+        // 而每建一行就去问一次宿主,一个有二十条授权的渠道会问二十遍。
+        _saved = [.. await _context.Sessions.ListSavedAsync()];
         _mcp = await _mcpStore.LoadAsync();
         _token = await _mcpStore.TokenAsync();
         await LoadModelsAsync();
@@ -216,6 +229,10 @@ public partial class CollaborationView : UserControl
         McpApprovalCombo.SelectedIndex = (int)_mcp.Approval;
         McpTargetsBox.Text = _mcp.AllowedTargets;
         McpTokenBox.Text = _token;
+
+        PairScopePanel.Children.Clear();
+        PairScopePanel.Children.Add(BuildPairScopePicker(out Func<SessionScope> readPairScope));
+        _pairScope = readPairScope;
 
         await RebuildChannelsAsync();
         UpdateVisibility();
@@ -332,10 +349,8 @@ public partial class CollaborationView : UserControl
             international = HostCheckBox(_loc["ChannelInternational"], config.International);
         }
 
-        TextBox chats = Field(_loc["ChannelChats"], string.Join("\n", config.AllowedChats), out StackPanel chatsPanel, multiline: true);
-        var chatsHint = new TextBlock { Text = _loc["ChannelChatsHint"] };
-        chatsHint.Classes.Add("hint");
-        chatsPanel.Children.Add(chatsHint);
+        List<GrantRow> grantRows = [];
+        StackPanel chatsPanel = BuildGrantsSection(config, grantRows, out StackPanel grantsList);
         TextBox users = Field(_loc["ChannelUsers"], string.Join("\n", config.AllowedUsers), out StackPanel usersPanel, multiline: true);
         TextBox approvers = Field(_loc["ChannelApprovers"], string.Join("\n", config.Approvers), out StackPanel approversPanel, multiline: true);
         TextBox target = Field(_loc["ChannelTarget"], config.DefaultTarget, out StackPanel targetPanel);
@@ -393,7 +408,8 @@ public partial class CollaborationView : UserControl
             Port = port,
             Path = path,
             International = international,
-            Chats = chats,
+            Grants = grantRows,
+            GrantsList = grantsList,
             Users = users,
             Approvers = approvers,
             Target = target
@@ -558,14 +574,20 @@ public partial class CollaborationView : UserControl
     }
 
     /// <summary>发一个新的配对码。</summary>
-    private void IssuePairCode()
+    /// <summary>读出「给群的配对码」那一段现在勾了什么范围。</summary>
+    private Func<SessionScope>? _pairScope;
+
+    /// <param name="scope">
+    /// 这个码兑现之后的范围。<see langword="null" /> = 不限范围(给自己单聊的那个按钮)。
+    /// </param>
+    private void IssuePairCode(SessionScope? scope)
     {
         if (_bridge is null)
         {
             StatusText.Text = _loc["PairNeedsBridge"];
             return;
         }
-        _bridge.Pairing.Issue();
+        _bridge.Pairing.Issue(scope is null ? null : new ChatGrant { Scope = scope, IsGroup = true });
         RefreshPairCode();
     }
 
@@ -654,11 +676,10 @@ public partial class CollaborationView : UserControl
         try
         {
             await _bridge.AllowAsync(chat);
-            // 白名单那个框里也要跟着出现,否则用户点了保存反而把刚放行的又抹掉了
-            if (_rows.Find(r => r.Config.Id == chat.ChannelId) is { } row
-                && !Lines(row.Chats.Text).Contains(chat.ChatId))
+            // 授权列表里也要跟着出现一行,否则用户点了保存反而把刚放行的又抹掉了
+            if (_rows.Find(r => r.Config.Id == chat.ChannelId) is { } row)
             {
-                row.Chats.Text = string.Join("\n", Lines(row.Chats.Text).Append(chat.ChatId));
+                AppendGrant(row, chat);
             }
             StatusText.Text = _loc.F("PairAllowed", chat.ChatId);
             RefreshPending();
@@ -723,7 +744,10 @@ public partial class CollaborationView : UserControl
                 config.AppId = (row.AppId?.Text ?? config.AppId).Trim();
                 config.AgentId = (row.AgentId?.Text ?? config.AgentId).Trim();
                 config.International = row.International?.IsChecked == true;
-                config.AllowedChats = Lines(row.Chats.Text);
+                // 授权是"能不能说话 + 能碰哪些机器 + 能做到什么程度"三个轴的那一份;
+                // AllowedChats 由 NormalizeGrants 从它派生出来,这里不再单独写。
+                config.Grants = [.. row.Grants.Select(g => g.Harvest()).OfType<ChatGrant>()];
+                config.NormalizeGrants();
                 config.AllowedUsers = Lines(row.Users.Text);
                 config.Approvers = Lines(row.Approvers.Text);
                 config.DefaultTarget = (row.Target.Text ?? "").Trim();

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -468,14 +468,6 @@ public sealed class Loc(string locale)
         ["ChannelEnabled"] = ["Enabled", "启用", "啟用", "有効", "사용"],
         ["ChannelName"] = ["Display name", "显示名", "顯示名", "表示名", "표시 이름"],
         ["ChannelInternational"] = ["International edition (larksuite.com)", "国际版(larksuite.com)", "國際版(larksuite.com)", "国際版(larksuite.com)", "국제판(larksuite.com)"],
-        ["ChannelChats"] = ["Allowed chats (one id per line)", "允许的聊天(每行一个 id)", "允許的聊天(每行一個 id)", "許可するチャット(1 行に 1 つの ID)", "허용할 대화(한 줄에 ID 하나)"],
-        ["ChannelChatsHint"] = [
-            "Empty means nobody is served. Message the bot once and its reply tells you the chat id.",
-            "留空 = 谁都不理。先在群里 @ 一下机器人,它会回一句告诉你这个群的 id。",
-            "留空 = 誰都不理。先在群裡 @ 一下機器人,它會回一句告訴你這個群的 id。",
-            "空欄なら誰にも応答しません。まずボットにメッセージを送ると、返信でチャット ID がわかります。",
-            "비워 두면 아무에게도 응답하지 않습니다. 봇에게 한 번 말을 걸면 답장에 대화 ID가 표시됩니다."
-        ],
         ["ChannelUsers"] = ["Allowed users (blank = anyone in those chats)", "允许的用户(留空 = 白名单聊天里的任何人)", "允許的使用者(留空 = 白名單聊天裡的任何人)", "許可するユーザー(空欄 = 上記チャットの全員)", "허용할 사용자(비우면 해당 대화의 모든 사람)"],
         ["ChannelApprovers"] = ["Approvers (blank = same as allowed users)", "审批人(留空 = 与允许的用户相同)", "審批人(留空 = 與允許的使用者相同)", "承認者(空欄 = 許可ユーザーと同じ)", "승인자(비우면 허용 사용자와 동일)"],
         ["ChannelTarget"] = ["Default server (user@host:port)", "默认服务器(user@host:port)", "預設伺服器(user@host:port)", "既定のサーバー(user@host:port)", "기본 서버(user@host:port)"],
@@ -494,11 +486,11 @@ public sealed class Loc(string locale)
         ["PairIssue"] = ["Generate", "生成", "產生", "生成", "생성"],
         ["PairExpiresIn"] = ["(expires in {0}m {1}s)", "({0} 分 {1} 秒后过期)", "({0} 分 {1} 秒後過期)", "(あと {0} 分 {1} 秒で失効)", "({0}분 {1}초 후 만료)"],
         ["PairHint"] = [
-            "Generate a code, then send \"/pair <code>\" in the chat you want to authorise — no need to copy chat ids around. One use, ten minutes, five wrong tries and it dies. It only lets that chat talk to the bot; the mode and approval settings above still apply.",
-            "点生成拿一个码,然后在想授权的那个聊天里发「/pair 码」—— 不用再来回抄群 id。一次性、十分钟过期、猜错五次作废。它只决定「这个聊天能不能跟机器人说话」,能不能动服务器仍旧由上面的挡位与审批管。",
-            "點產生拿一個碼,然後在想授權的那個聊天裡發「/pair 碼」—— 不用再來回抄群 id。一次性、十分鐘過期、猜錯五次作廢。它只決定「這個聊天能不能跟機器人說話」,能不能動伺服器仍舊由上面的擋位與審批管。",
-            "コードを生成し、許可したいチャットで「/pair コード」と送るだけです(チャット ID を書き写す必要はありません)。1 回限り・10 分で失効・5 回間違えると無効。許可するのは「そのチャットがボットと話せる」ことだけで、サーバー操作は上のモードと承認方式に従います。",
-            "코드를 생성한 뒤 허용할 대화에서 \"/pair 코드\"를 보내세요(대화 ID를 옮겨 적을 필요 없음). 일회용, 10분 만료, 5회 틀리면 폐기됩니다. 허용되는 것은 \"그 대화가 봇과 대화할 수 있다\"는 것뿐이며 서버 조작은 위의 모드와 승인 방식을 따릅니다."
+            "Generate a code, then send \"/pair <code>\" in the chat you want to authorise — no need to copy chat ids around. One use, ten minutes, five wrong tries and it dies. This one is for your own direct chat with the bot, so it carries no limit; a group gets its scope chosen below, before the code is issued.",
+            "点生成拿一个码,然后在想授权的那个聊天里发「/pair 码」—— 不用再来回抄群 id。一次性、十分钟过期、猜错五次作废。这个码是给「你自己跟机器人的单聊」用的,所以不带范围;给群的码在下面先选好范围再发。",
+            "點產生拿一個碼,然後在想授權的那個聊天裡發「/pair 碼」—— 不用再來回抄群 id。一次性、十分鐘過期、猜錯五次作廢。這個碼是給「你自己跟機器人的單聊」用的,所以不帶範圍;給群的碼在下面先選好範圍再發。",
+            "コードを生成し、許可したいチャットで「/pair コード」と送るだけです(チャット ID を書き写す必要はありません)。1 回限り・10 分で失効・5 回間違えると無効。これは自分とボットの個別チャット用なので範囲の制限は付きません。グループ用のコードは下で範囲を選んでから発行します。",
+            "코드를 생성한 뒤 허용할 대화에서 \"/pair 코드\"를 보내세요(대화 ID를 옮겨 적을 필요 없음). 일회용, 10분 만료, 5회 틀리면 폐기됩니다. 이 코드는 자신과 봇의 개인 대화용이라 범위 제한이 없으며, 그룹용 코드는 아래에서 범위를 고른 뒤 발급합니다."
         ],
         ["PairNeedsBridge"] = [
             "Turn the chat bridge on and save first — a pairing code is only useful while the bot is online.",
@@ -587,11 +579,34 @@ public sealed class Loc(string locale)
         ],
         ["BridgePairUsage"] = ["Usage: /pair <code> — the code is in VelaShell under Collaboration.", "用法:/pair 码 —— 码在 VelaShell 的「协作接入」页里。", "用法:/pair 碼 —— 碼在 VelaShell 的「協作接入」頁裡。", "使い方:/pair コード —— コードは VelaShell の「連携」画面にあります。", "사용법: /pair 코드 — 코드는 VelaShell의 「협업 연동」 화면에 있습니다."],
         ["BridgePairRejected"] = ["That code is not valid. Generate a fresh one in VelaShell.", "这个码不对。到 VelaShell 里重新生成一个。", "這個碼不對。到 VelaShell 裡重新產生一個。", "そのコードは使えません。VelaShell で新しく生成してください。", "이 코드는 사용할 수 없습니다. VelaShell에서 새로 생성하세요."],
+        // ---- 会话范围授权 ----
+        ["BridgePairedScoped"] = ["Paired — this chat can talk to me now, limited to: {0}. Try /help.", "配对成功,这个聊天现在可以跟我说话了,范围:{0}。试试 /help。", "配對成功,這個聊天現在可以跟我說話了,範圍:{0}。試試 /help。", "ペアリングできました。このチャットから話しかけられます(範囲:{0})。/help を試してください。", "페어링에 성공했습니다. 이제 이 대화에서 말을 걸 수 있습니다(범위: {0}). /help를 사용해 보세요."],
+        ["BridgeStatusScope"] = ["Scope: {0}", "范围:{0}", "範圍:{0}", "範囲:{0}", "범위: {0}"],
+        ["BridgeScopeAll"] = ["all machines", "全部机器", "全部機器", "すべてのマシン", "모든 머신"],
+        ["ScopeAll"] = ["No limit — every machine", "不限范围(全部机器)", "不限範圍(全部機器)", "制限なし(すべてのマシン)", "제한 없음(모든 머신)"],
+        ["ScopeLimited"] = ["Only what I tick below", "只有下面勾选的", "只有下面勾選的", "下でチェックしたものだけ", "아래에서 선택한 것만"],
+        ["ScopeLabel"] = ["Can operate", "能操作", "能操作", "操作できる範囲", "조작 범위"],
+        ["ScopeGroups"] = ["Groups", "分组", "分組", "グループ", "그룹"],
+        ["ScopeMachines"] = ["Individual machines", "单台机器", "單台機器", "個別のマシン", "개별 머신"],
+        ["ScopeEmptyWarning"] = ["Nothing ticked — this chat can reach no machine at all.", "一个都没勾:这个聊天碰不到任何机器。", "一個都沒勾:這個聊天碰不到任何機器。", "何もチェックされていません。このチャットはどのマシンにも到達できません。", "아무것도 선택되지 않았습니다. 이 대화는 어떤 머신에도 접근할 수 없습니다."],
+        ["ScopeNoSaved"] = ["No saved connections yet — save some in the session tree first.", "还没有已保存的连接,先去会话树里存几台。", "還沒有已保存的連線,先去工作階段樹裡存幾台。", "保存済みの接続がありません。先にセッションツリーに登録してください。", "저장된 연결이 없습니다. 먼저 세션 트리에 등록하세요."],
+        ["GrantsLabel"] = ["Authorized chats", "已授权的聊天", "已授權的聊天", "許可済みのチャット", "허가된 대화"],
+        ["GrantsHint"] = ["A group's scope is a property of the room, not of you — your own DM and the AI panel are never limited.", "群的范围是这个房间的属性,不是你的:你自己的单聊与 AI 面板永远不受限。", "群的範圍是這個房間的屬性,不是你的:你自己的單聊與 AI 面板永遠不受限。", "グループの範囲は部屋の属性であって、あなたの属性ではありません。自分との個別チャットと AI パネルは制限されません。", "그룹의 범위는 방의 속성이지 사용자의 속성이 아닙니다. 자신과의 개인 대화와 AI 패널은 제한되지 않습니다."],
+        ["GrantAdd"] = ["Add a chat", "添加聊天", "新增聊天", "チャットを追加", "대화 추가"],
+        ["GrantChatId"] = ["Chat id", "聊天 id", "聊天 id", "チャット ID", "대화 ID"],
+        ["GrantMode"] = ["Mode", "挡位", "擋位", "モード", "모드"],
+        ["GrantApproval"] = ["Approval", "审批", "審批", "承認", "승인"],
+        ["GrantFollowGlobal"] = ["Follow the global setting", "跟随全局设置", "跟隨全域設定", "全体設定に従う", "전역 설정 따르기"],
+        ["GrantIsGroup"] = ["group", "群", "群", "グループ", "그룹"],
+        ["GrantIsDirect"] = ["direct chat", "单聊", "單聊", "個別チャット", "개인 대화"],
+        ["PairForGroup"] = ["Pairing code for a group", "生成配对码(群)", "產生配對碼(群)", "グループ用のペアリングコード", "그룹용 페어링 코드"],
+        ["PairForSelf"] = ["Pairing code for myself (no limit)", "生成配对码(我自己 · 不限范围)", "產生配對碼(我自己 · 不限範圍)", "自分用のペアリングコード(制限なし)", "내 계정용 페어링 코드(제한 없음)"],
+        ["PairScopeHint"] = ["The code carries this scope — the chat is limited from its first second, with no window where it holds everything.", "配对码携带这份范围:群从第一秒起就受限,不存在\"先全开再收紧\"的窗口。", "配對碼攜帶這份範圍:群從第一秒起就受限,不存在\"先全開再收緊\"的視窗。", "コードはこの範囲を伴います。チャットは最初から制限され、「まず全開放してから絞る」窓は存在しません。", "코드가 이 범위를 함께 전달합니다. 대화는 처음부터 제한되며 \"먼저 전부 열고 나중에 좁히는\" 구간이 없습니다."],
         ["BridgePaired"] = ["Paired — this chat can talk to me now. Try /help.", "配对成功,这个聊天现在可以跟我说话了。试试 /help。", "配對成功,這個聊天現在可以跟我說話了。試試 /help。", "ペアリングできました。このチャットから話しかけられます。/help を試してください。", "페어링에 성공했습니다. 이제 이 대화에서 말을 걸 수 있습니다. /help를 사용해 보세요."],
         // ── 斜杠命令 ──
         ["BridgeHelp"] = [
-            "/sessions — list connected servers\n/use <user@host:port> — bind this chat to one\n/mode chat|plan|agent — change the mode\n/new — start a fresh conversation\n/stop — stop the current turn\n/status — show what this chat is set to",
-            "/sessions — 列出已连上的服务器\n/use <user@host:port> — 把本聊天绑到某一台\n/mode chat|plan|agent — 换挡位\n/new — 开一段新对话\n/stop — 中止当前这一轮\n/status — 看本聊天的当前设定",
+            "/sessions — list connected servers\n/use <user@host:port> — bind this chat to one\n/mode chat|plan|agent — change the mode\n/new — start a fresh conversation\n/stop — stop the current turn\n/status — show what this chat is set to, including which machines it may touch",
+            "/sessions — 列出已连上的服务器\n/use <user@host:port> — 把本聊天绑到某一台\n/mode chat|plan|agent — 换挡位\n/new — 开一段新对话\n/stop — 中止当前这一轮\n/status — 看本聊天的当前设定(含能操作哪些机器)",
             "/sessions — 列出已連上的伺服器\n/use <user@host:port> — 把本聊天綁到某一台\n/mode chat|plan|agent — 換擋位\n/new — 開一段新對話\n/stop — 中止目前這一輪\n/status — 看本聊天的目前設定",
             "/sessions — 接続中のサーバー一覧\n/use <user@host:port> — このチャットを 1 台に紐付け\n/mode chat|plan|agent — モード変更\n/new — 会話をやり直す\n/stop — 実行中のターンを中止\n/status — このチャットの設定を表示",
             "/sessions — 연결된 서버 목록\n/use <user@host:port> — 이 대화를 서버에 연결\n/mode chat|plan|agent — 모드 변경\n/new — 새 대화 시작\n/stop — 현재 턴 중단\n/status — 이 대화의 설정 보기"

--- a/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxScopeTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/AgentToolboxScopeTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 范围在<b>工具箱</b>这一层的强制点。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>为什么闸必须设在这里。</b>"这个聊天绑了哪台机器"从来只是一个默认值:工具箱里九个工具
+/// 都收可选的 <c>session_id</c>,<c>run_on_sessions</c> 收的还是一个 id <b>数组</b> ——
+/// 模型只要先 <c>list_sessions</c> 拿到 id 再显式传进去,任何做在"绑定"上的限制都当场失效。
+/// 所以这一组用例逐个入口去撞:显式 id、默认目标、批量、开新连接、两个列表工具。
+/// </para>
+/// <para>
+/// 同样重要的是反面:<b>没有范围时一切照旧</b>。聊天面板走的就是那条路,
+/// 它一个字节的行为都不该因为这套机制而改变。
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class AgentToolboxScopeTests
+{
+    private static async Task<string> InvokeAsync(AgentToolbox toolbox, string name,
+        Dictionary<string, object?>? args = null)
+    {
+        AIFunction function = toolbox.CreateTools(ChatMode.Agent).OfType<AIFunction>().Single(f => f.Name == name);
+        object? result = await function.InvokeAsync([with(args ?? [])], CancellationToken.None);
+        return result?.ToString() ?? "";
+    }
+
+    /// <summary>生产组一台、测试组一台,两台都连着。</summary>
+    private static (SessionInfo Prod, SessionInfo Test, SavedSessionInfo SavedTest) Two(TestPluginContext context)
+    {
+        context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", username: "root", group: "生产");
+        SavedSessionInfo savedTest =
+            context.FakeSessions.AddSaved(name: "test-1", host: "10.0.0.2", username: "root", group: "测试");
+        return (context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root"),
+            context.FakeSessions.AddConnected(host: "10.0.0.2", username: "root"),
+            savedTest);
+    }
+
+    private static AgentToolbox Scoped(TestPluginContext context, params string[] groups)
+        => new(context)
+        {
+            Scope = new SessionScope { Kind = ScopeKind.Limited, Groups = [.. groups] }.Resolve(context),
+            Approval = ApprovalMode.Bypass
+        };
+
+    /// <summary>
+    /// <b>这是整套设计的中心用例。</b>显式传一个范围外的 <c>session_id</c>,必须被挡下来。
+    /// </summary>
+    /// <remarks>
+    /// 调研里发现的第一件事就是:绑定拦不住任何人,因为每个工具都能显式传 id。
+    /// 这条用例要是绿的而实现却只挡默认目标,那这套授权就只是一层装饰。
+    /// </remarks>
+    [TestMethod]
+    public async Task ExplicitSessionId_OutsideTheScope_IsRefused()
+    {
+        using var context = new TestPluginContext();
+        (_, SessionInfo test, _) = Two(context);
+        context.FakeTerminal.Output[test.SessionId] = ["secret from the test box"];
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = test.SessionId });
+
+        Assert.Contains("outside the scope", result);
+        Assert.DoesNotContain("secret from the test box", result, "范围外机器的终端内容一个字都不该漏出去");
+    }
+
+    /// <summary>范围内的那台照常能用 —— 闸是筛子,不是墙。</summary>
+    [TestMethod]
+    public async Task ExplicitSessionId_InsideTheScope_StillWorks()
+    {
+        using var context = new TestPluginContext();
+        (SessionInfo prod, _, _) = Two(context);
+        context.FakeTerminal.Output[prod.SessionId] = ["active (running)"];
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = prod.SessionId });
+
+        Assert.Contains("active (running)", result);
+    }
+
+    /// <summary>
+    /// 默认目标也要过闸:授权之后用户可能把那台机器移出了分组,而绑定还留着。
+    /// </summary>
+    [TestMethod]
+    public async Task TheDefaultTarget_IsCheckedToo()
+    {
+        using var context = new TestPluginContext();
+        (_, SessionInfo test, _) = Two(context);
+        context.FakeTerminal.Output[test.SessionId] = ["secret from the test box"];
+        AgentToolbox toolbox = Scoped(context, "生产");
+        toolbox.SessionIdProvider = () => test.SessionId;
+
+        string result = await InvokeAsync(toolbox, "read_terminal");
+
+        Assert.Contains("outside the scope", result);
+        Assert.DoesNotContain("secret", result);
+    }
+
+    /// <summary>范围外的会话在 <c>list_sessions</c> 里不该出现 —— 连主机名都是信息。</summary>
+    [TestMethod]
+    public async Task ListSessions_HidesWhatIsOutOfScope()
+    {
+        using var context = new TestPluginContext();
+        Two(context);
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "list_sessions");
+
+        Assert.Contains("10.0.0.1", result);
+        Assert.DoesNotContain("10.0.0.2", result);
+    }
+
+    /// <summary>
+    /// <c>list_saved_sessions</c> 同理,而且它泄露的更多:<b>分组名本身</b>就在说明这台机器归谁管。
+    /// </summary>
+    [TestMethod]
+    public async Task ListSavedSessions_HidesWhatIsOutOfScope()
+    {
+        using var context = new TestPluginContext();
+        Two(context);
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "list_saved_sessions");
+
+        Assert.Contains("prod-1", result);
+        Assert.DoesNotContain("test-1", result);
+        Assert.DoesNotContain("测试", result);
+    }
+
+    /// <summary>范围内一台都没有时,说的是"范围内没有",而不是"你一台都没连"。</summary>
+    /// <remarks>后者会让用户跑去连一台机器,然后发现还是不行,而且不知道为什么。</remarks>
+    [TestMethod]
+    public async Task ListSessions_WithNothingInScope_SaysSo()
+    {
+        using var context = new TestPluginContext();
+        Two(context);
+        AgentToolbox toolbox = Scoped(context, "根本不存在的分组");
+
+        string result = await InvokeAsync(toolbox, "list_sessions");
+
+        Assert.Contains("within the scope", result);
+    }
+
+    /// <summary>
+    /// <b>批量执行是范围最容易漏掉的一处</b> —— 它收的是 id 数组,压根不经过单目标那条解析路径。
+    /// </summary>
+    [TestMethod]
+    public async Task RunOnSessions_RefusesTheWholeBatchIfAnyTargetIsOutOfScope()
+    {
+        using var context = new TestPluginContext();
+        (SessionInfo prod, SessionInfo test, _) = Two(context);
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "run_on_sessions", new Dictionary<string, object?>
+        {
+            ["sessionIds"] = new[] { prod.SessionId, test.SessionId },
+            ["command"] = "df -h"
+        });
+
+        Assert.Contains("outside the scope", result);
+    }
+
+    /// <summary>
+    /// <c>open_session</c> 的范围检查要排在<b>审批之前</b>:一个注定越界的请求
+    /// 不该先去惊动用户点一次头。
+    /// </summary>
+    [TestMethod]
+    public async Task OpenSession_OutsideTheScope_IsRefusedBeforeAskingForApproval()
+    {
+        using var context = new TestPluginContext();
+        (_, _, SavedSessionInfo savedTest) = Two(context);
+        var asked = 0;
+        var toolbox = new AgentToolbox(context)
+        {
+            Scope = new SessionScope { Kind = ScopeKind.Limited, Groups = ["生产"] }.Resolve(context),
+            Approval = ApprovalMode.Ask,
+            ApprovalHandler = _ =>
+            {
+                asked++;
+                return Task.FromResult(true);
+            }
+        };
+
+        string result = await InvokeAsync(toolbox, "open_session", new Dictionary<string, object?>
+        {
+            ["savedSessionId"] = savedTest.SavedSessionId,
+            ["reason"] = "Feishu group Ops: check disk"
+        });
+
+        Assert.Contains("outside the scope", result);
+        Assert.AreEqual(0, asked, "越界的请求不该惊动用户");
+    }
+
+    /// <summary>
+    /// 拒绝消息<b>不列出范围外有什么</b> —— 否则试一个 id 就能问出一份完整清单。
+    /// </summary>
+    [TestMethod]
+    public async Task TheRefusal_DoesNotEnumerateWhatIsOutOfScope()
+    {
+        using var context = new TestPluginContext();
+        (_, SessionInfo test, _) = Two(context);
+        AgentToolbox toolbox = Scoped(context, "生产");
+
+        string result = await InvokeAsync(toolbox, "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = test.SessionId });
+
+        Assert.DoesNotContain("10.0.0.1", result, "拒绝消息不该顺带报出范围内有哪些机器");
+        Assert.DoesNotContain("10.0.0.2", result);
+        Assert.DoesNotContain("生产", result);
+    }
+
+    // ---- 反面:没有范围 = 什么都没变 ----
+
+    /// <summary>
+    /// <b>不卡自己脖子。</b>聊天面板那条路不设范围,它必须够得着每一台机器。
+    /// </summary>
+    /// <remarks>
+    /// 一套把作者自己也拦住的权限设计,结局是被整个关掉、回到零防护。
+    /// 所以"没有范围"这条路要和"有范围"一样被钉住。
+    /// </remarks>
+    [TestMethod]
+    public async Task WithNoScope_EveryMachineIsStillReachable()
+    {
+        using var context = new TestPluginContext();
+        (SessionInfo prod, SessionInfo test, _) = Two(context);
+        context.FakeTerminal.Output[test.SessionId] = ["active (running)"];
+        var toolbox = new AgentToolbox(context) { Approval = ApprovalMode.Bypass };
+
+        string list = await InvokeAsync(toolbox, "list_sessions");
+        string read = await InvokeAsync(toolbox, "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = test.SessionId });
+
+        Assert.Contains(prod.Host, list);
+        Assert.Contains(test.Host, list);
+        Assert.Contains("active (running)", read);
+    }
+
+    /// <summary>
+    /// 手敲 <c>ssh</c> 连出去的临时会话:不受限那条路照常够得着,受限那条路够不着。
+    /// </summary>
+    /// <remarks>
+    /// 失败关闭的代价就在这里 —— 受限的群碰不到会话树之外的机器。这是对的:
+    /// 那恰恰是没人替它定过范围的一类,而你自己那条路本来就不受限。
+    /// </remarks>
+    [TestMethod]
+    public async Task AnAdHocSession_IsReachableWithoutAScopeAndRefusedWithOne()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", username: "root", group: "生产");
+        SessionInfo adhoc = context.FakeSessions.AddConnected(host: "10.0.0.99", username: "root");
+        context.FakeTerminal.Output[adhoc.SessionId] = ["ad-hoc box"];
+
+        string open = await InvokeAsync(new AgentToolbox(context), "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = adhoc.SessionId });
+        string limited = await InvokeAsync(Scoped(context, "生产"), "read_terminal",
+            new Dictionary<string, object?> { ["sessionId"] = adhoc.SessionId });
+
+        Assert.Contains("ad-hoc box", open);
+        Assert.Contains("outside the scope", limited);
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
@@ -26,7 +26,7 @@ public sealed class BridgeAgentRunnerTests
     {
         using var context = new TestPluginContext();
         BridgeTurn turn = await Create(context).RunAsync(new BridgeConversation("ch1", "chat-1"),
-            new BridgeSettings(), Message(), Deny, English, null, CancellationToken.None);
+            new BridgeSettings(), Message(), Deny, English, null, null, CancellationToken.None);
 
         Assert.AreEqual(English["BridgeNoModel"], turn.Text);
         Assert.AreEqual("", turn.Model);
@@ -56,8 +56,7 @@ public sealed class BridgeAgentRunnerTests
         var conversation = new BridgeConversation("ch1", "chat-1");
         var bridge = new BridgeSettings { Mode = ChatMode.Chat }; // 纯对话:不碰工具,免得牵进 MCP
 
-        BridgeTurn before = await runner.RunAsync(conversation, bridge, Message(), Deny, English, null,
-            CancellationToken.None);
+        BridgeTurn before = await runner.RunAsync(conversation, bridge, Message(), Deny, English, null, null, CancellationToken.None);
         Assert.AreEqual(English["BridgeNoModel"], before.Text, "with nothing configured it should say so");
 
         // runner 造好之后才配上模型 —— 快照式实现在这一步之后仍然会说"没配模型"
@@ -79,7 +78,7 @@ public sealed class BridgeAgentRunnerTests
         });
 
         InvalidOperationException error = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-            () => runner.RunAsync(conversation, bridge, Message(), Deny, English, null, CancellationToken.None));
+            () => runner.RunAsync(conversation, bridge, Message(), Deny, English, null, null, CancellationToken.None));
 
         // 报错里带着模型名 = 它确实读到了刚写进去的那份设置
         StringAssert.Contains(error.Message, "Local / probe");
@@ -114,7 +113,7 @@ public sealed class BridgeAgentRunnerTests
 
         InvalidOperationException error = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
             () => Create(context).RunAsync(new BridgeConversation("ch1", "chat-1"),
-                new BridgeSettings { Mode = ChatMode.Chat }, Message(), Deny, English, null, CancellationToken.None));
+                new BridgeSettings { Mode = ChatMode.Chat }, Message(), Deny, English, null, null, CancellationToken.None));
 
         StringAssert.StartsWith(error.Message, "Acme / some-model:");
     }

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeEndpointQuirksTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeEndpointQuirksTests.cs
@@ -60,7 +60,7 @@ public sealed class BridgeEndpointQuirksTests
         try
         {
             await runner.RunAsync(new BridgeConversation("ch1", "chat-1"), bridge, Message(),
-                Deny, English, null, CancellationToken.None);
+                Deny, English, null, null, CancellationToken.None);
         }
         catch (Exception)
         {

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
@@ -184,6 +184,128 @@ public sealed class BridgeRouterTests
         StringAssert.Contains(harness.Channel.Sent.Single(), "No connected session matches");
     }
 
+    // ---- 会话范围授权 ----
+
+    /// <summary>一份收紧过的授权,只给"生产"那个分组。</summary>
+    private static Harness Scoped()
+    {
+        var channel = new ChannelConfig
+        {
+            Id = "ch1",
+            Grants =
+            [
+                new ChatGrant
+                {
+                    ChatId = "chat-1",
+                    IsGroup = true,
+                    Scope = new SessionScope { Kind = ScopeKind.Limited, Groups = ["生产"] }
+                }
+            ]
+        };
+        return new Harness(new BridgeSettings { Enabled = true, Channels = [channel] });
+    }
+
+    /// <summary><c>/sessions</c> 只列范围内的 —— 主机名本身就是信息。</summary>
+    [TestMethod]
+    public async Task SlashSessions_ListsOnlyWhatIsInScope()
+    {
+        await using Harness harness = Scoped();
+        harness.Context.FakeSessions.AddSaved(name: "prod-1", host: "prod-1", username: "root", group: "生产");
+        harness.Context.FakeSessions.AddSaved(name: "test-1", host: "test-1", username: "root", group: "测试");
+        harness.Context.FakeSessions.AddConnected(host: "prod-1", username: "root");
+        harness.Context.FakeSessions.AddConnected(host: "test-1", username: "root");
+        await harness.StartAsync();
+
+        await harness.SendAsync("/sessions", isGroup: true);
+
+        string reply = harness.Channel.Sent.Single();
+        StringAssert.Contains(reply, "root@prod-1:22");
+        Assert.IsFalse(reply.Contains("test-1", StringComparison.Ordinal), "范围外的机器不该出现在清单里");
+    }
+
+    /// <summary>
+    /// <c>/use</c> 碰范围外的机器,回的是"没找到",<b>而不是"找到了但不给你"</b>。
+    /// </summary>
+    /// <remarks>
+    /// 后者会把这条命令变成探测接口:试一个主机名就能问出它在不在用户的机器列表里。
+    /// 日志里记全,群里说一半。
+    /// </remarks>
+    [TestMethod]
+    public async Task SlashUse_TreatsAnOutOfScopeMachineAsNonexistent()
+    {
+        await using Harness harness = Scoped();
+        harness.Context.FakeSessions.AddSaved(name: "test-1", host: "test-1", username: "root", group: "测试");
+        harness.Context.FakeSessions.AddConnected(host: "test-1", username: "root");
+        await harness.StartAsync();
+
+        await harness.SendAsync("/use root@test-1:22", isGroup: true);
+
+        string reply = harness.Channel.Sent.Single();
+        StringAssert.Contains(reply, "No connected session matches");
+        BridgeSettings stored = await harness.Store.LoadAsync();
+        Assert.IsFalse(stored.ChatBindings.ContainsKey("ch1/chat-1"), "越界的绑定不该被记下来");
+    }
+
+    /// <summary><c>/status</c> 要把范围报出来 —— 不然人只能靠撞墙才知道自己受限。</summary>
+    [TestMethod]
+    public async Task SlashStatus_ReportsTheScope()
+    {
+        await using Harness harness = Scoped();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/status", isGroup: true);
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "生产");
+    }
+
+    /// <summary>
+    /// <b>这条是安全用例。</b>挡位的天花板是<b>这个聊天</b>的,不是全局的。
+    /// </summary>
+    /// <remarks>
+    /// 全局设成 Agent、某个群单独摁回 Plan,那个群就不该能用一句 <c>/mode agent</c> 把自己抬回去 ——
+    /// 否则"只读群"这个概念根本立不住。
+    /// </remarks>
+    [TestMethod]
+    public async Task SlashMode_CeilingIsThePerChatGrantNotTheGlobalSetting()
+    {
+        var channel = new ChannelConfig
+        {
+            Id = "ch1",
+            Grants = [new ChatGrant { ChatId = "chat-1", Mode = ChatMode.Plan }]
+        };
+        await using var harness = new Harness(new BridgeSettings
+        {
+            Enabled = true,
+            Mode = ChatMode.Agent,
+            Channels = [channel]
+        });
+        await harness.StartAsync();
+
+        await harness.SendAsync("/mode agent");
+
+        StringAssert.Contains(harness.Channel.Sent.Single(), "turned off");
+    }
+
+    /// <summary>
+    /// <b>不卡自己脖子。</b>不限范围的授权(单聊、以及升级折算出来的那些)照常够得着所有机器。
+    /// </summary>
+    [TestMethod]
+    public async Task AnUnrestrictedGrant_StillSeesEverything()
+    {
+        await using var harness = new Harness();
+        harness.Context.FakeSessions.AddSaved(name: "test-1", host: "test-1", username: "root", group: "测试");
+        harness.Context.FakeSessions.AddConnected(host: "test-1", username: "root");
+        // 会话树里没有的临时机器也够得着 —— 失败关闭只作用于受限的那些
+        harness.Context.FakeSessions.AddConnected(host: "adhoc", username: "root");
+        await harness.StartAsync();
+
+        await harness.SendAsync("/sessions");
+
+        string reply = harness.Channel.Sent.Single();
+        StringAssert.Contains(reply, "root@test-1:22");
+        StringAssert.Contains(reply, "root@adhoc:22");
+    }
+
     /// <summary>
     /// <b>这条是安全用例。</b>白名单里的任何人都能发 <c>/mode agent</c> 的话,
     /// 设置页里那个"桥接默认只读"就形同虚设。

--- a/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
@@ -7,6 +7,7 @@ using Avalonia.LogicalTree;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using QRCoder;
+using VelaShell.Plugin.Ai.Agent;
 using VelaShell.Plugin.Ai.Bridge;
 using VelaShell.Plugin.Ai.Configuration;
 using VelaShell.Plugin.Ai.Interop;
@@ -248,7 +249,7 @@ public sealed class CollaborationViewUiTests
             await using var bridge = new BridgeService(context, new AiSettingsStore(context));
             await WithViewAsync(context, async view =>
             {
-                view.FindControl<Button>("IssuePairCodeButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                view.FindControl<Button>("IssuePairSelfButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                 await PumpAsync();
 
                 string shown = view.FindControl<TextBlock>("PairCodeText")!.Text ?? "";
@@ -267,11 +268,98 @@ public sealed class CollaborationViewUiTests
             using var context = new TestPluginContext();
             await WithViewAsync(context, async view =>
             {
-                view.FindControl<Button>("IssuePairCodeButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                view.FindControl<Button>("IssuePairSelfButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                 await PumpAsync();
 
                 StringAssert.Contains(view.FindControl<TextBlock>("StatusText")!.Text ?? "", "bridge on");
             });
+        });
+    }
+
+    /// <summary>
+    /// 授权编辑器要能<b>存下来再读回去</b>:聊天 id、范围、挡位三样都不能在往返里丢。
+    /// </summary>
+    /// <remarks>
+    /// 这一条守的是最难查的一类 bug:界面上勾好了、点了保存、看着也没报错,
+    /// 而落库的那一份少了范围 —— 于是那个群悄悄拥有全部机器,没有任何提示。
+    /// </remarks>
+    [TestMethod]
+    public void Grants_RoundTripThroughTheSettingsPage()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", group: "生产");
+            var store = new BridgeSettingsStore(context);
+            await store.SaveAsync(new BridgeSettings
+            {
+                Enabled = true,
+                Channels = [new ChannelConfig { Id = "c1", Kind = ChannelKind.Feishu, AllowedChats = ["oc_1"] }]
+            });
+            await WithViewAsync(context, async view =>
+            {
+                var channels = view.FindControl<StackPanel>("ChannelsPanel")!;
+                // 升级折算出来的那一行:不限范围
+                ComboBox scope = channels.GetLogicalDescendants().OfType<ComboBox>()
+                    .First(c => c.ItemsSource is string[] items && items.Length == 2);
+                Assert.AreEqual(0, scope.SelectedIndex, "老配置折算出来的授权应当不限范围");
+
+                scope.SelectedIndex = 1; // 收紧
+                await PumpAsync();
+                channels.GetLogicalDescendants().OfType<CheckBox>()
+                    .Single(c => (string?)c.Content == "生产").IsChecked = true;
+                // 挡位下拉:第 0 项是"跟随全局",选 Plan
+                ComboBox mode = channels.GetLogicalDescendants().OfType<ComboBox>()
+                    .First(c => c.ItemsSource is string[] items && items.Length == 4 && items[1] == "Chat");
+                mode.SelectedIndex = 2;
+
+                view.FindControl<Button>("SaveButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync(40);
+            });
+
+            ChannelConfig saved = (await store.LoadAsync()).Channels.Single();
+            ChatGrant grant = saved.GrantFor("oc_1")!;
+            Assert.AreEqual(ScopeKind.Limited, grant.Scope.Kind);
+            CollectionAssert.Contains(grant.Scope.Groups, "生产");
+            Assert.AreEqual(ChatMode.Plan, grant.Mode);
+            // 派生镜像也要跟着对:降级回旧版本时白名单还得在
+            CollectionAssert.Contains(saved.AllowedChats, "oc_1");
+        });
+    }
+
+    /// <summary>
+    /// 给自己单聊的码<b>不带范围</b>,给群的码带。
+    /// </summary>
+    /// <remarks>
+    /// 这是"不卡自己脖子"那条红线在界面上的落点:你不该为了让机器人认得自己,
+    /// 先去填一遍分组选择器 —— 那正是把作者自己拦住的第一步。
+    /// </remarks>
+    [TestMethod]
+    public void PairCode_ForSelfIsUnrestricted_ForAGroupCarriesTheScope()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", group: "生产");
+            await using var bridge = new BridgeService(context, new AiSettingsStore(context));
+            await WithViewAsync(context, async view =>
+            {
+                view.FindControl<Button>("IssuePairSelfButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync();
+                Assert.IsNull(bridge.Pairing.Template, "给自己的码不该带范围");
+
+                // 勾上"生产"那个分组,再发一个给群的码
+                CheckBox group = view.FindControl<StackPanel>("PairScopePanel")!
+                    .GetLogicalDescendants().OfType<CheckBox>().Single(c => (string?)c.Content == "生产");
+                group.IsChecked = true;
+                view.FindControl<Button>("IssuePairGroupButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                await PumpAsync();
+
+                ChatGrant? template = bridge.Pairing.Template;
+                Assert.IsNotNull(template);
+                Assert.AreEqual(ScopeKind.Limited, template.Scope.Kind);
+                CollectionAssert.Contains(template.Scope.Groups, "生产");
+            }, bridge);
         });
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
@@ -27,8 +27,8 @@ public sealed class PairingServiceTests
         var pairing = new PairingService();
         string code = pairing.Issue();
 
-        Assert.IsTrue(pairing.TryRedeem(code));
-        Assert.IsFalse(pairing.TryRedeem(code), "a pairing code must not be reusable");
+        Assert.IsTrue(pairing.TryRedeem(code, out _));
+        Assert.IsFalse(pairing.TryRedeem(code, out _), "a pairing code must not be reusable");
         Assert.IsNull(pairing.Code);
     }
 
@@ -39,8 +39,8 @@ public sealed class PairingServiceTests
         string code = pairing.Issue();
         string wrong = code == "000000" ? "111111" : "000000";
 
-        Assert.IsFalse(pairing.TryRedeem(wrong));
-        Assert.IsTrue(pairing.TryRedeem(code), "one wrong guess should not kill a valid code");
+        Assert.IsFalse(pairing.TryRedeem(wrong, out _));
+        Assert.IsTrue(pairing.TryRedeem(code, out _), "one wrong guess should not kill a valid code");
     }
 
     /// <summary>猜错够多次就作废 —— 六位数字挡得住随手试,挡不住脚本。</summary>
@@ -53,16 +53,16 @@ public sealed class PairingServiceTests
 
         for (int i = 0; i < 5; i++)
         {
-            Assert.IsFalse(pairing.TryRedeem(wrong));
+            Assert.IsFalse(pairing.TryRedeem(wrong, out _));
         }
 
         Assert.IsNull(pairing.Code, "the code should be dead after five wrong guesses");
-        Assert.IsFalse(pairing.TryRedeem(code), "even the right code must not work once it has been burnt");
+        Assert.IsFalse(pairing.TryRedeem(code, out _), "even the right code must not work once it has been burnt");
     }
 
     [TestMethod]
     public void Redeem_FailsWhenNoCodeWasIssued()
-        => Assert.IsFalse(new PairingService().TryRedeem("123456"));
+        => Assert.IsFalse(new PairingService().TryRedeem("123456", out _));
 
     [TestMethod]
     public void Issue_InvalidatesThePreviousCode()
@@ -71,7 +71,7 @@ public sealed class PairingServiceTests
         string first = pairing.Issue();
         pairing.Issue();
 
-        Assert.IsFalse(pairing.TryRedeem(first));
+        Assert.IsFalse(pairing.TryRedeem(first, out _));
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public sealed class PairingServiceTests
         pairing.Revoke();
 
         Assert.IsNull(pairing.Code);
-        Assert.IsFalse(pairing.TryRedeem(code));
+        Assert.IsFalse(pairing.TryRedeem(code, out _));
     }
 
     [TestMethod]

--- a/tests/VelaShell.Plugin.Ai.Tests/SessionScopeTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SessionScopeTests.cs
@@ -1,0 +1,273 @@
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Bridge;
+using VelaShell.PluginSdk.Sessions;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 会话范围授权:一份授权能碰哪些机器。
+/// </summary>
+/// <remarks>
+/// <b>这一整个文件都是安全用例。</b>从前"这个聊天绑了哪台机器"只是个默认值 ——
+/// 工具箱里九个工具都收可选的 <c>session_id</c>,传了就绕开默认值。这里守的是
+/// 收紧之后的那道闸:范围外的机器,不管从哪个入口进来都碰不到。
+/// <para>
+/// 反向的那一半同样要守:<b>不受限的那几条路必须一直不受限</b>。一套把作者自己也拦住的
+/// 权限设计,结局是被整个关掉,回到零防护 —— 所以"面板不受限""不限范围 = 没有闸"
+/// 也各有用例钉住。
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class SessionScopeTests
+{
+    private static SessionScope Limited(params string[] groups)
+        => new() { Kind = ScopeKind.Limited, Groups = [.. groups] };
+
+    // ---- 不限范围 = 压根没有闸 ----
+
+    /// <summary>
+    /// <b>这是"不卡自己脖子"那条红线的机器可读版本。</b>
+    /// </summary>
+    /// <remarks>
+    /// 不限范围不该是"一个放行全部的过滤器",而该是<b>没有过滤器</b> ——
+    /// 差别在于前者有一个可能写错的放行分支,后者没有分支可写。聊天面板走的就是这条路。
+    /// </remarks>
+    [TestMethod]
+    public void UnrestrictedScope_ResolvesToNoGateAtAll()
+    {
+        using var context = new TestPluginContext();
+
+        Assert.IsNull(new SessionScope().Resolve(context));
+        Assert.IsNull(new SessionScope { Kind = ScopeKind.All, Groups = ["生产"] }.Resolve(context));
+        Assert.IsNotNull(Limited("生产").Resolve(context));
+    }
+
+    /// <summary>反序列化一份没有 Kind 字段的旧配置,落在"不限范围"上 —— 升级不改变行为。</summary>
+    [TestMethod]
+    public void ScopeKind_DefaultsToAll() => Assert.AreEqual(ScopeKind.All, new SessionScope().Kind);
+
+    /// <summary>
+    /// <b>受限但一个都没勾 = 一台都不给。</b>
+    /// </summary>
+    /// <remarks>
+    /// 空列表最自然的读法是"什么都没选",而权限的默认值一旦读错方向,错的方向是放开。
+    /// 要不限范围就得明写 <see cref="ScopeKind.All" />。
+    /// </remarks>
+    [TestMethod]
+    public async Task LimitedScopeWithNothingTicked_AllowsNothing()
+    {
+        using var context = new TestPluginContext();
+        SavedSessionInfo saved = context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", group: "生产");
+        ISessionScope scope = new SessionScope { Kind = ScopeKind.Limited }.Resolve(context)!;
+
+        Assert.IsFalse(await scope.AllowsSavedAsync(saved, CancellationToken.None));
+    }
+
+    // ---- 分组与单台 ----
+
+    [TestMethod]
+    public async Task GroupScope_AllowsOnlyThatGroup()
+    {
+        using var context = new TestPluginContext();
+        SavedSessionInfo prod = context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", group: "生产");
+        SavedSessionInfo test = context.FakeSessions.AddSaved(name: "test-1", host: "10.0.0.2", group: "测试");
+        ISessionScope scope = Limited("生产").Resolve(context)!;
+
+        Assert.IsTrue(await scope.AllowsSavedAsync(prod, CancellationToken.None));
+        Assert.IsFalse(await scope.AllowsSavedAsync(test, CancellationToken.None));
+    }
+
+    /// <summary>分组名不分大小写:用户在会话树里改个大小写,授权不该跟着失效。</summary>
+    [TestMethod]
+    public async Task GroupScope_MatchesCaseInsensitively()
+    {
+        using var context = new TestPluginContext();
+        SavedSessionInfo saved = context.FakeSessions.AddSaved(host: "10.0.0.1", group: "Prod");
+        ISessionScope scope = Limited("prod").Resolve(context)!;
+
+        Assert.IsTrue(await scope.AllowsSavedAsync(saved, CancellationToken.None));
+    }
+
+    /// <summary>"就给这一台":分组之外还能单独放行某条配置。</summary>
+    [TestMethod]
+    public async Task SavedIdScope_AllowsOneMachineOutsideAnyGroup()
+    {
+        using var context = new TestPluginContext();
+        SavedSessionInfo db = context.FakeSessions.AddSaved(name: "db-1", host: "10.0.0.9", group: "数据库");
+        SavedSessionInfo other = context.FakeSessions.AddSaved(name: "db-2", host: "10.0.0.10", group: "数据库");
+        ISessionScope scope = new SessionScope
+        {
+            Kind = ScopeKind.Limited,
+            SavedIds = [db.SavedSessionId]
+        }.Resolve(context)!;
+
+        Assert.IsTrue(await scope.AllowsSavedAsync(db, CancellationToken.None));
+        Assert.IsFalse(await scope.AllowsSavedAsync(other, CancellationToken.None));
+    }
+
+    // ---- 活会话怎么映射回配置 ----
+
+    [TestMethod]
+    public async Task LiveSession_IsJudgedByTheSavedConfigItMatches()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", username: "root", group: "生产");
+        context.FakeSessions.AddSaved(name: "test-1", host: "10.0.0.2", username: "root", group: "测试");
+        SessionInfo prod = context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root");
+        SessionInfo test = context.FakeSessions.AddConnected(host: "10.0.0.2", username: "root");
+        ISessionScope scope = Limited("生产").Resolve(context)!;
+
+        Assert.IsTrue(await scope.AllowsLiveAsync(prod, CancellationToken.None));
+        Assert.IsFalse(await scope.AllowsLiveAsync(test, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// <b>失败关闭:对不上任何一条已保存配置的会话一律拒绝。</b>
+    /// </summary>
+    /// <remarks>
+    /// 这是最容易写反的一处。用户在终端里手敲 <c>ssh root@10.0.0.99</c> 连出去的那条会话,
+    /// 恰恰是<b>没人替它定过范围</b>的那种 —— 把它当成"不受管辖所以放行",
+    /// 等于给任何手敲的连接开了一道后门,而范围收得越紧、这道后门越显眼。
+    /// </remarks>
+    [TestMethod]
+    public async Task LiveSession_ThatMatchesNoSavedConfig_IsRefused()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddSaved(name: "prod-1", host: "10.0.0.1", username: "root", group: "生产");
+        SessionInfo adhoc = context.FakeSessions.AddConnected(host: "10.0.0.99", username: "root");
+        ISessionScope scope = Limited("生产").Resolve(context)!;
+
+        Assert.IsFalse(await scope.AllowsLiveAsync(adhoc, CancellationToken.None));
+    }
+
+    /// <summary>同一台机器保存了两条配置(不同分组),命中任意一条在范围内的就放行。</summary>
+    [TestMethod]
+    public async Task LiveSession_IsAllowedIfAnyMatchingConfigIsInScope()
+    {
+        using var context = new TestPluginContext();
+        context.FakeSessions.AddSaved(name: "a", host: "10.0.0.1", username: "root", group: "测试");
+        context.FakeSessions.AddSaved(name: "b", host: "10.0.0.1", username: "root", group: "生产");
+        SessionInfo live = context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root");
+        ISessionScope scope = Limited("生产").Resolve(context)!;
+
+        Assert.IsTrue(await scope.AllowsLiveAsync(live, CancellationToken.None));
+    }
+
+    // ---- 对外 MCP 那一份 ----
+
+    /// <summary>
+    /// <c>AllowedTargets</c> 的语义:清单为空 = 不限范围(默认值不动)。
+    /// </summary>
+    /// <remarks>
+    /// MCP 这条路的边界是回环地址 + 令牌 + 只读挡位。把用户自己机器上的 Claude Code / Codex
+    /// 一起收紧,挡不住任何攻击者,只挡得住用户自己 —— 所以这里的空值方向与桥接授权相反,
+    /// 而且是刻意相反的。
+    /// </remarks>
+    [TestMethod]
+    public void TargetListScope_IsEmptyWhenNothingIsConfigured()
+    {
+        Assert.IsTrue(new TargetListScope([]).IsEmpty);
+        Assert.IsTrue(new TargetListScope(["", "   "]).IsEmpty);
+        Assert.IsFalse(new TargetListScope(["root@10.0.0.1:22"]).IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task TargetListScope_MatchesUserHostPort()
+    {
+        using var context = new TestPluginContext();
+        SessionInfo allowed = context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root");
+        SessionInfo denied = context.FakeSessions.AddConnected(host: "10.0.0.2", username: "root");
+        var scope = new TargetListScope(["root@10.0.0.1:22"]);
+
+        Assert.IsTrue(await scope.AllowsLiveAsync(allowed, CancellationToken.None));
+        Assert.IsFalse(await scope.AllowsLiveAsync(denied, CancellationToken.None));
+    }
+
+    // ---- 授权的迁移 ----
+
+    /// <summary>
+    /// <b>升级不改变任何人当前的行为。</b>
+    /// </summary>
+    /// <remarks>
+    /// 既有的 <c>AllowedChats</c> 折算成不限范围、挡位审批跟随全局的授权 ——
+    /// 也就是与升级前逐字相同的行为。收紧是用户自己的决定,不该由一次升级替他做。
+    /// </remarks>
+    [TestMethod]
+    public void NormalizeGrants_FoldsTheOldAllowlistIntoUnrestrictedGrants()
+    {
+        var config = new ChannelConfig { AllowedChats = ["chat-1", "chat-2"] };
+
+        config.NormalizeGrants();
+
+        Assert.AreEqual(2, config.Grants.Count);
+        Assert.IsTrue(config.Grants.All(g => g.Scope.IsUnrestricted));
+        Assert.IsTrue(config.Grants.All(g => g.Mode is null && g.Approval is null));
+        Assert.IsNotNull(config.GrantFor("chat-1"));
+        Assert.IsNull(config.GrantFor("chat-3"));
+    }
+
+    /// <summary>
+    /// <c>AllowedChats</c> 是 <c>Grants</c> 的派生镜像,重算之后两边必须一致。
+    /// </summary>
+    /// <remarks>
+    /// 一个派生字段只要有一头没算,它就会开始撒谎 —— 而这一份撒谎的后果是
+    /// 用户降级回旧版本之后白名单缺了几条,机器人突然不理人。
+    /// </remarks>
+    [TestMethod]
+    public void NormalizeGrants_RebuildsTheLegacyMirror()
+    {
+        var config = new ChannelConfig
+        {
+            AllowedChats = ["chat-1"],
+            Grants = [new ChatGrant { ChatId = "chat-2", Scope = new SessionScope { Kind = ScopeKind.Limited } }]
+        };
+
+        config.NormalizeGrants();
+
+        CollectionAssert.AreEquivalent(new[] { "chat-1", "chat-2" }, config.AllowedChats);
+        // 折算出来的那条不限范围,原来就有的那条保持它自己的范围
+        Assert.IsTrue(config.GrantFor("chat-1")!.Scope.IsUnrestricted);
+        Assert.IsFalse(config.GrantFor("chat-2")!.Scope.IsUnrestricted);
+    }
+
+    /// <summary>重复调用不该把授权翻倍(读和写两头都会调它)。</summary>
+    [TestMethod]
+    public void NormalizeGrants_IsIdempotent()
+    {
+        var config = new ChannelConfig { AllowedChats = ["chat-1"] };
+
+        config.NormalizeGrants();
+        config.NormalizeGrants();
+        config.NormalizeGrants();
+
+        Assert.AreEqual(1, config.Grants.Count);
+        Assert.AreEqual(1, config.AllowedChats.Count);
+    }
+
+    /// <summary>配对码携带的是一份授权,而不是一张通行证。</summary>
+    [TestMethod]
+    public void PairingCode_CarriesTheScopeChosenWhenItWasIssued()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue(new ChatGrant { Scope = Limited("生产"), Mode = Configuration.ChatMode.Plan });
+
+        Assert.IsTrue(pairing.TryRedeem(code, out ChatGrant? template));
+        Assert.IsNotNull(template);
+        Assert.AreEqual(ScopeKind.Limited, template.Scope.Kind);
+        CollectionAssert.Contains(template.Scope.Groups, "生产");
+        Assert.AreEqual(Configuration.ChatMode.Plan, template.Mode);
+    }
+
+    /// <summary>不带模板发的码(给自己单聊的那种)兑现出不限范围的授权。</summary>
+    [TestMethod]
+    public void PairingCode_WithoutATemplate_YieldsAnUnrestrictedGrant()
+    {
+        var pairing = new PairingService();
+        string code = pairing.Issue();
+
+        Assert.IsTrue(pairing.TryRedeem(code, out ChatGrant? template));
+        Assert.IsNull(template);
+        Assert.IsTrue(new ChatGrant().Scope.IsUnrestricted);
+    }
+}


### PR DESCRIPTION
## 为什么

把机器人拉进一个群,群里的人就能操作我保存的**每一台**服务器。看起来有限制——每个聊天可以 `/use` 绑一台——但那只是个默认值:

- 工具箱里**九个工具**都收可选的 `session_id`,传了就绕开默认值;
- `run_on_sessions` 收的还是一个 id **数组**;
- `list_saved_sessions` 会把**分组名**一并交出去(分组名本身就在说明这台机器归谁管);
- 对外 MCP 那个「允许操作的服务器」只挡 `use_session`,是一句空话。

## 怎么改

闸设在 `AgentToolbox.Scope`(`ISessionScope`)上,**每次工具调用都要过**——显式 id、默认目标、批量执行、`open_session`,以及两个列表工具。范围按会话树的分组与单台配置来定;对外 MCP 用同一个接口的另一份实现(`user@host:port` 清单)。

每个聊天一份 `ChatGrant`:范围 / 挡位 / 审批各自可设,设置页上一行一个。

## 三条不能让步的红线

**1. 不把作者自己锁在门外。** 一套把自己也拦住的权限设计,结局是被整个关掉、回到零防护。所以:

| 路径 | 默认 | 为什么 |
|---|---|---|
| 聊天面板 | 不限制 | `Scope = null`,这条路一行代码都没改 |
| 你自己的单聊 | 不限制 | 只有一个对端,而且是你逐个放行的 |
| 对外 MCP | 不限制 | 边界是令牌 + 只读挡位,不是范围 |
| 群 | 要求先选 | 唯一收紧的地方——人数会在你不知情时增长 |

`null` 是"压根没有过滤器",不是"一个放行全部的过滤器"——于是不存在一个可能写错的放行分支。配对码也因此分两种:「我自己 · 不限范围」直接发,给群的先勾范围再发。

**2. 失败关闭。** 对不上任何已保存配置的活会话(手敲 `ssh` 连出去的)一律拒绝。那恰恰是没人替它定过范围的一类,当成"不受管辖所以放行"等于给任何手敲的连接开后门。

**3. 拒绝不枚举。** 越界回一句"不在范围内"就够了,不列出范围外有什么——否则试一个 id 就能把拒绝变成枚举接口。`/use` 同理:范围外的机器回"没找到",而不是"找到了但不给你"。

## 顺带

配对码从此**携带一份具体的授权**而不是一张通行证。原来的顺序是"先放进来,再去设置页收紧",在权限上是反的:从放行到收紧之间那个群拥有全部权限,而人往往就忘了第二步。

`/mode` 的天花板改成**这个聊天**的挡位而不是全局的,否则"只读群"立不住。

## 兼容

升级不改变任何人当前的行为:既有 `AllowedChats` 折算成不限范围、挡位审批跟随全局的授权;`AllowedChats` 变成 `Grants` 的派生镜像,降级回旧版本时白名单仍在。

## 验证

522 个用例全绿(新增 27 条范围用例 + 5 条桥接/界面用例)。做了两轮**变异验证**:把工具箱那道闸摘掉、把两个列表过滤器和 `open_session` 检查摘掉,各有 4 条转红——用例真的在守这些点,而不是碰巧是绿的。界面用 Skia 按宿主真实主题字典渲染核对过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfvL9PZhivkKKp4vduaGf8
