### PR TITLE
IM 里按各家的富文本渲染,并且能把服务器上的文件发进聊天

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
@@ -48,6 +48,9 @@ public sealed class AgentToolbox(IPluginContext context)
     /// <summary>一次并行执行最多铺多少台。再多就该写脚本了,而且输出也读不过来。</summary>
     private const int MaxParallelSessions = 16;
 
+    /// <summary><c>send_file</c> 唯一允许发出去的目录(<c>download_remote_file</c> 的落点)。</summary>
+    private const string DownloadFolder = "downloads";
+
     /// <summary>当前选中的目标会话 id(由聊天面板提供;null = 未选)。</summary>
     public Func<string?>? SessionIdProvider { get; set; }
 
@@ -97,6 +100,19 @@ public sealed class AgentToolbox(IPluginContext context)
     /// <summary>网络检索设置(SearXNG 地址、私网闸、截断上限)。由聊天面板每轮推过来。</summary>
     public WebSearchOptions WebSearch { get; set; } = new();
 
+    /// <summary>
+    /// 把一个本机文件送进这条对话所在的 IM 聊天。
+    /// <see langword="null" />(聊天面板与 MCP 那两条路)= <c>send_file</c> 根本不注册。
+    /// </summary>
+    /// <remarks>
+    /// 成功返回 <see langword="null" />,失败返回一句给模型看的话。
+    /// <para>
+    /// <b>为什么需要它。</b>机器人在服务器上看得见日志,人在手机上 ——
+    /// 复制一屏文字回去既丢格式又丢内容,而"打个包发给我"才是这件事的完整形态。
+    /// </para>
+    /// </remarks>
+    public Func<string, CancellationToken, Task<string?>>? FileSender { get; set; }
+
     /// <summary>全部内置工具的名称与一句说明,供"配置工具"窗口列出勾选项。</summary>
     public static IReadOnlyList<(string Name, string Description, bool ReadOnly)> Catalog { get; } =
     [
@@ -121,7 +137,8 @@ public sealed class AgentToolbox(IPluginContext context)
         ("rename_remote_path", "重命名 / 移动远端文件或目录(改配置前备份用)", false),
         ("upload_local_file", "把本机文件(如 MCP 工具刚生成的)经 SFTP 传到服务器", false),
         ("download_remote_file", "把远端文件拉到本机(交给本地 MCP 工具处理)", false),
-        ("write_terminal", "把文本敲进用户可见的终端", false)
+        ("write_terminal", "把文本敲进用户可见的终端", false),
+        ("send_file", "把已下载的文件当附件发进当前这个 IM 聊天(只有 IM 那条路有)", false)
     ];
 
     /// <summary>
@@ -231,6 +248,16 @@ public sealed class AgentToolbox(IPluginContext context)
                 + "Pick the results that look relevant and read them with web_fetch. "
                 + "Use it whenever the answer may have moved since training: package versions, CVE details, changelogs, "
                 + "vendor documentation, or an error message you do not recognise."), true));
+        }
+        // 只有 IM 那条路给得出落点,所以别的路上连这个工具都不该出现 ——
+        // 模型看得见一个永远失败的工具,只会反复去试。
+        if (FileSender is not null)
+        {
+            all.Add(("send_file", AIFunctionFactory.Create(SendFileAsync, "send_file",
+                "Send a file into the chat you are talking in, as an attachment the user can download. "
+                + "The path must be one that download_remote_file returned — this tool can ONLY send files that were "
+                + "downloaded from a server, never arbitrary files on the user's machine. "
+                + "To deliver logs: archive them on the server (tar/gzip) if there are several, download the file, then send it."), false));
         }
         if (WebSearch.Enabled)
         {
@@ -695,6 +722,83 @@ public sealed class AgentToolbox(IPluginContext context)
         }
     }
 
+    /// <summary>
+    /// 把一个文件当附件发进当前这个 IM 聊天。
+    /// </summary>
+    /// <remarks>
+    /// <b>这是一个出口,所以路径必须锁死。</b>一个"能读本机任意文件并推进群里"的工具,
+    /// 就是一条完整的外泄通道 —— 群里任何一个人只要说一句"帮我看看 id_rsa",
+    /// 而模型没有理由怀疑这句话。
+    /// <para>
+    /// 锁的办法不是黑名单(数不完),是<b>白名单一个目录</b>:只能发
+    /// <c>download_remote_file</c> 自己下下来的那些。于是能发出去的东西必然满足
+    /// "来自一台这次授权允许操作的服务器"——那一关在下载的时候已经过了。
+    /// 用户自己的桌面、密钥、浏览器数据,一律够不着。
+    /// </para>
+    /// <para>
+    /// 另外照样走审批:文件出了这台机器就收不回来,而"发哪个文件到哪个群"正是
+    /// 用户该看一眼的那种决定。
+    /// </para>
+    /// </remarks>
+    private async Task<string> SendFileAsync(
+        [Description("Local path returned by download_remote_file. Files outside the plugin's downloads folder are refused.")] string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (FileSender is not { } send)
+        {
+            return "This conversation has no chat to send files into.";
+        }
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return "path must not be empty; pass the local path download_remote_file returned.";
+        }
+        string full;
+        try
+        {
+            full = Path.GetFullPath(path.Trim());
+        }
+        catch (Exception ex)
+        {
+            return $"Not a usable path: {ex.Message}";
+        }
+        if (!IsSendable(full))
+        {
+            return "Refused: send_file can only send files that download_remote_file saved into the plugin's "
+                   + "downloads folder. Download the file from the server first, then send that path.";
+        }
+        if (!File.Exists(full))
+        {
+            return $"No such local file: {full}. Download it from the server first.";
+        }
+        var info = new FileInfo(full);
+        if (!await ApproveAsync(new ApprovalRequest("send_file", $"{info.Name}  ({info.Length} bytes)\n→ this chat"),
+                cancellationToken).ConfigureAwait(false))
+        {
+            return "The user DENIED sending this file. Do not retry; ask the user how to proceed.";
+        }
+        if (await send(full, cancellationToken).ConfigureAwait(false) is { } failure)
+        {
+            return $"Could not send the file: {failure}";
+        }
+        return $"Sent {info.Name} ({info.Length} bytes) into the chat.";
+    }
+
+    /// <summary>这个路径在允许发出去的那个目录里吗。</summary>
+    /// <remarks>
+    /// 比的是<b>规范化之后</b>的全路径,并且要求以目录分隔符结尾的前缀 ——
+    /// 少了那个分隔符,<c>…/downloads-secret/x</c> 也会被当成在 <c>…/downloads</c> 里面。
+    /// <c>..</c> 由 <see cref="Path.GetFullPath(string)" /> 先折平,所以穿不出去。
+    /// </remarks>
+    private bool IsSendable(string fullPath)
+    {
+        string folder = Path.GetFullPath(Path.Combine(context.DataDirectory, DownloadFolder));
+        if (!folder.EndsWith(Path.DirectorySeparatorChar))
+        {
+            folder += Path.DirectorySeparatorChar;
+        }
+        return Path.GetFullPath(fullPath).StartsWith(folder, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>关掉本插件自己开的那条会话(宿主拒绝关别人的)。</summary>
     /// <remarks>
     /// 不走审批闸。关的对象已经被宿主限死在"本插件开的那些"里,用户自己的标签页一根汗毛都动不了;
@@ -976,7 +1080,7 @@ public sealed class AgentToolbox(IPluginContext context)
         string target;
         if (string.IsNullOrWhiteSpace(localPath))
         {
-            string folder = Path.Combine(context.DataDirectory, "downloads");
+            string folder = Path.Combine(context.DataDirectory, DownloadFolder);
             Directory.CreateDirectory(folder);
             target = Path.Combine(folder, Path.GetFileName(remotePath.TrimEnd('/')));
         }
@@ -1011,7 +1115,10 @@ public sealed class AgentToolbox(IPluginContext context)
             }
             await context.RemoteFs.DownloadFileAsync(id, remotePath, target, cancellationToken: cancellationToken)
                          .ConfigureAwait(false);
-            return $"Downloaded to {target} ({entry.Size} bytes). Local tools can read it from there.";
+            return $"Downloaded to {target} ({entry.Size} bytes). Local tools can read it from there."
+                   + (FileSender is not null && IsSendable(target)
+                       ? " You can also hand it to the user with send_file."
+                       : "");;
         }
         catch (Exception ex)
         {

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeAgentRunner.cs
@@ -32,7 +32,8 @@ public sealed class BridgeAgentRunner(
     IPluginContext context,
     AiSettingsStore store,
     ChatHistoryStore history,
-    McpManager mcp)
+    McpManager mcp,
+    ChannelHub? hub = null)
 {
     /// <summary>函数调用循环的单轮上限。IM 那头没人盯着,给得比面板保守一点。</summary>
     private const int MaxToolIterations = 20;
@@ -101,6 +102,11 @@ public sealed class BridgeAgentRunner(
             ApprovalHandler = approve,
             Approval = approval,
             Scope = scope,
+            // 落点就是这条对话所在的聊天。渠道发不了文件时保持 null —— 那样 send_file
+            // 压根不注册,而不是摆一个永远失败的工具让模型反复去试。
+            FileSender = hub is { } channels && channels.CapabilitiesOf(conversation.ChannelId).MaxFileBytes > 0
+                ? (path, token) => channels.SendFileAsync(conversation.ChannelId, conversation.Reply, path, token)
+                : null,
             DisabledTools = new HashSet<string>(
                 (ai.DisabledBuiltinTools ?? "").Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
                 StringComparer.OrdinalIgnoreCase),

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeService.cs
@@ -63,7 +63,7 @@ public sealed class BridgeService(IPluginContext context, AiSettingsStore aiStor
 
             var hub = new ChannelHub(context);
             var approvals = new ImApprovalBroker(hub, context);
-            var runner = new BridgeAgentRunner(context, aiStore, _history, _mcp);
+            var runner = new BridgeAgentRunner(context, aiStore, _history, _mcp, hub);
             var router = new ConversationRouter(context, hub, runner, approvals, _bridgeStore, Pairing);
             router.Apply(bridge, _loc);
             hub.StatusChanged += status => StatusChanged?.Invoke(status);

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelContracts.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelContracts.cs
@@ -59,7 +59,12 @@ public readonly record struct OutboundTarget(string ChatId, string? ThreadId = n
 /// <summary>渠道能做什么。桥接据此决定进度提示是"改同一条"还是"再发一条"。</summary>
 /// <param name="CanEdit">能不能改已发出的消息。</param>
 /// <param name="MaxMessageChars">单条消息的字符上限(超出由桥接切段)。</param>
-public readonly record struct ChannelCapabilities(bool CanEdit, int MaxMessageChars = 4000);
+/// <param name="MaxFileBytes">
+/// 单个文件的上限;<b>0 = 这个渠道发不了文件</b>。各家差得很远(飞书 30MB、
+/// Telegram 50MB、钉钉与企微 20MB),而"发大了"在有些平台上是把整条消息静默丢掉,
+/// 所以宁可在发之前就说清楚。
+/// </param>
+public readonly record struct ChannelCapabilities(bool CanEdit, int MaxMessageChars = 4000, long MaxFileBytes = 0);
 
 /// <summary>
 /// 一个 IM 渠道。<b>只管收发,不认识 agent</b> —— 谁能说话、说了要不要干活,
@@ -97,4 +102,20 @@ public interface IMessageChannel : IAsyncDisposable
 
     /// <summary>改掉之前发出的一条消息。<see cref="ChannelCapabilities.CanEdit" /> 为 false 时不会被调用。</summary>
     Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 把一个<b>本机文件</b>发进聊天。
+    /// </summary>
+    /// <remarks>
+    /// 这条路存在的理由是"日志得能拿到手":机器人在服务器上看得见日志,而人在手机上,
+    /// 复制一屏文字回去既丢格式又丢内容。打个包下下来、发进聊天,才是这件事的完整形态。
+    /// <para>
+    /// 四家的做法一致:先把文件传上平台换一个 key,再发一条引用那个 key 的消息。
+    /// <see cref="ChannelCapabilities.MaxFileBytes" /> 为 0 的渠道不会被调用。
+    /// </para>
+    /// </remarks>
+    /// <param name="target">发到哪个聊天。</param>
+    /// <param name="localPath">本机绝对路径。</param>
+    /// <param name="cancellationToken">取消。</param>
+    Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken);
 }

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelHub.cs
@@ -120,6 +120,46 @@ public sealed class ChannelHub(IPluginContext context) : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// 把一个本机文件发进聊天。成功返回 null,失败返回<b>给模型看的那句话</b>。
+    /// </summary>
+    /// <remarks>
+    /// 这里刻意不像 <see cref="SendAsync" /> 那样把失败咽掉。发文件是用户<b>明确要的</b>
+    /// 一件事("把日志发我"),悄悄失败等于让他一直等一个永远不来的附件 ——
+    /// 而普通回复掉一条,下一轮还能再说一遍。
+    /// </remarks>
+    public async Task<string?> SendFileAsync(string channelId, OutboundTarget target, string localPath,
+        CancellationToken cancellationToken)
+    {
+        if (Find(channelId) is not { } channel)
+        {
+            return "This chat is not connected right now, so the file could not be sent.";
+        }
+        if (channel.Capabilities.MaxFileBytes <= 0)
+        {
+            return $"{channel.Label} cannot receive files from this bot.";
+        }
+        // 上限在发之前查:超了之后各家的表现不一(有的报错,有的静默丢),
+        // 而"传了两分钟然后无事发生"是最难查的一种。
+        var info = new FileInfo(localPath);
+        if (info.Exists && info.Length > channel.Capabilities.MaxFileBytes)
+        {
+            long limit = channel.Capabilities.MaxFileBytes / (1024 * 1024);
+            return $"That file is {info.Length / (1024 * 1024)} MB; {channel.Label} accepts at most {limit} MB. "
+                   + "Split or compress it on the server first, then download and send the smaller file.";
+        }
+        try
+        {
+            await channel.SendFileAsync(target, localPath, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            context.Log.Warn($"Bridge: sending a file to {channel.Label} failed: {ex.Message}");
+            return $"The platform refused the upload: {ex.Message}";
+        }
+    }
+
     /// <summary>取某渠道的能力(找不到则返回默认值)。</summary>
     public ChannelCapabilities CapabilitiesOf(string channelId)
         => Find(channelId)?.Capabilities ?? new ChannelCapabilities(false);

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
@@ -282,6 +282,21 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
     }
 
     /// <inheritdoc />
+    /// <summary>
+    /// 通知栏那一行标题:取正文第一行,去掉 Markdown 的记号。
+    /// </summary>
+    /// <remarks>
+    /// 钉钉的 <c>sampleMarkdown</c> 必须给标题,而它只出现在<b>通知栏</b>里、不进正文。
+    /// 填一个固定字符串的话,手机上一串推送长得一模一样,谁都分不出哪条是哪条。
+    /// </remarks>
+    private static string NotificationTitle(string text)
+    {
+        string line = text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault("VelaShell");
+        line = line.TrimStart('#', '-', '*', '>', ' ').Replace("**", "").Replace("`", "");
+        return line.Length <= 40 ? line : string.Concat(line.AsSpan(0, 40), "…");
+    }
+
     public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
     {
         if (!_routes.TryGetValue(target.ChatId, out (bool IsGroup, string UserId, string RobotCode) route))
@@ -290,18 +305,21 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
             return null;
         }
         string token = await TokenAsync(cancellationToken).ConfigureAwait(false);
-        string parameters = JsonSerializer.Serialize(new { content = text });
+        // Markdown 而不是纯文本:模型的回答天然带列表、行内代码与加粗,
+        // 发成纯文本的话那些符号本身就成了噪音,比没有格式更难读。
+        // 标题是钉钉在通知栏里显示的那一行,不进正文,所以取第一行的摘要。
+        string parameters = JsonSerializer.Serialize(new { title = NotificationTitle(text), text });
         object body = route.IsGroup
             ? new
             {
-                msgKey = "sampleText",
+                msgKey = "sampleMarkdown",
                 msgParam = parameters,
                 openConversationId = target.ChatId,
                 robotCode = route.RobotCode
             }
             : new
             {
-                msgKey = "sampleText",
+                msgKey = "sampleMarkdown",
                 msgParam = parameters,
                 robotCode = route.RobotCode,
                 userIds = new[] { route.UserId }

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/DingTalk/DingTalkChannel.cs
@@ -47,7 +47,7 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
 
     /// <inheritdoc />
     /// <remarks>钉钉的普通机器人消息发出去就改不了,所以进度只能另发一条 —— 由桥接决定别刷屏。</remarks>
-    public ChannelCapabilities Capabilities => new(false, 3000);
+    public ChannelCapabilities Capabilities => new(false, 3000, 20 * 1024 * 1024);
 
     /// <inheritdoc />
     public event Action? Connected;
@@ -345,6 +345,76 @@ internal sealed class DingTalkChannel(ChannelConfig config, string clientSecret,
     /// <inheritdoc />
     public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
         => Task.CompletedTask; // Capabilities.CanEdit = false,不会走到这里
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 素材上传走的是<b>老版</b> oapi(<c>oapi.dingtalk.com/media/upload</c>),
+    /// 而发消息走新版 <c>api.dingtalk.com</c> —— 两个域名、两套鉴权(前者 query 带
+    /// <c>access_token</c>,后者走 <c>x-acs-dingtalk-access-token</c> 头)。
+    /// 这不是笔误,是钉钉自己的历史。
+    /// </remarks>
+    public async Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken)
+    {
+        if (!_routes.TryGetValue(target.ChatId, out (bool IsGroup, string UserId, string RobotCode) route))
+        {
+            throw new InvalidOperationException($"No route for conversation {target.ChatId}.");
+        }
+        string token = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        string name = Path.GetFileName(localPath);
+        string mediaId;
+        await using (FileStream stream = File.OpenRead(localPath))
+        {
+            using var form = new MultipartFormDataContent { { new StringContent("file"), "type" } };
+            using var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            form.Add(content, "media", name);
+            using HttpResponseMessage upload = await _http.PostAsync(
+                $"https://oapi.dingtalk.com/media/upload?access_token={Uri.EscapeDataString(token)}&type=file",
+                form, cancellationToken).ConfigureAwait(false);
+            using JsonDocument document = JsonDocument.Parse(
+                await upload.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            if (document.RootElement.TryGetProperty("errcode", out JsonElement code) && code.GetInt32() != 0)
+            {
+                throw new InvalidOperationException($"DingTalk media upload failed: {document.RootElement}");
+            }
+            mediaId = document.RootElement.GetProperty("media_id").GetString()
+                      ?? throw new InvalidOperationException("DingTalk media upload returned no media_id.");
+        }
+        string extension = Path.GetExtension(name).TrimStart('.');
+        string parameters = JsonSerializer.Serialize(new
+        {
+            mediaId,
+            fileName = name,
+            fileType = extension.Length > 0 ? extension : "txt"
+        });
+        object body = route.IsGroup
+            ? new
+            {
+                msgKey = "sampleFile",
+                msgParam = parameters,
+                openConversationId = target.ChatId,
+                robotCode = route.RobotCode
+            }
+            : new
+            {
+                msgKey = "sampleFile",
+                msgParam = parameters,
+                robotCode = route.RobotCode,
+                userIds = new[] { route.UserId }
+            };
+        string path = route.IsGroup ? "/v1.0/robot/groupMessages/send" : "/v1.0/robot/oToMessages/batchSend";
+        using var request = new HttpRequestMessage(HttpMethod.Post, ApiBase + path)
+        {
+            Content = JsonContent.Create(body)
+        };
+        request.Headers.TryAddWithoutValidation("x-acs-dingtalk-access-token", token);
+        using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"DingTalk {path} failed: {await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)}");
+        }
+    }
 
     private static string Truncate(string text) => text.Length <= 200 ? text : string.Concat(text.AsSpan(0, 200), "…");
 

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
@@ -96,6 +96,55 @@ internal sealed class FeishuApi(string appId, string appSecret, bool internation
             new { content = Card(markdown) }, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// 传一个文件上去换 <c>file_key</c>,再发一条文件消息。
+    /// </summary>
+    /// <remarks>
+    /// 飞书把"传文件"和"发消息"分成两步,中间靠 <c>file_key</c> 串起来。
+    /// <c>file_type</c> 用 <c>stream</c> 这一档通吃 —— 另外那几档(opus/mp4/pdf…)
+    /// 会按类型做转码或预览,而日志包既不是音视频也不一定是 pdf,
+    /// 报错了反而说不清是哪一步的问题。
+    /// </remarks>
+    public async Task SendFileAsync(string chatId, string localPath, CancellationToken cancellationToken)
+    {
+        string name = Path.GetFileName(localPath);
+        string token = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        string fileKey;
+        await using (FileStream stream = File.OpenRead(localPath))
+        {
+            using var form = new MultipartFormDataContent
+            {
+                { new StringContent("stream"), "file_type" },
+                { new StringContent(name), "file_name" }
+            };
+            using var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            form.Add(content, "file", name);
+            using var request = new HttpRequestMessage(HttpMethod.Post, Domain + "/open-apis/im/v1/files")
+            {
+                Content = form
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using JsonDocument uploaded = await ReadAsync(response, cancellationToken).ConfigureAwait(false);
+            JsonElement root = uploaded.RootElement;
+            if (root.TryGetProperty("code", out JsonElement code) && code.GetInt32() != 0)
+            {
+                throw new InvalidOperationException($"Feishu file upload failed: {Message(root)} (code {code.GetInt32()}).");
+            }
+            fileKey = root.GetProperty("data").GetProperty("file_key").GetString()
+                      ?? throw new InvalidOperationException("Feishu file upload returned no file_key.");
+        }
+        using JsonDocument _ = await CallAsync(HttpMethod.Post,
+            "/open-apis/im/v1/messages?receive_id_type=chat_id",
+            new
+            {
+                receive_id = chatId,
+                msg_type = "file",
+                content = JsonSerializer.Serialize(new { file_key = fileKey })
+            }, cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>一张只有一个 Markdown 元素的卡片(序列化成字符串,接口要的就是字符串)。</summary>
     private static string Card(string markdown) => JsonSerializer.Serialize(new
     {

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuApi.cs
@@ -59,6 +59,58 @@ internal sealed class FeishuApi(string appId, string appSecret, bool internation
         }
     }
 
+    /// <summary>
+    /// 往一个会话发一张<b>能渲染 Markdown 的卡片</b>,返回消息 id。
+    /// </summary>
+    /// <remarks>
+    /// <b>为什么不是 <c>msg_type: text</c>。</b>模型的回答天然是 Markdown ——
+    /// 列表、行内代码、代码块、加粗。发成纯文本的话,飞书原样显示 <c>- **DeepX**:</c>
+    /// 和三个反引号,读起来比没有格式更糟:符号本身成了噪音。
+    /// <para>
+    /// 飞书这边能渲染 Markdown 的只有<b>卡片</b>。卡片 JSON 2.0 的 <c>markdown</c> 元素
+    /// 覆盖标题、列表、代码块、表格、链接,是这四家里最完整的一档。
+    /// <c>update_multi</c> 必须开,否则流式那几次改会被拒。
+    /// </para>
+    /// </remarks>
+    public async Task<string?> SendCardAsync(string chatId, string markdown, CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await CallAsync(HttpMethod.Post,
+            "/open-apis/im/v1/messages?receive_id_type=chat_id",
+            new
+            {
+                receive_id = chatId,
+                msg_type = "interactive",
+                content = Card(markdown)
+            }, cancellationToken).ConfigureAwait(false);
+        return MessageId(document);
+    }
+
+    /// <summary>更新一张已经发出的卡片。</summary>
+    /// <remarks>
+    /// 卡片走 <c>PATCH</c>,而文本走 <c>PUT</c> —— 这是两个不同的接口,用错那个会直接报错。
+    /// </remarks>
+    public async Task UpdateCardAsync(string messageId, string markdown, CancellationToken cancellationToken)
+    {
+        using JsonDocument _ = await CallAsync(HttpMethod.Patch,
+            $"/open-apis/im/v1/messages/{Uri.EscapeDataString(messageId)}",
+            new { content = Card(markdown) }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>一张只有一个 Markdown 元素的卡片(序列化成字符串,接口要的就是字符串)。</summary>
+    private static string Card(string markdown) => JsonSerializer.Serialize(new
+    {
+        schema = "2.0",
+        // 不开这个,同一张卡片改第二次就会被拒 —— 而流式进度天生要改很多次
+        config = new { update_multi = true },
+        body = new { elements = new object[] { new { tag = "markdown", content = markdown } } }
+    });
+
+    private static string? MessageId(JsonDocument document)
+        => document.RootElement.TryGetProperty("data", out JsonElement data)
+           && data.TryGetProperty("message_id", out JsonElement id)
+            ? id.GetString()
+            : null;
+
     /// <summary>往一个会话发文本,返回消息 id。</summary>
     public async Task<string?> SendTextAsync(string chatId, string text, CancellationToken cancellationToken)
     {
@@ -70,10 +122,7 @@ internal sealed class FeishuApi(string appId, string appSecret, bool internation
                 msg_type = "text",
                 content = JsonSerializer.Serialize(new { text })
             }, cancellationToken).ConfigureAwait(false);
-        return document.RootElement.TryGetProperty("data", out JsonElement data)
-               && data.TryGetProperty("message_id", out JsonElement id)
-            ? id.GetString()
-            : null;
+        return MessageId(document);
     }
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
@@ -49,7 +49,7 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
 
     /// <inheritdoc />
     /// <remarks>飞书能改已发出的文本消息,所以进度可以就地刷新,不必刷屏。</remarks>
-    public ChannelCapabilities Capabilities => new(true, 3000);
+    public ChannelCapabilities Capabilities => new(true, 3000, 30 * 1024 * 1024);
 
     /// <inheritdoc />
     public event Action? Connected;
@@ -457,6 +457,10 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
         }
         await _api.EditTextAsync(messageId, text, cancellationToken).ConfigureAwait(false);
     }
+
+    /// <inheritdoc />
+    public Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken)
+        => _api.SendFileAsync(target.ChatId, localPath, cancellationToken);
 
     private void Remember(string? messageId, bool card)
     {

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
@@ -408,13 +408,71 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
             : null;
     }
 
+    /// <summary>
+    /// 哪些消息 id 是卡片。卡片走 <c>PATCH</c>、文本走 <c>PUT</c>,用错接口会直接报错。
+    /// </summary>
+    /// <remarks>
+    /// 只记最近这些:流式改的永远是刚发出的那一条,记住整个历史没有意义。
+    /// </remarks>
+    private readonly Dictionary<string, bool> _isCard = [];
+
+    private const int MaxRemembered = 64;
+
     /// <inheritdoc />
+    /// <remarks>
+    /// <b>先按卡片发,失败了退回纯文本。</b>格式是锦上添花,消息本身不是 ——
+    /// 卡片被租户策略挡下、或者哪天字段改了名,用户该看到的是一条没格式的回答,
+    /// 而不是什么都没有。
+    /// </remarks>
     public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
-        => await _api.SendTextAsync(target.ChatId, text, cancellationToken).ConfigureAwait(false);
+    {
+        try
+        {
+            string? id = await _api.SendCardAsync(target.ChatId, text, cancellationToken).ConfigureAwait(false);
+            Remember(id, true);
+            return id;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            context.Log.Warn($"Bridge: {Label} could not send a card ({ex.Message}); falling back to plain text.");
+            string? id = await _api.SendTextAsync(target.ChatId, text, cancellationToken).ConfigureAwait(false);
+            Remember(id, false);
+            return id;
+        }
+    }
 
     /// <inheritdoc />
     public async Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
-        => await _api.EditTextAsync(messageId, text, cancellationToken).ConfigureAwait(false);
+    {
+        bool card;
+        lock (_isCard)
+        {
+            // 记不得就当卡片:这是发送那条路的默认形态
+            card = !_isCard.TryGetValue(messageId, out bool known) || known;
+        }
+        if (card)
+        {
+            await _api.UpdateCardAsync(messageId, text, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        await _api.EditTextAsync(messageId, text, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void Remember(string? messageId, bool card)
+    {
+        if (messageId is not { Length: > 0 })
+        {
+            return;
+        }
+        lock (_isCard)
+        {
+            if (_isCard.Count >= MaxRemembered)
+            {
+                _isCard.Clear();
+            }
+            _isCard[messageId] = card;
+        }
+    }
 
     /// <inheritdoc />
     public ValueTask DisposeAsync()

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using VelaShell.PluginSdk;
@@ -39,7 +40,7 @@ internal sealed class TelegramChannel(ChannelConfig config, string token, IPlugi
     public string Label => config.Label;
 
     /// <inheritdoc />
-    public ChannelCapabilities Capabilities => new(true, 4000);
+    public ChannelCapabilities Capabilities => new(true, 4000, 50 * 1024 * 1024);
 
     /// <inheritdoc />
     public event Action? Connected;
@@ -185,6 +186,29 @@ internal sealed class TelegramChannel(ChannelConfig config, string token, IPlugi
         {
             using JsonDocument _ = await CallAsync("editMessageText",
                 new { chat_id = chat, message_id = message, text }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Telegram 这一家最省事:一步 multipart,不用先换 key。
+    /// </remarks>
+    public async Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken)
+    {
+        string name = Path.GetFileName(localPath);
+        await using FileStream stream = File.OpenRead(localPath);
+        using var form = new MultipartFormDataContent { { new StringContent(target.ChatId), "chat_id" } };
+        using var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(content, "document", name);
+        using HttpResponseMessage response = await _http
+            .PostAsync($"https://api.telegram.org/bot{token}/sendDocument", form, cancellationToken)
+            .ConfigureAwait(false);
+        string payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = JsonDocument.Parse(payload);
+        if (!document.RootElement.TryGetProperty("ok", out JsonElement ok) || !ok.GetBoolean())
+        {
+            throw new InvalidOperationException($"Telegram sendDocument failed: {payload}");
         }
     }
 

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramChannel.cs
@@ -147,23 +147,56 @@ internal sealed class TelegramChannel(ChannelConfig config, string token, IPlugi
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <b>先按 HTML 发,被拒了退回纯文本。</b>转换器(<see cref="TelegramHtml" />)自己生成标签、
+    /// 结构上不会不闭合,但 Telegram 那边的实体规则还有别的讲究(比如嵌套限制),
+    /// 真撞上了该让用户看到一条没格式的回答,而不是什么都看不到。
+    /// </remarks>
     public async Task<string?> SendAsync(OutboundTarget target, string text, CancellationToken cancellationToken)
     {
-        using JsonDocument document = await CallAsync("sendMessage",
-            new { chat_id = long.Parse(target.ChatId), text }, cancellationToken).ConfigureAwait(false);
-        return document.RootElement.TryGetProperty("result", out JsonElement result)
-               && result.TryGetProperty("message_id", out JsonElement id)
-            ? id.GetRawText()
-            : null;
+        long chat = long.Parse(target.ChatId);
+        try
+        {
+            return MessageId(await CallAsync("sendMessage",
+                new { chat_id = chat, text = TelegramHtml.Convert(text), parse_mode = "HTML" },
+                cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            context.Log.Warn($"Bridge: {Label} could not send HTML ({ex.Message}); falling back to plain text.");
+            return MessageId(await CallAsync("sendMessage", new { chat_id = chat, text }, cancellationToken)
+                .ConfigureAwait(false));
+        }
     }
 
     /// <inheritdoc />
     public async Task EditAsync(OutboundTarget target, string messageId, string text,
         CancellationToken cancellationToken)
     {
-        using JsonDocument _ = await CallAsync("editMessageText",
-            new { chat_id = long.Parse(target.ChatId), message_id = long.Parse(messageId), text },
-            cancellationToken).ConfigureAwait(false);
+        long chat = long.Parse(target.ChatId);
+        long message = long.Parse(messageId);
+        try
+        {
+            using JsonDocument _ = await CallAsync("editMessageText",
+                new { chat_id = chat, message_id = message, text = TelegramHtml.Convert(text), parse_mode = "HTML" },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            using JsonDocument _ = await CallAsync("editMessageText",
+                new { chat_id = chat, message_id = message, text }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static string? MessageId(JsonDocument document)
+    {
+        using (document)
+        {
+            return document.RootElement.TryGetProperty("result", out JsonElement result)
+                   && result.TryGetProperty("message_id", out JsonElement id)
+                ? id.GetRawText()
+                : null;
+        }
     }
 
     private async Task<JsonDocument> CallAsync(string method, object? body, CancellationToken cancellationToken)

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramHtml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Telegram/TelegramHtml.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace VelaShell.Plugin.Ai.Bridge.Channels.Telegram;
+
+/// <summary>
+/// 把模型输出的 Markdown 转成 Telegram 认的那一小撮 HTML。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>为什么是 HTML 而不是 MarkdownV2。</b>MarkdownV2 要求把
+/// <c>_ * [ ] ( ) ~ ` &gt; # + - = | { } . !</c> 全部转义,漏一个整条消息就是
+/// <c>400 can't parse entities</c> —— 而模型的输出里这些字符成堆(列表的 <c>-</c>、
+/// 标题的 <c>#</c>、句号的 <c>.</c>)。更糟的是流式那条路发的是<b>半截</b>文本,
+/// 一个还没闭合的 <c>**</c> 就能让整轮回复发不出去。
+/// HTML 只有三个字符要转义(<c>&amp; &lt; &gt;</c>),标签由我们自己配对生成,
+/// 结构上不可能不闭合。
+/// </para>
+/// <para>
+/// Telegram 认的标签就那么几个:<c>b i u s code pre a blockquote</c>。
+/// 列表和标题它压根没有,所以在这里降级成排版字符(<c>•</c> 与加粗)——
+/// 保留意思,不假装有它没有的东西。
+/// </para>
+/// </remarks>
+internal static partial class TelegramHtml
+{
+    /// <summary>转换整段文本。</summary>
+    public static string Convert(string markdown)
+    {
+        var sb = new StringBuilder();
+        var fenced = false;
+        foreach (string raw in (markdown ?? "").Split('\n'))
+        {
+            string line = raw.TrimEnd('\r');
+            if (Fence().Match(line) is { Success: true } fence)
+            {
+                // 围栏代码块整段原样保留:里面的 * 和 _ 是代码,不是格式
+                sb.Append(fenced ? "</code></pre>" : Open(fence.Groups[1].Value.Trim())).Append('\n');
+                fenced = !fenced;
+                continue;
+            }
+            if (fenced)
+            {
+                sb.Append(Escape(line)).Append('\n');
+                continue;
+            }
+            sb.Append(Block(line)).Append('\n');
+        }
+        if (fenced)
+        {
+            // 流式发的是半截文本,围栏可能还没闭合。补上,别让标签漏出去。
+            sb.Append("</code></pre>\n");
+        }
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    private static string Open(string language)
+        => language.Length > 0
+            ? $"<pre><code class=\"language-{Escape(language)}\">"
+            : "<pre><code>";
+
+    /// <summary>一行块级排版:标题、列表、引用。</summary>
+    private static string Block(string line)
+    {
+        if (Heading().Match(line) is { Success: true } heading)
+        {
+            // Telegram 没有标题,退成加粗 —— 保留"这是一节的开头"这个意思
+            return $"<b>{Inline(heading.Groups[2].Value)}</b>";
+        }
+        if (Bullet().Match(line) is { Success: true } bullet)
+        {
+            return $"{bullet.Groups[1].Value}• {Inline(bullet.Groups[3].Value)}";
+        }
+        if (Quote().Match(line) is { Success: true } quote)
+        {
+            return $"<blockquote>{Inline(quote.Groups[1].Value)}</blockquote>";
+        }
+        return Inline(line);
+    }
+
+    /// <summary>
+    /// 行内记号。<b>行内代码要先摘出来</b> —— 里面的 <c>*</c> 与 <c>_</c> 是代码本身,
+    /// 再去当格式解释就会把代码改坏。
+    /// </summary>
+    private static string Inline(string text)
+    {
+        var sb = new StringBuilder();
+        var at = 0;
+        foreach (Match code in InlineCode().Matches(text))
+        {
+            sb.Append(Marks(text[at..code.Index]));
+            sb.Append("<code>").Append(Escape(code.Groups[1].Value)).Append("</code>");
+            at = code.Index + code.Length;
+        }
+        sb.Append(Marks(text[at..]));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// 加粗 / 斜体 / 删除线 / 链接。
+    /// </summary>
+    /// <remarks>
+    /// <b>先转义再插标签</b>,顺序反过来的话我们自己生成的 <c>&lt;b&gt;</c> 会被转义掉。
+    /// 每条正则都要求成对出现,配不上的记号就当普通字符留着 —— 半截的
+    /// <c>**</c> 在 HTML 里只是两个星号,不是一个语法错误。
+    /// </remarks>
+    private static string Marks(string text)
+    {
+        string s = Escape(text);
+        s = Link().Replace(s, m => $"<a href=\"{m.Groups[2].Value}\">{m.Groups[1].Value}</a>");
+        s = Bold().Replace(s, "<b>$1</b>");
+        s = Strike().Replace(s, "<s>$1</s>");
+        // 星号与下划线分成两条:写成一条带分支的正则,下划线那支捕获的是第 2 组,
+        // 于是 $1 永远是空的 —— _soon_ 会变成一个空的 <i></i>,内容凭空消失。
+        s = ItalicStar().Replace(s, "<i>$1</i>");
+        s = ItalicUnderscore().Replace(s, "<i>$1</i>");
+        return s;
+    }
+
+    private static string Escape(string text)
+        => text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+    [GeneratedRegex(@"^\s*```(.*)$")]
+    private static partial Regex Fence();
+
+    [GeneratedRegex(@"^(#{1,6})\s+(.+)$")]
+    private static partial Regex Heading();
+
+    [GeneratedRegex(@"^(\s*)([-*+])\s+(.*)$")]
+    private static partial Regex Bullet();
+
+    [GeneratedRegex(@"^&gt;\s?(.*)$|^>\s?(.*)$")]
+    private static partial Regex Quote();
+
+    [GeneratedRegex(@"`([^`]+)`")]
+    private static partial Regex InlineCode();
+
+    /// <summary>行内链接。地址里的 <c>)</c> 少见,不为它做转义栈。</summary>
+    [GeneratedRegex(@"\[([^\]\n]*)\]\((https?://[^)\s]+)\)")]
+    private static partial Regex Link();
+
+    [GeneratedRegex(@"\*\*(?=\S)(.+?)(?<=\S)\*\*")]
+    private static partial Regex Bold();
+
+    [GeneratedRegex(@"~~(?=\S)(.+?)(?<=\S)~~")]
+    private static partial Regex Strike();
+
+    /// <summary>单星号的斜体。加粗已经先被吃掉了,所以这里不会撞上 <c>**</c>。</summary>
+    [GeneratedRegex(@"(?<![\w*])\*(?=\S)([^*\n]+?)(?<=\S)\*(?![\w*])")]
+    private static partial Regex ItalicStar();
+
+    /// <summary>
+    /// 单下划线的斜体。
+    /// </summary>
+    /// <remarks>
+    /// 两侧那两个环视是为了放过 <c>snake_case_name</c> —— 服务器上的路径与标识符里
+    /// 下划线成堆,把它们当成斜体记号会把名字改坏,而用户会照着复制。
+    /// </remarks>
+    [GeneratedRegex(@"(?<![\w_])_(?=\S)([^_\n]+?)(?<=\S)_(?![\w_])")]
+    private static partial Regex ItalicUnderscore();
+}

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
@@ -241,14 +241,17 @@ internal sealed class WeComChannel(
         string accessToken = await TokenAsync(cancellationToken).ConfigureAwait(false);
         bool isGroup = _groups.TryGetValue(target.ChatId, out bool group) && group;
         string path = isGroup ? "/cgi-bin/appchat/send" : "/cgi-bin/message/send";
+        // Markdown 而不是纯文本:理由同其它三家 —— 模型的回答天然带列表与行内代码。
+        // 企微的 Markdown 是个子集(没有表格、没有代码块高亮),但列表、加粗、
+        // 行内代码、引用都认,已经比原样显示那些符号强得多。
         object body = isGroup
-            ? new { chatid = target.ChatId, msgtype = "text", text = new { content = text } }
+            ? new { chatid = target.ChatId, msgtype = "markdown", markdown = new { content = text } }
             : new
             {
                 touser = target.ChatId,
-                msgtype = "text",
+                msgtype = "markdown",
                 agentid = int.TryParse(config.AgentId, out int agent) ? agent : 0,
-                text = new { content = text }
+                markdown = new { content = text }
             };
         using HttpResponseMessage response = await _http.PostAsJsonAsync(
             $"{ApiBase}{path}?access_token={Uri.EscapeDataString(accessToken)}", body, cancellationToken)

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/WeCom/WeComChannel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net.Http.Headers;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
@@ -53,7 +54,7 @@ internal sealed class WeComChannel(
     public string Label => config.Label;
 
     /// <inheritdoc />
-    public ChannelCapabilities Capabilities => new(false, 2000);
+    public ChannelCapabilities Capabilities => new(false, 2000, 20 * 1024 * 1024);
 
     /// <inheritdoc />
     public event Action? Connected;
@@ -268,6 +269,55 @@ internal sealed class WeComChannel(
     /// <inheritdoc />
     public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
         => Task.CompletedTask; // Capabilities.CanEdit = false
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 临时素材换 <c>media_id</c> 再发。素材三天过期,而我们发完就不再引用它,所以不必留着。
+    /// </remarks>
+    public async Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken)
+    {
+        string accessToken = await TokenAsync(cancellationToken).ConfigureAwait(false);
+        string name = Path.GetFileName(localPath);
+        string mediaId;
+        await using (FileStream stream = File.OpenRead(localPath))
+        {
+            using var form = new MultipartFormDataContent();
+            using var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            form.Add(content, "media", name);
+            using HttpResponseMessage upload = await _http.PostAsync(
+                $"{ApiBase}/cgi-bin/media/upload?access_token={Uri.EscapeDataString(accessToken)}&type=file",
+                form, cancellationToken).ConfigureAwait(false);
+            using JsonDocument document = JsonDocument.Parse(
+                await upload.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            if (document.RootElement.TryGetProperty("errcode", out JsonElement code) && code.GetInt32() != 0)
+            {
+                throw new InvalidOperationException($"WeCom media upload failed: {Describe(document.RootElement)}");
+            }
+            mediaId = document.RootElement.GetProperty("media_id").GetString()
+                      ?? throw new InvalidOperationException("WeCom media upload returned no media_id.");
+        }
+        bool isGroup = _groups.TryGetValue(target.ChatId, out bool group) && group;
+        string path = isGroup ? "/cgi-bin/appchat/send" : "/cgi-bin/message/send";
+        object body = isGroup
+            ? new { chatid = target.ChatId, msgtype = "file", file = new { media_id = mediaId } }
+            : new
+            {
+                touser = target.ChatId,
+                msgtype = "file",
+                agentid = int.TryParse(config.AgentId, out int agent) ? agent : 0,
+                file = new { media_id = mediaId }
+            };
+        using HttpResponseMessage response = await _http.PostAsJsonAsync(
+            $"{ApiBase}{path}?access_token={Uri.EscapeDataString(accessToken)}", body, cancellationToken)
+            .ConfigureAwait(false);
+        using JsonDocument sent = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+        if (sent.RootElement.TryGetProperty("errcode", out JsonElement sendCode) && sendCode.GetInt32() != 0)
+        {
+            throw new InvalidOperationException($"WeCom {path} failed: {Describe(sent.RootElement)}");
+        }
+    }
 
     private static string Describe(JsonElement root)
     {

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
@@ -176,13 +176,18 @@ public sealed class ConversationRouter(
         ChatGrant grant = (template ?? new ChatGrant()).Clone();
         grant.ChatId = message.ChatId;
         grant.IsGroup = message.IsGroup;
-        await AllowChatAsync(config, grant).ConfigureAwait(false);
+        await AllowChatAsync(config, grant, announce: false).ConfigureAwait(false);
         context.Log.Info($"Bridge: {message.ChatKey} was paired by {message.UserName} " +
                          $"(scope: {DescribeScope(grant)}).");
         await hub.SendAsync(message.ChannelId, target,
             grant.Scope.IsUnrestricted
                 ? Loc["BridgePaired"]
                 : Loc.F("BridgePairedScoped", DescribeScope(grant)),
+            CancellationToken.None).ConfigureAwait(false);
+        // 紧跟一条欢迎语:刚被放行的人此刻最需要知道的是"我能干什么、我受什么限",
+        // 而不是自己去猜一个命令名。
+        await hub.SendAsync(message.ChannelId, target,
+            Welcome(null, config, grant),
             CancellationToken.None).ConfigureAwait(false);
         return true;
     }
@@ -195,7 +200,14 @@ public sealed class ConversationRouter(
     /// 落盘走"读—改—写"而不是把内存那份整个盖上去 —— 设置页可能正开着,
     /// 用它内存里的快照覆盖会把用户刚改的别的字段抹掉。
     /// </remarks>
-    public async Task AllowChatAsync(ChannelConfig config, ChatGrant grant)
+    /// <param name="config">这个渠道。</param>
+    /// <param name="grant">给这个聊天的授权。</param>
+    /// <param name="announce">
+    /// 放行之后往那个聊天里发一条欢迎语。设置页那个「允许」按钮要发(人在手机上等着,
+    /// 不打声招呼他不知道成了没有);<c>/pair</c> 那条路<b>不要</b> ——
+    /// 它自己会先回一句"配对成功"再跟欢迎语,顺序才对,由这里代劳会重复发一条。
+    /// </param>
+    public async Task AllowChatAsync(ChannelConfig config, ChatGrant grant, bool announce = true)
     {
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(grant);
@@ -224,6 +236,19 @@ public sealed class ConversationRouter(
                              "it will be forgotten on restart until the settings are saved.");
         }
         pairing.Forget(config.Id, chatId);
+        if (announce)
+        {
+            try
+            {
+                await hub.SendAsync(config.Id, new OutboundTarget(chatId, null),
+                    Welcome(null, config, grant), CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // 打招呼失败不该让放行本身失败 —— 授权已经写进去了,那才是这次操作的意义
+                context.Log.Warn($"Bridge: {chatId} was authorized but the welcome message failed: {ex.Message}");
+            }
+        }
         lock (_sync)
         {
             // 放行之后那句"未授权"的提醒也该复位:万一以后又被移出白名单,还得再提示一次
@@ -330,7 +355,7 @@ public sealed class ConversationRouter(
         string argument = parts.Length > 1 ? parts[1] : "";
         string? reply = command switch
         {
-            "/help" or "/?" => Loc["BridgeHelp"],
+            "/help" or "/?" => Welcome(conversation, config, grant),
             "/new" or "/reset" => Reset(conversation),
             "/stop" => Stop(conversation),
             "/status" => await StatusAsync(conversation, config, grant).ConfigureAwait(false),
@@ -363,6 +388,31 @@ public sealed class ConversationRouter(
         }
         running.Cancel();
         return Loc["BridgeStopped"];
+    }
+
+    /// <summary>
+    /// 欢迎语 / <c>/help</c>:自我介绍 + <b>此刻真实的</b>设定 + 命令表。
+    /// </summary>
+    /// <remarks>
+    /// <b>刻意不是一段静态文案。</b>一个只读、只授权了"测试"分组的群里,印着
+    /// "你可以让我重启服务"比不印更糟 —— 人会照着去下命令,然后对着一句拒绝发懵,
+    /// 而那句拒绝(按设计)不会告诉他范围外有什么。把当前挡位、审批、范围、绑定
+    /// 一并写在欢迎语里,人一进来就知道自己站在哪儿。
+    /// <para>
+    /// 同一份内容既当欢迎语(配对成功、设置页放行)也当 <c>/help</c>,
+    /// 于是不存在"帮助说的和实际不一样"这种缝。
+    /// </para>
+    /// </remarks>
+    private string Welcome(BridgeConversation? conversation, ChannelConfig config, ChatGrant grant)
+    {
+        ChatMode mode = conversation?.ModeOverride ?? grant.Mode ?? Settings.Mode;
+        ApprovalMode approval = grant.Approval ?? Settings.Approval;
+        string bound = conversation?.BoundTarget is { Length: > 0 } target
+            ? target
+            : config.DefaultTarget is { Length: > 0 } fallback
+                ? fallback
+                : "—";
+        return Loc.F("BridgeWelcome", mode, approval, DescribeScope(grant), bound, Loc["BridgeHelp"]);
     }
 
     /// <summary><c>/status</c>:把这个聊天<b>实际</b>生效的那几个值报出来,包括范围。</summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -604,6 +604,16 @@ public sealed class Loc(string locale)
         ["PairScopeHint"] = ["The code carries this scope — the chat is limited from its first second, with no window where it holds everything.", "配对码携带这份范围:群从第一秒起就受限,不存在\"先全开再收紧\"的窗口。", "配對碼攜帶這份範圍:群從第一秒起就受限,不存在\"先全開再收緊\"的視窗。", "コードはこの範囲を伴います。チャットは最初から制限され、「まず全開放してから絞る」窓は存在しません。", "코드가 이 범위를 함께 전달합니다. 대화는 처음부터 제한되며 \"먼저 전부 열고 나중에 좁히는\" 구간이 없습니다."],
         ["BridgePaired"] = ["Paired — this chat can talk to me now. Try /help.", "配对成功,这个聊天现在可以跟我说话了。试试 /help。", "配對成功,這個聊天現在可以跟我說話了。試試 /help。", "ペアリングできました。このチャットから話しかけられます。/help を試してください。", "페어링에 성공했습니다. 이제 이 대화에서 말을 걸 수 있습니다. /help를 사용해 보세요."],
         // ── 斜杠命令 ──
+        // 欢迎语 = 自我介绍 + **此刻真实的**设定 + 命令表({4} 塞的就是下面那份)。
+        // 设定不写死成静态文案:一个只读、只授权了某个分组的群里,印着"你可以让我重启服务"
+        // 比不印更糟 —— 人会照着去下命令,然后撞上一句(按设计)不解释范围的拒绝。
+        ["BridgeWelcome"] = [
+            "**VelaShell assistant** is connected to this chat. I can reach the servers you saved in VelaShell — read logs, check services, run commands.\n\n**Right now**\n- Mode: {0}\n- Approval: {1}\n- Can operate: {2}\n- Bound to: {3}\n\n**Commands**\n{4}\n\nOr just ask, e.g. \"any errors in the 32601 service today?\". In a group, @ me first.",
+            "**VelaShell 助手**已接入这个聊天。我能连到你在 VelaShell 里保存的服务器,读日志、看服务、跑命令。\n\n**当前设定**\n- 挡位:{0}\n- 审批:{1}\n- 能操作:{2}\n- 绑定:{3}\n\n**命令**\n{4}\n\n也可以直接问,比如「32601 那个服务今天有报错吗」。群里记得先 @ 我。",
+            "**VelaShell 助手**已接入這個聊天。我能連到你在 VelaShell 裡儲存的伺服器,讀日誌、看服務、跑命令。\n\n**目前設定**\n- 擋位:{0}\n- 審批:{1}\n- 能操作:{2}\n- 綁定:{3}\n\n**命令**\n{4}\n\n也可以直接問,比如「32601 那個服務今天有報錯嗎」。群裡記得先 @ 我。",
+            "**VelaShell アシスタント**がこのチャットに接続しました。VelaShell に保存したサーバーに接続して、ログの確認・サービスの状態確認・コマンド実行ができます。\n\n**現在の設定**\n- モード:{0}\n- 承認:{1}\n- 操作できる範囲:{2}\n- 接続先:{3}\n\n**コマンド**\n{4}\n\nそのまま質問しても構いません(例:「32601 のサービスに今日エラーは出ていますか」)。グループでは先に @ してください。",
+            "**VelaShell 어시스턴트**가 이 대화에 연결되었습니다. VelaShell에 저장한 서버에 접속해 로그 확인, 서비스 상태 확인, 명령 실행을 할 수 있습니다.\n\n**현재 설정**\n- 모드: {0}\n- 승인: {1}\n- 조작 범위: {2}\n- 대상: {3}\n\n**명령**\n{4}\n\n그냥 물어봐도 됩니다(예: \"32601 서비스에 오늘 오류가 있나요?\"). 그룹에서는 먼저 @ 해 주세요."
+        ],
         ["BridgeHelp"] = [
             "/sessions — list connected servers\n/use <user@host:port> — bind this chat to one\n/mode chat|plan|agent — change the mode\n/new — start a fresh conversation\n/stop — stop the current turn\n/status — show what this chat is set to, including which machines it may touch",
             "/sessions — 列出已连上的服务器\n/use <user@host:port> — 把本聊天绑到某一台\n/mode chat|plan|agent — 换挡位\n/new — 开一段新对话\n/stop — 中止当前这一轮\n/status — 看本聊天的当前设定(含能操作哪些机器)",

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
@@ -246,6 +246,41 @@ public sealed class BridgeRouterTests
         Assert.IsFalse(stored.ChatBindings.ContainsKey("ch1/chat-1"), "越界的绑定不该被记下来");
     }
 
+    /// <summary>
+    /// <c>/help</c> 报的是<b>这个聊天此刻真实的</b>设定,不是一段静态文案。
+    /// </summary>
+    /// <remarks>
+    /// 一个只读、只授权了某个分组的群里,帮助里印着"你可以让我重启服务"比不印更糟 ——
+    /// 人会照着去下命令,然后撞上一句(按设计)不解释范围的拒绝,完全不知道为什么。
+    /// </remarks>
+    [TestMethod]
+    public async Task SlashHelp_ReportsWhatThisChatCanActuallyDo()
+    {
+        await using Harness harness = Scoped();
+        await harness.StartAsync();
+
+        await harness.SendAsync("/help", isGroup: true);
+
+        string reply = harness.Channel.Sent.Single();
+        StringAssert.Contains(reply, "生产");          // 范围
+        StringAssert.Contains(reply, "/sessions");     // 命令表
+    }
+
+    /// <summary>刚被放行的人应当收到一条欢迎语,而不是自己去猜命令名。</summary>
+    [TestMethod]
+    public async Task Pairing_IsFollowedByAWelcome()
+    {
+        await using var harness = new Harness();
+        await harness.StartAsync();
+        string code = harness.Pairing.Issue();
+
+        await harness.SendAsync($"/pair {code}", chatId: "chat-new");
+
+        // 一条"配对成功",紧跟一条欢迎语
+        Assert.AreEqual(2, harness.Channel.Sent.Count);
+        StringAssert.Contains(harness.Channel.Sent[1], "/sessions");
+    }
+
     /// <summary><c>/status</c> 要把范围报出来 —— 不然人只能靠撞墙才知道自己受限。</summary>
     [TestMethod]
     public async Task SlashStatus_ReportsTheScope()
@@ -391,7 +426,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync($"/pair {code}", chatId: "chat-new");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "Paired");
+        StringAssert.Contains(harness.Channel.Sent[0], "Paired");
         // 内存里立刻生效:紧接着的一句话不该再被当成陌生人
         harness.Channel.Sent.Clear();
         await harness.SendAsync("/help", chatId: "chat-new");

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
@@ -29,7 +29,10 @@ public sealed class BridgeRouterTests
 
         public string Label => "fake";
 
-        public ChannelCapabilities Capabilities => new(true, 4000);
+        public ChannelCapabilities Capabilities => new(true, 4000, 30 * 1024 * 1024);
+
+        /// <summary>发出去的文件(路径)。</summary>
+        public List<string> Files { get; } = [];
 
         public event Action? Connected;
 
@@ -48,6 +51,12 @@ public sealed class BridgeRouterTests
         public Task EditAsync(OutboundTarget target, string messageId, string text, CancellationToken cancellationToken)
         {
             Sent.Add($"[edit {messageId}] {text}");
+            return Task.CompletedTask;
+        }
+
+        public Task SendFileAsync(OutboundTarget target, string localPath, CancellationToken cancellationToken)
+        {
+            Files.Add(localPath);
             return Task.CompletedTask;
         }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/SendFileToolTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SendFileToolTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Agent;
+using VelaShell.Plugin.Ai.Configuration;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// <c>send_file</c>:把已下载的文件当附件发进 IM 聊天。
+/// </summary>
+/// <remarks>
+/// <b>这整个文件都是安全用例。</b>一个"能读本机文件并推进群里"的工具,就是一条完整的
+/// 外泄通道 —— 群里任何一个人说一句"帮我看看 id_rsa",模型没有理由怀疑这句话。
+/// 挡住它的不是黑名单(数不完),是<b>白名单一个目录</b>:只能发
+/// <c>download_remote_file</c> 自己下下来的那些,于是发得出去的东西必然来自一台
+/// 这次授权允许操作的服务器 —— 那一关在下载的时候就过了。
+/// </remarks>
+[TestClass]
+public sealed class SendFileToolTests
+{
+    private static async Task<string> InvokeAsync(AgentToolbox toolbox, string path)
+    {
+        AIFunction function = toolbox.CreateTools(ChatMode.Agent).OfType<AIFunction>().Single(f => f.Name == "send_file");
+        object? result = await function.InvokeAsync(
+            [with(new Dictionary<string, object?> { ["path"] = path })], CancellationToken.None);
+        return result?.ToString() ?? "";
+    }
+
+    private static AgentToolbox WithSink(TestPluginContext context, List<string> sent)
+        => new(context)
+        {
+            Approval = ApprovalMode.Bypass,
+            FileSender = (path, _) =>
+            {
+                sent.Add(path);
+                return Task.FromResult<string?>(null);
+            }
+        };
+
+    /// <summary>下载目录里的文件照常发得出去。</summary>
+    [TestMethod]
+    public async Task AFileInTheDownloadsFolder_IsSent()
+    {
+        using var context = new TestPluginContext();
+        string path = Downloaded(context, "2026-09-03.txt");
+        List<string> sent = [];
+
+        string result = await InvokeAsync(WithSink(context, sent), path);
+
+        Assert.Contains("Sent", result);
+        CollectionAssert.Contains(sent, path);
+    }
+
+    /// <summary>
+    /// <b>下载目录之外的一律拒绝。</b>用户自己的密钥、桌面、浏览器数据,一个都够不着。
+    /// </summary>
+    [TestMethod]
+    public async Task AFileOutsideTheDownloadsFolder_IsRefused()
+    {
+        using var context = new TestPluginContext();
+        string outside = Path.Combine(context.DataDirectory, "id_rsa");
+        File.WriteAllText(outside, "PRIVATE KEY");
+        List<string> sent = [];
+
+        string result = await InvokeAsync(WithSink(context, sent), outside);
+
+        Assert.Contains("Refused", result);
+        Assert.IsEmpty(sent, "范围之外的文件一个字节都不该发出去");
+    }
+
+    /// <summary>
+    /// <c>..</c> 穿不出去 —— 路径先规范化再比。
+    /// </summary>
+    /// <remarks>
+    /// 这是路径白名单最典型的绕法:名义上还在 <c>downloads/</c> 下面,
+    /// 拼出来却落到了用户的主目录里。
+    /// </remarks>
+    [TestMethod]
+    public async Task ATraversalOutOfTheDownloadsFolder_IsRefused()
+    {
+        using var context = new TestPluginContext();
+        string secret = Path.Combine(context.DataDirectory, "secrets.txt");
+        File.WriteAllText(secret, "token");
+        string traversal = Path.Combine(context.DataDirectory, "downloads", "..", "secrets.txt");
+        List<string> sent = [];
+
+        string result = await InvokeAsync(WithSink(context, sent), traversal);
+
+        Assert.Contains("Refused", result);
+        Assert.IsEmpty(sent);
+    }
+
+    /// <summary>
+    /// 前缀比对必须带目录分隔符,否则 <c>downloads-x/</c> 会被当成 <c>downloads/</c> 里面。
+    /// </summary>
+    [TestMethod]
+    public async Task ASiblingFolderWithTheSamePrefix_IsRefused()
+    {
+        using var context = new TestPluginContext();
+        string folder = Path.Combine(context.DataDirectory, "downloads-secret");
+        Directory.CreateDirectory(folder);
+        string path = Path.Combine(folder, "x.txt");
+        File.WriteAllText(path, "nope");
+        List<string> sent = [];
+
+        string result = await InvokeAsync(WithSink(context, sent), path);
+
+        Assert.Contains("Refused", result);
+        Assert.IsEmpty(sent);
+    }
+
+    /// <summary>路径对但文件不在,说的是"先下下来",而不是一句转义失败。</summary>
+    [TestMethod]
+    public async Task AMissingFile_SaysToDownloadItFirst()
+    {
+        using var context = new TestPluginContext();
+        Directory.CreateDirectory(Path.Combine(context.DataDirectory, "downloads"));
+        string path = Path.Combine(context.DataDirectory, "downloads", "not-there.txt");
+
+        string result = await InvokeAsync(WithSink(context, []), path);
+
+        Assert.Contains("No such local file", result);
+    }
+
+    /// <summary>审批被拒就不发,而且不该换个姿势再试。</summary>
+    [TestMethod]
+    public async Task ADeniedApproval_StopsTheSend()
+    {
+        using var context = new TestPluginContext();
+        string path = Downloaded(context, "log.txt");
+        List<string> sent = [];
+        var toolbox = new AgentToolbox(context)
+        {
+            Approval = ApprovalMode.Ask,
+            ApprovalHandler = _ => Task.FromResult(false),
+            FileSender = (p, _) =>
+            {
+                sent.Add(p);
+                return Task.FromResult<string?>(null);
+            }
+        };
+
+        string result = await InvokeAsync(toolbox, path);
+
+        Assert.Contains("DENIED", result);
+        Assert.IsEmpty(sent);
+    }
+
+    /// <summary>
+    /// <b>没有落点就不注册这个工具。</b>聊天面板与对外 MCP 走的就是这条路。
+    /// </summary>
+    /// <remarks>
+    /// 摆一个永远失败的工具比不摆更糟:模型看得见它,就会反复去试,
+    /// 然后把这次失败当成自己的问题,绕着弯子重来。
+    /// </remarks>
+    [TestMethod]
+    public void WithNoChatToSendInto_TheToolIsNotEvenRegistered()
+    {
+        using var context = new TestPluginContext();
+
+        string[] names = [.. new AgentToolbox(context).CreateTools(ChatMode.Agent)
+            .OfType<AIFunction>().Select(f => f.Name)];
+
+        CollectionAssert.DoesNotContain(names, "send_file");
+    }
+
+    /// <summary>渠道那头失败时,原话回给模型,而不是假装发出去了。</summary>
+    [TestMethod]
+    public async Task AChannelFailure_IsReportedNotSwallowed()
+    {
+        using var context = new TestPluginContext();
+        string path = Downloaded(context, "big.tar.gz");
+        var toolbox = new AgentToolbox(context)
+        {
+            Approval = ApprovalMode.Bypass,
+            FileSender = (_, _) => Task.FromResult<string?>("Feishu accepts at most 30 MB.")
+        };
+
+        string result = await InvokeAsync(toolbox, path);
+
+        Assert.Contains("30 MB", result);
+        Assert.DoesNotContain("Sent", result);
+    }
+
+    private static string Downloaded(TestPluginContext context, string name)
+    {
+        string folder = Path.Combine(context.DataDirectory, "downloads");
+        Directory.CreateDirectory(folder);
+        string path = Path.Combine(folder, name);
+        File.WriteAllText(path, "2026-09-03 10:00:00 INFO started");
+        return path;
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/TelegramHtmlTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/TelegramHtmlTests.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+using VelaShell.Plugin.Ai.Bridge.Channels.Telegram;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// Markdown → Telegram HTML。
+/// </summary>
+/// <remarks>
+/// <b>这一层最怕的不是转得难看,是转出一个发不出去的串。</b>Telegram 对实体的语法很严,
+/// 而喂进来的东西有两个特点:模型写的 Markdown(星号、下划线、反引号成堆),
+/// 以及流式那条路发的<b>半截</b>文本。所以用例里既有"转得对不对",
+/// 也有一组专门撞畸形输入的。
+/// </remarks>
+[TestClass]
+public sealed class TelegramHtmlTests
+{
+    [TestMethod]
+    public void Bold_BecomesTheBoldTag()
+        => Assert.AreEqual("<b>DeepX</b> is up", TelegramHtml.Convert("**DeepX** is up"));
+
+    [TestMethod]
+    public void InlineCode_BecomesTheCodeTag()
+        => Assert.AreEqual("port <code>32601</code>", TelegramHtml.Convert("port `32601`"));
+
+    [TestMethod]
+    public void Italic_AcceptsBothMarkers()
+    {
+        Assert.AreEqual("<i>soon</i>", TelegramHtml.Convert("*soon*"));
+        Assert.AreEqual("<i>soon</i>", TelegramHtml.Convert("_soon_"));
+    }
+
+    /// <summary>列表 Telegram 根本没有,退成排版字符而不是把 <c>-</c> 留在那儿。</summary>
+    [TestMethod]
+    public void Bullets_BecomeATypographicMarker()
+        => Assert.AreEqual("• <b>DeepX</b>: <code>release</code>",
+            TelegramHtml.Convert("- **DeepX**: `release`"));
+
+    [TestMethod]
+    public void Headings_BecomeBoldBecauseTelegramHasNone()
+        => Assert.AreEqual("<b>部署清单</b>", TelegramHtml.Convert("## 部署清单"));
+
+    [TestMethod]
+    public void FencedCode_BecomesAPreBlockWithItsLanguage()
+    {
+        string html = TelegramHtml.Convert("```bash\nls -la\n```");
+
+        Assert.Contains("<pre><code class=\"language-bash\">", html);
+        Assert.Contains("ls -la", html);
+        Assert.Contains("</code></pre>", html);
+    }
+
+    /// <summary>
+    /// <b>代码块里的记号是代码,不是格式。</b>
+    /// </summary>
+    /// <remarks>
+    /// 把 <c>*</c> 当成斜体去解释,吐出来的就是一段被改坏的命令 ——
+    /// 而用户会把它复制去生产机上执行。
+    /// </remarks>
+    [TestMethod]
+    public void FencedCode_KeepsMarkdownMarkersVerbatim()
+    {
+        string html = TelegramHtml.Convert("```\nrm -rf /var/log/*.log\ncat a_b_c\n```");
+
+        Assert.Contains("rm -rf /var/log/*.log", html);
+        Assert.Contains("cat a_b_c", html);
+        Assert.DoesNotContain("<i>", html);
+    }
+
+    /// <summary>行内代码同理:里面的下划线不该变成斜体。</summary>
+    [TestMethod]
+    public void InlineCode_KeepsMarkersVerbatim()
+        => Assert.AreEqual("<code>a_b_c</code>", TelegramHtml.Convert("`a_b_c`"));
+
+    /// <summary>HTML 特殊字符先转义,否则日志里一个 <c>&lt;</c> 就能把消息弄成非法实体。</summary>
+    [TestMethod]
+    public void HtmlSpecialCharacters_AreEscaped()
+        => Assert.AreEqual("a &amp; b &lt;tag&gt;", TelegramHtml.Convert("a & b <tag>"));
+
+    [TestMethod]
+    public void EscapingHappensBeforeTagsAreInserted()
+        => Assert.AreEqual("<b>&lt;b&gt;</b>", TelegramHtml.Convert("**<b>**"));
+
+    [TestMethod]
+    public void Links_BecomeAnchors()
+        => Assert.AreEqual("<a href=\"https://example.com/x\">docs</a>",
+            TelegramHtml.Convert("[docs](https://example.com/x)"));
+
+    // ---- 畸形输入 ----
+
+    /// <summary>
+    /// <b>流式发的是半截文本。</b>一个还没闭合的围栏不该让标签漏出去。
+    /// </summary>
+    [TestMethod]
+    public void AnUnclosedFence_IsClosedForUs()
+    {
+        string html = TelegramHtml.Convert("看这个:\n```bash\nls -la");
+
+        Assert.Contains("<pre><code class=\"language-bash\">", html);
+        Assert.EndsWith("</code></pre>", html);
+    }
+
+    /// <summary>配不上的记号就当普通字符 —— 在 HTML 里两个星号只是两个星号。</summary>
+    [TestMethod]
+    public void UnpairedMarkers_StayAsLiteralText()
+    {
+        Assert.AreEqual("**half", TelegramHtml.Convert("**half"));
+        Assert.AreEqual("2 * 3 * 4", TelegramHtml.Convert("2 * 3 * 4"));
+        Assert.AreEqual("snake_case_name", TelegramHtml.Convert("snake_case_name"));
+    }
+
+    /// <summary>
+    /// 每个开标签都有闭标签 —— 这条是整个转换器存在的理由。
+    /// </summary>
+    /// <remarks>
+    /// 拿一段"什么都有"的畸形文本去撞:半截加粗、孤立的下划线、没闭合的反引号、
+    /// 尖括号、以及一个开着的围栏。只要标签是配对的,Telegram 就不会 400。
+    /// </remarks>
+    [TestMethod]
+    public void EveryTagIsBalanced_EvenOnMalformedInput()
+    {
+        string html = TelegramHtml.Convert(
+            "## 报告 **未闭合\n- a_b `未闭合\n> 引用 <script>\n2 * 3\n```py\nprint('x')");
+
+        foreach (string tag in (string[])["b", "i", "s", "code", "pre", "a", "blockquote"])
+        {
+            // 开标签有的带属性(<a href=…>、<code class=…>),所以按"名字后面跟空格或 >"数 ——
+            // 直接数 "<b" 会把 <blockquote> 也算成一个加粗。
+            int opened = Regex.Matches(html, $"<{tag}[ >]").Count;
+            Assert.AreEqual(opened, Count(html, $"</{tag}>"), $"<{tag}> 没有配对");
+        }
+        Assert.DoesNotContain("<script>", html);
+    }
+
+    [TestMethod]
+    public void PlainText_IsLeftAlone()
+        => Assert.AreEqual("当前服务器上运行中的 .NET 程序如下:",
+            TelegramHtml.Convert("当前服务器上运行中的 .NET 程序如下:"));
+
+    private static int Count(string haystack, string needle)
+    {
+        var count = 0;
+        int at = haystack.IndexOf(needle, StringComparison.Ordinal);
+        while (at >= 0)
+        {
+            count++;
+            at = haystack.IndexOf(needle, at + needle.Length, StringComparison.Ordinal);
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
接着 #350。两件在真机上用出来的问题。

## 1. Markdown 记号被当正文甩给用户

模型的回答天然是 Markdown —— 列表、行内代码、代码块、加粗。四家渠道一直发的是 `msg_type: text`,于是飞书上原样显示 `- **DeepX**:` 和三个反引号:符号本身成了噪音,**比没有格式更难读**。

| 渠道 | 改成 | 能渲染 |
|---|---|---|
| 飞书 | 卡片(JSON 2.0 的 `markdown` 元素) | 标题 / 列表 / 代码块 / 表格 / 链接 |
| 钉钉 | `sampleMarkdown` | 标准子集 |
| 企微 | `markdown` 消息类型 | 子集(无表格) |
| Telegram | 转 HTML | 加粗 / 斜体 / 代码 / 引用 / 链接 |

几处值得说的:

- **飞书卡片更新走 `PATCH`,文本走 `PUT`**,是两个接口,用错直接报错 —— 所以要记住哪些消息 id 是卡片。`update_multi` 必须开,否则流式那几次改会被拒。
- **Telegram 用 HTML 而不是 MarkdownV2。** MarkdownV2 要求转义十八个字符,漏一个整条消息就是 `400 can't parse entities`;而流式发的是**半截**文本,一个还没闭合的 `**` 就能让整轮回复发不出去。HTML 只有三个字符要转义,标签由转换器自己配对生成,结构上不可能不闭合。
- **四家都是先按富文本发、被拒了退回纯文本。** 格式是锦上添花,消息本身不是。

转换器写完就被自己的用例抓出两个真 bug:斜体那条正则把星号与下划线写成一条分支,下划线那支捕获的是第 2 组,于是 `_soon_` 变成一个空的 `<i></i>` —— 内容凭空消失。

顺带:**欢迎语与 `/help` 现在报的是这个聊天此刻真实的挡位、审批、范围与绑定**,不是一段静态文案。一个只读群里印着"你可以让我重启服务"比不印更糟:人会照着下命令,然后撞上一句(按 #350 的设计)不解释范围的拒绝。配对成功与设置页放行之后都会收到它。

## 2. 日志拿不到手

原来那条路是断的:机器人能把日志下到**你电脑上**,然后回一句"当前没有可用的飞书发送接口",让人自己去聊天里上传 —— 而人正在手机上,电脑在工位上。

新增工具 `send_file`,四家都实现了 `SendFileAsync`(飞书 30MB / Telegram 50MB / 钉钉与企微 20MB)。完整用法:服务器上 `tar` 打包 → `download_remote_file` → `send_file`。上限在发之前查,因为超了之后各家表现不一(有的报错、有的静默丢),而"传了两分钟然后无事发生"最难查。

**路径锁死在下载目录里,这是这个功能的安全前提。** 一个"能读本机文件并推进群里"的工具就是一条完整的外泄通道 —— 群里任何一个人说一句"帮我看看 id_rsa",而模型没有理由怀疑这句话。挡它的不是黑名单(数不完),是**白名单一个目录**:只能发 `download_remote_file` 自己下下来的那些,于是发得出去的东西必然来自一台这次授权允许操作的服务器 —— 那一关在下载的时候就过了。用户的密钥、桌面、浏览器数据一律够不着。另外照样走审批:文件出了这台机器就收不回来。

工具只在 IM 那条路注册(面板与对外 MCP 给不出落点)—— 摆一个永远失败的工具只会让模型反复去试。

## 验证

555 个用例全绿(新增 23 条)。两轮变异验证:把路径白名单放开 → 3 条转红;前缀比对少了目录分隔符(于是 `downloads-secret/` 被当成 `downloads/` 里面)→ 1 条转红。

**没在真机上验证过的两处**,提审时请留意:飞书卡片在具体租户下的可用性(被策略挡下会自动退回纯文本,行为是安全的);以及钉钉的素材上传走老版 `oapi.dingtalk.com` 而发消息走新版 `api.dingtalk.com`,两个域名两套鉴权 —— 按文档写的,没跑过真机。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfvL9PZhivkKKp4vduaGf8
