### PR TITLE
引入多会话分桶，隔离聊天面板状态

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeConversation.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeConversation.cs
@@ -46,7 +46,7 @@ public sealed class BridgeConversation(string channelId, string chatId)
     public DateTimeOffset LastActivity { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>本会话内"总是允许"过的操作键(见 <c>ApprovalRequest.RepeatKey</c>)。</summary>
-    public HashSet<string> AlwaysApproved { get; } = new(StringComparer.Ordinal);
+    public HashSet<string> AlwaysApproved { get; } = [with(StringComparer.Ordinal)];
 
     /// <summary>会话创建时刻(历史库里那个"每会话一个点"的摘要用它当时间戳)。</summary>
     public DateTimeOffset CreatedAt { get; private set; } = DateTimeOffset.UtcNow;

--- a/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/Channels/Feishu/FeishuChannel.cs
@@ -31,7 +31,7 @@ internal sealed class FeishuChannel(ChannelConfig config, string appSecret, IPlu
     private readonly FeishuApi _api = new(config.AppId, appSecret, config.International, context.Log);
     private readonly Dictionary<string, (byte[]?[] Parts, DateTimeOffset At)> _fragments = [];
     private readonly Queue<string> _seenEvents = new();
-    private readonly HashSet<string> _seenEventSet = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _seenEventSet = [with(StringComparer.Ordinal)];
     private readonly Lock _sync = new();
 
     private ClientWebSocket? _socket;

--- a/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ConversationRouter.cs
@@ -23,7 +23,7 @@ public sealed class ConversationRouter(
     private static readonly TimeSpan EditInterval = TimeSpan.FromMilliseconds(1200);
 
     private readonly Dictionary<string, BridgeConversation> _conversations = [];
-    private readonly HashSet<string> _unauthorizedNotified = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _unauthorizedNotified = [with(StringComparer.Ordinal)];
     private readonly Lock _sync = new();
     private SemaphoreSlim _turnGate = new(2, 2);
 

--- a/plugins/VelaShell.Plugin.Ai/Chat/ContextCompactor.cs
+++ b/plugins/VelaShell.Plugin.Ai/Chat/ContextCompactor.cs
@@ -91,8 +91,10 @@ public static class ContextCompactor
     /// <param name="cut">本次要折到哪儿为止(不含)。</param>
     /// <param name="locale">让摘要用用户的语言写。</param>
     /// <param name="cancellationToken">用户按停止时一并取消。</param>
+    /// <param name="tuneOptions">可选:在发压缩请求前调一遍请求选项(用来套用端点脾气,摘掉这一家不收的参数)。</param>
     public static async Task<CompactionResult?> CompactAsync(IChatClient client, IReadOnlyList<ChatMessage> history,
-        int summarizedThrough, string previousSummary, int cut, string locale, CancellationToken cancellationToken)
+        int summarizedThrough, string previousSummary, int cut, string locale, CancellationToken cancellationToken,
+        Action<ChatOptions>? tuneOptions = null)
     {
         ArgumentNullException.ThrowIfNull(client);
         ArgumentNullException.ThrowIfNull(history);
@@ -101,8 +103,11 @@ public static class ContextCompactor
             return null;
         }
         string prompt = BuildPrompt(history, summarizedThrough, previousSummary, cut, locale);
+        // 和正式一轮走同一套"端点脾气"处理:这一家不收的参数在这儿摘掉,免得这条附带请求 400。
+        var options = new ChatOptions { MaxOutputTokens = SummaryTokens };
+        tuneOptions?.Invoke(options);
         ChatResponse response = await client
-            .GetResponseAsync(prompt, new ChatOptions { MaxOutputTokens = SummaryTokens }, cancellationToken)
+            .GetResponseAsync(prompt, options, cancellationToken)
             .ConfigureAwait(false);
 
         string summary = response.Text.Trim();

--- a/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
+++ b/plugins/VelaShell.Plugin.Ai/Interop/McpToolHost.cs
@@ -84,7 +84,7 @@ internal sealed class McpToolHost
         {
             throw new KeyNotFoundException($"Unknown tool: {name}");
         }
-        object? result = await tool.InvokeAsync(new AIFunctionArguments(arguments), cancellationToken)
+        object? result = await tool.InvokeAsync([with(arguments)], cancellationToken)
             .ConfigureAwait(false);
         return result?.ToString() ?? "";
     }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Compaction.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Compaction.cs
@@ -11,16 +11,12 @@ namespace VelaShell.Plugin.Ai.Ui;
 /// </summary>
 public partial class ChatPanelView
 {
-    /// <summary>当前的滚动摘要(空 = 还没压过)。它代表 <see cref="_summarizedThrough" /> 之前的那些消息。</summary>
-    private string _contextSummary = "";
-
-    /// <summary>摘要覆盖到 <c>_history</c> 的哪个下标为止(不含)。</summary>
-    private int _summarizedThrough;
+    // 滚动摘要与它覆盖到的下标按对话各持一份(见 Conversation):_contextSummary / _summarizedThrough。
 
     private void ResetCompaction()
     {
-        _contextSummary = "";
-        _summarizedThrough = 0;
+        ContextSummary = "";
+        SummarizedThrough = 0;
     }
 
     /// <summary>
@@ -30,13 +26,13 @@ public partial class ChatPanelView
     private async Task CompactIfNeededAsync(ResolvedModel provider, CancellationToken cancellationToken)
     {
         if (!_settings.CompactContext
-            || !ContextCompactor.ShouldCompact(_history, _summarizedThrough, _contextSummary,
+            || !ContextCompactor.ShouldCompact(History, SummarizedThrough, ContextSummary,
                 provider.MaxInputTokens, provider.MaxTokens))
         {
             return;
         }
-        int cut = ContextCompactor.PlanCutPoint(_history, _summarizedThrough, provider.MaxInputTokens, provider.MaxTokens);
-        if (cut <= _summarizedThrough)
+        int cut = ContextCompactor.PlanCutPoint(History, SummarizedThrough, provider.MaxInputTokens, provider.MaxTokens);
+        if (cut <= SummarizedThrough)
         {
             return;
         }
@@ -46,22 +42,23 @@ public partial class ChatPanelView
             // 裸客户端:压缩这一问不该带工具,也不该进对话历史
             IChatClient client = await _store.CreateClientAsync(provider, cancellationToken: cancellationToken);
             CompactionResult? result = await Task.Run(
-                () => ContextCompactor.CompactAsync(client, _history, _summarizedThrough, _contextSummary, cut,
-                    _context.Host.Locale, cancellationToken), cancellationToken);
+                () => ContextCompactor.CompactAsync(client, History, SummarizedThrough, ContextSummary, cut,
+                    _context.Host.Locale, cancellationToken,
+                    tuneOptions: o => AiSettingsStore.ApplyEndpointQuirks(o, provider)), cancellationToken);
             if (result is not { } compaction)
             {
                 return;
             }
 
-            _contextSummary = compaction.Summary;
-            _summarizedThrough = compaction.Through;
+            ContextSummary = compaction.Summary;
+            SummarizedThrough = compaction.Through;
             // 压缩自身的用量也算进累计(是真花的钱),但不动"上一轮上下文"那个读数
             if (compaction.Usage is { } usage)
             {
-                _totalInputTokens += usage.InputTokenCount ?? 0;
-                _totalOutputTokens += usage.OutputTokenCount ?? 0;
+                TotalInputTokens += usage.InputTokenCount ?? 0;
+                TotalOutputTokens += usage.OutputTokenCount ?? 0;
             }
-            await _historyStore.SaveSummaryAsync(_conversationId, _contextSummary, _summarizedThrough, cancellationToken);
+            await _historyStore.SaveSummaryAsync(ConversationId, ContextSummary, SummarizedThrough, cancellationToken);
             ShowCompactionMarker(compaction.FoldedMessages);
             UpdateUsageText();
         }
@@ -88,7 +85,7 @@ public partial class ChatPanelView
     {
         var collapsible = new Collapsible(this, _loc.F("Compacted", foldedMessages),
             iconKey: "AiIcon.scissors", iconBrushKey: "VelaAccent");
-        collapsible.SetBody(_contextSummary);
+        collapsible.SetBody(ContextSummary);
         var host = new Border { Classes = { "compactionMarker" }, Child = collapsible.Root };
         MessagesPanel.Children.Add(host);
         RequestAutoScroll(force: true);
@@ -97,9 +94,9 @@ public partial class ChatPanelView
     /// <summary>载入历史会话时把上次压缩的结果一并恢复,免得一进来就重压一次。</summary>
     private async Task RestoreSummaryAsync()
     {
-        (string summary, int through) = await _historyStore.LoadSummaryAsync(_conversationId);
+        (string summary, int through) = await _historyStore.LoadSummaryAsync(ConversationId);
         // 摘要覆盖范围不能超过实际条数(会话被编辑/删除截断过就会这样),对不上就整个作废
-        _contextSummary = through > 0 && through <= _history.Count ? summary : "";
-        _summarizedThrough = _contextSummary.Length > 0 ? through : 0;
+        ContextSummary = through > 0 && through <= History.Count ? summary : "";
+        SummarizedThrough = ContextSummary.Length > 0 ? through : 0;
     }
 }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Conversation.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Conversation.cs
@@ -1,0 +1,82 @@
+using Avalonia.Controls;
+using Microsoft.Extensions.AI;
+using VelaShell.Plugin.Ai.Chat;
+
+namespace VelaShell.Plugin.Ai.Ui;
+
+public partial class ChatPanelView
+{
+    /// <summary>
+    /// 一段独立对话的<b>全部</b>可变状态:历史、记账、在途一轮、插话、压缩、审批放行记忆,
+    /// 以及它自己那条消息流面板(<see cref="Messages" />)。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 按会话各持一份 —— 键是顶栏下拉选中的那台机器的会话 id,<c>""</c> 是"不绑机器"的通用对话。
+    /// 切下拉即把 <see cref="_active" /> 换成对应的这一份、并把它的 <see cref="Messages" />
+    /// 挂进 <c>ChatScroll</c>:切换是<b>换引用</b>,不是重建,所以即时、也不串台。
+    /// </para>
+    /// <para>
+    /// 后台并行靠的也是它:一轮开始时用 <see cref="_turnScope" /> 记下"这一轮属于哪一份",
+    /// 那之后被 await 串起来的整条流水线(渲染、记账、插话、入库)都落到<b>这一份</b>上,
+    /// 而不是"当前正显示的那一份"。于是切走之后它照样把话答完,气泡就长在自己那条(此刻不可见的)
+    /// 面板里,切回来即见,谁也不打断谁。
+    /// </para>
+    /// </remarks>
+    internal sealed class Conversation(string sessionKey, StackPanel messages)
+    {
+        /// <summary>这一份绑的是哪条会话(会话的不透明 id);<c>""</c> = 不绑机器的通用对话。</summary>
+        public string SessionKey { get; } = sessionKey;
+
+        /// <summary>本对话自己的消息流面板。切到本对话时它被挂进 <c>ChatScroll</c>,平时(后台)脱离可视树留着。</summary>
+        public StackPanel Messages { get; } = messages;
+
+        // ---------- 历史与上下文 ----------
+        public List<ChatMessage> History { get; } = [];
+        public int TurnHistoryStart;
+        public string ConversationId = ChatHistoryStore.NewConversationId();
+        public DateTimeOffset ConversationStartedAt = DateTimeOffset.UtcNow;
+        public int PersistedCount;
+        public int DroppedFromContext;
+        public int SequenceHighWater;
+
+        // ---------- 记账 ----------
+        public long TotalInputTokens;
+        public long TotalOutputTokens;
+        public long TotalReasoningTokens;
+        public long LastInputTokens;
+        public long LastCachedInputTokens;
+        public long TotalCachedInputTokens;
+        public long TotalCacheWriteTokens;
+
+        // ---------- 在途一轮 ----------
+        public CancellationTokenSource? Cts;
+        public bool Busy;
+        public AssistantBubble? ActiveBubble;
+
+        /// <summary>本段对话是否已提示过"没请求思考"(一次就够)。</summary>
+        public bool ThinkingHintShown;
+
+        // ---------- 插话(边跑边补)----------
+        public SteeringQueue SteeringQueue { get; } = new();
+        public SteeringChatClient? Steering;
+        public int SteeringCommitted;
+
+        // ---------- 上下文压缩 ----------
+        public string ContextSummary = "";
+        public int SummarizedThrough;
+
+        // ---------- 审批放行记忆(仅本段对话)----------
+        public HashSet<string> AlwaysApproved { get; } = [with(StringComparer.Ordinal)];
+
+        // ---------- 消息窗口(折叠早期气泡)----------
+        public List<Control> CollapsedMessages { get; } = [];
+        public Border? CollapsedBanner;
+
+        // ---------- 用户气泡 → 历史下标(编辑/截断用)----------
+        public Dictionary<Control, int> UserBubbleIndex { get; } = [];
+
+        /// <summary>顶栏状态行的当前内容 —— 后台轮次写这里,切回本对话时照原样贴回共享的状态行。</summary>
+        public string Status = "";
+    }
+}

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
@@ -19,23 +19,17 @@ namespace VelaShell.Plugin.Ai.Ui;
 /// </remarks>
 public partial class ChatPanelView
 {
-    /// <summary>用户气泡 → 它在 <c>_history</c> 里的下标。截断时要靠它找到"从哪儿开始扔"。</summary>
-    private readonly Dictionary<Control, int> _userBubbleIndex = [];
-
-    /// <summary>
-    /// 已经用掉的最大序号。截断后新消息从这里往后续号,<b>不复用旧号</b> ——
-    /// 旧号上可能还挂着被删那截的附加信息,复用会张冠李戴。
-    /// </summary>
-    private int _sequenceHighWater;
+    // 用户气泡→历史下标的索引,以及序号高水位,按对话各持一份(见 Conversation):
+    // _userBubbleIndex / _sequenceHighWater。
 
     private void ResetEditing()
     {
-        _userBubbleIndex.Clear();
-        _sequenceHighWater = _persistedCount;
+        UserBubbleIndex.Clear();
+        SequenceHighWater = PersistedCount;
     }
 
     /// <summary>把一条用户气泡登记进索引(截断时才知道它对应历史里的哪一条)。</summary>
-    private void TrackUserBubble(Control bubble, int historyIndex) => _userBubbleIndex[bubble] = historyIndex;
+    private void TrackUserBubble(Control bubble, int historyIndex) => UserBubbleIndex[bubble] = historyIndex;
 
     /// <summary>编辑这条用户消息:截断到它之前,原文回到输入框。</summary>
     private async Task EditUserMessageAsync(Control bubble, string original)
@@ -74,16 +68,16 @@ public partial class ChatPanelView
     /// <summary>回到最后一条用户消息,原样再问一次。</summary>
     private async Task RegenerateAsync()
     {
-        if (_busy)
+        if (Busy)
         {
             return;
         }
-        int index = _history.FindLastIndex(m => m.Role == ChatRole.User);
+        int index = History.FindLastIndex(m => m.Role == ChatRole.User);
         if (index < 0)
         {
             return;
         }
-        string text = _history[index].Text;
+        string text = History[index].Text;
         if (!await TruncateToAsync(index))
         {
             return;
@@ -93,14 +87,14 @@ public partial class ChatPanelView
 
     /// <summary>截断到某条用户气泡之前。返回是否真的动了。</summary>
     private async Task<bool> TruncateAtAsync(Control bubble)
-        => _userBubbleIndex.TryGetValue(bubble, out int index) && await TruncateToAsync(index);
+        => UserBubbleIndex.TryGetValue(bubble, out int index) && await TruncateToAsync(index);
 
     /// <summary>
     /// 丢掉 <paramref name="historyIndex" /> 及其之后的全部消息:界面、上下文、库三处一起。
     /// </summary>
     private async Task<bool> TruncateToAsync(int historyIndex)
     {
-        if (_busy || historyIndex < 0 || historyIndex >= _history.Count)
+        if (Busy || historyIndex < 0 || historyIndex >= History.Count)
         {
             return false;
         }
@@ -108,7 +102,7 @@ public partial class ChatPanelView
         RestoreCollapsedMessages();
 
         // 界面:找到该下标对应的气泡,从它起往后全部移除
-        if (_userBubbleIndex.FirstOrDefault(pair => pair.Value == historyIndex).Key is { } anchor)
+        if (UserBubbleIndex.FirstOrDefault(pair => pair.Value == historyIndex).Key is { } anchor)
         {
             int from = MessagesPanel.Children.IndexOf(anchor);
             if (from >= 0)
@@ -119,26 +113,26 @@ public partial class ChatPanelView
                 }
             }
         }
-        foreach (Control stale in _userBubbleIndex.Where(p => p.Value >= historyIndex).Select(p => p.Key).ToList())
+        foreach (Control stale in UserBubbleIndex.Where(p => p.Value >= historyIndex).Select(p => p.Key).ToList())
         {
-            _userBubbleIndex.Remove(stale);
+            UserBubbleIndex.Remove(stale);
         }
 
         // 上下文
-        _history.RemoveRange(historyIndex, _history.Count - historyIndex);
+        History.RemoveRange(historyIndex, History.Count - historyIndex);
 
         // 库:整段重写(时序库删不了单条),序号沿用原值以便附加信息还能对上
-        var surviving = new List<(int, string, string)>(_history.Count);
-        for (int i = 0; i < _history.Count; i++)
+        var surviving = new List<(int, string, string)>(History.Count);
+        for (int i = 0; i < History.Count; i++)
         {
-            string role = _history[i].Role == ChatRole.User ? "user" : "assistant";
-            surviving.Add((i, role, _history[i].Text));
+            string role = History[i].Role == ChatRole.User ? "user" : "assistant";
+            surviving.Add((i, role, History[i].Text));
         }
-        await _historyStore.RewriteAsync(_conversationId, _conversationStartedAt, surviving);
+        await _historyStore.RewriteAsync(ConversationId, ConversationStartedAt, surviving);
 
         // 新消息从旧的最大序号之后续,别复用可能还挂着附加信息的旧号
-        _sequenceHighWater = Math.Max(_sequenceHighWater, _persistedCount);
-        _persistedCount = _sequenceHighWater;
+        SequenceHighWater = Math.Max(SequenceHighWater, PersistedCount);
+        PersistedCount = SequenceHighWater;
 
         // 摘要覆盖的是被截断之前的那些消息,截断后它的范围就不可信了 —— 整个作废,
         // 下次接近窗口时重新压一遍。宁可多花一次压缩,也不能让模型读到对不上号的摘要。

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
@@ -107,7 +107,7 @@ public partial class ChatPanelView
         grid.Children.Add(tools);
 
         var row = new Border { Classes = { "historyRow" }, Child = grid };
-        if (session.Id == _conversationId)
+        if (session.Id == ConversationId)
         {
             row.Classes.Add("current");
         }
@@ -115,7 +115,7 @@ public partial class ChatPanelView
         {
             e.Handled = true;
             await _historyStore.DeleteAsync(session.Id);
-            if (session.Id == _conversationId)
+            if (session.Id == ConversationId)
             {
                 StartNewChat();
                 SetActiveView(PanelView.History);
@@ -179,17 +179,17 @@ public partial class ChatPanelView
     {
         try
         {
-            _cts?.Cancel();
+            Cts?.Cancel();
             IReadOnlyList<ChatEntry> entries = await _historyStore.LoadAsync(session.Id);
-            _history.Clear();
+            History.Clear();
             MessagesPanel.Children.Clear();
             ResetUsage();
-            _alwaysApproved.Clear(); // 放行记忆只在同一段对话里有效
-            _userBubbleIndex.Clear();
+            AlwaysApproved.Clear(); // 放行记忆只在同一段对话里有效
+            UserBubbleIndex.Clear();
             ClearSuggestions(); // 载入的是别的会话,上一段的建议不再相关
-            _conversationId = session.Id;
-            _conversationStartedAt = session.CreatedAt;
-            _persistedCount = entries.Count;
+            ConversationId = session.Id;
+            ConversationStartedAt = session.CreatedAt;
+            PersistedCount = entries.Count;
             _inputHistoryIndex = -1;
             ResetMessageWindow();
             for (int index = 0; index < entries.Count; index++)
@@ -200,7 +200,7 @@ public partial class ChatPanelView
                 if (entry.Role == "user")
                 {
                     AddUserBubble(entry.Text);
-                    _history.Add(new(ChatRole.User, entry.Text));
+                    History.Add(new(ChatRole.User, entry.Text));
                 }
                 else
                 {
@@ -216,12 +216,12 @@ public partial class ChatPanelView
                         entry.Meta?.Model,
                         entry.At.ToLocalTime(),
                         entry.Meta is { ElapsedMs: > 0 } m ? TimeSpan.FromMilliseconds(m.ElapsedMs) : null);
-                    _history.Add(new(ChatRole.Assistant, entry.Text));
+                    History.Add(new(ChatRole.Assistant, entry.Text));
                 }
             }
             TrimMessageWindow();
             // 载入的这段会话已经用掉了这些序号,新消息要从它们之后续
-            _sequenceHighWater = _persistedCount;
+            SequenceHighWater = PersistedCount;
             // 上次压过的摘要一并恢复,免得一进来就重压一次(那是一次白花的请求)
             await RestoreSummaryAsync();
             StatusText.Text = _loc.F("HistoryLoaded", entries.Count);

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.MessageWindow.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.MessageWindow.cs
@@ -27,10 +27,8 @@ public partial class ChatPanelView
     /// <summary>回放历史时每帧建几条。整段一次性建完会把 UI 线程按住好几秒。</summary>
     private const int ReplayBatch = 8;
 
-    /// <summary>被折叠起来的早期气泡(按原顺序);点横幅可以整批放回去。</summary>
-    private readonly List<Control> _collapsedMessages = [];
-
-    private Border? _collapsedBanner;
+    // 折叠起来的早期气泡与那枚横幅,按对话各持一份(见 Conversation):
+    // _collapsedMessages / _collapsedBanner。
 
     /// <summary>
     /// 新消息进来之后调用:超出窗口就把最早的一批移出可视树。
@@ -38,12 +36,12 @@ public partial class ChatPanelView
     /// </summary>
     private void TrimMessageWindow()
     {
-        int live = MessagesPanel.Children.Count - (_collapsedBanner is null ? 0 : 1);
+        int live = MessagesPanel.Children.Count - (CollapsedBanner is null ? 0 : 1);
         if (live <= LiveMessageWindow + CollapseBatch)
         {
             return;
         }
-        int bannerOffset = _collapsedBanner is null ? 0 : 1;
+        int bannerOffset = CollapsedBanner is null ? 0 : 1;
         int take = live - LiveMessageWindow;
         var moved = new List<Control>(take);
         for (int i = 0; i < take; i++)
@@ -52,65 +50,65 @@ public partial class ChatPanelView
             MessagesPanel.Children.RemoveAt(bannerOffset);
             moved.Add(child);
         }
-        _collapsedMessages.InsertRange(0, moved);
+        CollapsedMessages.InsertRange(0, moved);
         ShowCollapsedBanner();
     }
 
     /// <summary>顶部那枚"显示更早的 N 条"横幅(点一下全部放回)。</summary>
     private void ShowCollapsedBanner()
     {
-        if (_collapsedMessages.Count == 0)
+        if (CollapsedMessages.Count == 0)
         {
             RemoveCollapsedBanner();
             return;
         }
-        if (_collapsedBanner is null)
+        if (CollapsedBanner is null)
         {
             var text = new TextBlock { Classes = { "dim" } };
-            _collapsedBanner = new Border
+            CollapsedBanner = new Border
             {
                 Classes = { "earlierBanner" },
                 Child = text,
                 Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand)
             };
-            _collapsedBanner.PointerPressed += (_, e) =>
+            CollapsedBanner.PointerPressed += (_, e) =>
             {
                 e.Handled = true;
                 RestoreCollapsedMessages();
             };
-            MessagesPanel.Children.Insert(0, _collapsedBanner);
+            MessagesPanel.Children.Insert(0, CollapsedBanner);
         }
-        ((TextBlock)_collapsedBanner.Child!).Text = _loc.F("ShowEarlier", _collapsedMessages.Count);
+        ((TextBlock)CollapsedBanner.Child!).Text = _loc.F("ShowEarlier", CollapsedMessages.Count);
     }
 
     private void RestoreCollapsedMessages()
     {
-        if (_collapsedMessages.Count == 0)
+        if (CollapsedMessages.Count == 0)
         {
             return;
         }
         RemoveCollapsedBanner();
-        for (int i = 0; i < _collapsedMessages.Count; i++)
+        for (int i = 0; i < CollapsedMessages.Count; i++)
         {
-            MessagesPanel.Children.Insert(i, _collapsedMessages[i]);
+            MessagesPanel.Children.Insert(i, CollapsedMessages[i]);
         }
-        _collapsedMessages.Clear();
+        CollapsedMessages.Clear();
     }
 
     private void RemoveCollapsedBanner()
     {
-        if (_collapsedBanner is { } banner)
+        if (CollapsedBanner is { } banner)
         {
             MessagesPanel.Children.Remove(banner);
-            _collapsedBanner = null;
+            CollapsedBanner = null;
         }
     }
 
     /// <summary>换会话/新建会话时连折叠区一起清干净。</summary>
     private void ResetMessageWindow()
     {
-        _collapsedMessages.Clear();
-        _collapsedBanner = null;
+        CollapsedMessages.Clear();
+        CollapsedBanner = null;
     }
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Steering.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Steering.cs
@@ -36,13 +36,8 @@ public partial class ChatPanelView
     /// <summary>单枚排队芯片上显示几个字。</summary>
     private const int MaxQueuedChipChars = 42;
 
-    private readonly SteeringQueue _steeringQueue = new();
-
-    /// <summary>本轮的插话通道(仅在一轮进行中非空)。</summary>
-    private SteeringChatClient? _steering;
-
-    /// <summary>已经补进界面与历史的插话条数(通道自己的送达名单里,前多少条已被消化)。</summary>
-    private int _steeringCommitted;
+    // 插话状态(队列 / 本轮通道 / 已提交条数)按对话各持一份,见 Conversation。
+    // 这里经代理落到当前那一轮的那一份:_steeringQueue / _steering / _steeringCommitted。
 
     // ---------- 入队 ----------
 
@@ -60,7 +55,7 @@ public partial class ChatPanelView
         {
             return;
         }
-        if (_steeringQueue.Count >= MaxQueuedMessages)
+        if (SteeringQueue.Count >= MaxQueuedMessages)
         {
             StatusText.Text = _loc.F("QueueFull", MaxQueuedMessages);
             return;
@@ -79,7 +74,7 @@ public partial class ChatPanelView
             // 引用在<b>入队这一刻</b>展开:排队期间远端文件还可能被改,
             // 用户按下回车时看到的那份才是他想发的那份。
             (string modelText, IReadOnlyList<string> _, IReadOnlyList<string> unreadable) = fromUser
-                ? await ResolveAttachmentsAsync(text, _cts?.Token ?? CancellationToken.None)
+                ? await ResolveAttachmentsAsync(text, Cts?.Token ?? CancellationToken.None)
                 : (text, [], []);
             if (unreadable.Count > 0)
             {
@@ -87,7 +82,7 @@ public partial class ChatPanelView
             }
             var message = new ChatMessage(ChatRole.User, BuildUserContents(modelText));
             ClearAttachments();
-            _steeringQueue.Enqueue(new SteeringMessage(display, text, message));
+            SteeringQueue.Enqueue(new SteeringMessage(display, text, message));
         }
         catch (OperationCanceledException)
         {
@@ -104,9 +99,9 @@ public partial class ChatPanelView
         RenderQueuedChips();
         // 展开远端引用要走一趟 SFTP,那期间这一轮可能已经答完了 —— 队里没人来取了,
         // 就地当作下一轮发出去,别让它一直挂在那儿。
-        if (!_busy)
+        if (!Busy)
         {
-            if (_steeringQueue.DrainMerged() is { } next)
+            if (SteeringQueue.DrainMerged() is { } next)
             {
                 RenderQueuedChips();
                 await SendAsync(next.DisplayText, fromUser: false, prepared: next);
@@ -120,8 +115,9 @@ public partial class ChatPanelView
 
     /// <summary>
     /// 插话通道的送达回调。<b>在发请求的那个线程上被调</b>,所以只负责把活儿甩回 UI 线程。
+    /// 带上 <paramref name="conv" />:这条回调不在原轮的异步流里,得显式说清楚补给哪份对话。
     /// </summary>
-    private void OnSteeringDelivered() => Dispatcher.UIThread.Post(() => _ = CommitSteeringAsync());
+    private void OnSteeringDelivered(Conversation conv) => Dispatcher.UIThread.Post(() => _ = CommitSteeringAsync(conv));
 
     /// <summary>
     /// 把"已经送进请求"的插话补进界面、对话历史与库。
@@ -130,25 +126,28 @@ public partial class ChatPanelView
     /// <b>只在 UI 线程调</b>,且必须可重入:送达回调与本轮收尾都会调它(收尾那次是兜底 ——
     /// 回调的 Post 可能还排在队里没跑到)。名单指针在任何 await 之前就推进,重入不会重复提交。
     /// </remarks>
-    private async Task CommitSteeringAsync()
+    private async Task CommitSteeringAsync(Conversation conv)
     {
-        if (_steering is not { } steering)
+        // 送达回调经 Post 过来时并不在原轮的异步流里,代理会误落到"正显示的那份"——
+        // 显式把本次读写钉在 conv 上(在原轮主线里调用时,这一步是无害的重复)。
+        _turnScope.Value = conv;
+        if (Steering is not { } steering)
         {
             return;
         }
         IReadOnlyList<SteeringMessage> delivered = steering.Delivered;
-        if (delivered.Count <= _steeringCommitted)
+        if (delivered.Count <= SteeringCommitted)
         {
             return;
         }
-        List<SteeringMessage> fresh = [.. delivered.Skip(_steeringCommitted)];
-        _steeringCommitted = delivered.Count;
+        List<SteeringMessage> fresh = [.. delivered.Skip(SteeringCommitted)];
+        SteeringCommitted = delivered.Count;
         foreach (SteeringMessage item in fresh)
         {
             // 卡先挂、历史后加:没有回复气泡可挂时退回一条普通用户气泡,
             // 而那条气泡要按"它将落到历史的哪个下标"登记(见 AddUserBubble)。
             AddSteeringCard(item.DisplayText);
-            _history.Add(item.Message);
+            History.Add(item.Message);
         }
         RenderQueuedChips();
         UpdateEmptyState();
@@ -166,7 +165,7 @@ public partial class ChatPanelView
     /// </summary>
     private void AddSteeringCard(string text)
     {
-        if (_activeBubble is not { } bubble)
+        if (ActiveBubble is not { } bubble)
         {
             // 没有回复气泡可挂(还没开口就送进去了):当作一条普通用户消息摆进消息流
             AddUserBubble(text);
@@ -189,15 +188,15 @@ public partial class ChatPanelView
     /// <summary>一轮开始:换一条通道,送达名单从头数。</summary>
     private void BeginSteering(SteeringChatClient steering)
     {
-        _steering = steering;
-        _steeringCommitted = 0;
+        Steering = steering;
+        SteeringCommitted = 0;
     }
 
     /// <summary>一轮结束:通道作废(晚到的送达回调就此变成空转)。</summary>
     private void EndSteering()
     {
-        _steering = null;
-        _steeringCommitted = 0;
+        Steering = null;
+        SteeringCommitted = 0;
     }
 
     /// <summary>
@@ -206,7 +205,7 @@ public partial class ChatPanelView
     /// </summary>
     private void RestoreQueuedToInput()
     {
-        IReadOnlyList<SteeringMessage> left = _steeringQueue.DrainAll();
+        IReadOnlyList<SteeringMessage> left = SteeringQueue.DrainAll();
         if (left.Count == 0)
         {
             return;
@@ -231,7 +230,7 @@ public partial class ChatPanelView
     /// <summary>清空队列(换会话、关面板时用)。</summary>
     private void ClearQueuedMessages()
     {
-        _steeringQueue.DrainAll();
+        SteeringQueue.DrainAll();
         RenderQueuedChips();
     }
 
@@ -240,8 +239,13 @@ public partial class ChatPanelView
     /// <summary>把排队中的插话画成一排可撤回的芯片(输入框上方,与附件芯片同一副长相)。</summary>
     private void RenderQueuedChips()
     {
+        // 排队芯片是共享顶栏,只画正显示那份的队列;后台那份切回来时由 RefreshForeground 重画。
+        if (!IsForeground)
+        {
+            return;
+        }
         QueuedBar.Children.Clear();
-        foreach (SteeringMessage item in _steeringQueue.Snapshot())
+        foreach (SteeringMessage item in SteeringQueue.Snapshot())
         {
             QueuedBar.Children.Add(BuildQueuedChip(item));
         }
@@ -269,7 +273,7 @@ public partial class ChatPanelView
         chip.PointerPressed += (_, e) =>
         {
             e.Handled = true;
-            if (_steeringQueue.Remove(item))
+            if (SteeringQueue.Remove(item))
             {
                 RenderQueuedChips();
             }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Suggestions.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Suggestions.cs
@@ -89,6 +89,10 @@ public partial class ChatPanelView
             {
                 options.Reasoning = new ReasoningOptions { Effort = ReasoningEffort.None, Output = ReasoningOutput.None };
             }
+            // 和正式一轮走同一套"端点脾气"处理:这一家不收的参数(max_tokens / temperature …)在这儿摘掉。
+            // 少了这一步,后续提问这条附带请求会比正文多带几个字段,私有后端/中转站一律回 400 ——
+            // 正文能答、"后续提问"却总是失败,就是漏了它(见 AiSettingsStore.ApplyEndpointQuirks)。
+            AiSettingsStore.ApplyEndpointQuirks(options, provider);
 
             ChatResponse response = await Task.Run(
                 () => client.GetResponseAsync(BuildFollowUpPrompt(userText, replyText), options, token), token);
@@ -98,8 +102,8 @@ public partial class ChatPanelView
             // 那个数表示的是对话本身占了多少窗口,掺进这一问会误导。
             if (response.Usage is { } usage)
             {
-                _totalInputTokens += usage.InputTokenCount ?? 0;
-                _totalOutputTokens += usage.OutputTokenCount ?? 0;
+                TotalInputTokens += usage.InputTokenCount ?? 0;
+                TotalOutputTokens += usage.OutputTokenCount ?? 0;
                 UpdateUsageText();
             }
             RenderSuggestions(ParseSuggestions(response.Text));

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -884,9 +884,9 @@
          滚动条留白放在内容的 Margin 上(同 ResourceMonitor 的做法,勿用 ScrollViewer.Padding):
          悬停展开的覆盖式滚动条约 12px 宽,留 19px 保证不压住消息卡片。 -->
     <Panel>
-      <ScrollViewer x:Name="ChatScroll" HorizontalScrollBarVisibility="Disabled">
-        <StackPanel x:Name="MessagesPanel" Spacing="8" Margin="5,4,19,4" />
-      </ScrollViewer>
+      <!-- 消息流容器在运行时按"当前这份对话"整体挂进来(见 ChatPanelView 的 MessagesPanel /
+           SwitchConversation);每份对话各持一条 StackPanel,切换即换 Content,后台那几条留在内存里。 -->
+      <ScrollViewer x:Name="ChatScroll" HorizontalScrollBarVisibility="Disabled" />
       <!-- 历史会话:与聊天流/设置页三选一显示 -->
       <DockPanel x:Name="HistoryHost" IsVisible="False" Margin="5,4,19,4">
         <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,6">

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -50,12 +50,66 @@ public partial class ChatPanelView : UserControl
     private readonly Loc _loc;
     private readonly AgentToolbox _toolbox;
     private readonly McpManager _mcp;
-    private readonly List<ChatMessage> _history = [];
     private readonly ChatHistoryStore _historyStore;
 
+    // ---------- 按会话分桶的对话 ----------
+    // 每台机器(顶栏下拉选中的会话;""=不绑机器的通用对话)各持一份 Conversation。
+    // 切下拉 = 换 _active 的引用并把它的面板挂进 ChatScroll;各自的请求在后台独立跑完。
+    private readonly Dictionary<string, Conversation> _conversations = [with(StringComparer.Ordinal)];
+
+    /// <summary>当前正显示的这一份(顶栏共享控件——状态行/用量/忙态——反映的都是它)。</summary>
+    private Conversation _active = null!;
+
+    /// <summary>
+    /// "这一轮属于哪一份"。一轮开始时置为它所属的 Conversation,那之后被 await 串起来的
+    /// 整条流水线都读它 —— 于是后台轮次写自己那一份,而不是"当前正显示的那一份"。
+    /// <see cref="AsyncLocal{T}" /> 按异步流各自独立,并发的多轮不会互相串。
+    /// </summary>
+    private readonly AsyncLocal<Conversation?> _turnScope = new();
+
+    /// <summary>本次读写落到哪一份:在某一轮里 = 那一轮的;否则 = 正显示的那一份。</summary>
+    private Conversation Cur => _turnScope.Value ?? _active;
+
+    /// <summary>当前上下文是否就是正显示的那一份(后台轮次据此跳过一切对共享控件的改动)。</summary>
+    private bool IsForeground => _turnScope.Value is null || ReferenceEquals(_turnScope.Value, _active);
+
+    /// <summary>正在重建会话下拉(别把代码回填选中项当成用户在切对话)。</summary>
+    private bool _switchingSessions;
+
+    // 下面这些以前是散落各处的实例字段,现在一律代理到 Cur(=某一轮的那一份 / 正显示的那一份)。
+    // 好处是原来一百多处 `_history`/`_cts`/... 的写法一个字都不用改,后台并行却能落到对的那一份上。
+    private List<ChatMessage> History => Cur.History;
+    private AssistantBubble? ActiveBubble { get => Cur.ActiveBubble; set => Cur.ActiveBubble = value; }
+    private CancellationTokenSource? Cts { get => Cur.Cts; set => Cur.Cts = value; }
+    private bool Busy { get => Cur.Busy; set => Cur.Busy = value; }
+    private int TurnHistoryStart { get => Cur.TurnHistoryStart; set => Cur.TurnHistoryStart = value; }
+    private string ConversationId { get => Cur.ConversationId; set => Cur.ConversationId = value; }
+    private DateTimeOffset ConversationStartedAt { get => Cur.ConversationStartedAt; set => Cur.ConversationStartedAt = value; }
+    private int PersistedCount { get => Cur.PersistedCount; set => Cur.PersistedCount = value; }
+    private int DroppedFromContext { get => Cur.DroppedFromContext; set => Cur.DroppedFromContext = value; }
+    private int SequenceHighWater { get => Cur.SequenceHighWater; set => Cur.SequenceHighWater = value; }
+    private long TotalInputTokens { get => Cur.TotalInputTokens; set => Cur.TotalInputTokens = value; }
+    private long TotalOutputTokens { get => Cur.TotalOutputTokens; set => Cur.TotalOutputTokens = value; }
+    private long TotalReasoningTokens { get => Cur.TotalReasoningTokens; set => Cur.TotalReasoningTokens = value; }
+    private long LastInputTokens { get => Cur.LastInputTokens; set => Cur.LastInputTokens = value; }
+    private long LastCachedInputTokens { get => Cur.LastCachedInputTokens; set => Cur.LastCachedInputTokens = value; }
+    private long TotalCachedInputTokens { get => Cur.TotalCachedInputTokens; set => Cur.TotalCachedInputTokens = value; }
+    private long TotalCacheWriteTokens { get => Cur.TotalCacheWriteTokens; set => Cur.TotalCacheWriteTokens = value; }
+    private bool ThinkingHintShown { get => Cur.ThinkingHintShown; set => Cur.ThinkingHintShown = value; }
+    private SteeringQueue SteeringQueue => Cur.SteeringQueue;
+    private SteeringChatClient? Steering { get => Cur.Steering; set => Cur.Steering = value; }
+    private int SteeringCommitted { get => Cur.SteeringCommitted; set => Cur.SteeringCommitted = value; }
+    private string ContextSummary { get => Cur.ContextSummary; set => Cur.ContextSummary = value; }
+    private int SummarizedThrough { get => Cur.SummarizedThrough; set => Cur.SummarizedThrough = value; }
+    private HashSet<string> AlwaysApproved => Cur.AlwaysApproved;
+    private List<Control> CollapsedMessages => Cur.CollapsedMessages;
+    private Border? CollapsedBanner { get => Cur.CollapsedBanner; set => Cur.CollapsedBanner = value; }
+    private Dictionary<Control, int> UserBubbleIndex => Cur.UserBubbleIndex;
+
+    /// <summary>正显示对话的消息流面板(命令式建气泡都往这挂;后台轮次经 <see cref="Cur" /> 落到自己那条)。</summary>
+    private StackPanel MessagesPanel => Cur.Messages;
+
     private AiSettings _settings = new();
-    /// <summary>正在流的那条回复。审批卡与失败卡要挂进它里面(而不是气泡外面),所以得有个把手。</summary>
-    private AssistantBubble? _activeBubble;
     /// <summary>当前该不该显示空状态(还要再与"中部正显示聊天流"取与,见 <see cref="SetActiveView" />)。</summary>
     private bool _showEmptyState;
     /// <summary>已摆出来的是哪一版空状态(true = 引导去配模型那版);null = 还没摆。</summary>
@@ -76,31 +130,9 @@ public partial class ChatPanelView : UserControl
     /// <summary>正在由代码回填下拉选中项(别把这一下当成用户在选)。</summary>
     private bool _syncingReasoning;
     private List<SessionInfo> _sessions = [];
-    private CancellationTokenSource? _cts;
-    private bool _busy;
-    /// <summary>这一轮往 <c>_history</c> 里加的第一条的下标(那之后的全是本轮的东西)。</summary>
-    private int _turnHistoryStart;
-
-    // 当前会话在时序库中的身份:摘要点的时间戳恒为 _conversationStartedAt(覆盖式更新),
-    // _persistedCount 既是已入库条数,也是下一条消息的序号。
-    private string _conversationId = ChatHistoryStore.NewConversationId();
-    private DateTimeOffset _conversationStartedAt = DateTimeOffset.UtcNow;
-    private int _persistedCount;
     private bool _switchingView;
     private bool _autoScroll = true;
     private bool _scrollScheduled;
-    private long _totalInputTokens;
-    private long _totalOutputTokens;
-    private long _totalReasoningTokens;
-    // 最近一轮的输入 token ≈ 当前上下文占用(整段对话每轮都重发),用作输入框下方那个占比的分子
-    private long _lastInputTokens;
-    // 缓存命中:两家的口径实测已被适配器抹平 —— InputTokenCount 都含缓存读取,
-    // 于是 Cached/Input 在两边都是同一个意思(见 UpdateUsageText 的注释)
-    private long _lastCachedInputTokens;
-    private long _totalCachedInputTokens;
-    private long _totalCacheWriteTokens;
-    // 上一轮为了塞进上下文窗口而没有发出去的早期消息条数(界面与库里都还留着)
-    private int _droppedFromContext;
     private ThemeName _codeBlockTheme = ThemeName.DarkPlus;
     private Color _mathTextColor = Colors.Black;
     private Color _mathErrorColor = Colors.Red;
@@ -112,9 +144,16 @@ public partial class ChatPanelView : UserControl
         _store = store;
         _loc = new Loc(context.Host.Locale);
         _historyStore = new ChatHistoryStore(context);
+        // 至少要有一份对话在手(不绑机器的通用对话):任何代理到 Cur 的读写都得有落点。
+        // 连上机器后顶栏下拉一选,就切到对应机器那一份(见 SwitchConversation)。
+        _active = NewConversation("");
+        _conversations[""] = _active;
         _toolbox = new AgentToolbox(context)
         {
-            SessionIdProvider = () => SelectedSessionId,
+            // 工具打在<b>这一轮所属对话</b>绑的那台机器上,而不是此刻下拉选中的那台 ——
+            // 否则后台跑着的 A 轮会把命令打到你刚切过去正看的 B 上。工具调用发生在本轮的异步流里,
+            // Cur 经 _turnScope 落到 A,取到的正是 A 绑的会话。
+            SessionIdProvider = CurrentToolSessionId,
             ApprovalHandler = RequestApprovalAsync
         };
         _mcp = new McpManager(context) { ApprovalHandler = RequestApprovalAsync };
@@ -127,9 +166,21 @@ public partial class ChatPanelView : UserControl
         ApplyLoc();
 
         SendButton.Click += (_, _) => _ = SendAsync(InputBox.Text ?? "");
-        StopButton.Click += (_, _) => _cts?.Cancel();
+        StopButton.Click += (_, _) => Cts?.Cancel();
         ChatScroll.ScrollChanged += OnChatScrollChanged;
+        // 消息流的实际容器是"当前这一份对话"的面板,运行时挂上;切对话时整体替换(见 SwitchConversation)。
+        ChatScroll.Content = _active.Messages;
         NewChatButton.Click += (_, _) => StartNewChat();
+        // 顶栏下拉换一台机器 = 换一份对话:面板即时切到那台机器自己的聊天(它的请求在后台照跑)。
+        // 重建下拉时的代码回填不算(_switchingSessions 挡着),那一步由 RefreshSessionsAsync 自己收尾。
+        SessionCombo.SelectionChanged += (_, _) =>
+        {
+            if (_switchingSessions)
+            {
+                return;
+            }
+            SwitchConversation(SelectedSessionId ?? "");
+        };
         InputBox.AddHandler(KeyDownEvent, OnInputKeyDown, RoutingStrategies.Tunnel);
         InputBox.TextChanged += (_, _) =>
         {
@@ -219,7 +270,11 @@ public partial class ChatPanelView : UserControl
         DisposeSuggestions();
         try
         {
-            _cts?.Cancel();
+            // 关面板 = 所有对话都收摊:每份对话在途的那一轮都掐掉(不只当前显示的这份)。
+            foreach (Conversation conversation in _conversations.Values)
+            {
+                conversation.Cts?.Cancel();
+            }
             // 面板级取消源:补全请求之间靠代次判废,只有面板真的关了才在这里取消
             _fileCts?.Cancel();
             _fileCts?.Dispose();
@@ -358,8 +413,8 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void ConfigureMarkdown()
     {
-        // 链接是冒泡路由事件,挂在消息流上就覆盖所有气泡,不必逐段订阅
-        MessagesPanel.AddHandler(MarkdownTextBlock.LinkClickEvent, OnMarkdownLinkClicked);
+        // 链接点击是冒泡路由事件,逐个对话面板在建面板时挂一次即可(见 NewConversation)——
+        // 现在消息流按对话各持一份,不能只挂在某一份上。
 
         // 库默认第一个处理器就是 HTTP,模型回复里的图片 URL 会被直接抓取 —— 那等于给
         // 任意模型输出开了个追踪像素通道。这里摘掉 HTTP,只留本地文件 / data: / 内嵌资源。
@@ -405,10 +460,15 @@ public partial class ChatPanelView : UserControl
         // 这两样不是资源键而是控件属性,已生成的渲染器要逐个改
         ThemeName codeTheme = ActualThemeVariant == ThemeVariant.Dark ? ThemeName.DarkPlus : ThemeName.LightPlus;
         _codeBlockTheme = codeTheme;
-        foreach (MarkdownRenderer renderer in MessagesPanel.GetVisualDescendants().OfType<MarkdownRenderer>())
+        // 每份对话各有一条消息流面板,后台那几条此刻不在可视树上但气泡还在 —— 全都要换皮,
+        // 否则切回一份后台对话时它的代码块还停在上一套配色上。
+        foreach (Conversation conversation in _conversations.Values)
         {
-            renderer.CodeBlockColorTheme = codeTheme;
-            ApplyMathColors(renderer);
+            foreach (MarkdownRenderer renderer in conversation.Messages.GetVisualDescendants().OfType<MarkdownRenderer>())
+            {
+                renderer.CodeBlockColorTheme = codeTheme;
+                ApplyMathColors(renderer);
+            }
         }
 
         void Skin(string key, string velaKey)
@@ -475,8 +535,13 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void UpdateEmptyState()
     {
+        // 空状态是共享中部,只反映正显示的那份;后台那份改不着这里(切回它时会重算)。
+        if (!IsForeground)
+        {
+            return;
+        }
         // 这段对话一个字都还没有 —— 无论模型配没配,中部都不该是一整块空白
-        _showEmptyState = _history.Count == 0 && MessagesPanel.Children.Count == 0;
+        _showEmptyState = History.Count == 0 && MessagesPanel.Children.Count == 0;
         EmptyStateHost.IsVisible = _showEmptyState && ChatScroll.IsVisible;
         if (!_showEmptyState)
         {
@@ -641,8 +706,13 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void UpdateUsageText()
     {
+        // 用量条是共享顶栏,只反映正显示的那份;后台那份记在自己身上,切回它时重算贴出。
+        if (!IsForeground)
+        {
+            return;
+        }
         int window = ActiveProvider?.MaxInputTokens ?? 0;
-        if (_totalInputTokens == 0 && _totalOutputTokens == 0)
+        if (TotalInputTokens == 0 && TotalOutputTokens == 0)
         {
             UsageText.Text = "";
             UsageMeterTrack.IsVisible = false;
@@ -652,16 +722,16 @@ public partial class ChatPanelView : UserControl
 
         var detail = new StringBuilder();
         var label = new StringBuilder();
-        if (window > 0 && _lastInputTokens > 0)
+        if (window > 0 && LastInputTokens > 0)
         {
-            int percent = (int)Math.Min(100, Math.Round(_lastInputTokens * 100.0 / window));
-            label.Append($"{Compact(_lastInputTokens)}/{Compact(window)} · {percent}%");
-            detail.AppendLine(_loc.F("UsageContextLine", $"{_lastInputTokens:N0}", $"{window:N0}", percent));
+            int percent = (int)Math.Min(100, Math.Round(LastInputTokens * 100.0 / window));
+            label.Append($"{Compact(LastInputTokens)}/{Compact(window)} · {percent}%");
+            detail.AppendLine(_loc.F("UsageContextLine", $"{LastInputTokens:N0}", $"{window:N0}", percent));
             SetUsageMeter(percent);
         }
         else
         {
-            label.Append($"↑{Compact(_totalInputTokens)} ↓{Compact(_totalOutputTokens)}");
+            label.Append($"↑{Compact(TotalInputTokens)} ↓{Compact(TotalOutputTokens)}");
             // 不知道窗口多大就画不出占比,整条隐掉(留一根空槽反而像"用量为零")
             UsageMeterTrack.IsVisible = false;
         }
@@ -669,27 +739,27 @@ public partial class ChatPanelView : UserControl
         // 命中率 = 缓存读取 / 输入。两家口径实测已被适配器抹平:OpenAI 的 prompt_tokens 本就含
         // cached_tokens;Anthropic 的 input_tokens 原本不含缓存,但适配器把 cache_read 与
         // cache_creation 都并进了 InputTokenCount(200+800+120=1120)。所以同一个式子两边都成立。
-        if (_lastCachedInputTokens > 0 && _lastInputTokens > 0)
+        if (LastCachedInputTokens > 0 && LastInputTokens > 0)
         {
-            int hit = (int)Math.Min(100, Math.Round(_lastCachedInputTokens * 100.0 / _lastInputTokens));
+            int hit = (int)Math.Min(100, Math.Round(LastCachedInputTokens * 100.0 / LastInputTokens));
             label.Append($" · {_loc["CacheShort"]} {hit}%");
-            detail.AppendLine(_loc.F("UsageCacheLine", $"{_lastCachedInputTokens:N0}", $"{_lastInputTokens:N0}", hit));
+            detail.AppendLine(_loc.F("UsageCacheLine", $"{LastCachedInputTokens:N0}", $"{LastInputTokens:N0}", hit));
         }
 
         UsageText.Text = label.ToString();
-        detail.AppendLine(_loc.F("UsageTotalsLine", $"{_totalInputTokens:N0}", $"{_totalOutputTokens:N0}"));
-        if (_totalCachedInputTokens > 0 || _totalCacheWriteTokens > 0)
+        detail.AppendLine(_loc.F("UsageTotalsLine", $"{TotalInputTokens:N0}", $"{TotalOutputTokens:N0}"));
+        if (TotalCachedInputTokens > 0 || TotalCacheWriteTokens > 0)
         {
-            detail.AppendLine(_loc.F("UsageCacheTotalsLine", $"{_totalCachedInputTokens:N0}", $"{_totalCacheWriteTokens:N0}"));
+            detail.AppendLine(_loc.F("UsageCacheTotalsLine", $"{TotalCachedInputTokens:N0}", $"{TotalCacheWriteTokens:N0}"));
         }
-        if (_totalReasoningTokens > 0)
+        if (TotalReasoningTokens > 0)
         {
-            detail.AppendLine(_loc.F("UsageReasoningLine", $"{_totalReasoningTokens:N0}"));
+            detail.AppendLine(_loc.F("UsageReasoningLine", $"{TotalReasoningTokens:N0}"));
         }
-        if (_droppedFromContext > 0)
+        if (DroppedFromContext > 0)
         {
             // 裁剪不能悄悄发生:用户得知道模型"看不到"最早那几条了
-            detail.AppendLine(_loc.F("UsageTrimmedLine", _droppedFromContext));
+            detail.AppendLine(_loc.F("UsageTrimmedLine", DroppedFromContext));
         }
         if (ActiveProvider is { } provider)
         {
@@ -741,10 +811,10 @@ public partial class ChatPanelView : UserControl
         double cachedPrice = provider.CachedInputPricePerMillion > 0
             ? provider.CachedInputPricePerMillion
             : provider.InputPricePerMillion;
-        long freshInput = Math.Max(0, _totalInputTokens - _totalCachedInputTokens);
+        long freshInput = Math.Max(0, TotalInputTokens - TotalCachedInputTokens);
         return ((freshInput * provider.InputPricePerMillion)
-                + (_totalCachedInputTokens * cachedPrice)
-                + (_totalOutputTokens * provider.OutputPricePerMillion)) / 1_000_000d;
+                + (TotalCachedInputTokens * cachedPrice)
+                + (TotalOutputTokens * provider.OutputPricePerMillion)) / 1_000_000d;
     }
 
     /// <summary>把 token 计数压成 <c>12.3k</c> / <c>1.2M</c> 这种短形式(工具条按字符宽度计价)。</summary>
@@ -761,6 +831,19 @@ public partial class ChatPanelView : UserControl
             ? _sessions[SessionCombo.SelectedIndex].SessionId
             : null;
 
+    /// <summary>
+    /// 当前这一轮的工具该打在哪台机器上:本轮所属对话绑的那条会话(<c>""</c> 通用对话 = 不绑,给 null)。
+    /// </summary>
+    /// <remarks>
+    /// 工具调用发生在本轮的异步流里,<see cref="Cur" /> 经 <see cref="_turnScope" /> 落到本轮那份对话,
+    /// 所以后台轮次取到的是它自己那台机器,而不是此刻下拉选中的那台。
+    /// </remarks>
+    private string? CurrentToolSessionId()
+    {
+        string key = Cur.SessionKey;
+        return string.IsNullOrEmpty(key) ? null : key;
+    }
+
     private void OnSessionEvent(SessionInfo info) => Dispatcher.UIThread.Post(() => _ = RefreshSessionsAsync());
 
     private async Task RefreshSessionsAsync()
@@ -770,21 +853,142 @@ public partial class ChatPanelView : UserControl
             IReadOnlyList<SessionInfo> all = await _context.Sessions.ListAsync();
             string? previous = SelectedSessionId;
             _sessions = [.. all.Where(s => s.State == SessionState.Connected)];
+            // 顶栏的会话行显示的是<b>连接的名字</b>,不是 user@host。名字在已保存的配置里
+            // (会话树上那个用户认得的名),而在途会话本身不带它 —— 按 主机/端口/用户 对回去取。
+            // 对不上的(临时会话、没起名的)退回 user@host,总有个能认的落点。
+            Dictionary<(string, int, string), string> names = await LoadSessionNamesAsync();
             // 顶栏的会话行前面带一颗状态点。列表里只有"已连接"的会话,所以点恒为绿;
             // 一台都没有时那条占位项给灰点 —— 空着不画反而会让整行的对齐跳一下。
             IBrush online = FindBrush("VelaStatusConnected") ?? Brushes.LimeGreen;
             IBrush offline = FindBrush("VelaTextMuted") ?? Brushes.Gray;
-            SessionCombo.ItemsSource = _sessions.Count == 0
-                ? (IReadOnlyList<SessionNavItem>)[new SessionNavItem(_loc["NoSession"], offline)]
-                : [.. _sessions.Select(s => new SessionNavItem($"{s.Username}@{s.Host}", online))];
-            int keep = _sessions.FindIndex(s => s.SessionId == previous);
-            SessionCombo.SelectedIndex = keep >= 0 ? keep : 0;
+            // 重建下拉这一下会连带触发 SelectionChanged,但那只是代码回填、不是用户在切对话 ——
+            // 用 _switchingSessions 挡住它,选中项定下来之后由本方法自己按最终选中值切一次。
+            _switchingSessions = true;
+            try
+            {
+                SessionCombo.ItemsSource = _sessions.Count == 0
+                    ? (IReadOnlyList<SessionNavItem>)[new SessionNavItem(_loc["NoSession"], offline)]
+                    : [.. _sessions.Select(s => new SessionNavItem(SessionLabel(s, names), online))];
+                int keep = _sessions.FindIndex(s => s.SessionId == previous);
+                SessionCombo.SelectedIndex = keep >= 0 ? keep : 0;
+            }
+            finally
+            {
+                _switchingSessions = false;
+            }
+            // 选中值可能变了(原会话断了、掉到别台上):把显示的这份对话对齐到它。
+            // 同一份 = 无操作,所以刷新列表不会打断你正在看的对话。
+            SwitchConversation(SelectedSessionId ?? "");
         }
         catch (Exception ex)
         {
             _context.Log.Error("Refresh sessions failed.", ex);
         }
     }
+
+    /// <summary>建一份新对话(连带它自己那条消息流面板,并把链接点击处理挂上)。</summary>
+    private Conversation NewConversation(string sessionKey)
+    {
+        var messages = new StackPanel
+        {
+            Spacing = 8,
+            Margin = new Thickness(5, 4, 19, 4)
+        };
+        // 链接是冒泡路由事件,挂在这条面板上就覆盖它里面的所有气泡。
+        messages.AddHandler(MarkdownTextBlock.LinkClickEvent, OnMarkdownLinkClicked);
+        return new Conversation(sessionKey, messages);
+    }
+
+    /// <summary>
+    /// 切到某台机器(<paramref name="key" /> = 会话 id;<c>""</c> = 通用对话)的那份对话:
+    /// 换 <see cref="_active" /> 的引用、把它的面板挂进 <c>ChatScroll</c>、再把共享顶栏对齐到它。
+    /// </summary>
+    /// <remarks>
+    /// 是<b>换引用</b>不是重建:目标那份对话(含它的历史气泡、在途请求)一直在内存里活着,
+    /// 所以切换即时、后台不断、也不串台。没有这份就现建一份空的。
+    /// </remarks>
+    private void SwitchConversation(string key)
+    {
+        if (ReferenceEquals(Cur, _active) && _active.SessionKey == key)
+        {
+            return;
+        }
+        if (!_conversations.TryGetValue(key, out Conversation? target))
+        {
+            target = NewConversation(key);
+            _conversations[key] = target;
+        }
+        if (ReferenceEquals(target, _active))
+        {
+            return;
+        }
+        _active = target;
+        ChatScroll.Content = _active.Messages;
+        RefreshForeground();
+    }
+
+    /// <summary>把共享的顶栏控件(忙态 / 状态行 / 用量 / 排队芯片 / 空状态)对齐到当前显示的这份对话。</summary>
+    private void RefreshForeground()
+    {
+        SetBusy(_active.Busy);
+        StatusText.Text = _active.Status;
+        StatusText.Classes.Remove("retrying");
+        RenderQueuedChips();
+        UpdateUsageText();
+        UpdateEmptyState();
+        // 切到别的对话时上一份的后续提问药丸不再相关;各份的后续提问是即时算的,不做保留。
+        ClearSuggestions();
+        RequestAutoScroll(force: true);
+    }
+
+    /// <summary>
+    /// 设置状态行文字:只有正显示的这份对话才真的去改共享的状态行;后台那份只把话记在自己身上,
+    /// 切回来时由 <see cref="RefreshForeground" /> 贴回去(否则后台一句"MCP 连接中"会盖住你正看的对话)。
+    /// </summary>
+    private void SetStatus(string text)
+    {
+        Cur.Status = text;
+        if (IsForeground)
+        {
+            StatusText.Text = text;
+        }
+    }
+
+    /// <summary>
+    /// 已保存配置的「名字」查表:键是能把在途会话对回配置的那三样(主机 / 端口 / 用户)。
+    /// </summary>
+    /// <remarks>
+    /// 取不到(宿主没给已保存列表、或调用出错)就返回空表,顶栏照样能用 user@host 兜底 ——
+    /// 名字只是更好认,拿不到不该让会话列表本身塌掉。
+    /// 同一 主机/端口/用户 下配了多条(少见),留先出现的那个名。
+    /// </remarks>
+    private async Task<Dictionary<(string, int, string), string>> LoadSessionNamesAsync()
+    {
+        try
+        {
+            IReadOnlyList<SavedSessionInfo> saved = await _context.Sessions.ListSavedAsync();
+            var map = new Dictionary<(string, int, string), string>();
+            foreach (SavedSessionInfo p in saved)
+            {
+                if (!string.IsNullOrWhiteSpace(p.Name))
+                {
+                    map.TryAdd((p.Host, p.Port, p.Username), p.Name);
+                }
+            }
+            return map;
+        }
+        catch (Exception ex)
+        {
+            _context.Log.Warn($"Loading saved session names failed: {ex.Message}");
+            return [];
+        }
+    }
+
+    /// <summary>顶栏一条会话该显示的名字:优先已保存配置的名,对不上退回 user@host。</summary>
+    private static string SessionLabel(SessionInfo s, Dictionary<(string, int, string), string> names)
+        => names.TryGetValue((s.Host, s.Port, s.Username), out string? name) && !string.IsNullOrWhiteSpace(name)
+            ? name
+            : $"{s.Username}@{s.Host}";
 
     /// <summary>记住用户拖分割条拖出来的侧栏宽度(百分比,宿主在拖动结束时通知一次)。</summary>
     /// <remarks>
@@ -857,7 +1061,13 @@ public partial class ChatPanelView : UserControl
     /// </remarks>
     private void SetBusy(bool busy)
     {
-        _busy = busy;
+        Busy = busy; // 落到当前这一轮的那份对话
+        // 忙态指示(停止键/发送键文案/发光)是共享顶栏,只反映正显示的那份;
+        // 后台那份自己忙自己的,不该动这里(切回它时 RefreshForeground 会照它的忙态贴回)。
+        if (!IsForeground)
+        {
+            return;
+        }
         StopButton.IsVisible = busy;
         SyncSendButton();
         SetBusyGlow(busy);
@@ -866,9 +1076,9 @@ public partial class ChatPanelView : UserControl
     /// <summary>发送键与输入框提示按"忙不忙"取词(语言切换与忙闲切换都经这里)。</summary>
     private void SyncSendButton()
     {
-        SendText.Text = _loc[_busy ? "Queue" : "Send"];
-        ToolTip.SetTip(SendButton, _loc[_busy ? "QueueTip" : "Send"]);
-        InputPlaceholder.Text = _loc[_busy ? "InputPlaceholderBusy" : "InputPlaceholder"];
+        SendText.Text = _loc[Busy ? "Queue" : "Send"];
+        ToolTip.SetTip(SendButton, _loc[Busy ? "QueueTip" : "Send"]);
+        InputPlaceholder.Text = _loc[Busy ? "InputPlaceholderBusy" : "InputPlaceholder"];
     }
 
     /// <summary>
@@ -891,6 +1101,11 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void RequestAutoScroll(bool force = false)
     {
+        // 后台那份的气泡长在不可见的面板里,别去动共享的滚动条。
+        if (!IsForeground)
+        {
+            return;
+        }
         if (force)
         {
             _autoScroll = true;
@@ -922,6 +1137,11 @@ public partial class ChatPanelView : UserControl
     private async Task SendAsync(string text, bool fromUser = true, SteeringMessage? prepared = null)
     {
         text = text.Trim();
+        // 记下这一轮属于哪份对话:通常就是正显示的这份;后台续跑的下一轮(队列排空)沿用原来那份。
+        // 置进 _turnScope 后,这条方法(及它 await 出去的整条流水线)所有代理都落到这份上,
+        // 而不是"此刻正显示的那份"—— 这就是切走之后它还能把话答完、且不串台的关键。
+        Conversation conv = Cur;
+        _turnScope.Value = conv;
         // 只带附件、正文为空也算一次有效发送(比如"看看这张图")
         if (text.Length == 0 && _attachments.Count == 0 && prepared is null)
         {
@@ -929,7 +1149,7 @@ public partial class ChatPanelView : UserControl
         }
         // 上一轮还在跑就不抢它:排进队列,由插话通道在模型下一步之前送进去
         // (见 ChatPanelView.Steering.cs —— 这正是"边跑边补"的入口)。
-        if (_busy)
+        if (Busy)
         {
             await QueueWhileBusyAsync(text, fromUser);
             return;
@@ -938,22 +1158,33 @@ public partial class ChatPanelView : UserControl
         if (ActiveProviderForRequest is not { } provider)
         {
             // 这次是用户主动发消息才撞上"没配接入",直接把设置窗口开给他
-            StatusText.Text = _loc["NoProvider"];
-            OpenSettingsDialog();
+            SetStatus(_loc["NoProvider"]);
+            if (IsForeground)
+            {
+                OpenSettingsDialog();
+            }
             return;
         }
 
         SetBusy(true);
-        InputBox.Text = "";
+        // 输入框/文件选择器/视图切换都是共享控件:只有正显示这份时才动它们,
+        // 否则后台续跑会把你正在别份对话里敲的字清掉、把你正看的历史页切走。
+        if (IsForeground)
+        {
+            InputBox.Text = "";
+            CloseFilePicker();
+            SetActiveView(PanelView.Chat);
+        }
         // 状态行只说"这一刻"的事:新一轮开始,上一轮的取消/报错提示就该退场
-        StatusText.Text = "";
-        ClearSuggestions(); // 上一轮的后续提问已经过期,并掐掉可能还在途的那次求建议
-        CloseFilePicker();
+        SetStatus("");
+        if (IsForeground)
+        {
+            ClearSuggestions(); // 上一轮的后续提问已经过期,并掐掉可能还在途的那次求建议
+        }
         if (fromUser)
         {
             RememberInput(text);
         }
-        SetActiveView(PanelView.Chat);
 
         // 界面与库里留的是这一份(短名引用 + 附件留痕);送给模型的那份在下面单独装配
         string display = prepared?.DisplayText ?? text + AttachmentTrace();
@@ -961,8 +1192,8 @@ public partial class ChatPanelView : UserControl
         UpdateEmptyState(); // 消息流有东西了,居中的空状态得让位
         RequestAutoScroll(force: true);
 
-        _cts = new CancellationTokenSource();
-        CancellationToken token = _cts.Token;
+        Cts = new CancellationTokenSource();
+        CancellationToken token = Cts.Token;
         AssistantBubble? bubble = null;
         long startedAt = Environment.TickCount64;
         bool cancelled = false;
@@ -989,12 +1220,12 @@ public partial class ChatPanelView : UserControl
                 userMessage = new ChatMessage(ChatRole.User, BuildUserContents(modelText));
             }
             // 这一轮往历史里加的第一条 —— 一个字都没换来时要按它整批撤回(见 SettleUnfinishedTurnAsync)
-            _turnHistoryStart = _history.Count;
-            _history.Add(userMessage);
+            TurnHistoryStart = History.Count;
+            History.Add(userMessage);
             await PersistAsync("user", display);
             ClearAttachments();
             bubble = new AssistantBubble(this);
-            _activeBubble = bubble;
+            ActiveBubble = bubble;
             MessagesPanel.Children.Add(bubble.Root);
             TrimMessageWindow(); // 常驻条数封顶,别让可视树越聊越长
             RequestAutoScroll(force: true);
@@ -1003,7 +1234,7 @@ public partial class ChatPanelView : UserControl
             // 排队中的补充说明就能赶在模型下一步之前进上下文(见 SteeringChatClient)。
             var steering = new SteeringChatClient(
                 await _store.CreateClientAsync(provider, cancellationToken: token),
-                _steeringQueue, OnSteeringDelivered);
+                SteeringQueue, () => OnSteeringDelivered(conv));
             BeginSteering(steering);
             IChatClient client = steering;
             var options = new ChatOptions
@@ -1040,15 +1271,15 @@ public partial class ChatPanelView : UserControl
                 // 而"计划"的承诺是这一步不动任何东西。
                 if (mode == ChatMode.Agent && _settings.McpServers.Any(s => s.Enabled))
                 {
-                    StatusText.Text = _loc["McpConnecting"];
+                    SetStatus(_loc["McpConnecting"]);
                     (List<AITool> mcpTools, List<string> mcpErrors) = await _mcp.GetToolsAsync(_settings.McpServers, token);
                     foreach (AITool tool in mcpTools)
                     {
                         tools.Add(tool);
                     }
-                    StatusText.Text = mcpErrors.Count > 0
+                    SetStatus(mcpErrors.Count > 0
                         ? $"{_loc["Error"]} (MCP): {string.Join("; ", mcpErrors)}"
-                        : "";
+                        : "");
                 }
                 if (nativeSearch)
                 {
@@ -1066,10 +1297,10 @@ public partial class ChatPanelView : UserControl
             await CompactIfNeededAsync(provider, token);
             // 装配上下文:摘要 + 近几轮原文,按窗口裁剪并把相邻同角色的消息并起来(见 ContextBuilder)
             RequestContext request = ContextBuilder.Build(
-                BuildSystemPrompt(mode, nativeSearch), _history, provider.MaxInputTokens, provider.MaxTokens,
-                _contextSummary, _summarizedThrough);
+                BuildSystemPrompt(mode, nativeSearch), History, provider.MaxInputTokens, provider.MaxTokens,
+                ContextSummary, SummarizedThrough);
             List<ChatMessage> requestMessages = request.Messages;
-            _droppedFromContext = request.DroppedMessages;
+            DroppedFromContext = request.DroppedMessages;
             // 有的订阅型端点不收 system 角色(ChatGPT 的 Codex 后端会回
             // 400 {"detail":"System messages are not allowed"})。那时把系统提示词挪到
             // Responses 协议自己的 instructions 字段上 —— 内容一个字不少,只是换了个位置。
@@ -1085,7 +1316,7 @@ public partial class ChatPanelView : UserControl
             else
             {
                 // 关掉之后要把历史上残留的标记抹干净,否则一直挂着(内容对象跨轮复用)
-                PromptCache.Clear(_history);
+                PromptCache.Clear(History);
             }
 
             var updates = new List<ChatResponseUpdate>();
@@ -1147,39 +1378,45 @@ public partial class ChatPanelView : UserControl
                 {
                     _context.Log.Warn($"Stream failed before any content (attempt {attempt + 1}): {ex.Message}");
                     // 重试是瞬时故障,给 warn 色区别于普通提示;成功后连色带字一起撤掉
-                    StatusText.Classes.Add("retrying");
-                    StatusText.Text = _loc.F("Retrying", attempt + 1);
+                    if (IsForeground)
+                    {
+                        StatusText.Classes.Add("retrying");
+                    }
+                    SetStatus(_loc.F("Retrying", attempt + 1));
                     await Task.Delay(TimeSpan.FromMilliseconds(400 * (attempt + 1)), token);
                 }
             }
-            StatusText.Classes.Remove("retrying");
-            StatusText.Text = "";
+            if (IsForeground)
+            {
+                StatusText.Classes.Remove("retrying");
+            }
+            SetStatus("");
             DrainUpdates(); // 兜底清空残留批(此处已回到 UI 线程)
 
             var response = updates.ToChatResponse();
             // 兜底补齐插话:送达回调的 Post 可能还排在队里没跑到,而它必须排在
             // 这一轮的回复之前进历史与库(顺序:原消息 → 插话 → 回复)。
-            await CommitSteeringAsync();
-            _history.AddMessages(response);
+            await CommitSteeringAsync(conv);
+            History.AddMessages(response);
             int sequence = await PersistAsync("assistant", response.Text);
             if (sequence >= 0 && bubble is not null)
             {
                 // 思考、工具调用、模型、耗时另存一行 —— 翻回旧会话时这些才是"Agent 做了什么"的证据
-                await _historyStore.AppendMetaAsync(_conversationId, sequence,
+                await _historyStore.AppendMetaAsync(ConversationId, sequence,
                     bubble.Snapshot(ModelLabel(provider),
                         TimeSpan.FromMilliseconds(Environment.TickCount64 - startedAt)));
             }
             HintIfThinkingWasNeverRequested(bubble, provider);
             if (response.Usage is { } usage)
             {
-                _lastInputTokens = usage.InputTokenCount ?? _lastInputTokens;
-                _totalInputTokens += usage.InputTokenCount ?? 0;
-                _totalOutputTokens += usage.OutputTokenCount ?? 0;
-                _totalReasoningTokens += usage.ReasoningTokenCount ?? 0;
-                _lastCachedInputTokens = usage.CachedInputTokenCount ?? 0;
-                _totalCachedInputTokens += _lastCachedInputTokens;
+                LastInputTokens = usage.InputTokenCount ?? LastInputTokens;
+                TotalInputTokens += usage.InputTokenCount ?? 0;
+                TotalOutputTokens += usage.OutputTokenCount ?? 0;
+                TotalReasoningTokens += usage.ReasoningTokenCount ?? 0;
+                LastCachedInputTokens = usage.CachedInputTokenCount ?? 0;
+                TotalCachedInputTokens += LastCachedInputTokens;
                 // 缓存"写入"只有 Anthropic 报(它单独收费),OpenAI 系没有这个概念
-                _totalCacheWriteTokens += usage.AdditionalCounts?.GetValueOrDefault("CacheCreationInputTokens") ?? 0;
+                TotalCacheWriteTokens += usage.AdditionalCounts?.GetValueOrDefault("CacheCreationInputTokens") ?? 0;
             }
             UpdateUsageText();
             replyText = response.Text;
@@ -1188,7 +1425,7 @@ public partial class ChatPanelView : UserControl
         {
             // 取消是"这条回复"的属性,记在气泡头部;状态行不留话(留了就一直挂着,见截图反馈)
             cancelled = true;
-            await CommitSteeringAsync(); // 已经送到模型那儿的插话照样算数
+            await CommitSteeringAsync(conv); // 已经送到模型那儿的插话照样算数
             await SettleUnfinishedTurnAsync(bubble);
         }
         catch (Exception ex)
@@ -1202,16 +1439,19 @@ public partial class ChatPanelView : UserControl
             // 失败不再当成一段 Markdown 追加进正文:它不是模型说的话,混排会让人分不清
             // 哪句是回答、哪句是故障。改成一张 error 卡挂在这条回复里(见 AddErrorCard)。
             AddErrorCard(bubble, detail);
-            await CommitSteeringAsync();
+            await CommitSteeringAsync(conv);
             await SettleUnfinishedTurnAsync(bubble);
         }
         finally
         {
-            _cts?.Dispose();
-            _cts = null;
-            _activeBubble = null;
+            Cts?.Dispose();
+            Cts = null;
+            ActiveBubble = null;
             EndSteering();
-            StatusText.Classes.Remove("retrying");
+            if (IsForeground)
+            {
+                StatusText.Classes.Remove("retrying");
+            }
             SetBusy(false);
             // 一轮到此为止(成功/取消/出错都算):收起思考区,补上"耗时 · 步数"与"时间 · 模型"
             bubble?.FinishStreaming(
@@ -1227,18 +1467,27 @@ public partial class ChatPanelView : UserControl
         // 被停掉或出错了就原样放回输入框 —— 该重试还是该改写由用户决定。
         if (cancelled || failed)
         {
-            RestoreQueuedToInput();
+            // 放回输入框只对正显示这份有意义;后台那份被停/出错就把余下插话丢掉(输入框不是它的)。
+            if (IsForeground)
+            {
+                RestoreQueuedToInput();
+            }
+            else
+            {
+                SteeringQueue.DrainAll();
+            }
             return;
         }
-        if (_steeringQueue.DrainMerged() is { } next)
+        if (SteeringQueue.DrainMerged() is { } next)
         {
             RenderQueuedChips();
             await SendAsync(next.DisplayText, fromUser: false, prepared: next);
             return;
         }
 
-        // 顺利答完才给后续提问:取消/报错时用户要的是重试,不是被塞几条建议
-        if (replyText.Length > 0)
+        // 顺利答完才给后续提问:取消/报错时用户要的是重试,不是被塞几条建议;
+        // 后台那份也不弹后续提问(那是给正看着的人的)。
+        if (replyText.Length > 0 && IsForeground)
         {
             await SuggestFollowUpsAsync(provider, text, replyText);
         }
@@ -1313,13 +1562,13 @@ public partial class ChatPanelView : UserControl
     /// <summary>用量归零(换会话时用:计数是"这一段对话"的,不是进程级的)。</summary>
     private void ResetUsage()
     {
-        _totalInputTokens = 0;
-        _totalOutputTokens = 0;
-        _totalReasoningTokens = 0;
-        _lastInputTokens = 0;
-        _lastCachedInputTokens = 0;
-        _totalCachedInputTokens = 0;
-        _totalCacheWriteTokens = 0;
+        TotalInputTokens = 0;
+        TotalOutputTokens = 0;
+        TotalReasoningTokens = 0;
+        LastInputTokens = 0;
+        LastCachedInputTokens = 0;
+        TotalCachedInputTokens = 0;
+        TotalCacheWriteTokens = 0;
         UpdateUsageText();
     }
 
@@ -1343,13 +1592,13 @@ public partial class ChatPanelView : UserControl
         string partial = bubble?.ReplyText.Trim() ?? "";
         if (partial.Length > 0)
         {
-            _history.Add(new ChatMessage(ChatRole.Assistant, partial));
+            History.Add(new ChatMessage(ChatRole.Assistant, partial));
             await PersistAsync("assistant", partial);
             return;
         }
-        if (_history.Count > _turnHistoryStart && _history[^1].Role == ChatRole.User)
+        if (History.Count > TurnHistoryStart && History[^1].Role == ChatRole.User)
         {
-            _history.RemoveRange(_turnHistoryStart, _history.Count - _turnHistoryStart);
+            History.RemoveRange(TurnHistoryStart, History.Count - TurnHistoryStart);
         }
     }
 
@@ -1363,13 +1612,12 @@ public partial class ChatPanelView : UserControl
         {
             return -1;
         }
-        int sequence = _persistedCount++;
-        await _historyStore.AppendAsync(_conversationId, _conversationStartedAt, sequence, role, text);
+        int sequence = PersistedCount++;
+        await _historyStore.AppendAsync(ConversationId, ConversationStartedAt, sequence, role, text);
         return sequence;
     }
 
-    /// <summary>本次会话是否已经提示过"没请求思考"(一次就够,别每轮都刷)。</summary>
-    private bool _thinkingHintShown;
+    // “本段对话是否已提示过没请求思考”按对话各持一份(见 Conversation):_thinkingHintShown。
 
     /// <summary>
     /// 一整轮下来一点思考都没有,而模型的"思考过程"正是「不请求」时,说明一下为什么。
@@ -1383,13 +1631,13 @@ public partial class ChatPanelView : UserControl
     /// </remarks>
     private void HintIfThinkingWasNeverRequested(AssistantBubble? bubble, ResolvedModel provider)
     {
-        if (_thinkingHintShown || bubble is null || bubble.HasThinking
+        if (ThinkingHintShown || bubble is null || bubble.HasThinking
             || provider.Reasoning != ReasoningLevel.Default)
         {
             return;
         }
-        _thinkingHintShown = true;
-        StatusText.Text = _loc["ReasoningOffHint"];
+        ThinkingHintShown = true;
+        SetStatus(_loc["ReasoningOffHint"]);
     }
 
     private void RenderUpdate(AssistantBubble bubble, ChatResponseUpdate update)
@@ -1539,20 +1787,20 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void StartNewChat()
     {
-        _cts?.Cancel();
-        _history.Clear();
+        Cts?.Cancel();
+        History.Clear();
         ClearQueuedMessages(); // 排着的插话是给上一段对话的,换会话就作废
         MessagesPanel.Children.Clear();
         ResetMessageWindow();
         ResetEditing();
         ResetCompaction();
-        _alwaysApproved.Clear(); // 放行记忆只在同一段对话里有效
+        AlwaysApproved.Clear(); // 放行记忆只在同一段对话里有效
         _pendingApprovals.Clear(); // 连同卡片一起被清出可视树了,名册不能留着
         ResetUsage();
-        _conversationId = ChatHistoryStore.NewConversationId();
-        _thinkingHintShown = false;
-        _conversationStartedAt = DateTimeOffset.UtcNow;
-        _persistedCount = 0;
+        ConversationId = ChatHistoryStore.NewConversationId();
+        ThinkingHintShown = false;
+        ConversationStartedAt = DateTimeOffset.UtcNow;
+        PersistedCount = 0;
         _inputHistoryIndex = -1;
         StatusText.Text = "";
         ClearSuggestions();
@@ -1563,11 +1811,7 @@ public partial class ChatPanelView : UserControl
 
     // ---------- 审批交互 ----------
 
-    /// <summary>
-    /// 本次会话里已被"总是允许"的操作键。只活在内存里 —— 换会话、关面板即失效,
-    /// 不写进配置:一次排查里放行 <c>ls</c>,不代表下次打开还想默认放行。
-    /// </summary>
-    private readonly HashSet<string> _alwaysApproved = [with(StringComparer.Ordinal)];
+    // “总是允许”的操作键按对话各持一份(见 Conversation),只活在内存里:_alwaysApproved。
 
     /// <summary>一张还悬着的审批卡:它请求的是什么,以及怎么替用户按下去。</summary>
     /// <param name="Request">这次请求。</param>
@@ -1585,7 +1829,7 @@ public partial class ChatPanelView : UserControl
 
     private async Task<bool> RequestApprovalAsync(ApprovalRequest request)
     {
-        if (request.RepeatKey is { } key && _alwaysApproved.Contains(key))
+        if (request.RepeatKey is { } key && AlwaysApproved.Contains(key))
         {
             return true;
         }
@@ -1730,7 +1974,7 @@ public partial class ChatPanelView : UserControl
     {
         // 就地抓住"这张卡属于哪条回复":整轮结束后 _activeBubble 会被清掉,
         // 而卡上的按钮此刻可能还活着(用户按了停止、审批却没落定),那时仍要能把芯片撤回去。
-        AssistantBubble? host = _activeBubble;
+        AssistantBubble? host = ActiveBubble;
         var stack = new StackPanel { Spacing = 6 };
         // 头行的盾牌与标题在落定时要换成绿/红,所以两者都留个把手
         Grid header = BuildCardHeader("AiIcon.shield-alert", "VelaWarning",
@@ -1800,7 +2044,7 @@ public partial class ChatPanelView : UserControl
             host?.SetWaitingForApproval(false);
             if (remember && request.RepeatKey is { } key)
             {
-                _alwaysApproved.Add(key);
+                AlwaysApproved.Add(key);
             }
 
             // 落定之后整张卡换成结果态:左边条、盾牌、标题一起转绿(批准)或转红(拒绝)。
@@ -1893,7 +2137,7 @@ public partial class ChatPanelView : UserControl
         actions.Children.Add(IconAction("Icon.pencil", _loc["EditMessage"], () => _ = EditUserMessageAsync(bubble, text)));
         actions.Children.Add(IconAction("Icon.trash-2", _loc["DeleteFromHere"], () => _ = DeleteFromAsync(bubble)));
         // 登记在加进 _history 之前:此刻的 Count 正是这条消息将要落到的下标
-        TrackUserBubble(bubble, _history.Count);
+        TrackUserBubble(bubble, History.Count);
         MessagesPanel.Children.Add(bubble);
     }
 
@@ -1985,7 +2229,7 @@ public partial class ChatPanelView : UserControl
     /// Markdown 段落与工具卡片,末尾是"复制整段 | 时间 · 模型"的元信息条。
     /// 版式对齐 GitHub Copilot 的回复块。
     /// </summary>
-    private sealed class AssistantBubble
+    internal sealed class AssistantBubble
     {
         private readonly ChatPanelView _owner;
         private readonly StackPanel _stack;

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
@@ -136,7 +136,7 @@ public partial class CollaborationView
         kind.Classes.Add("hint");
         Button remove = HostButton(_loc["ChannelRemove"], 64);
 
-        var head = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        var head = new Grid { ColumnDefinitions = [with("*,Auto,Auto")] };
         head.Children.Add(chatId);
         Grid.SetColumn(kind, 1);
         head.Children.Add(kind);

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.axaml.cs
@@ -282,7 +282,7 @@ public partial class CollaborationView : UserControl
         Button test = HostButton(_loc["ChannelTest"], 72);
         Button remove = HostButton(_loc["ChannelRemove"], 72);
         remove.Margin = new Thickness(8, 0, 0, 0);
-        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        var header = new Grid { ColumnDefinitions = [with("*,Auto,Auto")] };
         header.Children.Add(title);
         Grid.SetColumn(test, 1);
         header.Children.Add(test);
@@ -335,7 +335,7 @@ public partial class CollaborationView : UserControl
             port = Field(_loc["ChannelWebhookPort"], config.WebhookPort.ToString(), out StackPanel portPanel);
             path = Field(_loc["ChannelWebhookPath"], config.WebhookPath, out StackPanel pathPanel);
             endpointPanel = new StackPanel();
-            var endpoint = new Grid { ColumnDefinitions = new ColumnDefinitions("*,12,2*") };
+            var endpoint = new Grid { ColumnDefinitions = [with("*,12,2*")] };
             endpoint.Children.Add(portPanel);
             Grid.SetColumn(pathPanel, 2);
             endpoint.Children.Add(pathPanel);
@@ -681,7 +681,7 @@ public partial class CollaborationView : UserControl
         var text = new StackPanel();
         text.Children.Add(title);
         text.Children.Add(id);
-        var grid = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto,Auto") };
+        var grid = new Grid { ColumnDefinitions = [with("*,Auto,Auto")] };
         grid.Children.Add(text);
         Grid.SetColumn(allow, 1);
         grid.Children.Add(allow);

--- a/plugins/VelaShell.Plugin.Ai/Ui/ProviderSetupView.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ProviderSetupView.cs
@@ -247,7 +247,7 @@ public sealed class ProviderSetupView : UserControl
         // 二来按钮坐在行的命中区里,按下会冒泡、抬起才是 Click,天然是个双触发的坑。
         var header = new Grid
         {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
+            ColumnDefinitions = [with("Auto,*,Auto")],
             // 整行都要能点,而不是只有那几个字:Grid 没有背景就不吃命中测试
             Background = Brushes.Transparent,
             Cursor = new Cursor(StandardCursorType.Hand)
@@ -304,10 +304,10 @@ public sealed class ProviderSetupView : UserControl
         => Existing(entry) is { } provider && _connected.Contains(provider.Id);
 
     /// <summary>已登录的供应商 id(<see cref="RefreshStatusAsync" /> 刷新;读机密是异步的,不能在点击路径上现读)。</summary>
-    private readonly HashSet<string> _connected = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _connected = [with(StringComparer.Ordinal)];
 
     /// <summary>已配好 Key 的供应商 id。</summary>
-    private readonly HashSet<string> _keyed = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _keyed = [with(StringComparer.Ordinal)];
 
     private void Collapse()
     {
@@ -626,7 +626,7 @@ public sealed class ProviderSetupView : UserControl
             VerticalAlignment = VerticalAlignment.Center,
             Children = { _primary, _pull, _secondary }
         };
-        var line = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto"), Margin = new Thickness(0, 14, 0, 0) };
+        var line = new Grid { ColumnDefinitions = [with("*,Auto")], Margin = new Thickness(0, 14, 0, 0) };
         Grid.SetColumn(buttons, 1);
         line.Children.Add(_progress);
         line.Children.Add(buttons);
@@ -1129,7 +1129,7 @@ public sealed class ProviderSetupView : UserControl
         eye[!Shape.StrokeProperty] = new DynamicResourceExtension("VelaTextSecondary");
         reveal.Content = new Viewbox { Width = 13, Height = 13, Child = eye };
         reveal.IsCheckedChanged += (_, _) => box.PasswordChar = reveal.IsChecked == true ? '\0' : '●';
-        var grid = new Grid { ColumnDefinitions = new ColumnDefinitions("*,6,Auto") };
+        var grid = new Grid { ColumnDefinitions = [with("*,6,Auto")] };
         Grid.SetColumn(reveal, 2);
         grid.Children.Add(box);
         grid.Children.Add(reveal);

--- a/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginPermissionGate.cs
@@ -56,7 +56,7 @@ public sealed class PluginPermissionGate(IAppDataStore? store, IPluginPermission
     private sealed class Grants(string documentId)
     {
         public string DocumentId { get; } = documentId;
-        public HashSet<string> SessionAllowed { get; } = new(StringComparer.Ordinal);
+        public HashSet<string> SessionAllowed { get; } = [with(StringComparer.Ordinal)];
         public HashSet<string>? AlwaysAllowed { get; set; }
     }
 

--- a/tests/VelaShell.Core.Tests/Models/UiThemeCatalogTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/UiThemeCatalogTests.cs
@@ -24,13 +24,13 @@ public sealed class UiThemeCatalogTests
     [TestMethod]
     public void Catalog_HasUniqueIdsAndNames()
     {
-        Assert.AreEqual(
+        Assert.HasCount(
             UiThemeCatalog.All.Length,
-            UiThemeCatalog.All.Select(theme => theme.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+            UiThemeCatalog.All.Select(theme => theme.Id).Distinct(StringComparer.OrdinalIgnoreCase),
             "主题 Id 会被写进配置文件,重复即意味着有一套主题永远选不中。");
-        Assert.AreEqual(
+        Assert.HasCount(
             UiThemeCatalog.All.Length,
-            UiThemeCatalog.All.Select(theme => theme.Name).Distinct(StringComparer.Ordinal).Count(),
+            UiThemeCatalog.All.Select(theme => theme.Name).Distinct(StringComparer.Ordinal),
             "下拉里出现两个同名主题,用户无从分辨。");
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginProtocolTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginProtocolTests.cs
@@ -121,7 +121,7 @@ public sealed class PluginProtocolTests
 
         Assert.IsEmpty(registry.Tabs);
         Assert.IsFalse(registry.TryGet(ProtocolId, out _));
-        CollectionAssert.Contains(unregistered, ProtocolId);
+        Assert.Contains(ProtocolId, unregistered);
     }
 
     /// <summary>

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
@@ -216,7 +216,7 @@ public sealed class PluginWorkspaceTests
 
         Assert.IsEmpty(registry.Tabs);
         Assert.IsFalse(registry.TryGetWorkspace(WorkspaceId, out _));
-        CollectionAssert.Contains(unregistered, WorkspaceId);
+        Assert.Contains(WorkspaceId, unregistered);
     }
 
     /// <summary>
@@ -249,7 +249,7 @@ public sealed class PluginWorkspaceTests
 
         registry.RegisterWorkspace(PluginId, Descriptor(), new FakeWorkspaceProvider());
 
-        CollectionAssert.Contains(unregistered, WorkspaceId);
+        Assert.Contains(WorkspaceId, unregistered);
     }
 
     /// <summary>注销句柄只撤自己那一份:同 id 被后来者替换过时不能把别人的注册删掉。</summary>

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
@@ -166,11 +166,11 @@ public class SessionRoutingTests
                 new SessionOpenRequest(profile.Id.ToString(), "查磁盘", true), TimeSpan.FromSeconds(5));
             Assert.AreEqual(opened.ToString(), session!.SessionId);
             Assert.AreEqual(SessionState.Connected, session.State);
-            Assert.AreEqual(1, sessions.Count);
+            Assert.HasCount(1, sessions);
 
             await plugin.RequestAsync<object>(PluginRpc.SessionsClose,
                 new SessionRef(session.SessionId), TimeSpan.FromSeconds(5));
-            CollectionAssert.AreEqual(new[] { opened }, opener.Closed);
+            Assert.AreSequenceEqual([opened], opener.Closed);
         }
     }
 

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SessionsCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SessionsCapabilityTests.cs
@@ -119,7 +119,7 @@ public class SessionsCapabilityTests
 
         IReadOnlyList<SavedSessionInfo> saved = await capability.ListSavedAsync();
 
-        Assert.AreEqual(1, saved.Count);
+        Assert.HasCount(1, saved);
         Assert.AreEqual(ssh.Id.ToString(), saved[0].SavedSessionId);
     }
 
@@ -223,7 +223,7 @@ public class SessionsCapabilityTests
         await capability.OpenAsync(profile.Id.ToString(), new("查磁盘", ReuseConnected: false));
 
         Assert.AreEqual(1, opener.Calls);
-        Assert.AreEqual(2, sessions.Count);
+        Assert.HasCount(2, sessions);
     }
 
     [TestMethod]
@@ -238,7 +238,7 @@ public class SessionsCapabilityTests
         SessionInfo session = await capability.OpenAsync(profile.Id.ToString(), new("查磁盘"));
         await capability.CloseAsync(session.SessionId);
 
-        CollectionAssert.AreEqual(new[] { opened }, opener.Closed);
+        Assert.AreSequenceEqual([opened], opener.Closed);
     }
 
     /// <summary>
@@ -259,7 +259,7 @@ public class SessionsCapabilityTests
 
         await Assert.ThrowsExactlyAsync<PluginPermissionDeniedException>(() => capability.CloseAsync(reused.SessionId));
         Assert.IsEmpty(opener.Closed);
-        Assert.AreEqual(1, sessions.Count, "用户的会话必须原封不动");
+        Assert.HasCount(1, sessions, "用户的会话必须原封不动");
     }
 
     /// <summary>会话已经不在了(用户先手动关了)不算错:此方法幂等。</summary>

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeAgentRunnerTests.cs
@@ -81,7 +81,7 @@ public sealed class BridgeAgentRunnerTests
             () => runner.RunAsync(conversation, bridge, Message(), Deny, English, null, null, CancellationToken.None));
 
         // 报错里带着模型名 = 它确实读到了刚写进去的那份设置
-        StringAssert.Contains(error.Message, "Local / probe");
+        Assert.Contains("Local / probe", error.Message);
     }
 
     /// <summary>

--- a/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/BridgeRouterTests.cs
@@ -126,9 +126,9 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("hello", chatId: "chat-stranger");
 
-        Assert.AreEqual(1, harness.Channel.Sent.Count);
-        StringAssert.Contains(harness.Channel.Sent[0], "chat-stranger");
-        StringAssert.Contains(harness.Channel.Sent[0], "not authorised");
+        Assert.HasCount(1, harness.Channel.Sent);
+        Assert.Contains("chat-stranger", harness.Channel.Sent[0]);
+        Assert.Contains("not authorised", harness.Channel.Sent[0]);
     }
 
     /// <summary>同一个陌生聊天只提示一次,不然它每说一句我们就刷一条。</summary>
@@ -141,7 +141,7 @@ public sealed class BridgeRouterTests
         await harness.SendAsync("hello", chatId: "chat-stranger");
         await harness.SendAsync("anyone there?", chatId: "chat-stranger");
 
-        Assert.AreEqual(1, harness.Channel.Sent.Count);
+        Assert.HasCount(1, harness.Channel.Sent);
     }
 
     /// <summary>群里没 @ 就当没听见 —— 机器人不该插进同事之间的正常对话。</summary>
@@ -153,7 +153,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("we should restart nginx", isGroup: true, mentions: false);
 
-        Assert.AreEqual(0, harness.Channel.Sent.Count);
+        Assert.IsEmpty(harness.Channel.Sent);
     }
 
     [TestMethod]
@@ -165,7 +165,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/sessions");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "root@prod-1:22");
+        Assert.Contains("root@prod-1:22", harness.Channel.Sent.Single());
     }
 
     [TestMethod]
@@ -177,7 +177,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/use root@prod-1:22");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "root@prod-1:22");
+        Assert.Contains("root@prod-1:22", harness.Channel.Sent.Single());
         BridgeSettings stored = await harness.Store.LoadAsync();
         Assert.AreEqual("root@prod-1:22", stored.ChatBindings["ch1/chat-1"]);
     }
@@ -190,7 +190,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/use root@nowhere:22");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "No connected session matches");
+        Assert.Contains("No connected session matches", harness.Channel.Sent.Single());
     }
 
     // ---- 会话范围授权 ----
@@ -228,7 +228,7 @@ public sealed class BridgeRouterTests
         await harness.SendAsync("/sessions", isGroup: true);
 
         string reply = harness.Channel.Sent.Single();
-        StringAssert.Contains(reply, "root@prod-1:22");
+        Assert.Contains("root@prod-1:22", reply);
         Assert.IsFalse(reply.Contains("test-1", StringComparison.Ordinal), "范围外的机器不该出现在清单里");
     }
 
@@ -250,7 +250,7 @@ public sealed class BridgeRouterTests
         await harness.SendAsync("/use root@test-1:22", isGroup: true);
 
         string reply = harness.Channel.Sent.Single();
-        StringAssert.Contains(reply, "No connected session matches");
+        Assert.Contains("No connected session matches", reply);
         BridgeSettings stored = await harness.Store.LoadAsync();
         Assert.IsFalse(stored.ChatBindings.ContainsKey("ch1/chat-1"), "越界的绑定不该被记下来");
     }
@@ -271,8 +271,8 @@ public sealed class BridgeRouterTests
         await harness.SendAsync("/help", isGroup: true);
 
         string reply = harness.Channel.Sent.Single();
-        StringAssert.Contains(reply, "生产");          // 范围
-        StringAssert.Contains(reply, "/sessions");     // 命令表
+        Assert.Contains("生产", reply);          // 范围
+        Assert.Contains("/sessions", reply);     // 命令表
     }
 
     /// <summary>刚被放行的人应当收到一条欢迎语,而不是自己去猜命令名。</summary>
@@ -286,8 +286,8 @@ public sealed class BridgeRouterTests
         await harness.SendAsync($"/pair {code}", chatId: "chat-new");
 
         // 一条"配对成功",紧跟一条欢迎语
-        Assert.AreEqual(2, harness.Channel.Sent.Count);
-        StringAssert.Contains(harness.Channel.Sent[1], "/sessions");
+        Assert.HasCount(2, harness.Channel.Sent);
+        Assert.Contains("/sessions", harness.Channel.Sent[1]);
     }
 
     /// <summary><c>/status</c> 要把范围报出来 —— 不然人只能靠撞墙才知道自己受限。</summary>
@@ -299,7 +299,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/status", isGroup: true);
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "生产");
+        Assert.Contains("生产", harness.Channel.Sent.Single());
     }
 
     /// <summary>
@@ -327,7 +327,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/mode agent");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "turned off");
+        Assert.Contains("turned off", harness.Channel.Sent.Single());
     }
 
     /// <summary>
@@ -346,8 +346,8 @@ public sealed class BridgeRouterTests
         await harness.SendAsync("/sessions");
 
         string reply = harness.Channel.Sent.Single();
-        StringAssert.Contains(reply, "root@test-1:22");
-        StringAssert.Contains(reply, "root@adhoc:22");
+        Assert.Contains("root@test-1:22", reply);
+        Assert.Contains("root@adhoc:22", reply);
     }
 
     /// <summary>
@@ -362,7 +362,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/mode agent");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "turned off");
+        Assert.Contains("turned off", harness.Channel.Sent.Single());
     }
 
     [TestMethod]
@@ -380,7 +380,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/mode agent");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "Agent");
+        Assert.Contains("Agent", harness.Channel.Sent.Single());
     }
 
     /// <summary>往低了换永远允许 —— 收紧权限不该需要谁批准。</summary>
@@ -392,7 +392,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/mode chat");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "Chat");
+        Assert.Contains("Chat", harness.Channel.Sent.Single());
     }
 
     [TestMethod]
@@ -403,7 +403,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/help");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "/sessions");
+        Assert.Contains("/sessions", harness.Channel.Sent.Single());
     }
 
     /// <summary>用户白名单非空时,名单外的人说话一律不理(连提示都不给 —— 他不是配置者)。</summary>
@@ -420,7 +420,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/help");
 
-        Assert.AreEqual(0, harness.Channel.Sent.Count);
+        Assert.IsEmpty(harness.Channel.Sent);
     }
 
     /// <summary>
@@ -435,14 +435,14 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync($"/pair {code}", chatId: "chat-new");
 
-        StringAssert.Contains(harness.Channel.Sent[0], "Paired");
+        Assert.Contains("Paired", harness.Channel.Sent[0]);
         // 内存里立刻生效:紧接着的一句话不该再被当成陌生人
         harness.Channel.Sent.Clear();
         await harness.SendAsync("/help", chatId: "chat-new");
-        StringAssert.Contains(harness.Channel.Sent.Single(), "/sessions");
+        Assert.Contains("/sessions", harness.Channel.Sent.Single());
         // 而且落了盘,重启之后还在
         BridgeSettings stored = await harness.Store.LoadAsync();
-        CollectionAssert.Contains(stored.Channels.Single().AllowedChats, "chat-new");
+        Assert.Contains("chat-new", stored.Channels.Single().AllowedChats);
     }
 
     [TestMethod]
@@ -455,11 +455,11 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync($"/pair {wrong}", chatId: "chat-new");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "not valid");
+        Assert.Contains("not valid", harness.Channel.Sent.Single());
         BridgeSettings stored = await harness.Store.LoadAsync();
         // 白名单里仍旧只有一开始那条,陌生聊天没被放进去
-        CollectionAssert.DoesNotContain(stored.Channels.Single().AllowedChats, "chat-new");
-        Assert.AreEqual(1, stored.Channels.Single().AllowedChats.Count);
+        Assert.DoesNotContain("chat-new", stored.Channels.Single().AllowedChats);
+        Assert.HasCount(1, stored.Channels.Single().AllowedChats);
     }
 
     /// <summary>没生成过码的时候,任何 /pair 都不该放行。</summary>
@@ -471,7 +471,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/pair 123456", chatId: "chat-new");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "not valid");
+        Assert.Contains("not valid", harness.Channel.Sent.Single());
     }
 
     [TestMethod]
@@ -482,7 +482,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync("/pair", chatId: "chat-new");
 
-        StringAssert.Contains(harness.Channel.Sent.Single(), "Usage");
+        Assert.Contains("Usage", harness.Channel.Sent.Single());
     }
 
     /// <summary>敲过门的聊天要被记下来,设置页那个「允许」按钮才有东西可点。</summary>
@@ -510,7 +510,7 @@ public sealed class BridgeRouterTests
 
         await harness.SendAsync($"/pair {code}", chatId: "chat-new");
 
-        Assert.AreEqual(0, harness.Pairing.Pending().Count);
+        Assert.IsEmpty(harness.Pairing.Pending());
     }
 }
 
@@ -562,7 +562,7 @@ public sealed class SessionTargetsTests
 
         string text = await SessionTargets.DescribeAsync(context, CancellationToken.None);
 
-        StringAssert.Contains(text, "root@prod-1:22");
-        StringAssert.Contains(text, "deploy@db-2:22");
+        Assert.Contains("root@prod-1:22", text);
+        Assert.Contains("deploy@db-2:22", text);
     }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Sessions.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Sessions.cs
@@ -1,0 +1,104 @@
+using Avalonia.Controls;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// 顶栏会话下拉的两条新行为:一是显示<b>连接的名字</b>而不是 user@host;
+/// 二是每台机器各持一份对话 —— 切下拉即换那份的消息面板,切回来还是原来那一份(状态不丢、不串台)。
+/// </summary>
+public sealed partial class ChatPanelViewUiTests
+{
+    [TestMethod]
+    public void SessionCombo_ShowsConnectionName_NotIp()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            // 已保存配置里给这台机器起了名;在途会话本身只带 主机/端口/用户。
+            context.FakeSessions.AddSaved(name: "我的生产机", host: "10.0.0.1", username: "root");
+            context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root");
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                ComboBox combo = Find<ComboBox>(panel, "SessionCombo");
+                List<SessionNavItem> items = [.. combo.ItemsSource!.Cast<SessionNavItem>()];
+                Assert.HasCount(1, items);
+                Assert.AreEqual("我的生产机", items[0].Text, "下拉该显示连接名,而不是 root@10.0.0.1");
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [TestMethod]
+    public void SessionCombo_FallsBackToUserAtHost_WhenNoSavedName()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            // 没有对得上的已保存配置(临时会话):退回 user@host,总有个能认的落点。
+            context.FakeSessions.AddConnected(host: "10.0.0.9", username: "root");
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                ComboBox combo = Find<ComboBox>(panel, "SessionCombo");
+                List<SessionNavItem> items = [.. combo.ItemsSource!.Cast<SessionNavItem>()];
+                Assert.HasCount(1, items);
+                Assert.AreEqual("root@10.0.0.9", items[0].Text);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [TestMethod]
+    public void SwitchingSession_SwapsConversationPanel_AndPreservesState()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            context.FakeSessions.AddConnected(host: "10.0.0.1", username: "root"); // A(下拉第 0 项)
+            context.FakeSessions.AddConnected(host: "10.0.0.2", username: "root"); // B(下拉第 1 项)
+
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                ScrollViewer scroll = Find<ScrollViewer>(panel, "ChatScroll");
+                ComboBox combo = Find<ComboBox>(panel, "SessionCombo");
+
+                // 初始选中第 0 台(A):记下它的消息面板,并在里面放一枚标记,模拟"A 里已经聊了内容"。
+                var panelA = (StackPanel)scroll.Content!;
+                panelA.Children.Add(new TextBlock { Text = "marker-A" });
+
+                // 切到 B:消息面板应换成另一条(A 的内容不该出现在 B 里 —— 不串台)。
+                combo.SelectedIndex = 1;
+                await PumpAsync();
+                var panelB = (StackPanel)scroll.Content!;
+                Assert.AreNotSame(panelA, panelB, "每台机器各有自己的消息面板");
+                Assert.DoesNotContain(
+                    t => t.Text == "marker-A", panelB.Children.OfType<TextBlock>(),
+                    "B 的面板里不该看到 A 的内容");
+
+                // 切回 A:应回到<b>同一条</b>面板,里面的标记还在(状态没丢)。
+                combo.SelectedIndex = 0;
+                await PumpAsync();
+                Assert.AreSame(panelA, scroll.Content, "切回同一台机器要回到同一份对话面板");
+                Assert.Contains(
+                    t => t.Text == "marker-A", panelA.Children.OfType<TextBlock>(),
+                    "切走再切回,A 里的内容应原样还在");
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+}

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.cs
@@ -64,7 +64,11 @@ public sealed partial class ChatPanelViewUiTests
     }
 
     private static T Find<T>(ChatPanelView panel, string name) where T : Control
-        => panel.GetControl<T>(name);
+        // 消息流现在按对话各持一条 StackPanel,当前那条挂在 ChatScroll.Content 上(不再有静态 x:Name)——
+        // "MessagesPanel" 就解析成当前显示这份对话的那条面板(见 ChatPanelView.SwitchConversation)。
+        => name == "MessagesPanel"
+            ? (T)(object)(StackPanel)panel.GetControl<ScrollViewer>("ChatScroll").Content!
+            : panel.GetControl<T>(name);
 
     /// <summary>
     /// 在 headless UI 线程上跑一段<b>异步</b>测试体,并把里面的异常/断言失败带回本线程。

--- a/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/CollaborationViewUiTests.cs
@@ -149,13 +149,13 @@ public sealed class CollaborationViewUiTests
                     .. view.GetLogicalDescendants().OfType<Button>().Where(b => b is not ToggleButton)
                 ];
 
-                Assert.IsTrue(buttons.Length >= 8, $"expected the whole page, only found {buttons.Length} buttons");
+                Assert.IsGreaterThanOrEqualTo(8, buttons.Length, $"expected the whole page, only found {buttons.Length} buttons");
                 string[] offenders =
                 [
                     .. buttons.Where(b => b.HorizontalContentAlignment != HorizontalAlignment.Center)
                               .Select(b => $"{b.Name ?? "(code-built)"}:{b.Content}")
                 ];
-                Assert.AreEqual(0, offenders.Length,
+                Assert.IsEmpty(offenders,
                     "these buttons render their label off-centre: " + string.Join(", ", offenders));
             }, bridge);
         });
@@ -175,9 +175,9 @@ public sealed class CollaborationViewUiTests
             {
                 string sample = view.FindControl<TextBox>("McpCommandBox")!.Text ?? "";
 
-                StringAssert.Contains(sample, "http://127.0.0.1:9123/mcp");
-                StringAssert.Contains(sample, token);
-                StringAssert.Contains(sample, "claude mcp add --transport http");
+                Assert.Contains("http://127.0.0.1:9123/mcp", sample);
+                Assert.Contains(token, sample);
+                Assert.Contains("claude mcp add --transport http", sample);
                 return Task.CompletedTask;
             });
         });
@@ -206,7 +206,7 @@ public sealed class CollaborationViewUiTests
                 var panel = view.FindControl<StackPanel>("ChannelsPanel")!;
                 Assert.AreEqual(1, panel.Children.Count);
                 TextBox[] boxes = [.. panel.GetLogicalDescendants().OfType<TextBox>()];
-                Assert.IsTrue(boxes.Any(b => b.Text == "cli_abc"), "the App ID should be shown");
+                Assert.Contains(b => b.Text == "cli_abc", boxes, "the App ID should be shown");
                 TextBox? secret = boxes.FirstOrDefault(b => b.Text == "s3cret");
                 Assert.IsNotNull(secret, "the stored secret should be loaded back");
                 Assert.AreEqual('●', secret.PasswordChar);
@@ -235,8 +235,8 @@ public sealed class CollaborationViewUiTests
                     .. view.FindControl<StackPanel>("ChannelsPanel")!
                            .GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")
                 ];
-                CollectionAssert.Contains(labels, "Bot Token");
-                CollectionAssert.DoesNotContain(labels, "App ID");
+                Assert.Contains("Bot Token", labels);
+                Assert.DoesNotContain("App ID", labels);
                 return Task.CompletedTask;
             });
         });
@@ -257,7 +257,7 @@ public sealed class CollaborationViewUiTests
 
                 string shown = view.FindControl<TextBlock>("PairCodeText")!.Text ?? "";
                 Assert.IsNotNull(bridge.Pairing.Code);
-                StringAssert.Contains(shown, bridge.Pairing.Code!);
+                Assert.Contains(bridge.Pairing.Code!, shown);
             }, bridge);
         });
     }
@@ -274,7 +274,7 @@ public sealed class CollaborationViewUiTests
                 view.FindControl<Button>("IssuePairSelfButton")!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                 await PumpAsync();
 
-                StringAssert.Contains(view.FindControl<TextBlock>("StatusText")!.Text ?? "", "bridge on");
+                Assert.Contains("bridge on", view.FindControl<TextBlock>("StatusText")!.Text ?? "");
             });
         });
     }
@@ -323,10 +323,10 @@ public sealed class CollaborationViewUiTests
             ChannelConfig saved = (await store.LoadAsync()).Channels.Single();
             ChatGrant grant = saved.GrantFor("oc_1")!;
             Assert.AreEqual(ScopeKind.Limited, grant.Scope.Kind);
-            CollectionAssert.Contains(grant.Scope.Groups, "生产");
+            Assert.Contains("生产", grant.Scope.Groups);
             Assert.AreEqual(ChatMode.Plan, grant.Mode);
             // 派生镜像也要跟着对:降级回旧版本时白名单还得在
-            CollectionAssert.Contains(saved.AllowedChats, "oc_1");
+            Assert.Contains("oc_1", saved.AllowedChats);
         });
     }
 
@@ -361,7 +361,7 @@ public sealed class CollaborationViewUiTests
                 ChatGrant? template = bridge.Pairing.Template;
                 Assert.IsNotNull(template);
                 Assert.AreEqual(ScopeKind.Limited, template.Scope.Kind);
-                CollectionAssert.Contains(template.Scope.Groups, "生产");
+                Assert.Contains("生产", template.Scope.Groups);
             }, bridge);
         });
     }
@@ -382,9 +382,9 @@ public sealed class CollaborationViewUiTests
                 var panel = view.FindControl<StackPanel>("PendingPanel")!;
                 Assert.AreEqual(1, panel.Children.Count);
                 string[] text = [.. panel.GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text ?? "")];
-                CollectionAssert.Contains(text, "oc_abc");
-                Assert.IsTrue(text.Any(t => t.Contains("Ann")), "the row should say who knocked");
-                Assert.IsTrue(panel.GetLogicalDescendants().OfType<Button>().Any(b => (string?)b.Content == "Allow"));
+                Assert.Contains("oc_abc", text);
+                Assert.Contains(t => t.Contains("Ann"), text, "the row should say who knocked");
+                Assert.Contains(b => (string?)b.Content == "Allow", panel.GetLogicalDescendants().OfType<Button>());
             }, bridge);
         });
     }

--- a/tests/VelaShell.Plugin.Ai.Tests/EndpointModelCatalogTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/EndpointModelCatalogTests.cs
@@ -123,7 +123,7 @@ public sealed class EndpointModelCatalogTests
             ]}
             """);
 
-        CollectionAssert.AreEqual(new[] { "gpt-4o-audio-preview", "gpt-5" }, ids.ToArray());
+        Assert.AreSequenceEqual(["gpt-4o-audio-preview", "gpt-5"], ids.ToArray());
     }
 
     [TestMethod]
@@ -149,7 +149,7 @@ public sealed class EndpointModelCatalogTests
             {"models":[{"name":"llama3.1:8b","size":1},{"name":"qwen3:14b","size":2}]}
             """);
 
-        CollectionAssert.AreEqual(new[] { "llama3.1:8b", "qwen3:14b" }, ids.ToArray());
+        Assert.AreSequenceEqual(["llama3.1:8b", "qwen3:14b"], ids.ToArray());
     }
 
     [TestMethod]
@@ -159,7 +159,7 @@ public sealed class EndpointModelCatalogTests
             {"data":[{"id":"b"},{"id":"a"},{"id":"B"}]}
             """);
 
-        CollectionAssert.AreEqual(new[] { "a", "b" }, ids.ToArray());
+        Assert.AreSequenceEqual(["a", "b"], ids.ToArray());
     }
 
     [TestMethod]

--- a/tests/VelaShell.Plugin.Ai.Tests/FeishuApiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/FeishuApiTests.cs
@@ -28,8 +28,8 @@ public sealed class FeishuApiTests
         string json = JsonSerializer.Serialize(new FeishuApi.EndpointRequest("cli_x", "s3cret"),
             new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
-        StringAssert.Contains(json, "\"AppID\"");
-        StringAssert.Contains(json, "\"AppSecret\"");
+        Assert.Contains("\"AppID\"", json);
+        Assert.Contains("\"AppSecret\"", json);
         Assert.IsFalse(json.Contains("\"appID\"", StringComparison.Ordinal),
             $"the camelCased name is what the platform rejects with code 9499; got {json}");
     }

--- a/tests/VelaShell.Plugin.Ai.Tests/LocTableTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/LocTableTests.cs
@@ -32,7 +32,7 @@ public sealed class LocTableTests
                       .Select(entry => $"{entry.Key} ({entry.Value.Length})")
         ];
 
-        Assert.AreEqual(0, broken.Count,
+        Assert.IsEmpty(broken,
             $"These keys do not have exactly five translations: {string.Join(", ", broken)}");
     }
 
@@ -44,7 +44,7 @@ public sealed class LocTableTests
             .. Table().Where(entry => entry.Value.Any(string.IsNullOrWhiteSpace)).Select(entry => entry.Key)
         ];
 
-        Assert.AreEqual(0, blank.Count, $"These keys have a blank translation: {string.Join(", ", blank)}");
+        Assert.IsEmpty(blank, $"These keys have a blank translation: {string.Join(", ", blank)}");
     }
 
     /// <summary>取词真的跟着语言走(顺序 en / zh-Hans / zh-Hant / ja / ko)。</summary>
@@ -87,7 +87,7 @@ public sealed class LocTableTests
                     .Select(g => $"{g.Key} (×{g.Count()})")
         ];
 
-        Assert.AreEqual(0, duplicates.Count,
+        Assert.IsEmpty(duplicates,
             "these keys are defined more than once; the later one silently wins: " + string.Join(", ", duplicates));
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/McpEndpointTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/McpEndpointTests.cs
@@ -155,10 +155,10 @@ public sealed class McpEndpointTests
                 .. document.RootElement.GetProperty("result").GetProperty("tools")
                            .EnumerateArray().Select(t => t.GetProperty("name").GetString()!)
             ];
-            CollectionAssert.Contains(names, "list_sessions");
-            CollectionAssert.Contains(names, "use_session");
-            CollectionAssert.DoesNotContain(names, "run_command");
-            CollectionAssert.DoesNotContain(names, "write_remote_file");
+            Assert.Contains("list_sessions", names);
+            Assert.Contains("use_session", names);
+            Assert.DoesNotContain("run_command", names);
+            Assert.DoesNotContain("write_remote_file", names);
         }
     }
 
@@ -180,7 +180,7 @@ public sealed class McpEndpointTests
                 .. document.RootElement.GetProperty("result").GetProperty("tools")
                            .EnumerateArray().Select(t => t.GetProperty("name").GetString()!)
             ];
-            CollectionAssert.Contains(names, "run_command");
+            Assert.Contains("run_command", names);
         }
     }
 
@@ -206,7 +206,7 @@ public sealed class McpEndpointTests
             JsonElement result = document.RootElement.GetProperty("result");
             Assert.IsFalse(result.GetProperty("isError").GetBoolean());
             string text = result.GetProperty("content")[0].GetProperty("text").GetString()!;
-            StringAssert.Contains(text, "prod-1");
+            Assert.Contains("prod-1", text);
         }
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/ModelsDevCatalogTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ModelsDevCatalogTests.cs
@@ -90,8 +90,8 @@ public sealed class ModelsDevCatalogTests
         Dictionary<string, List<ModelSpec>> reloaded =
             ModelsDevCatalog.Parse(ModelsDevCatalog.Serialize(upstream));
 
-        CollectionAssert.AreEqual(upstream["openai"], reloaded["openai"]);
-        CollectionAssert.AreEqual(upstream["ollama"], reloaded["ollama"]);
+        Assert.AreSequenceEqual(upstream["openai"], reloaded["openai"]);
+        Assert.AreSequenceEqual(upstream["ollama"], reloaded["ollama"]);
     }
 
     [TestMethod]
@@ -172,14 +172,14 @@ public sealed class ModelsDevCatalogTests
         // 线上有两百来个标了 deprecated 的;摆出来只会让人选中一个已经用不了的型号
         List<ModelSpec> models = ModelsDevCatalog.Parse(NoisyShape)["openai"];
 
-        Assert.IsFalse(models.Any(m => m.Id == "gpt-4-turbo"), "已下架的不该出现");
+        Assert.DoesNotContain(m => m.Id == "gpt-4-turbo", models, "已下架的不该出现");
     }
 
     [TestMethod]
     public void Parse_KeepsBetaModels()
     {
         // beta 是能用的,别跟着 deprecated 一起筛掉
-        Assert.IsTrue(ModelsDevCatalog.Parse(NoisyShape)["openai"].Any(m => m.Id == "gpt-5.6-beta"));
+        Assert.Contains(m => m.Id == "gpt-5.6-beta", ModelsDevCatalog.Parse(NoisyShape)["openai"]);
     }
 
     [TestMethod]
@@ -188,14 +188,14 @@ public sealed class ModelsDevCatalogTests
         List<ModelSpec> models = ModelsDevCatalog.Parse(NoisyShape)["openai"];
 
         // 画图那类根本不产出 token
-        Assert.IsFalse(models.Any(m => m.Id == "gpt-image-2"));
+        Assert.DoesNotContain(m => m.Id == "gpt-image-2", models);
         // 向量模型:它那个 output 填的是维度不是 token 数,只能靠名字认
-        Assert.IsFalse(models.Any(m => m.Id == "text-embedding-3-small"));
+        Assert.DoesNotContain(m => m.Id == "text-embedding-3-small", models);
     }
 
     [TestMethod]
     public void Parse_KeepsTheOrdinaryChatModels()
-        => Assert.IsTrue(ModelsDevCatalog.Parse(NoisyShape)["openai"].Any(m => m.Id == "gpt-5"));
+        => Assert.Contains(m => m.Id == "gpt-5", ModelsDevCatalog.Parse(NoisyShape)["openai"]);
 
     [TestMethod]
     public void SlimCache_SurvivesTheFilterOnReload()
@@ -205,7 +205,7 @@ public sealed class ModelsDevCatalogTests
         Dictionary<string, List<ModelSpec>> reloaded =
             ModelsDevCatalog.Parse(ModelsDevCatalog.Serialize(first));
 
-        CollectionAssert.AreEqual(first["openai"], reloaded["openai"]);
+        Assert.AreSequenceEqual(first["openai"], reloaded["openai"]);
     }
 
     // ---- 落成真正可选的模型 ----
@@ -222,9 +222,8 @@ public sealed class ModelsDevCatalogTests
 
         Assert.AreEqual(2, total);
         Assert.HasCount(2, provider.Models);
-        CollectionAssert.AreEquivalent(
-            new[] { "gpt-5", "gpt-5.3-codex" },
-            provider.Models.Select(m => m.Model).ToArray());
+        Assert.AreSequenceEqual(
+            ["gpt-5", "gpt-5.3-codex"], provider.Models.Select(m => m.Model).ToArray(), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         // 顺带把规格填好,不是光加一行空模型
         AiModelConfig codex = provider.Models.First(m => m.Model == "gpt-5.3-codex");
         Assert.AreEqual(400000, codex.MaxInputTokens);
@@ -302,8 +301,8 @@ public sealed class ModelsDevCatalogTests
 
         List<ResolvedModel> resolved = settings.ResolveModels();
         Assert.HasCount(2, resolved);
-        CollectionAssert.AreEquivalent(
-            new[] { "gpt-5", "gpt-5.3-codex" }, resolved.Select(r => r.Model).ToArray());
+        Assert.AreSequenceEqual(
+            ["gpt-5", "gpt-5.3-codex"], resolved.Select(r => r.Model).ToArray(), Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
     }
 
     // ---- 默认模型的选法 ----

--- a/tests/VelaShell.Plugin.Ai.Tests/OAuthClientTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/OAuthClientTests.cs
@@ -284,9 +284,8 @@ public sealed class OAuthClientTests
         Assert.AreEqual(TimeSpan.FromSeconds(2), grant.Interval);
         Assert.AreEqual("at-device", tokens.AccessToken);
         // 服务端喊 slow_down 之后,间隔必须真的加上去,否则会一直被限速
-        CollectionAssert.AreEqual(
-            new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(7) },
-            waits);
+        Assert.AreSequenceEqual(
+            [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(7)], waits);
         Dictionary<string, string> poll = Query(stub.Requests[1].Body);
         Assert.AreEqual("urn:ietf:params:oauth:grant-type:device_code", poll["grant_type"]);
         Assert.AreEqual("dc", poll["device_code"]);

--- a/tests/VelaShell.Plugin.Ai.Tests/OpencodeProvidersTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/OpencodeProvidersTests.cs
@@ -184,7 +184,7 @@ public sealed class OpencodeProvidersTests
 
         Assert.AreEqual("do-tok", tokens.AccessToken);
         Assert.IsEmpty(tokens.RefreshToken ?? "", "隐式流不发 refresh token,过期只能重登");
-        Assert.AreEqual(0, stub.Requests.Count, "这一路不该有任何 token 交换");
+        Assert.IsEmpty(stub.Requests, "这一路不该有任何 token 交换");
     }
 
     // ---- 目录整体 ----

--- a/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/PairingTests.cs
@@ -97,7 +97,7 @@ public sealed class PairingServiceTests
 
         IReadOnlyList<PendingChat> pending = pairing.Pending();
 
-        Assert.AreEqual(2, pending.Count);
+        Assert.HasCount(2, pending);
         Assert.AreEqual("b", pending[0].ChatId);
         Assert.AreEqual("Cara", pending.Single(p => p.ChatId == "a").UserName);
     }
@@ -110,6 +110,6 @@ public sealed class PairingServiceTests
 
         pairing.Forget("ch1", "a");
 
-        Assert.AreEqual(0, pairing.Pending().Count);
+        Assert.IsEmpty(pairing.Pending());
     }
 }

--- a/tests/VelaShell.Plugin.Ai.Tests/Pbbp2Tests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/Pbbp2Tests.cs
@@ -69,8 +69,8 @@ public sealed class Pbbp2Tests
 
         Assert.AreEqual(Pbbp2.FrameTypeControl, decoded.Method);
         Assert.AreEqual("ping", decoded.Header(Pbbp2.HeaderNames.Type));
-        Assert.AreEqual(0, decoded.Payload.Length);
-        Assert.AreEqual(1, decoded.Headers.Count);
+        Assert.IsEmpty(decoded.Payload);
+        Assert.HasCount(1, decoded.Headers);
     }
 
     /// <summary>同名头只留最后一份 —— 应答帧会重复设 biz_rt,不能越堆越多。</summary>
@@ -81,7 +81,7 @@ public sealed class Pbbp2Tests
         frame.SetHeader(Pbbp2.HeaderNames.BizRt, "10");
         frame.SetHeader(Pbbp2.HeaderNames.BizRt, "20");
 
-        Assert.AreEqual(1, frame.Headers.Count);
+        Assert.HasCount(1, frame.Headers);
         Assert.AreEqual("20", frame.Header(Pbbp2.HeaderNames.BizRt));
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/ProviderSetupViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ProviderSetupViewUiTests.cs
@@ -259,7 +259,7 @@ public sealed class ProviderSetupViewUiTests
                 await ShowAsync(context, focus: "deepseek");
             try
             {
-                CollectionAssert.AreEqual(new[] { "SetupKeyBox" }, VisibleBoxes(view));
+                Assert.AreSequenceEqual(["SetupKeyBox"], VisibleBoxes(view));
 
                 Find<TextBox>(view, "SetupKeyBox").Text = "sk-deepseek";
                 Click(Find<Button>(view, "SetupPrimaryButton"));
@@ -289,15 +289,15 @@ public sealed class ProviderSetupViewUiTests
             (Window window, ProviderSetupView view, _, _) = await ShowAsync(context, focus: "anthropic");
             try
             {
-                CollectionAssert.AreEqual(new[] { "SetupKeyBox" }, VisibleBoxes(view));
+                Assert.AreSequenceEqual(["SetupKeyBox"], VisibleBoxes(view));
 
                 Find<ToggleButton>(view, "SetupAdvancedToggle").IsChecked = true;
                 await PumpAsync();
 
                 List<string> boxes = VisibleBoxes(view);
-                CollectionAssert.Contains(boxes, "SetupNameBox");
-                CollectionAssert.Contains(boxes, "SetupModelBox");
-                CollectionAssert.Contains(boxes, "SetupBaseUrlBox");
+                Assert.Contains("SetupNameBox", boxes);
+                Assert.Contains("SetupModelBox", boxes);
+                Assert.Contains("SetupBaseUrlBox", boxes);
                 Assert.AreEqual("https://api.anthropic.com", Find<TextBox>(view, "SetupBaseUrlBox").Text);
             }
             finally
@@ -319,10 +319,9 @@ public sealed class ProviderSetupViewUiTests
             {
                 Assert.AreEqual("", ProviderCatalog.Find("huggingface")!.CreateProvider().OAuth!.ClientId,
                     "这条用例的前提是客户端 id 还空着;填上之后请把它挪到一键登录那条用例");
-                CollectionAssert.AreEqual(new[] { "SetupClientIdBox" }, VisibleBoxes(view));
-                Assert.IsTrue(
-                    view.GetLogicalDescendants().OfType<Button>()
-                        .Any(b => (string?)b.Content == "Open the registration page"),
+                Assert.AreSequenceEqual(["SetupClientIdBox"], VisibleBoxes(view));
+                Assert.Contains(
+                    b => (string?)b.Content == "Open the registration page", view.GetLogicalDescendants().OfType<Button>(),
                     "空着的客户端 id 旁边必须有去注册的入口");
 
                 Click(Find<Button>(view, "SetupPrimaryButton"));
@@ -348,8 +347,8 @@ public sealed class ProviderSetupViewUiTests
             try
             {
                 List<string> boxes = VisibleBoxes(view);
-                CollectionAssert.Contains(boxes, "SetupClientIdBox");
-                CollectionAssert.Contains(boxes, "SetupBaseUrlBox");
+                Assert.Contains("SetupClientIdBox", boxes);
+                Assert.Contains("SetupBaseUrlBox", boxes);
                 // 占位符不能当默认值端上来 —— 用户十有八九连尖括号一起提交
                 Assert.AreEqual("", Find<TextBox>(view, "SetupBaseUrlBox").Text);
             }
@@ -402,7 +401,7 @@ public sealed class ProviderSetupViewUiTests
                 await PumpAsync();
 
                 var picker = Find<ComboBox>(view, "SetupModelPicker");
-                CollectionAssert.AreEqual(groq.AvailableModels, (System.Collections.ICollection)picker.ItemsSource!);
+                Assert.AreSequenceEqual(groq.AvailableModels, (System.Collections.ICollection)picker.ItemsSource!);
                 // 出厂示例正好在列表里,应当已经选中
                 Assert.AreEqual("llama-3.3-70b-versatile", picker.SelectedItem);
 

--- a/tests/VelaShell.Plugin.Ai.Tests/QrCodeTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/QrCodeTests.cs
@@ -63,8 +63,8 @@ public sealed class QrCodeTests
         {
             for (int version = 2; version <= 40; version++)
             {
-                Assert.IsTrue(
-                    CapacityBytes(version, ecc) > CapacityBytes(version - 1, ecc),
+                Assert.IsGreaterThan(
+                    CapacityBytes(version - 1, ecc), CapacityBytes(version, ecc),
                     $"{ecc} 档:版本 {version} 的容量没有比 {version - 1} 大 —— 容量表抄错了");
             }
         }

--- a/tests/VelaShell.Plugin.Ai.Tests/ResponsesWireTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ResponsesWireTests.cs
@@ -123,12 +123,13 @@ public sealed class ResponsesWireTests
     /// Codex 后端接受的<b>全部</b>顶层字段,取自它自己的请求结构
     /// (<c>openai/codex</c> 的 <c>codex-rs/core/src/client.rs</c>,<c>ResponsesApiRequest</c>)。
     /// </summary>
-    private static readonly HashSet<string> CodexAcceptedFields = new(StringComparer.Ordinal)
-    {
+    private static readonly HashSet<string> CodexAcceptedFields =
+    [
+        with(StringComparer.Ordinal),
         "model", "instructions", "input", "tools", "tool_choice", "parallel_tool_calls",
         "reasoning", "store", "stream", "stream_options", "include", "service_tier",
         "prompt_cache_key", "text", "client_metadata", "access_programs"
-    };
+    ];
 
     /// <summary>
     /// 发出去的报文里<b>不能有</b>它清单之外的字段。
@@ -164,7 +165,7 @@ public sealed class ResponsesWireTests
 
         string body = await WireBodyAsync(messages, options);
 
-        using JsonDocument document = JsonDocument.Parse(body);
+        using var document = JsonDocument.Parse(body);
         List<string> unexpected = [.. document.RootElement.EnumerateObject()
             .Select(p => p.Name)
             .Where(name => !CodexAcceptedFields.Contains(name))];

--- a/tests/VelaShell.Plugin.Ai.Tests/SendFileToolTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SendFileToolTests.cs
@@ -48,7 +48,7 @@ public sealed class SendFileToolTests
         string result = await InvokeAsync(WithSink(context, sent), path);
 
         Assert.Contains("Sent", result);
-        CollectionAssert.Contains(sent, path);
+        Assert.Contains(path, sent);
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ public sealed class SendFileToolTests
         string[] names = [.. new AgentToolbox(context).CreateTools(ChatMode.Agent)
             .OfType<AIFunction>().Select(f => f.Name)];
 
-        CollectionAssert.DoesNotContain(names, "send_file");
+        Assert.DoesNotContain("send_file", names);
     }
 
     /// <summary>渠道那头失败时,原话回给模型,而不是假装发出去了。</summary>

--- a/tests/VelaShell.Plugin.Ai.Tests/SessionScopeTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SessionScopeTests.cs
@@ -200,7 +200,7 @@ public sealed class SessionScopeTests
 
         config.NormalizeGrants();
 
-        Assert.AreEqual(2, config.Grants.Count);
+        Assert.HasCount(2, config.Grants);
         Assert.IsTrue(config.Grants.All(g => g.Scope.IsUnrestricted));
         Assert.IsTrue(config.Grants.All(g => g.Mode is null && g.Approval is null));
         Assert.IsNotNull(config.GrantFor("chat-1"));
@@ -225,7 +225,7 @@ public sealed class SessionScopeTests
 
         config.NormalizeGrants();
 
-        CollectionAssert.AreEquivalent(new[] { "chat-1", "chat-2" }, config.AllowedChats);
+        Assert.AreSequenceEqual(["chat-1", "chat-2"], config.AllowedChats, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
         // 折算出来的那条不限范围,原来就有的那条保持它自己的范围
         Assert.IsTrue(config.GrantFor("chat-1")!.Scope.IsUnrestricted);
         Assert.IsFalse(config.GrantFor("chat-2")!.Scope.IsUnrestricted);
@@ -241,8 +241,8 @@ public sealed class SessionScopeTests
         config.NormalizeGrants();
         config.NormalizeGrants();
 
-        Assert.AreEqual(1, config.Grants.Count);
-        Assert.AreEqual(1, config.AllowedChats.Count);
+        Assert.HasCount(1, config.Grants);
+        Assert.HasCount(1, config.AllowedChats);
     }
 
     /// <summary>配对码携带的是一份授权,而不是一张通行证。</summary>
@@ -255,7 +255,7 @@ public sealed class SessionScopeTests
         Assert.IsTrue(pairing.TryRedeem(code, out ChatGrant? template));
         Assert.IsNotNull(template);
         Assert.AreEqual(ScopeKind.Limited, template.Scope.Kind);
-        CollectionAssert.Contains(template.Scope.Groups, "生产");
+        Assert.Contains("生产", template.Scope.Groups);
         Assert.AreEqual(Configuration.ChatMode.Plan, template.Mode);
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/SubscriptionProviderTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SubscriptionProviderTests.cs
@@ -64,7 +64,7 @@ public sealed class SubscriptionProviderTests
             }
         }
         // 出厂即可登录的那条要真的存在 —— 否则这个功能对新用户等于不存在
-        Assert.IsTrue(ProviderCatalog.All.Any(e => e.IsSubscription && e.CreateProvider().CanSignIn),
+        Assert.Contains(e => e.IsSubscription && e.CreateProvider().CanSignIn, ProviderCatalog.All,
             "至少要有一家开箱即登的");
     }
 

--- a/tests/VelaShell.Plugin.Ai.Tests/ThemeTokenUsageTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ThemeTokenUsageTests.cs
@@ -95,7 +95,7 @@ public sealed class ThemeTokenUsageTests
     {
         DirectoryInfo root = RepositoryRoot();
         HashSet<string> defined = DefinedKeys(root);
-        Assert.IsTrue(defined.Count > 50, $"only found {defined.Count} defined keys — the scan is probably looking in the wrong place");
+        Assert.IsGreaterThan(50, defined.Count, $"only found {defined.Count} defined keys — the scan is probably looking in the wrong place");
 
         string ui = Path.Combine(root.FullName, "plugins", "VelaShell.Plugin.Ai", "Ui");
         List<string> missing = [];
@@ -111,7 +111,7 @@ public sealed class ThemeTokenUsageTests
             }
         }
 
-        Assert.AreEqual(0, missing.Count,
+        Assert.IsEmpty(missing,
             "these resource keys resolve to nothing at runtime (no error, just no styling): "
             + string.Join(", ", missing.Distinct()));
     }
@@ -148,7 +148,7 @@ public sealed class ThemeTokenUsageTests
                     .Select(e => Regex.Replace(e, @"\s+", " ").Trim())
         ];
 
-        Assert.AreEqual(0, bare.Count,
+        Assert.IsEmpty(bare,
             "these controls carry no host class, so they fall back to the default look "
             + "(and their labels are not centred): " + string.Join(" | ", bare));
     }

--- a/tests/VelaShell.Plugin.Ai.Tests/WeComCryptoTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/WeComCryptoTests.cs
@@ -28,7 +28,7 @@ public sealed class WeComCryptoTests
 
     [TestMethod]
     public void ParseKey_Yields32Bytes()
-        => Assert.AreEqual(32, WeComCrypto.ParseKey(SampleKey).Length);
+        => Assert.HasCount(32, WeComCrypto.ParseKey(SampleKey));
 
     [TestMethod]
     public void ParseKey_RejectsAKeyOfTheWrongLength()

--- a/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
@@ -38,7 +38,7 @@ public sealed class ThemeTokenApplierTests
                     .Where(key => key != "VelaShadowWindow")
                     .Order(StringComparer.Ordinal),
             ];
-            CollectionAssert.AreEqual(expected, actual, $"{theme.Name} 写出的令牌集合与其它主题不一致。");
+            Assert.AreSequenceEqual(expected, actual, $"{theme.Name} 写出的令牌集合与其它主题不一致。");
             Assert.IsTrue(resources.ContainsKey("VelaShadowWindow"), $"{theme.Name} 少了浮层投影令牌。");
         }
     }

--- a/tests/VelaShell.Tests/Views/ThemeTokenShadowingUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ThemeTokenShadowingUiTests.cs
@@ -109,7 +109,7 @@ public sealed class ThemeTokenShadowingUiTests
 
             // 换一格实测发 3 次(摘旧的、挂新的、认领 Owner 各一次)。钉的是"与令牌数无关"这件事:
             // 逐个写会随令牌数线性上去,眼下是六十多次。
-            Assert.IsTrue(notifications <= 4,
+            Assert.IsLessThanOrEqualTo(4, notifications,
                 $"贴一套主题发了 {notifications} 次资源变更通知 —— 多半是又改回了逐个令牌写 "
                 + "Application.Resources。每一次通知都要把整棵树上的 DynamicResource 重解析一遍。");
             return Task.FromResult(true);


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次改动为 ChatPanelView 引入“多会话分桶”机制，实现每台机器（会话）独立的对话状态与消息流面板。切换会话时即时切换引用和 UI，状态不丢失、不串台。主要包括：新增 Conversation 类封装会话状态，所有相关字段和操作代理到当前会话实例；消息流面板按会话分离，切换时 UI 自动切换；会话下拉支持显示连接名；各类 UI 状态和插件操作均绑定当前会话，后台并发互不干扰。同步更新测试用例，统一集合初始化和断言写法。显著提升多会话并行体验，为后续扩展和并发处理奠定基础。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [x] 重构(行为不变)
- [x] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [x] `dotnet build VelaShell.slnx` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试(或说明为什么不需要)
- [x] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [x] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
