### PR TITLE
修复 MSTest 4.4.0 的 AreSequenceEqual 在实参里遇到 await 会丢操作数

### DIFF
--- a/tests/VelaShell.Infrastructure.Tests/AreSequenceEqualAwaitTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/AreSequenceEqualAwaitTests.cs
@@ -1,0 +1,158 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>
+/// MSTest 4.4.0 的 <c>Assert.AreSequenceEqual</c> 有一个会误导人的 bug,这里把它钉住。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>症状</b>:把 <c>await</c> 直接写在实参位置、并且那个 await <b>真的挂起</b>时,
+/// 第一个操作数会变成空序列,断言随即以
+/// <c>序列长度不同(预期: 0,实际: N)</c> 失败。两边内容其实完全一样。
+/// </para>
+/// <code>
+/// Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(path));   // 挂
+/// byte[] read = await File.ReadAllBytesAsync(path);
+/// Assert.AreSequenceEqual(payload, read);                                 // 过
+/// </code>
+/// <para>
+/// <b>为什么值得单独立一个文件</b>:这个 bug 报出来的是"两个序列不相等",
+/// 把人直直地引向被测代码。`FtpFileServiceIntegrationTests` 的三条上传用例就这么红了一阵子,
+/// 排查时先去查了 FTP 的上传路径、又插桩排除了落盘竞态,最后才发现文件一直是好的
+/// (上传返回后立刻读就是完整的 40005 字节),是断言自己丢了操作数。
+/// </para>
+/// <para>
+/// <b>为什么现在只有一部分调用中招</b>:await 的那个 <c>Task</c> 若已经完成
+/// (例如 <c>await tcs.Task</c> 而结果早已 SetResult),await 不会真的挂起,于是碰不到这个 bug。
+/// 也就是说没中招的那些是<b>侥幸</b> —— 换台慢机器、或改了那些 Task 的完成时机就会变红。
+/// 所以全仓一律把 await 提到局部变量,而不是只修红了的那几条。
+/// </para>
+/// <para>
+/// <b>什么时候可以删掉这个文件</b>:<see cref="Bug_IsStillPresent_WhenAwaitSitsInTheArgumentList" />
+/// 是留给未来的引信 —— MSTest 哪天修好了,它会失败,那时就可以把这个文件连同全仓的
+/// "先落局部变量"注释一起删掉。
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed partial class AreSequenceEqualAwaitTests
+{
+    /// <summary>本文件自己会在字符串里写出那个模式,扫描时要排除自己。</summary>
+    private const string SelfFileName = "AreSequenceEqualAwaitTests.cs";
+
+    /// <summary>
+    /// <c>AreSequenceEqual(</c> 到语句末尾的分号之间出现 <c>await</c>。
+    /// </summary>
+    /// <remarks>
+    /// 必须跨行匹配:这个调用常常把实参拆成好几行(仓里就有一处那样写的,只扫单行会漏)。
+    /// 非贪婪 + 排除分号,保证不会越过语句边界去够到下一条语句里的 await。
+    /// </remarks>
+    [GeneratedRegex(@"AreSequenceEqual\([^;]*?\bawait\b", RegexOptions.Singleline)]
+    private static partial Regex AwaitInsideAssert { get; }
+
+    private static async Task<(byte[] Payload, string Path)> WriteTempAsync()
+    {
+        byte[] payload = Encoding.UTF8.GetBytes(new string('x', 40_000) + "-tail");
+        string path = Path.Combine(Path.GetTempPath(), $"vela-seq-{Guid.NewGuid():N}.bin");
+        await File.WriteAllBytesAsync(path, payload);
+        return (payload, path);
+    }
+
+    /// <summary>
+    /// 引信:MSTest 修好之前,这条"期望它失败"的写法确实会失败;修好之后这条用例就该红,
+    /// 提醒把全仓的绕法撤掉。
+    /// </summary>
+    [TestMethod]
+    public async Task Bug_IsStillPresent_WhenAwaitSitsInTheArgumentList()
+    {
+        (byte[] payload, string path) = await WriteTempAsync();
+        try
+        {
+            bool threw = false;
+            try
+            {
+                // 就是这一句会误报。两边内容一模一样,它却说序列不等。
+                Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(path));
+            }
+            catch (AssertFailedException)
+            {
+                threw = true;
+            }
+
+            Assert.IsTrue(
+                threw,
+                "MSTest 的 Assert.AreSequenceEqual 看起来已经修好了(实参里的 await 不再丢操作数)。"
+                + "确认之后,请把本文件删掉,并把全仓那些为绕开它而写的"
+                + "「先 await 到局部变量」的注释一并清理。");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>绕法本身必须是有效的 —— 否则上面那条引信就失去参照。</summary>
+    [TestMethod]
+    public async Task Workaround_HoistingTheAwaitIntoALocal_Works()
+    {
+        (byte[] payload, string path) = await WriteTempAsync();
+        try
+        {
+            byte[] read = await File.ReadAllBytesAsync(path);
+            Assert.AreSequenceEqual(payload, read);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// 全仓不许再出现「await 写在 <c>AreSequenceEqual</c> 实参里」的写法。
+    /// </summary>
+    /// <remarks>
+    /// 靠人记住是记不住的:这个写法写起来更顺手,而且只有在 await 真的挂起时才炸 ——
+    /// 本机绿了推上去别人那儿红。所以直接扫源码。
+    /// </remarks>
+    [TestMethod]
+    public void NoTestSource_PutsAnAwaitInsideAreSequenceEqual()
+    {
+        string testsRoot = Path.Combine(RepoRoot(), "tests");
+        List<string> offenders = [];
+        foreach (string file in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || Path.GetFileName(file) == SelfFileName)
+            {
+                continue;
+            }
+            string text = File.ReadAllText(file);
+            foreach (Match match in AwaitInsideAssert.Matches(text))
+            {
+                // 匹配可能跨行,行号按匹配起点(也就是 AreSequenceEqual 那一行)算。
+                int line = text.AsSpan(0, match.Index).Count('\n') + 1;
+                offenders.Add($"  {Path.GetRelativePath(RepoRoot(), file)}:{line}");
+            }
+        }
+
+        Assert.IsEmpty(
+            offenders,
+            "以下位置把 await 写进了 Assert.AreSequenceEqual 的实参里,MSTest 4.4.0 会丢掉另一个操作数、"
+            + "报成「序列不相等」(见本文件的注释)。请先 await 到局部变量再断言:\n"
+            + string.Join("\n", offenders));
+    }
+
+    private static string RepoRoot()
+    {
+        for (string? dir = AppContext.BaseDirectory; dir is not null; dir = Directory.GetParent(dir)?.FullName)
+        {
+            if (File.Exists(Path.Combine(dir, "VelaShell.slnx")))
+            {
+                return dir;
+            }
+        }
+        throw new InvalidOperationException("未能从测试输出目录向上定位到仓库根目录(找不到 VelaShell.slnx)。");
+    }
+}

--- a/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Ftp/FtpFileServiceIntegrationTests.cs
@@ -88,14 +88,16 @@ public class FtpFileServiceIntegrationTests
 
             string remoteOnDisk = Path.Combine(_root, "uploaded.bin");
             Assert.IsTrue(File.Exists(remoteOnDisk), "上传后服务器根目录下应出现该文件。");
-            Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(remoteOnDisk));
+            byte[] uploaded = await File.ReadAllBytesAsync(remoteOnDisk);
+            Assert.AreSequenceEqual(payload, uploaded);
             Assert.IsTrue(await _service.ExistsAsync(sessionId, "/uploaded.bin"));
 
             RemoteFileInfo info = await _service.GetFileInfoAsync(sessionId, "/uploaded.bin");
             Assert.AreEqual(payload.Length, info.Size);
 
             await _service.DownloadFileAsync(sessionId, "/uploaded.bin", localTarget);
-            Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(localTarget));
+            byte[] downloaded = await File.ReadAllBytesAsync(localTarget);
+            Assert.AreSequenceEqual(payload, downloaded);
         }
         finally
         {
@@ -248,7 +250,8 @@ public class FtpFileServiceIntegrationTests
             {
                 string landed = Path.Combine(_root, Path.GetFileName(source));
                 Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
-                Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+                byte[] landedBytes = await File.ReadAllBytesAsync(landed, TestContext.CancellationToken);
+                Assert.AreSequenceEqual(payload, landedBytes);
             }
             Assert.IsFalse(faulted, "退化成单连接是正常降级,不该把整条会话标记为离线。");
         }
@@ -292,7 +295,8 @@ public class FtpFileServiceIntegrationTests
             {
                 string landed = Path.Combine(_root, Path.GetFileName(source));
                 Assert.IsTrue(File.Exists(landed), $"{Path.GetFileName(source)} 应已上传。");
-                Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(landed, TestContext.CancellationToken));
+                byte[] landedBytes = await File.ReadAllBytesAsync(landed, TestContext.CancellationToken);
+                Assert.AreSequenceEqual(payload, landedBytes);
             }
         }
         finally

--- a/tests/VelaShell.Infrastructure.Tests/Net/ProxySupportTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Net/ProxySupportTests.cs
@@ -66,14 +66,17 @@ public class ProxySupportTests
         var route = new ProxyRoute(ProxyKind.Socks5, "127.0.0.1", server.Port);
         await using Stream tunnel = await ProxyStreamConnector.ConnectAsync(route, "target.example", 2222, cts.Token);
 
-        Assert.AreSequenceEqual(new byte[] { 0x05, 0x01, 0x00 }, await greeting.Task);
+        // await 不能写在 Assert.AreSequenceEqual 的实参位置,理由见 AreSequenceEqualAwaitTests.cs。
+        byte[] greetingBytes = await greeting.Task;
+        Assert.AreSequenceEqual(new byte[] { 0x05, 0x01, 0x00 }, greetingBytes);
         byte[] expectedRequest =
         [
             0x05, 0x01, 0x00, 0x03, 0x0E,
             .. Encoding.ASCII.GetBytes("target.example"),
             0x08, 0xAE, // 2222
         ];
-        Assert.AreSequenceEqual(expectedRequest, await request.Task);
+        byte[] requestBytes = await request.Task;
+        Assert.AreSequenceEqual(expectedRequest, requestBytes);
         Assert.AreEqual("SSH-2.0-Fake\r\n", Encoding.ASCII.GetString(await ReadAsync(tunnel, 14, cts.Token)));
     }
 
@@ -97,13 +100,16 @@ public class ProxySupportTests
         var route = new ProxyRoute(ProxyKind.Socks5, "127.0.0.1", server.Port, "us", "secret");
         await using Stream tunnel = await ProxyStreamConnector.ConnectAsync(route, "target.example", 22, cts.Token);
 
-        Assert.AreSequenceEqual(new byte[] { 0x05, 0x02, 0x00, 0x02 }, await greeting.Task);
+        // 同上:await 先落到局部变量。
+        byte[] greetingBytes = await greeting.Task;
+        Assert.AreSequenceEqual(new byte[] { 0x05, 0x02, 0x00, 0x02 }, greetingBytes);
         byte[] expectedAuth =
         [
             0x01, 0x02, (byte)'u', (byte)'s',
             0x06, .. Encoding.ASCII.GetBytes("secret"),
         ];
-        Assert.AreSequenceEqual(expectedAuth, await auth.Task);
+        byte[] authBytes = await auth.Task;
+        Assert.AreSequenceEqual(expectedAuth, authBytes);
     }
 
     /// <summary>认证被拒(RFC 1929 status != 0)必须抛错,不得带着未认证的链路继续。</summary>
@@ -141,9 +147,11 @@ public class ProxySupportTests
         var route = new ProxyRoute(ProxyKind.Socks5, "127.0.0.1", server.Port, ProxyDns: false);
         await using Stream tunnel = await ProxyStreamConnector.ConnectAsync(route, "localhost", 2222, cts.Token);
 
+        // 同上:await 先落到局部变量。
+        byte[] requestBytes = await request.Task;
         Assert.AreSequenceEqual(
             new byte[] { 0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0x08, 0xAE },
-            await request.Task);
+            requestBytes);
     }
 
     /// <summary>代理拒绝连接(REP != 0)必须抛错。</summary>

--- a/tests/VelaShell.Infrastructure.Tests/PluginTimeSeriesTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/PluginTimeSeriesTests.cs
@@ -139,7 +139,9 @@ public sealed class PluginTimeSeriesTests : IDisposable
         ]);
 
         Assert.AreEqual(2, await series.CountAsync("seq", new() { Tags = new Dictionary<string, string> { ["conv"] = "c1" } }));
-        Assert.AreSequenceEqual(["c1", "c2"], [.. (await series.DistinctTagValuesAsync("conv"))], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+        // await 不能写在 Assert.AreSequenceEqual 的实参位置,理由见 AreSequenceEqualAwaitTests.cs。
+        string[] conversations = [.. await series.DistinctTagValuesAsync("conv")];
+        Assert.AreSequenceEqual(["c1", "c2"], conversations, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
 
         await series.DeleteAsync(new Dictionary<string, string> { ["conv"] = "c1" });
         Assert.IsEmpty(await series.QueryAsync(new() { Tags = new Dictionary<string, string> { ["conv"] = "c1" } }));

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/JsonFilePluginStorageTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/JsonFilePluginStorageTests.cs
@@ -42,7 +42,9 @@ public class JsonFilePluginStorageTests
         Assert.IsNull(await storage.GetAsync<string>("missing"));
         Assert.IsTrue(await storage.RemoveAsync("count"));
         Assert.IsFalse(await storage.RemoveAsync("count"));
-        Assert.AreSequenceEqual(NameKeyOnly, [.. (await storage.GetKeysAsync())], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+        // await 不能写在 Assert.AreSequenceEqual 的实参位置,理由见 AreSequenceEqualAwaitTests.cs。
+        string[] remainingKeys = [.. await storage.GetKeysAsync()];
+        Assert.AreSequenceEqual(NameKeyOnly, remainingKeys, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SonnetDbPluginDataStoreTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SonnetDbPluginDataStoreTests.cs
@@ -65,7 +65,9 @@ public class SonnetDbPluginDataStoreTests
         Snapshot? snapshot = await storage.GetAsync<Snapshot>("snapshot");
         Assert.AreEqual("s1", snapshot!.Name);
         Assert.AreSequenceEqual(SnapshotValues, snapshot.Values);
-        Assert.AreSequenceEqual(CountAndSnapshotKeys, [.. (await storage.GetKeysAsync())], Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+        // await 不能写在 Assert.AreSequenceEqual 的实参位置,理由见 AreSequenceEqualAwaitTests.cs。
+        string[] keys = [.. await storage.GetKeysAsync()];
+        Assert.AreSequenceEqual(CountAndSnapshotKeys, keys, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         Assert.IsTrue(await storage.RemoveAsync("count"));
         Assert.IsFalse(await storage.RemoveAsync("count"));
         Assert.AreEqual(0, await storage.GetAsync<int>("count"));
@@ -111,9 +113,12 @@ public class SonnetDbPluginDataStoreTests
         await _store.CreateSecrets("acme.one").SetAsync("s", "v");
         await _store.CreateStorage("acme.two").SetAsync("k", 2);
 
-        Assert.AreSequenceEqual(BothPluginIds, [.. (await _store.ListPluginIdsAsync())]);
+        // 同上:await 先落到局部变量。
+        string[] before = [.. await _store.ListPluginIdsAsync()];
+        Assert.AreSequenceEqual(BothPluginIds, before);
         await _store.PurgeAsync("acme.one");
-        Assert.AreSequenceEqual(SecondPluginIdOnly, [.. (await _store.ListPluginIdsAsync())]);
+        string[] afterPurge = [.. await _store.ListPluginIdsAsync()];
+        Assert.AreSequenceEqual(SecondPluginIdOnly, afterPurge);
         Assert.AreEqual(0, await _store.CreateStorage("acme.one").GetAsync<int>("k"));
         Assert.IsNull(await _store.CreateSecrets("acme.one").GetAsync("s"));
         Assert.AreEqual(2, await _store.CreateStorage("acme.two").GetAsync<int>("k"));


### PR DESCRIPTION
## 这个 PR 做了什么

修掉 `tests/VelaShell.Infrastructure.Tests` 里三条一直红着的 FTP 上传用例。**根因不是 FTP** —— 是 MSTest 4.4.0 的 `Assert.AreSequenceEqual` 有 bug。产品代码一行未动。

## 为什么这么改

### 症状

```
Assertion failed. 预期序列相等。
序列长度不同(预期: 0，实际: 40005)。
expected: []
actual:   [120, 120, 120, …]
```

两边内容其实**一模一样**。触发条件是：`await` 直接写在实参位置，**并且那个 await 真的挂起**。

```csharp
Assert.AreSequenceEqual(payload, await File.ReadAllBytesAsync(path));   // 挂
byte[] read = await File.ReadAllBytesAsync(path);
Assert.AreSequenceEqual(payload, read);                                 // 过
```

最小复现只差这一行写法（本 PR 里作为用例留下了）。

### 排查过程

这个 bug 最坏的地方是它把「框架自己丢了操作数」报成「被测代码算错了」，我一开始确实往 FTP 上传路径查了：

1. 在 `c77b992` 建 worktree 重跑那三条 —— **全过**。
2. `git diff c77b992..HEAD -- src/VelaShell.Infrastructure/Ftp/` —— **FTP 源码一行没改**，只有测试里几处 `CollectionAssert.AreEqual` 换成了 `Assert.AreSequenceEqual`。
3. 插桩排除落盘竞态：上传返回后**立刻**读，文件就是完整的 40005 字节，等 300ms 还是 40005。上传下载都完全正确。
4. 时间线吻合：`b7355fe 升级 MSTest 包至 4.4.0` 正排在 `c77b992` 之后。

### 为什么把 14 处全改了，而不是只修红的 4 处

其余 10 处现在是绿的，但绿得**靠运气** —— 它们 `await` 的 `Task` 早已完成（`await tcs.Task` 而结果先前就 `SetResult` 了），await 不会真的挂起，于是碰不到这个 bug。换台慢机器、或改了那些 Task 的完成时机，就会跟着红。这是潜在 flaky，一并改掉才算修完。

其中一处是**跨行**写法（`ProxySupportTests.cs`），第一版扫描只认单行，漏了它 —— 守卫的正则因此改成跨行匹配。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [x] 其他: 测试基础设施

## 怎么验证的

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— **全绿**
- [x] 新增/修改的行为有对应测试
- [ ] 界面改动已在应用里实际跑过（无界面改动）

**实测环境:** Windows 11 x64

**新增 `AreSequenceEqualAwaitTests` 三条：**

* **引信** —— 断言「这个 bug 现在还在」。MSTest 哪天修好了，这条会红，提醒把整套绕法连同注释一起撤掉。自带退休机制，不会变成永久的历史包袱。
* **绕法有效** —— 否则引信失去参照。
* **扫全仓测试源码** —— 不许这个写法再溜回来。靠人记住是记不住的：它写起来更顺手，而且只有 await 真挂起时才炸，本机绿了推上去别人那儿红。

**测试结果:**

```
VelaShell.Controls.Tests            10 通过
VelaShell.Terminal.RenderTests       3 通过
VelaShell.Presentation.Tests        55 通过
VelaShell.Terminal.Tests           362 通过
VelaShell.Core.Tests               416 通过
VelaShell.Infrastructure.Tests     360 通过 / 2 跳过   ← 改动前 354 通过 / 3 失败
VelaShell.Tests                    979 通过 / 2 跳过
VelaShell.Plugin.Ai.Tests          555 通过
──────────────────────────────────────────────
合计                              2740 通过 / 0 失败 / 4 跳过
```

4 条跳过都是缺外部依赖时的 Inconclusive（WinSCP / Xshell 未安装等），不是失败。

## 补充说明

本 PR **直接提到 main**（按仓库主的要求），不走 `dev` —— 免得再补一个 dev→main 的 PR。

这个 bug 值得给 MSTest 报一个 issue：它把框架自己的缺陷报成被测代码的缺陷，而且只在 await 真正挂起时才现形，非常容易让人往错的方向查。要报的话我可以把最小复现整理出来。

---

- [x] 我已阅读 CONTRIBUTING.md，并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiNHSs5NhkYkDSrjzjzmHa
