### PR TITLE
增加网络瞬时故障自动重试及异常文本返回

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/AgentToolbox.cs
@@ -359,8 +359,17 @@ public sealed class AgentToolbox(IPluginContext context)
             return error!;
         }
         lines = Math.Clamp(lines, 1, 2000);
-        string output = await context.Terminal.GetOutputAsync(id, lines, cancellationToken).ConfigureAwait(false);
-        return string.IsNullOrWhiteSpace(output) ? "(terminal buffer is empty)" : output;
+        try
+        {
+            string output = await context.Terminal.GetOutputAsync(id, lines, cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(output) ? "(terminal buffer is empty)" : output;
+        }
+        catch (Exception ex)
+        {
+            // 异常一律转文本,别中断整轮对话(与其它工具同一口径)——
+            // 抛出去会让挂着的 tool_use 收不到结果,下次请求就被服务端以 "cannot be absent" 挡回来。
+            return $"Failed to read the terminal: {ex.Message}";
+        }
     }
 
     private async Task<string> SearchTerminalAsync(

--- a/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
@@ -34,6 +36,27 @@ public sealed class McpManager(IPluginContext context) : IAsyncDisposable
 
     /// <summary>审批方式(与内置工具共用同一设置)。</summary>
     public ApprovalMode Approval { get; set; } = ApprovalMode.Ask;
+
+    /// <summary>把一条工具执行告警写进插件日志(供嵌套的工具包装器用,它拿不到 <c>context</c>)。</summary>
+    internal void LogToolWarning(string message) => context.Log.Warn(message);
+
+    /// <summary>
+    /// 是不是那种"再试一次多半就好"的瞬时故障:网络层的断连 / 超时 / DNS 抖动。
+    /// 用来决定 MCP 工具调用要不要自动重试 —— 语义类错误(参数不对、服务端 4xx)重试没意义。
+    /// </summary>
+    internal static bool IsTransientToolFailure(Exception ex)
+    {
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+        {
+            // HttpClient 超时抛的是 TaskCanceledException(OperationCanceledException 的子类);
+            // 真正的"用户按停止"在调用点已按 cancellationToken 单独拦下,到这儿的都是内部超时。
+            if (e is HttpRequestException or IOException or SocketException or TimeoutException or TaskCanceledException)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
     /// 汇集全部启用服务器的工具。逐服务器容错:单个失败不影响其余,
@@ -308,7 +331,43 @@ public sealed class McpManager(IPluginContext context) : IAsyncDisposable
                     return "The user DENIED this MCP tool call. Do not retry it; ask the user how to proceed.";
                 }
             }
-            return await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+
+            // MCP 工具常常连着一台远端服务器,链路一抖(尤其在墙内)整条调用就抛。
+            // 以前这里直接把异常放出去:这一轮里挂着的 tool_use 收不到结果,下一次请求就被服务端
+            // 以 "'<tool>' cannot be absent" 挡回来 —— 整轮作废,还没法重试。
+            // 现在:①瞬时网络故障自动重试几次(仅对服务器自称只读的工具,免得把有副作用的调用重放两遍);
+            //       ②最终仍失败就把原因转成给模型看的文本(而不是抛)—— 工具调用始终有个结果,
+            //         tool_use 不再悬空,模型可以自己决定再试一次还是如实告诉用户。
+            // 只有用户按了停止(cancellationToken)才照旧抛出,交给外层统一收尾。
+            bool retrySafe = inner.ProtocolTool.Annotations?.ReadOnlyHint == true;
+            int maxAttempts = retrySafe ? 3 : 1;
+            for (int attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (attempt < maxAttempts && IsTransientToolFailure(ex))
+                {
+                    owner.LogToolWarning(
+                        $"MCP tool '{Name}' failed (attempt {attempt}/{maxAttempts}), retrying: {ex.Message}");
+                    await Task.Delay(TimeSpan.FromMilliseconds(400 * attempt), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    owner.LogToolWarning($"MCP tool '{Name}' failed: {ex.Message}");
+                    string hint = IsTransientToolFailure(ex)
+                        ? " This looks like a transient network issue (the MCP server may be unreachable or blocked);"
+                          + " you may retry the call."
+                        : "";
+                    return $"The MCP tool '{Name}' failed: {ex.Message}.{hint}"
+                           + " Do not treat this as your own mistake — report what happened to the user if it keeps failing.";
+                }
+            }
         }
 
         private static string SerializeArguments(AIFunctionArguments arguments)

--- a/plugins/VelaShell.Plugin.Ai/Agent/Web/WebAccess.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/Web/WebAccess.cs
@@ -37,6 +37,23 @@ internal class WebAccess(WebSearchOptions options)
     /// <summary>同站跳转最多跟几跳。</summary>
     private const int MaxRedirects = 5;
 
+    /// <summary>一次抓取遇到瞬时网络故障最多试几次(含首次)。</summary>
+    private const int MaxSendAttempts = 3;
+
+    /// <summary>是不是"再试一次多半就好"的瞬时网络故障(断连 / 超时 / DNS 抖动)。</summary>
+    private static bool IsTransient(Exception ex)
+    {
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+        {
+            // HttpClient 超时抛的是 TaskCanceledException(OCE 子类);用户按停止那条已在上面按 token 拦下。
+            if (e is HttpRequestException or IOException or SocketException or TimeoutException or TaskCanceledException)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /// <summary>响应体最多读多少字节(转文本前的原始上限,防止一个大文件把内存吃了)。</summary>
     private const int MaxResponseBytes = 8 * 1024 * 1024;
 
@@ -124,20 +141,30 @@ internal class WebAccess(WebSearchOptions options)
                 return new FetchResult(false, blocked, current);
             }
             HttpResponseMessage response;
-            try
+            // 墙内抓外网常常链路一抖就断:瞬时故障退避后重试几次(web_fetch 只读,重放安全),
+            // 都不行才把原因转成文本返回 —— 全程不抛,免得中断整轮对话。
+            for (int attempt = 1; ; attempt++)
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, current);
-                request.Headers.Accept.ParseAdd("text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.5");
-                response = await Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                                     .ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                return new FetchResult(false, $"Could not fetch {current}: {ex.Message}", current);
+                try
+                {
+                    using var request = new HttpRequestMessage(HttpMethod.Get, current);
+                    request.Headers.Accept.ParseAdd("text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.5");
+                    response = await Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                                         .ConfigureAwait(false);
+                    break;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (attempt < MaxSendAttempts && IsTransient(ex))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(400 * attempt), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    return new FetchResult(false, $"Could not fetch {current}: {ex.Message}", current);
+                }
             }
 
             using (response)


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

为终端输出、MCP 工具和 Web 抓取等网络相关操作增加瞬时网络故障的自动重试机制，避免因异常抛出导致对话中断。具体包括：
- AgentToolbox.cs：终端输出读取异常时返回错误文本。
- McpManager.cs：实现瞬时故障判断与自动重试，最终失败返回详细错误文本及重试建议。
- WebAccess.cs：Web 抓取增加自动重试，所有异常转为文本返回。
- 相关位置补充日志，便于问题排查。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
