### PR TITLE
修复 macOS 打包签名失败，恢复 codesign --deep 并预检带点号目录

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,17 +232,32 @@ jobs:
             # 后续自更新替换 Contents/MacOS 里的文件会使 bundle 印章失效 —— 对未公证的
             # ad-hoc 应用无影响(系统只校验各二进制自身的嵌入签名,dotnet publish 的产物自带)。
             #
-            # **不要加回 --deep。** 苹果自己早就说它只该用于校验、不该用于签名,而在这里它是纯负债:
-            # --deep 会把包内每个"看着像 bundle"的目录当嵌套代码去签,而**目录名里带点号就算**。
-            # 于是随便哪个 NuGet 包带进来一个 runtimes/win/lib/net6.0/,打包就会以
-            # "bundle format unrecognized, invalid, or unsuitable" 整个失败 ——
-            # 1.4.8 被 QRCoder → System.Drawing.Common 这条链炸过一次,1.2.0 则是插件目录名
-            # 带点号炸的(那次的应对是改目录名,见 plugins/README.md)。
-            # 去掉 --deep 之后这一类问题从根上不会再发生:真正被系统校验的是各二进制自身的嵌入签名,
-            # 那是 dotnet publish 给的,重签一遍毫无意义。
-            # 想确认这一点看 tar.gz 那条路就够了:同一批二进制,从来没有经过任何 bundle 签名,
-            # 一直跑得好好的 —— 自更新换版之后的应用也正是这个状态。
-            codesign --force --sign - "$app"
+            # **--deep 在这套布局下是硬要求,别再想着去掉。** 1.4.8 试过一次,换来的是
+            # "code object is not signed at all / In subcomponent: …/System.Diagnostics.Contracts.dll":
+            # Contents/MacOS 在 bundle 格式里是**代码区**,里面除主可执行体之外的每个文件都算嵌套代码,
+            # codesign 要求它们事先各自签好;而我们往那儿摊的是三百多个 dll/dylib,
+            # 谁也不会挨个去签 —— --deep 干的正是这件事。苹果那句"--deep 不该用于签名"
+            # 针对的是"应该把嵌套代码在各自的构建里签好"的项目,不是我们这种整包摊平的形态。
+            # 这个布局本身不能动:Contents/MacOS 必须与 tar.gz 逐字节一致,自更新才走得通(见文件头)。
+            #
+            # --deep 的已知代价是下面这道闸挡着的那件事,读完再动这一段。
+            #
+            # --deep 会把包内每个"看着像 bundle"的目录当嵌套代码去解析,而**目录名里带点号就算**。
+            # 撞上就是一句看不出该动哪里的 "bundle format unrecognized, invalid, or unsuitable":
+            # 1.2.0 栽在插件目录名 velashell.ai 上(应对是改目录名,见 plugins/README.md),
+            # 1.4.8 栽在 QRCoder → System.Drawing.Common 带进来的 runtimes/win/lib/net6.0/ 上
+            # (应对是把 QRCoder 换成自研编码器,见 plugins/VelaShell.Plugin.Ai/Ui/QrCode.cs)。
+            # 两次都是"新加一个依赖"引发的,而报错里完全看不出这层因果 —— 所以先自己扫一遍,
+            # 把话说清楚再失败。目前包内 34 个目录一个带点号的都没有,这道闸平时不作声。
+            dotted="$(find "$app" -mindepth 1 -type d -name '*.*')"
+            if [ -n "$dotted" ]; then
+              echo "::error::.app 内出现带点号的目录,codesign --deep 会把它当成嵌套 bundle 而失败:"
+              echo "$dotted"
+              echo "多半是新加的 NuGet 包带进来的 runtimes/<rid>/lib/<tfm>/。"
+              echo "要么去掉那个依赖,要么在打 .app 之前把用不上的 runtimes 子树剪掉。"
+              exit 1
+            fi
+            codesign --force --deep --sign - "$app"
 
             # dmg:VelaShell.app + /Applications 快捷方式的经典拖装布局。
             # hdiutil -srcfolder 会先建一个与内容等大的可写镜像(挂到 /Volumes/VelaShell)灌进去

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -63,11 +63,13 @@ SDK 契约程序集取 nuget.org 上的正式包，**不做工程引用**：
   机密的命名空间，改了等于让已有用户的配置（AI 插件的 API key 就在里面）全部失联。
   目录名不参与任何逻辑：宿主枚举子目录后从 `plugin.json` 读 id。
 
-  这条规矩当初是为了绕开 `codesign --deep`：它会把 `.app` 内带点号的目录当成嵌套 bundle
-  而签名失败（1.2.0 踩过）。**1.4.8 起 `release.yml` 不再用 `--deep`**——那次是某个 NuGet 包
-  带进来一个 `runtimes/win/lib/net6.0/`，目录名同样带点，我们控制不了，只能从签名方式上解决
-  （细节见 `release.yml` 里 codesign 那一步的注释）。根因既已消失，这条命名规矩就只是惯例了，
-  但没有理由改回去：改了同样会让已有安装找不到目录。
+  这条规矩是为了绕开 `codesign --deep`：它会把 `.app` 内带点号的目录当成嵌套 bundle
+  而签名失败（1.2.0 踩过）。`--deep` 去不掉——`Contents/MacOS` 在 bundle 格式里是代码区，
+  我们往那儿摊了三百多个 dll/dylib，不加 `--deep` 就得挨个签（1.4.8 试过，换来一句
+  `code object is not signed at all`）。所以这条约束一直有效，**而且不止约束目录名：
+  新加的 NuGet 包只要带进来一个 `runtimes/<rid>/lib/net6.0/`，同样会炸**（1.4.8 的
+  `QRCoder → System.Drawing.Common` 就是这么来的）。`release.yml` 在签名前会先扫一遍
+  并给出可读的报错，细节见那一步的注释。
 
 ## 测试
 


### PR DESCRIPTION
## 这个 PR 做了什么

把 macOS 打包那一步的 `codesign --deep` 加回来，并在签名前加一道预检：扫到 `.app` 内有带点号的目录就直接报错说清楚，而不是让 codesign 抛出一句看不出所以然的话。

## 为什么这么改

1.4.8 的 `build-macos` 连着炸了两次，是**两个不同的错**，第二次是我上一次修错了方向。

**第一次**（QRCoder 那条链，已由 #351 解决）：

```
out/dmg-osx-x64/VelaShell.app: bundle format unrecognized, invalid, or unsuitable
In subcomponent: .../Contents/MacOS/plugins/velashell-ai/runtimes/win/lib/net6.0
```

`codesign --deep` 会把包内每个"看着像 bundle"的目录当嵌套代码去解析，**目录名带点号就算**。`QRCoder 1.8.0` 的 netstandard2.0 目标传递依赖 `System.Drawing.Common 6.0.0`，后者带进来一整套 `runtimes/{win,unix}/lib/net6.0/` —— 叶子目录带点，撞上了。1.2.0 也栽过一次，那次是插件目录名 `velashell.ai`（应对是把点换成短横，见 `plugins/README.md`）。

**第二次**（本 PR 修的）：当时的判断是"`--deep` 是纯负债，苹果自己也说它只该用于校验"，于是把它去掉了。结果换来另一句错：

```
out/dmg-osx-x64/VelaShell.app: code object is not signed at all
In subcomponent: .../Contents/MacOS/System.Diagnostics.Contracts.dll
```

**`Contents/MacOS` 在 bundle 格式里是代码区**，里面除主可执行体之外的每个文件都算嵌套代码、要求事先各自签好；而我们往那儿摊的是三百多个 dll/dylib，没人会挨个去签 —— `--deep` 干的正是这件事。苹果那句话针对的是"嵌套代码在各自构建里就签好"的项目，不是我们这种整包摊平的形态。当时还拿 tar.gz 那条路"从没签过 bundle 也能跑"当佐证，那也是错的：tar.gz 根本没有 bundle，不存在这条要求，两者不可类比。

而**布局本身动不了**：`Contents/MacOS` 必须与 tar.gz 逐字节一致，自更新才走得通（见 `release.yml` 文件头的「macOS 双产物分工」）。

所以结论是：**这套布局下 `--deep` 是硬要求**，能做的是把它唯一的雷挡在前面。两次发作都由"新加一个依赖"引起，而报错里完全看不出这层因果，所以签名前先自己扫一遍：

```bash
dotted="$(find "$app" -mindepth 1 -type d -name '*.*')"
if [ -n "$dotted" ]; then
  echo "::error::.app 内出现带点号的目录,codesign --deep 会把它当成嵌套 bundle 而失败:"
  ...
  exit 1
fi
codesign --force --deep --sign - "$app"
```

### 考虑过但没选的方案

* **在打 .app 前把用不上的 `runtimes/<rid>/` 子树剪掉** —— 只能盖住"点号来自 RID 资产目录"这一种情况，别处冒出来的带点目录照样炸；而且剪了就破坏 `Contents/MacOS` 与 tar.gz 的逐字节一致。
* **把负载移出 `Contents/MacOS`**（例如放 `Contents/Resources/app/`，`MacOS` 只留一个启动器）—— 这才是真正让 `--deep` 变得不必要的办法，但它动到自更新对"应用目录"的假设，需要真机验证，不适合在卡着发布的时候顺手做。想做的话应该单开一个 PR。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [x] 文档
- [x] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 见下，有 4 例先于本 PR 就在失败
- [x] 新增/修改的行为有对应测试（说明见下）
- [ ] 界面改动已在应用里实际跑过（本 PR 无界面改动）

**实测环境:** Windows 11 x64（macOS runner 上的签名本身无法在本机复现）

**这道闸怎么验的**（改的是流水线，写不了单测，所以本机把两条路都走了一遍）：

1. 本机交叉发布一份 `osx-x64` 自包含产物：316 个文件、34 个目录，**没有一个目录名带点号** —— 也就是 #351 换掉 QRCoder 之后，`--deep` 已经是干净的。
2. 照 `release.yml` 的做法搭出 `VelaShell.app/Contents/MacOS`，跑同一条 `find`：放行。
3. 手工塞一个 `plugins/velashell-ai/runtimes/win/lib/net6.0` 进去再跑：准确抓到，正是 1.4.8 那次的形状。

**测试结果:**

```
VelaShell.Core.Tests             416 通过
VelaShell.Terminal.Tests         362 通过
VelaShell.Terminal.RenderTests     3 通过
VelaShell.Presentation.Tests      55 通过
VelaShell.Plugin.Ai.Tests        530 通过
VelaShell.Tests                  963 通过 / 1 失败
VelaShell.Infrastructure.Tests   354 通过 / 3 失败
```

**这 4 例与本 PR 无关**（本 PR 只动了一个 YAML 和一个 Markdown，不参与编译），而且是干净检出就会失败的：

* `ShortcutCatalogTests.Doc_ListsEveryCatalogEntry` —— 找 `docs/快捷键参考.md`，但仓库里**根本没有 `docs/` 目录**：文档早已迁到 velashell-docs 仓库，这条用例是当时漏改的。
* `FtpFileServiceIntegrationTests` 的 3 例（`UploadThenDownload_RoundTripsContent`、两条 `ConcurrentUploads_*`）—— 对着进程内 `LoopbackFtpServer` 跑，下载回来是空的；看起来是 PASV 数据连接在本机环境下建不起来。

两处都值得单独修，但不该混进这个 PR。

## 同步检查

- [x] **改了文档** → `plugins/README.md` 里"目录名去点号"那条的理由已改对（上一版写成了"1.4.8 起不再用 `--deep`"，现在不成立了）

## 补充说明

**没有在 macOS 上实测过** —— 本机没有 macOS，签名这一步只能在 runner 上验。但这次是回到 1.0–1.4.7 一直在跑的那条路（`--deep` 从未出过问题，直到 1.4.8 那个带点号的目录），加上上面第 1 条实测确认雷已排除，比上一版的风险低得多。

合进 dev 后建议直接用 `workflow_dispatch` 对 `1.4.8` 补跑一次：产物上传走的是 `gh release upload --clobber`，对同一标签重复跑是幂等的。那一趟也会第一次真正跑到前面加的 AppImage / deb / rpm 三种打包。

---

- [x] 我已阅读 CONTRIBUTING.md，并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiNHSs5NhkYkDSrjzjzmHa
