### PR TITLE
文档型连接连不上时弹提示框,别让"点了连接什么都没发生"

### DIFF
--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -538,6 +538,20 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// </summary>
     public Func<SessionProfile, PluginProtocolCertificateException, Task<bool>>? PluginCertificateTrustPrompt { get; set; }
 
+    /// <summary>
+    /// 文档型连接(SFTP / FTP / 插件文件系统 / 工作台)首次连接失败时的提示弹窗。
+    /// <para>
+    /// SSH 标签的失败画在标签页内的覆盖层上(设计 yxjmg),所以它不需要这条路径;而上面这四类
+    /// <b>连不上就根本没有标签页</b> —— 失败原因只落到状态栏的话,用户看到的就是"点了连接,
+    /// 什么都没发生"。本地没起 Redis 时点开一条 Redis 会话正是这个样子。
+    /// </para>
+    /// <para>
+    /// 由 View 层挂上(与 <see cref="InteractiveAuthenticator" /> 同样的手法);未挂时(headless
+    /// 测试、插件代开会话)退回状态栏,不影响连接流程本身。
+    /// </para>
+    /// </summary>
+    public Func<SessionProfile, string, Task>? ConnectionFailureReporter { get; set; }
+
     /// <summary>最近一次连接的错误消息,若上次尝试成功则为 null。</summary>
     public string? LastConnectionError
     {
@@ -3047,6 +3061,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
 
         SessionProfile current = profile;
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页。
+        Exception? lastAuthFailure = null;
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresCredentials(current))
@@ -3058,6 +3074,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
+                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    LastConnectionError = null;
                     return null;
                 }
                 current = prompted;
@@ -3101,12 +3119,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 }
                 return null;
             }
-            catch (VelaSshAuthenticationException)
+            catch (VelaSshAuthenticationException auth)
             {
                 if (session is not null)
                 {
                     await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken).ConfigureAwait(true);
                 }
+                lastAuthFailure = auth;
                 continue;
             }
             catch (Exception ex)
@@ -3115,10 +3134,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 {
                     await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken).ConfigureAwait(true);
                 }
-                LastConnectionError = DescribeConnectionError(ex, current);
-                StatusBar.Status = LastConnectionError;
+                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
                 return null;
             }
+        }
+        if (lastAuthFailure is not null)
+        {
+            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
         }
         return null;
     }
@@ -3142,6 +3164,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
 
         SessionProfile current = profile;
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页。
+        Exception? lastAuthFailure = null;
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresFtpCredentials(current))
@@ -3153,6 +3177,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
+                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    LastConnectionError = null;
                     return null;
                 }
                 current = prompted;
@@ -3195,20 +3221,25 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     attempt--; // 信任后的这次重连不算认证重试
                     continue;
                 }
+                // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 StatusBar.Status = LastConnectionError;
                 return null;
             }
-            catch (VelaFtpAuthenticationException)
+            catch (VelaFtpAuthenticationException auth)
             {
+                lastAuthFailure = auth;
                 continue;
             }
             catch (Exception ex)
             {
-                LastConnectionError = DescribeConnectionError(ex, current);
-                StatusBar.Status = LastConnectionError;
+                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
                 return null;
             }
+        }
+        if (lastAuthFailure is not null)
+        {
+            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
         }
         return null;
     }
@@ -3252,6 +3283,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         // 多节点各自签一张证书的端点(DNS 轮询的 MinIO/Ceph)每轮都是"新证书",
         // 不设独立上限的话用户只能靠点"不信任"才退得出来。
         int certPrompts = 0;
+        // 三次认证都没过时的最后一条原因(理由同工作台那条路径)。
+        Exception? lastAuthFailure = null;
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresPluginCredentials(current, allowsAnonymous))
@@ -3263,6 +3296,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
+                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    LastConnectionError = null;
                     return null;
                 }
                 current = prompted;
@@ -3317,20 +3352,25 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     }
                     continue;
                 }
+                // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 StatusBar.Status = LastConnectionError;
                 return null;
             }
-            catch (PluginProtocolAuthenticationException)
+            catch (PluginProtocolAuthenticationException auth)
             {
+                lastAuthFailure = auth;
                 continue;
             }
             catch (Exception ex)
             {
-                LastConnectionError = DescribeConnectionError(ex, current);
-                StatusBar.Status = LastConnectionError;
+                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
                 return null;
             }
+        }
+        if (lastAuthFailure is not null)
+        {
+            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
         }
         return null;
     }
@@ -3485,6 +3525,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
         SessionProfile current = profile;
         int certPrompts = 0;
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页,
+        // 不记下来的话用户面对的是"密码弹了三次,然后什么都没有"。
+        Exception? lastAuthFailure = null;
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresPluginCredentials(current, allowsAnonymous))
@@ -3496,6 +3539,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
+                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    LastConnectionError = null;
                     return null;
                 }
                 current = prompted;
@@ -3549,20 +3594,25 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     }
                     continue;
                 }
+                // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 StatusBar.Status = LastConnectionError;
                 return null;
             }
-            catch (PluginProtocolAuthenticationException)
+            catch (PluginProtocolAuthenticationException auth)
             {
+                lastAuthFailure = auth;
                 continue;
             }
             catch (Exception ex)
             {
-                LastConnectionError = DescribeConnectionError(ex, current);
-                StatusBar.Status = LastConnectionError;
+                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
                 return null;
             }
+        }
+        if (lastAuthFailure is not null)
+        {
+            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
         }
         return null;
     }
@@ -3941,11 +3991,45 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         return await TryConnectProfileAsync(profile, cancellationToken);
     }
 
+    /// <summary>
+    /// 文档型连接的失败上报:状态栏 + 一扇提示弹窗。
+    /// <para>
+    /// 弹窗是这里的重点。SFTP / FTP / 插件文件系统 / 工作台连不上时**不会留下任何标签页**,
+    /// 只写状态栏等于没提示 —— 用户看到的是"点了连接,什么都没发生"。
+    /// </para>
+    /// </summary>
+    /// <param name="profile">这次连的配置(弹窗按它描述目标)。</param>
+    /// <param name="ex">失败原因。</param>
+    private async Task ReportConnectionFailureAsync(SessionProfile profile, Exception ex)
+    {
+        string message = DescribeConnectionError(ex, profile);
+        LastConnectionError = message;
+        StatusBar.Status = message;
+        if (ConnectionFailureReporter is not { } report)
+        {
+            return;
+        }
+        try
+        {
+            await report(profile, message).ConfigureAwait(true);
+        }
+        catch (Exception dialogFailure)
+        {
+            // 提示弹窗自己出问题不该盖掉真正的连接错误 —— 那条已经在状态栏上了。
+            System.Diagnostics.Trace.WriteLine(
+                $"[Connect] Reporting the failure of '{profile.Name}' threw: {dialogFailure.Message}");
+        }
+    }
+
     private static string DescribeConnectionError(Exception ex, SessionProfile profile)
     {
+        // 用户名为空是一条正当路径(匿名 S3 桶、没设 requirepass 的 Redis),
+        // 那时不能拼出 "@127.0.0.1:6379" 这种前面缺了一截的目标。
         string target = string.IsNullOrWhiteSpace(profile.Host)
             ? profile.Name
-            : $"{profile.Username}@{profile.Host}:{profile.Port}";
+            : string.IsNullOrWhiteSpace(profile.Username)
+                ? $"{profile.Host}:{profile.Port}"
+                : $"{profile.Username}@{profile.Host}:{profile.Port}";
         // 提取 Tmds.Ssh ConnectFailedException 中的具体原因(若存在),以便用户诊断。
         string detail = ExtractTmdsReason(ex.Message) ?? ex.Message;
         // 直接匹配 Core 的中立异常族(VelaSsh*Exception)。
@@ -3960,6 +4044,11 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             VelaSshOperationTimeoutException or TimeoutException => Strings.Format("Msg_ConnectTimeout", target),
             VelaSshConnectionException => $"{Strings.Format("Msg_ConnectFailed", target)}\n{detail}",
             SocketException => Strings.Format("Msg_NetworkError", target),
+            // 插件协议族的消息按 SDK 契约就是**面向用户**的,并且已经带上了端点。
+            // 再套一层"连接 X 失败:"只会把同一个地址写两遍。
+            PluginProtocolConnectionException
+                or PluginProtocolAuthenticationException
+                or PluginProtocolUnavailableException => detail,
             _ => Strings.Format("Msg_ConnectGenericFailed", target, detail),
         };
     }

--- a/src/VelaShell/Views/MainWindow.axaml.cs
+++ b/src/VelaShell/Views/MainWindow.axaml.cs
@@ -382,6 +382,9 @@ public partial class MainWindow : Window
             vm.PluginCertificateTrustPrompt = (profile, certificate) => PromptCertificateTrustAsync(
                 profile.Host, certificate.Subject, certificate.Issuer,
                 certificate.ExpiresOn, certificate.Thumbprint, certificate.PolicyErrors);
+            // 文档型连接(SFTP / FTP / S3 / Redis…)连不上时没有标签页可以承载失败提示,
+            // 由窗口弹一扇框 —— 否则点了"连接"之后屏幕上什么都不会发生。
+            vm.ConnectionFailureReporter = ReportConnectionFailureAsync;
             // 插件提议一条连接(如 Redis 插件从 SSH 会话里探到一个实例):
             // 打开宿主自己的「新建连接」对话框并预填。**插件不能自己写会话库** ——
             // 那是用户数据、凭据也在里面;它只能提议,由用户过一眼再按保存。
@@ -1353,15 +1356,44 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// 登录验证弹窗的串行闸门:同一时刻只允许一扇凭据对话框。启动恢复会话是并发发起的
+    /// 连接流程弹窗的串行闸门:同一时刻只允许一扇。启动恢复会话是并发发起的
     /// (#118),资源管理器树的双击/右键连接也是即发即忘,两条路径都可能同时要凭据;
     /// 同一 owner 上叠两扇模态框会互相争抢 owner 的禁用/启用,表现为对话框点不动。
+    /// <para>
+    /// 凭据框与连接失败提示共用这一道闸,而不是各管各的:恢复五条会话时,一扇密码框和
+    /// 三扇"连不上"若各自为政,照样会叠在同一个 owner 上。
+    /// </para>
     /// </summary>
-    private readonly SemaphoreSlim _credentialPromptGate = new(1, 1);
+    private readonly SemaphoreSlim _connectPromptGate = new(1, 1);
+
+    /// <summary>
+    /// 文档型连接(SFTP / FTP / S3 / Redis…)首次连接失败的提示。
+    /// <para>
+    /// 这条路径**连不上就没有标签页**,不像 SSH 还能把失败画在标签页内的覆盖层上
+    /// (设计 yxjmg)—— 没有这扇框,本机没起 Redis 时点开一条 Redis 会话是彻底静默的。
+    /// </para>
+    /// </summary>
+    private async Task ReportConnectionFailureAsync(SessionProfile profile, string message)
+    {
+        // 不带 ConfigureAwait(false):后续 ShowDialog 必须回到 UI 线程。
+        await _connectPromptGate.WaitAsync();
+        try
+        {
+            await MessageDialog.ShowMessageAsync(
+                this,
+                Strings.Get("Msg_ConnectionFailedTitle"),
+                string.IsNullOrWhiteSpace(profile.Name) ? message : $"{profile.Name}\n\n{message}",
+                MessageDialogKind.Error);
+        }
+        finally
+        {
+            _connectPromptGate.Release();
+        }
+    }
 
     /// <summary>
     /// 登录验证流程(设计:身份验证 第1步/第2步):补全用户名与认证凭据。
-    /// 一次只弹一扇(见 <see cref="_credentialPromptGate" />),排队的连接依次拿到弹窗。
+    /// 一次只弹一扇(见 <see cref="_connectPromptGate" />),排队的连接依次拿到弹窗。
     /// </summary>
     /// <summary>
     /// 服务器证书未通过校验时的信任提示(FTPS 与插件协议的 TLS 端点共用)。
@@ -1418,14 +1450,14 @@ public partial class MainWindow : Window
     private async Task<SessionProfile?> PromptCredentialsAsync(SessionProfile profile)
     {
         // 不带 ConfigureAwait(false):后续 ShowDialog 必须回到 UI 线程。
-        await _credentialPromptGate.WaitAsync();
+        await _connectPromptGate.WaitAsync();
         try
         {
             return await PromptCredentialsCoreAsync(profile);
         }
         finally
         {
-            _credentialPromptGate.Release();
+            _connectPromptGate.Release();
         }
     }
 

--- a/tests/VelaShell.Tests/ViewModels/WorkspaceConnectionFailureTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/WorkspaceConnectionFailureTests.cs
@@ -1,0 +1,159 @@
+using VelaShell.Core.Models;
+using VelaShell.Core.Protocols;
+using VelaShell.Docking;
+using VelaShell.Infrastructure.Plugins.Protocols;
+using VelaShell.PluginSdk.Protocols;
+using VelaShell.PluginSdk.Workspaces;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 工作台连接(Redis 等由插件全权渲染界面的类型)连不上时**必须有提示**。
+/// <para>
+/// 这条路径与 SSH 的关键差别:连不上就没有标签页,失败没有地方可画 —— 只写状态栏的话
+/// 用户看到的是"点了连接,什么都没发生"。本机没起 Redis 时点开一条 Redis 会话正是这个样子,
+/// 这组用例守的就是那扇提示框还在。
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class WorkspaceConnectionFailureTests
+{
+    private const string WorkspaceId = "acme.cache";
+
+    /// <summary>连接必失败的工作台:一次握手都不放过去。</summary>
+    private sealed class FailingWorkspaceProvider(Exception failure) : IWorkspaceProvider
+    {
+        public Task<IWorkspaceDocument> OpenAsync(
+            WorkspaceConnectRequest request,
+            CancellationToken cancellationToken = default) =>
+            Task.FromException<IWorkspaceDocument>(failure);
+    }
+
+    private static (MainWindowViewModel Vm, SessionProfile Profile) Arrange(Exception failure)
+    {
+        var registry = new PluginProtocolRegistry();
+        registry.RegisterWorkspace(
+            WorkspaceId,
+            new()
+            {
+                Id = WorkspaceId,
+                DisplayName = "Acme Cache",
+                DefaultPort = 6379,
+                // 匿名可连:与 Redis 一样,不填口令不该弹登录框 —— 否则这组用例
+                // 测到的是弹凭据,而不是失败提示。
+                Features = WorkspaceFeatures.AnonymousAccess
+            },
+            new FailingWorkspaceProvider(failure));
+        var vm = new MainWindowViewModel(
+            protocolRegistry: registry,
+            workspaceLauncher: new PluginWorkspaceLauncher(registry));
+        return (vm, new()
+        {
+            Name = "本地 Redis",
+            ConnectionType = ConnectionType.Plugin,
+            PluginProtocolId = WorkspaceId,
+            Host = "127.0.0.1",
+            Port = 6379
+        });
+    }
+
+    /// <summary>
+    /// 端点不可达(本机没起 Redis):不开标签页,但要把原因报到提示钩子上。
+    /// </summary>
+    [TestMethod]
+    public async Task ConnectionRefused_ReportsTheFailure_AndOpensNoDocument()
+    {
+        (MainWindowViewModel vm, SessionProfile profile) =
+            Arrange(new ProtocolConnectionException("连不上 127.0.0.1:6379:Connection refused"));
+        var reported = new List<string>();
+        vm.ConnectionFailureReporter = (_, message) =>
+        {
+            reported.Add(message);
+            return Task.CompletedTask;
+        };
+
+        PluginWorkspaceDocument? document = await vm.OpenWorkspaceDocumentForProfileAsync(profile);
+
+        Assert.IsNull(document);
+        Assert.HasCount(1, reported);
+        Assert.Contains("Connection refused", reported[0]);
+        // 匿名连接(Redis 常态)不该拼出 "@127.0.0.1:6379" 这种前面缺了一截的目标。
+        Assert.Contains("127.0.0.1:6379", reported[0]);
+        Assert.DoesNotContain("@127.0.0.1", reported[0]);
+        // 状态栏与 LastConnectionError 仍是同一条消息:插件代开会话那条路径靠它区分
+        // "没连上"与"人不同意"(见 HostSessionOpener)。
+        Assert.AreEqual(reported[0], vm.LastConnectionError);
+        Assert.IsEmpty(vm.Layout.AllDocuments());
+    }
+
+    /// <summary>
+    /// 没挂提示钩子(headless 单测、插件代开会话)时连接流程照旧,只是不弹框。
+    /// </summary>
+    [TestMethod]
+    public async Task WithoutAReporter_TheFailureStillLandsOnLastConnectionError()
+    {
+        (MainWindowViewModel vm, SessionProfile profile) =
+            Arrange(new ProtocolConnectionException("端点不可达"));
+
+        Assert.IsNull(await vm.OpenWorkspaceDocumentForProfileAsync(profile));
+
+        Assert.IsNotNull(vm.LastConnectionError);
+        Assert.Contains("端点不可达", vm.LastConnectionError);
+    }
+
+    /// <summary>
+    /// 三次凭据都没过之后,循环走完了也要报一次 —— 否则用户对着密码框输三遍,
+    /// 得到的是一片安静。
+    /// </summary>
+    [TestMethod]
+    public async Task ExhaustedAuthenticationRetries_ReportsTheLastFailure()
+    {
+        (MainWindowViewModel vm, SessionProfile profile) =
+            Arrange(new ProtocolAuthenticationException("WRONGPASS 口令不对"));
+        profile.Username = "default";
+        int prompts = 0;
+        vm.InteractiveAuthenticator = candidate =>
+        {
+            prompts++;
+            candidate.Password = "nope";
+            return Task.FromResult<SessionProfile?>(candidate);
+        };
+        var reported = new List<string>();
+        vm.ConnectionFailureReporter = (_, message) =>
+        {
+            reported.Add(message);
+            return Task.CompletedTask;
+        };
+
+        Assert.IsNull(await vm.OpenWorkspaceDocumentForProfileAsync(profile));
+
+        Assert.AreEqual(3, prompts);
+        Assert.HasCount(1, reported);
+        Assert.Contains("WRONGPASS", reported[0]);
+    }
+
+    /// <summary>
+    /// 用户在凭据框上点取消是"不连了",不是失败:不弹提示,并且要把上一条错误清掉
+    /// —— <c>HostSessionOpener</c> 正是靠 <c>LastConnectionError</c> 为空来区分这两者的。
+    /// </summary>
+    [TestMethod]
+    public async Task CancelledCredentialPrompt_ReportsNothing()
+    {
+        (MainWindowViewModel vm, SessionProfile profile) =
+            Arrange(new ProtocolConnectionException("不该走到这里"));
+        profile.Username = "default";
+        vm.InteractiveAuthenticator = _ => Task.FromResult<SessionProfile?>(null);
+        int reports = 0;
+        vm.ConnectionFailureReporter = (_, _) =>
+        {
+            reports++;
+            return Task.CompletedTask;
+        };
+
+        Assert.IsNull(await vm.OpenWorkspaceDocumentForProfileAsync(profile));
+
+        Assert.AreEqual(0, reports);
+        Assert.IsNull(vm.LastConnectionError);
+    }
+}


### PR DESCRIPTION
## 这个 PR 做了什么

SFTP / FTP / 插件文件系统(S3…)/ 插件工作台(Redis…)首次连接失败时,弹一扇错误提示框(标题「连接失败」,正文 = 配置名 + 具体原因),而不是只往 24px 状态栏写一行字。顺带补上三个相邻的静默口子。

## 为什么这么改

用户报的现象:本机没起 Redis,点开一条 `127.0.0.1:6379` 的 Redis 会话 —— **没有任何提示,也没有打开任何选项卡**。

排查下来插件那边是对的,`RedisWorkspaceProvider.OpenAsync` 老老实实抛了 `ProtocolConnectionException`。问题在这边:

```csharp
catch (Exception ex)
{
    LastConnectionError = DescribeConnectionError(ex, current);
    StatusBar.Status = LastConnectionError;
    return null;          // ← 到此为止
}
```

SSH 的失败之所以看得见,是因为**终端标签在握手之前就建出来了**,失败画在标签页内的覆盖层上(设计 `yxjmg`),`MarkConnectionFailed` 一句就够。而上面这四类是**连上了才有标签页** —— 失败时既没有标签页承载提示,状态栏那行字又几乎等于不存在,于是就成了"点了连接,什么都没发生"。

同一个洞在 SFTP / FTP / S3 三条路径上一模一样(它们与工作台是同一套结构),一并补了 —— 只修 Redis 会留下三条同样静默的路径。

**为什么是弹框而不是"开一个失败态标签页"。** 后者更贴近 `yxjmg` 的取向,但要为四种文档类型各造一个空壳文档 + 失败覆盖层,改动量与风险都大得多,而且这四类没有"重连"这个动作可挂。弹框是既有手法(证书信任提示、多行粘贴确认都走 `MessageDialog`),一次就够。

### 具体改动

- `MainWindowViewModel`:新增 `ConnectionFailureReporter` 钩子(View 层挂上,手法同 `InteractiveAuthenticator`;未挂时退回状态栏,不影响连接流程),四条路径的失败统一走新的 `ReportConnectionFailureAsync`。
- `MainWindow`:实现那扇框。**与凭据框共用同一道串行闸**(`_credentialPromptGate` 改名 `_connectPromptGate`)—— 启动恢复多条会话是并发发起的(#118),一扇密码框和三扇"连不上"若各管各的,照样会叠在同一个 owner 上互相争抢禁用/启用,表现为对话框点不动。
- 三次凭据都没过、循环退出时也报一次。原来输三遍密码之后得到的是一片安静。
- 凭据框上取消时清空 `LastConnectionError` —— `HostSessionOpener` 正是靠它为空来区分"没连上"与"人不同意"。这条与 SSH 路径原本就一致,四条文档路径漏了。
- `DescribeConnectionError`:匿名连接(公开 S3 桶、没设 `requirepass` 的 Redis)的目标不再拼成 `@127.0.0.1:6379` 这种前面缺一截的样子;插件协议族的异常消息按 SDK 契约本就是面向用户的、且已带端点,原样呈现,不再套一层"连接 X 失败:"把同一个地址写两遍。

**用户主动取消不弹框**:凭据框上点取消、证书提示上点"不信任",都只更新状态栏 —— 那只是复述他刚做的决定。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试
- [ ] 界面改动已在应用里实际跑过 —— **没跑**,见「补充说明」

**实测环境:** Windows 11 Pro 26H2 (10.0.29648) x64 / .NET 11

**测试结果:**

```
已通过! - 失败: 0，通过:    10，已跳过: 0，总计:    10 - VelaShell.Controls.Tests.dll
已通过! - 失败: 0，通过:     3，已跳过: 0，总计:     3 - VelaShell.Terminal.RenderTests.dll
已通过! - 失败: 0，通过:    55，已跳过: 0，总计:    55 - VelaShell.Presentation.Tests.dll
已通过! - 失败: 0，通过:   362，已跳过: 0，总计:   362 - VelaShell.Terminal.Tests.dll
已通过! - 失败: 0，通过:   416，已跳过: 0，总计:   416 - VelaShell.Core.Tests.dll
已通过! - 失败: 0，通过:   360，已跳过: 2，总计:   362 - VelaShell.Infrastructure.Tests.dll
已通过! - 失败: 0，通过:   983，已跳过: 2，总计:   985 - VelaShell.Tests.dll
已通过! - 失败: 0，通过:   555，已跳过: 0，总计:   555 - VelaShell.Plugin.Ai.Tests.dll
```

新增 `WorkspaceConnectionFailureTests`(4 例,`VelaShell.Tests`):

| 用例 | 守住什么 |
|---|---|
| `ConnectionRefused_ReportsTheFailure_AndOpensNoDocument` | 端点不可达要报到钩子上、不开标签页、`LastConnectionError` 与提示同文,且目标不带前置 `@` |
| `WithoutAReporter_TheFailureStillLandsOnLastConnectionError` | 没挂钩子(headless 单测、插件代开会话)时连接流程照旧 |
| `ExhaustedAuthenticationRetries_ReportsTheLastFailure` | 三次凭据都没过之后,循环退出时也报一次 |
| `CancelledCredentialPrompt_ReportsNothing` | 取消不弹框,并且清空 `LastConnectionError` |

## 同步检查

- [x] **新增了界面文案** → 没有新增。弹框标题复用既有的 `Msg_ConnectionFailedTitle`(五份 resx 都已有)
- [x] **改了文档** → 已另开 PR,`zh/` 与 `en/` 两侧都改了

## 补充说明

- **「界面改动已在应用里实际跑过」这一栏我没勾。** 弹框本体是三行 `MessageDialog.ShowMessageAsync`,与既有调用点(`Main_ExportFailed` 那处)同形;单测覆盖到"钩子被调用、带什么消息"为止,再往后那一段没有在真机上点过。合并前最好有人本地起一次、关掉本地 Redis 点一条 Redis 会话确认一眼。
- 全量测试的第一轮里 `VelaShell.Infrastructure.Tests` 有 1 例偶发失败,单独重跑与整轮重跑都是全绿,与本改动无关(这条路径的代码没被动过)。


## 关联 PR(一起合)

- 文档:https://github.com/VelaShellLabs/velashell-docs/pull/16 —— 规格 §7 补「文档型连接的失败提示」
- Redis 插件:https://github.com/VelaShellLabs/velashell-plugins/pull/22 —— 把库写给开发者的 `abortConnect` 建议从消息里剪掉,免得它出现在这个 PR 新加的提示框里
