### PR TITLE
修复 SSH 目录上报钩子拼出 ;; 导致每次提示符报语法错误

### DIFF
--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -55,19 +55,49 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// 由「设置 → 终端 → 会话 → 上报终端工作目录」开关控制,关掉即一字节不注入(#286)。
     /// </summary>
     /// <remarks>
-    /// bash 代码放在单引号包裹的 eval 参数里,避免 fish 等 shell 预解析函数体时报错;
-    /// 外层守卫让非 bash shell 不执行。只追加 PROMPT_COMMAND,不覆盖用户已有的
-    /// starship/direnv/atuin 等钩子,并在重连时按函数名去重。
+    /// <para>
+    /// <b>bash 代码必须留在单引号包裹的 eval 参数里。</b>shell 会先把整行解析完再执行,
+    /// 裸写的函数定义与 <c>[[ ]]</c>、<c>${var//a/b}</c> 会让 fish 在<b>解析阶段</b>就报错 ——
+    /// 那时外层守卫还没来得及短路。包进单引号后 fish 只看到一个字符串,静默跳过,屏幕上一个字符都不留。
+    /// </para>
     /// <para>
     /// 这道守卫只在 POSIX 世界内部有效:它挡得住 fish/csh,挡不住 cmd.exe ——
     /// Windows OpenSSH 的默认 shell 把整行当命令执行,屏幕上就是
     /// <c>'test' 不是内部或外部命令</c>(#305)。所以注入前必须先用
     /// <see cref="RemoteShellProbe" /> 确认对端认 sh 语法,守卫是第二道闸不是第一道。
     /// </para>
+    /// <para>
+    /// <b>装法是"先把自己摘掉、清干净首尾、再装回去",不是"发现装过就跳过"。</b>
+    /// 后者看着更省事,实际漏了两种情况,而这两种在真机上都撞到了:
+    /// </para>
+    /// <list type="number">
+    /// <item>
+    /// 原值结尾自带分号时会拼出 <c>;;</c>。pyenv-virtualenv 的初始化在 PROMPT_COMMAND 为空时
+    /// 就是设成 <c>_pyenv_virtualenv_hook;</c>,于是追加后成了
+    /// <c>_pyenv_virtualenv_hook;;vela_shell_osc7</c> —— <c>;;</c> 出了 case 就是语法错误,
+    /// 用户**每敲一次回车**都会看到一行报错。所以追加前必须把尾部的分号与空白剪掉。
+    /// </item>
+    /// <item>
+    /// 会话一旦已经是坏的,"跳过"就永远修不回来:去重看到里面已有 <c>vela_shell_osc7</c>,
+    /// 认定装过了,坏值原样留着。改成无条件重装之后,这种会话再连一次就自愈。
+    /// </item>
+    /// </list>
+    /// <para>
+    /// <b>只剪首尾,绝不动中间。</b>看着更彻底的 <c>${PROMPT_COMMAND//;;/;}</c> 会把用户
+    /// PROMPT_COMMAND 里合法的 <c>case</c> 分支(<c>… ;; *) … ;; esac</c>)切坏 ——
+    /// 换来的是另一个语法错误。问题出在尾部,就只该剪尾部。
+    /// </para>
+    /// <para>
+    /// 摘自己时先去 <c>;vela_shell_osc7</c> 再去裸的 <c>vela_shell_osc7</c>:前者把分隔符一并带走,
+    /// 免得在中间留下 <c>;;</c>;后者收尾开头那份或分号后带空格的写法。
+    /// 这段是 shell 语义,C# 单测只断言得了字符串里有什么,拦不住"跑起来才炸" ——
+    /// 真正的状态矩阵在 <c>tests/VelaShell.Tests/ViewModels/PromptHookShellTests.cs</c>,
+    /// 它把这个常量原样交给真正的 bash 跑。
+    /// </para>
     /// </remarks>
-    private const string WorkingDirectoryReportHook =
+    internal const string WorkingDirectoryReportHook =
         """
-        test -n "$BASH_VERSION" && eval 'vela_shell_osc7() { printf "\033]7;file://%s%s\033\\\\" "$HOSTNAME" "$PWD"; }; case ";$PROMPT_COMMAND;" in *";vela_shell_osc7;"*) ;; *) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}vela_shell_osc7";; esac'; printf "\r\033[2K"
+        test -n "${BASH_VERSION:-}" && eval 'vela_shell_osc7() { printf "\033]7;file://%s%s\033\\\\" "${HOSTNAME:-}" "$PWD"; }; PROMPT_COMMAND="${PROMPT_COMMAND:-}"; PROMPT_COMMAND="${PROMPT_COMMAND//;vela_shell_osc7/}"; PROMPT_COMMAND="${PROMPT_COMMAND//vela_shell_osc7/}"; while [[ -n $PROMPT_COMMAND && $PROMPT_COMMAND == [\;[:space:]]* ]]; do PROMPT_COMMAND=${PROMPT_COMMAND#?}; done; while [[ -n $PROMPT_COMMAND && $PROMPT_COMMAND == *[\;[:space:]] ]]; do PROMPT_COMMAND=${PROMPT_COMMAND%?}; done; PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}vela_shell_osc7"'; printf "\r\033[2K"
         """;
 
     /// <summary>RIS(ESC c)完全重置序列:重开会话前清掉旧进程的残留缓冲。</summary>

--- a/tests/VelaShell.Tests/ViewModels/PromptHookShellTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/PromptHookShellTests.cs
@@ -1,0 +1,269 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 把 <c>MainWindowViewModel.WorkingDirectoryReportHook</c> 原样交给<b>真正的 bash</b> 跑一遍。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 这段钩子是 shell 语义,C# 只断言得了"字符串里有没有某几个词"
+/// (<see cref="MainWindowSshFeatureTests" /> 就是那么做的),拦不住"跑起来才炸" ——
+/// 而它已经炸过两次,两次都是这类:
+/// </para>
+/// <list type="bullet">
+/// <item>原值结尾带分号 → 拼出 <c>;;</c> → 用户每敲一次回车都看到一行语法错误;</item>
+/// <item>会话已经是坏的 → 旧的"装过就跳过"判定认为无事可做 → 永远修不回来。</item>
+/// </list>
+/// <para>
+/// 所以这里逐个状态真跑:装完的 <c>PROMPT_COMMAND</c> 必须<b>等于</b>期望值,并且必须
+/// <b>真的能执行</b>(bash 拿它当命令跑一遍,语法错就算失败)。每个状态连跑三遍,顺带验幂等 ——
+/// 重连、多开标签都会把同一段再注入一次。
+/// </para>
+/// <para>
+/// 找不到 bash 就报 Inconclusive:Windows 开发机上 bash 来自 Git for Windows,不是人人都装。
+/// Linux/macOS 上它一定在,CI 与真机验证不会被绕过去。
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class PromptHookShellTests
+{
+    /// <summary>钩子里那个函数名;摘装与断言都围着它转。</summary>
+    private const string HookFunction = "vela_shell_osc7";
+
+    private static string? _bash;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _bash = FindBash();
+
+    /// <summary>
+    /// 每个用例:进来时的 <c>PROMPT_COMMAND</c>(null = 完全未设置)→ 装完之后应该是什么。
+    /// </summary>
+    private static IEnumerable<object?[]> Cases =>
+    [
+        // 完全没有别的钩子。
+        [null, HookFunction, "未设置"],
+        [string.Empty, HookFunction, "空串"],
+
+        // pyenv-virtualenv 在 PROMPT_COMMAND 原本为空时就是设成带尾分号的 ——
+        // 正是它让旧版拼出 `_pyenv_virtualenv_hook;;vela_shell_osc7`(真机报的那个)。
+        ["_pyenv_virtualenv_hook;", $"_pyenv_virtualenv_hook;{HookFunction}", "尾部带分号"],
+        ["_pyenv_virtualenv_hook; ", $"_pyenv_virtualenv_hook;{HookFunction}", "尾部分号加空格"],
+        ["_pyenv_virtualenv_hook", $"_pyenv_virtualenv_hook;{HookFunction}", "尾部干净"],
+        ["a;b", $"a;b;{HookFunction}", "两个已有钩子"],
+
+        // 已经被旧版毒过的会话:再连一次必须自愈,而不是"看到装过了就跳过"。
+        [$"_pyenv_virtualenv_hook;;{HookFunction}", $"_pyenv_virtualenv_hook;{HookFunction}", "已中招"],
+        [$"_pyenv_virtualenv_hook; ;{HookFunction}", $"_pyenv_virtualenv_hook;{HookFunction}", "已中招(带空格)"],
+
+        // 已经装好的各种写法:结果不变,也不许重复追加。
+        [$"a;{HookFunction}", $"a;{HookFunction}", "已装好"],
+        [$"a; {HookFunction}", $"a;{HookFunction}", "已装好(分号后带空格)"],
+        [HookFunction, HookFunction, "只有自己"],
+
+        // 自己不在末尾:摘掉时不能在中间留下 `;;`,也不能留下开头的分号。
+        [$"{HookFunction};a", $"a;{HookFunction}", "自己在开头"],
+        [$"a;{HookFunction};b", $"a;b;{HookFunction}", "自己夹在中间"],
+
+        // 用户 PROMPT_COMMAND 里合法的 case 分支带 `;;` —— 一个字符都不许动。
+        [
+            "case $TERM in xterm*) :;; *) :;; esac",
+            $"case $TERM in xterm*) :;; *) :;; esac;{HookFunction}",
+            "用户自带 case"
+        ]
+    ];
+
+    /// <summary>找一个能用的 bash:Unix 上就是自带的那份,Windows 上从 PATH 里挑 Git 带的那份。</summary>
+    /// <remarks>
+    /// Windows 上要<b>跳过</b> <c>%SystemRoot%\System32\bash.exe</c> 与 <c>WindowsApps\bash.exe</c> ——
+    /// 那两个是 WSL 的入口,不是 Git for Windows 的 bash。用它跑脚本会掉进 WSL 的文件系统视图,
+    /// 临时脚本的路径(<c>/c/Users/…</c>)在那边根本不存在(WSL 是 <c>/mnt/c/…</c>),
+    /// 表现是一句莫名其妙的 "No such file or directory"。Git 也不一定装在 Program Files
+    /// (本机就在 D:\Git),所以按 PATH 找而不是猜几个固定路径。
+    /// </remarks>
+    private static string? FindBash()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return File.Exists("/bin/bash") ? "/bin/bash" : null;
+        }
+        string system = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        foreach (string dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+        {
+            if (dir.Length == 0
+                || dir.StartsWith(system, StringComparison.OrdinalIgnoreCase)
+                || dir.Contains("WindowsApps", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            string candidate;
+            try
+            {
+                candidate = Path.Combine(dir, "bash.exe");
+            }
+            catch (ArgumentException)
+            {
+                // PATH 里混进了带非法字符的项,跳过就是。
+                continue;
+            }
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 建一段脚本:摆好初始状态 → 把钩子原样跑三遍 → 打印结果并试着真执行一次。
+    /// </summary>
+    /// <remarks>
+    /// 钩子那三行整个重定向到 /dev/null:它末尾那记清行(<c>printf "\r\033[2K"</c>)会往
+    /// stdout 写控制字符,混进来就没法比对了。跑完把 <c>vela_shell_osc7</c> 覆盖成空操作,
+    /// 免得末尾那次试执行真的吐一串 OSC 7 出来。
+    /// </remarks>
+    private static string BuildScript(string? initial)
+    {
+        string hook = MainWindowViewModel.WorkingDirectoryReportHook;
+        // 刻意用逐行拼接而不是内插原始字符串:脚本里大括号很多(函数体、命令组),
+        // 内插会逼着把每一个都写成 {{ }},读起来比脚本本身还难。
+        string[] lines =
+        [
+            "set -u",
+            "_pyenv_virtualenv_hook() { :; }",
+            "a() { :; }",
+            "b() { :; }",
+            initial is null ? "unset PROMPT_COMMAND" : "PROMPT_COMMAND=" + Quote(initial),
+            "{",
+            hook,
+            hook,
+            hook,
+            "} >/dev/null 2>&1",
+            HookFunction + "() { :; }",
+            "printf 'RESULT<%s>\\n' \"$PROMPT_COMMAND\"",
+            "if ( eval \"$PROMPT_COMMAND\" ) >/dev/null 2>&1; then printf 'RUNS<yes>\\n'; else printf 'RUNS<no>\\n'; fi"
+        ];
+        return string.Join('\n', lines);
+    }
+
+    /// <summary>包成 shell 单引号字面量(内部的单引号按 <c>'\''</c> 拆开重接)。</summary>
+    private static string Quote(string value) => "'" + value.Replace("'", "'\\''") + "'";
+
+    private static (string PromptCommand, bool Runs) RunHook(string? initial)
+    {
+        string script = Path.Combine(Path.GetTempPath(), $"vela-prompt-hook-{Guid.NewGuid():N}.sh");
+        // bash 只认 LF;Windows 上写出 CRLF 会得到 "$'\r': command not found"。
+        File.WriteAllText(script, BuildScript(initial).ReplaceLineEndings("\n"));
+        try
+        {
+            ProcessStartInfo psi = new()
+            {
+                FileName = _bash!,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            // Windows 的 bash 不认盘符路径,转成 /c/... 形式。
+            psi.ArgumentList.Add(ToBashPath(script));
+
+            using Process process = Process.Start(psi)!;
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            Assert.IsTrue(process.WaitForExit(30_000), "bash 没有在 30 秒内退出");
+            Assert.IsEmpty(stderr.Trim(), $"钩子本身向 stderr 写了东西:{stderr}");
+
+            return (Extract(stdout, "RESULT"), Extract(stdout, "RUNS") == "yes");
+        }
+        finally
+        {
+            File.Delete(script);
+        }
+    }
+
+    private static string ToBashPath(string path) =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "/" + char.ToLowerInvariant(path[0]) + path[2..].Replace('\\', '/')
+            : path;
+
+    private static string Extract(string output, string tag)
+    {
+        int start = output.IndexOf(tag + "<", StringComparison.Ordinal);
+        // 打不出标记通常不是"输出错了",是脚本半路就退出了 —— 钩子那三行的 stderr 被丢进
+        // /dev/null(不然它自己的噪音会混进来比对),所以这里得替它把最可能的原因说出来。
+        Assert.IsGreaterThanOrEqualTo(
+            0,
+            start,
+            $"bash 输出里没有 {tag}<…>,脚本多半中途退出了(常见原因:set -u 撞上未定义的变量)。实际输出:{output}");
+        start += tag.Length + 1;
+        int end = output.IndexOf('>', start);
+        Assert.IsGreaterThanOrEqualTo(0, end, $"bash 输出里的 {tag}<…> 没有闭合:{output}");
+        return output[start..end];
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(Cases))]
+    public void Hook_LeavesPromptCommandUsable(string? initial, string expected, string description)
+    {
+        if (_bash is null)
+        {
+            Assert.Inconclusive("本机没有 bash(Windows 上需要 Git for Windows),跳过 shell 语义验证。");
+            return;
+        }
+
+        (string promptCommand, bool runs) = RunHook(initial);
+
+        Assert.AreEqual(expected, promptCommand, $"{description}:装完的 PROMPT_COMMAND 不对");
+        Assert.IsTrue(runs, $"{description}:PROMPT_COMMAND 执行不了(多半是拼出了 ;;)—— [{promptCommand}]");
+    }
+
+    /// <summary>
+    /// 守卫为假时(非 bash),除了那记清行不许有任何输出 —— 用户不该在屏幕上看见这段脚本。
+    /// </summary>
+    /// <remarks>
+    /// 这里靠置空 <c>BASH_VERSION</c> 模拟:真正的 fish/csh 是在**解析阶段**就炸,
+    /// 而那正是钩子把 bash 代码包进单引号 eval 的原因 —— 那条路本机无法复现,
+    /// 这条用例守的是"守卫为假 = 不产生副作用"这一半。
+    /// </remarks>
+    [TestMethod]
+    public void Hook_WhenNotBash_ProducesNothingButTheLineClear()
+    {
+        if (_bash is null)
+        {
+            Assert.Inconclusive("本机没有 bash,跳过。");
+            return;
+        }
+
+        string script = Path.Combine(Path.GetTempPath(), $"vela-prompt-hook-{Guid.NewGuid():N}.sh");
+        File.WriteAllText(
+            script,
+            $"BASH_VERSION=''\n{MainWindowViewModel.WorkingDirectoryReportHook}\nprintf 'AFTER<%s>\\n' \"${{PROMPT_COMMAND:-}}\"\n"
+                .ReplaceLineEndings("\n"));
+        try
+        {
+            ProcessStartInfo psi = new()
+            {
+                FileName = _bash!,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add(ToBashPath(script));
+            using Process process = Process.Start(psi)!;
+            string stdout = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(30_000);
+
+            Assert.IsEmpty(Extract(stdout, "AFTER"), "守卫为假却动了 PROMPT_COMMAND");
+            // 清行之外一个可见字符都不许有。
+            Assert.DoesNotContain(HookFunction, stdout, "守卫为假却把脚本内容回显了出来");
+            Assert.StartsWith("\r[2K", stdout, "末尾那记清行不见了 —— 注入的那一行会留在屏幕上");
+        }
+        finally
+        {
+            File.Delete(script);
+        }
+    }
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

<!-- 一两句话说清改动的结果。「改了什么」看 diff 就知道,重点写在下一栏。 -->

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
