### PR TITLE
修复 macOS 打包签名失败，恢复 codesign --deep 并预检带点号目录

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,17 +232,32 @@ jobs:
             # 后续自更新替换 Contents/MacOS 里的文件会使 bundle 印章失效 —— 对未公证的
             # ad-hoc 应用无影响(系统只校验各二进制自身的嵌入签名,dotnet publish 的产物自带)。
             #
-            # **不要加回 --deep。** 苹果自己早就说它只该用于校验、不该用于签名,而在这里它是纯负债:
-            # --deep 会把包内每个"看着像 bundle"的目录当嵌套代码去签,而**目录名里带点号就算**。
-            # 于是随便哪个 NuGet 包带进来一个 runtimes/win/lib/net6.0/,打包就会以
-            # "bundle format unrecognized, invalid, or unsuitable" 整个失败 ——
-            # 1.4.8 被 QRCoder → System.Drawing.Common 这条链炸过一次,1.2.0 则是插件目录名
-            # 带点号炸的(那次的应对是改目录名,见 plugins/README.md)。
-            # 去掉 --deep 之后这一类问题从根上不会再发生:真正被系统校验的是各二进制自身的嵌入签名,
-            # 那是 dotnet publish 给的,重签一遍毫无意义。
-            # 想确认这一点看 tar.gz 那条路就够了:同一批二进制,从来没有经过任何 bundle 签名,
-            # 一直跑得好好的 —— 自更新换版之后的应用也正是这个状态。
-            codesign --force --sign - "$app"
+            # **--deep 在这套布局下是硬要求,别再想着去掉。** 1.4.8 试过一次,换来的是
+            # "code object is not signed at all / In subcomponent: …/System.Diagnostics.Contracts.dll":
+            # Contents/MacOS 在 bundle 格式里是**代码区**,里面除主可执行体之外的每个文件都算嵌套代码,
+            # codesign 要求它们事先各自签好;而我们往那儿摊的是三百多个 dll/dylib,
+            # 谁也不会挨个去签 —— --deep 干的正是这件事。苹果那句"--deep 不该用于签名"
+            # 针对的是"应该把嵌套代码在各自的构建里签好"的项目,不是我们这种整包摊平的形态。
+            # 这个布局本身不能动:Contents/MacOS 必须与 tar.gz 逐字节一致,自更新才走得通(见文件头)。
+            #
+            # --deep 的已知代价是下面这道闸挡着的那件事,读完再动这一段。
+            #
+            # --deep 会把包内每个"看着像 bundle"的目录当嵌套代码去解析,而**目录名里带点号就算**。
+            # 撞上就是一句看不出该动哪里的 "bundle format unrecognized, invalid, or unsuitable":
+            # 1.2.0 栽在插件目录名 velashell.ai 上(应对是改目录名,见 plugins/README.md),
+            # 1.4.8 栽在 QRCoder → System.Drawing.Common 带进来的 runtimes/win/lib/net6.0/ 上
+            # (应对是把 QRCoder 换成自研编码器,见 plugins/VelaShell.Plugin.Ai/Ui/QrCode.cs)。
+            # 两次都是"新加一个依赖"引发的,而报错里完全看不出这层因果 —— 所以先自己扫一遍,
+            # 把话说清楚再失败。目前包内 34 个目录一个带点号的都没有,这道闸平时不作声。
+            dotted="$(find "$app" -mindepth 1 -type d -name '*.*')"
+            if [ -n "$dotted" ]; then
+              echo "::error::.app 内出现带点号的目录,codesign --deep 会把它当成嵌套 bundle 而失败:"
+              echo "$dotted"
+              echo "多半是新加的 NuGet 包带进来的 runtimes/<rid>/lib/<tfm>/。"
+              echo "要么去掉那个依赖,要么在打 .app 之前把用不上的 runtimes 子树剪掉。"
+              exit 1
+            fi
+            codesign --force --deep --sign - "$app"
 
             # dmg:VelaShell.app + /Applications 快捷方式的经典拖装布局。
             # hdiutil -srcfolder 会先建一个与内容等大的可写镜像(挂到 /Volumes/VelaShell)灌进去

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -63,11 +63,13 @@ SDK 契约程序集取 nuget.org 上的正式包，**不做工程引用**：
   机密的命名空间，改了等于让已有用户的配置（AI 插件的 API key 就在里面）全部失联。
   目录名不参与任何逻辑：宿主枚举子目录后从 `plugin.json` 读 id。
 
-  这条规矩当初是为了绕开 `codesign --deep`：它会把 `.app` 内带点号的目录当成嵌套 bundle
-  而签名失败（1.2.0 踩过）。**1.4.8 起 `release.yml` 不再用 `--deep`**——那次是某个 NuGet 包
-  带进来一个 `runtimes/win/lib/net6.0/`，目录名同样带点，我们控制不了，只能从签名方式上解决
-  （细节见 `release.yml` 里 codesign 那一步的注释）。根因既已消失，这条命名规矩就只是惯例了，
-  但没有理由改回去：改了同样会让已有安装找不到目录。
+  这条规矩是为了绕开 `codesign --deep`：它会把 `.app` 内带点号的目录当成嵌套 bundle
+  而签名失败（1.2.0 踩过）。`--deep` 去不掉——`Contents/MacOS` 在 bundle 格式里是代码区，
+  我们往那儿摊了三百多个 dll/dylib，不加 `--deep` 就得挨个签（1.4.8 试过，换来一句
+  `code object is not signed at all`）。所以这条约束一直有效，**而且不止约束目录名：
+  新加的 NuGet 包只要带进来一个 `runtimes/<rid>/lib/net6.0/`，同样会炸**（1.4.8 的
+  `QRCoder → System.Drawing.Common` 就是这么来的）。`release.yml` 在签名前会先扫一遍
+  并给出可读的报错，细节见那一步的注释。
 
 ## 测试
 


### PR DESCRIPTION
1.4.8 为了绕开 QRCoder 带进来的 runtimes/win/lib/net6.0/ 去掉了 --deep，换来的是 另一句错:code object is not signed at all(In subcomponent: …/System.Diagnostics.Contracts.dll)。 Contents/MacOS 在 bundle 格式里是代码区,里面除主可执行体之外的每个文件都算嵌套代码、 要求事先各自签好,而这里摊着三百多个 dll/dylib —— --deep 干的正是这件事,这套布局下去不掉。 布局本身也动不了:Contents/MacOS 必须与 tar.gz 逐字节一致,自更新才走得通。

--deep 唯一的雷是"包内目录名带点号会被当成嵌套 bundle",两次发作(1.2.0 的 velashell.ai、 1.4.8 的 runtimes/win/lib/net6.0)都由新加依赖引起,而 "bundle format unrecognized" 这句 报错里完全看不出这层因果。所以签名前先自己扫一遍,把话说清楚再失败。

QRCoder 已在 #351 换成自研编码器,当前 osx-x64 产物的 34 个目录无一带点号(本机交叉发布实测), 这道闸平时不作声。


Claude-Session: https://claude.ai/code/session_01FiNHSs5NhkYkDSrjzjzmHa

<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
