### PR TITLE
聊天面板新增“跳到末尾”按钮及相关逻辑

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
+++ b/plugins/VelaShell.Plugin.Ai/Agent/McpManager.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.AI;

--- a/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/AiTheme.axaml
@@ -14,6 +14,7 @@
   <StreamGeometry x:Key="AiIcon.sparkles">M9.94 14.32a1 1 0 0 0-.66-.66l-4.24-1.32a.5.5 0 0 1 0-.96l4.24-1.32a1 1 0 0 0 .66-.66l1.32-4.24a.5.5 0 0 1 .96 0l1.32 4.24a1 1 0 0 0 .66.66l4.24 1.32a.5.5 0 0 1 0 .96l-4.24 1.32a1 1 0 0 0-.66.66l-1.32 4.24a.5.5 0 0 1-.96 0Z M20 3v4 M22 5h-4 M4 17v2 M5 18H3</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.scissors">M20 4L8.12 15.88 M14.47 14.48L20 20 M8.12 8.12L12 12 M9.5 6.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z M9.5 17.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.chevron-up">M18 15l-6-6-6 6</StreamGeometry>
+  <StreamGeometry x:Key="AiIcon.chevron-down">M6 9l6 6 6-6</StreamGeometry>
   <!-- 模型配置页面包屑右侧那枚测试结果徽章的两个态(lucide circle-check / circle-x) -->
   <StreamGeometry x:Key="AiIcon.circle-check">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M9 12l2 2 4-4</StreamGeometry>
   <StreamGeometry x:Key="AiIcon.circle-x">M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z M15 9l-6 6 M9 9l6 6</StreamGeometry>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.History.cs
@@ -59,6 +59,8 @@ public partial class ChatPanelView
         {
             ResetClearHistoryButton();
         }
+        // 切到历史/设置时聊天流让位了,"跳到末尾"钮也得收起;切回聊天再按当前位置决定显隐。
+        UpdateJumpToBottomButton();
     }
 
     // ---------- 会话列表 ----------

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml
@@ -82,6 +82,29 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
     </Style>
 
+    <!-- 跳到末尾:滚上去看旧消息时,消息区右下角浮出一枚圆钮,点它回到最新一条。
+         只在"不在底部"时显形(见 UpdateJumpToBottomButton);在底部/流式粘底时不出现。 -->
+    <Style Selector="Border.jumpToBottom">
+      <Setter Property="Width" Value="34" />
+      <Setter Property="Height" Value="34" />
+      <Setter Property="CornerRadius" Value="17" />
+      <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="HorizontalAlignment" Value="Right" />
+      <Setter Property="VerticalAlignment" Value="Bottom" />
+      <Setter Property="Margin" Value="0,0,24,14" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="BoxShadow" Value="0 2 8 0 #40000000" />
+    </Style>
+    <Style Selector="Border.jumpToBottom:pointerover">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaAccent}" />
+    </Style>
+    <Style Selector="Border.jumpToBottom:pointerover Path">
+      <Setter Property="Stroke" Value="{DynamicResource VelaTextPrimary}" />
+    </Style>
+
     <!-- 输入框上方的建议药丸(同 Copilot 的后续提问):整枚可点,悬停换强调描边 -->
     <Style Selector="Border.suggestChip">
       <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
@@ -927,6 +950,15 @@
            StackPanel 里的东西永远是顶着上沿排的。 -->
       <StackPanel x:Name="EmptyStateHost" IsVisible="False" Spacing="10" MaxWidth="340"
                   VerticalAlignment="Center" HorizontalAlignment="Center" Margin="24,0" />
+      <!-- 跳到末尾的圆钮:浮在消息区右下角,默认隐藏,滚上去时显形(见 UpdateJumpToBottomButton)。
+           摆在 Panel 最后 = 叠在消息流之上;点击回到最新并恢复粘底。 -->
+      <Border x:Name="JumpToBottomButton" Classes="jumpToBottom" IsVisible="False">
+        <Viewbox Width="16" Height="16">
+          <Path Width="24" Height="24" Data="{DynamicResource AiIcon.chevron-down}"
+                Stroke="{DynamicResource VelaTextSecondary}" StrokeThickness="2"
+                StrokeLineCap="Round" StrokeJoin="Round" />
+        </Viewbox>
+      </Border>
     </Panel>
   </DockPanel>
 </UserControl>

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.axaml.cs
@@ -168,6 +168,14 @@ public partial class ChatPanelView : UserControl
         SendButton.Click += (_, _) => _ = SendAsync(InputBox.Text ?? "");
         StopButton.Click += (_, _) => Cts?.Cancel();
         ChatScroll.ScrollChanged += OnChatScrollChanged;
+        // 跳到末尾:点一下回到最新一条,并恢复"粘底"(此后新消息继续跟着走)。
+        // 先乐观隐藏,真正滚到底后 ScrollChanged 会再确认一次。
+        JumpToBottomButton.PointerPressed += (_, e) =>
+        {
+            e.Handled = true;
+            JumpToBottomButton.IsVisible = false;
+            RequestAutoScroll(force: true);
+        };
         // 消息流的实际容器是"当前这一份对话"的面板,运行时挂上;切对话时整体替换(见 SwitchConversation)。
         ChatScroll.Content = _active.Messages;
         NewChatButton.Click += (_, _) => StartNewChat();
@@ -351,6 +359,7 @@ public partial class ChatPanelView : UserControl
         SyncModeUi();
         // 「新会话」也是纯图标钮了(顶栏四枚统一 26×30),文案只剩提示这一处
         ToolTip.SetTip(NewChatButton, $"{_loc["NewChat"]} — {_loc["NewChatTip"]}");
+        ToolTip.SetTip(JumpToBottomButton, _loc["ScrollToBottom"]);
         ToolTip.SetTip(UsageMeterTrack, _loc["MeterTip"]);
         ToolTip.SetTip(SettingsButton, _loc["ModelSettings"]);
         ToolTip.SetTip(ToolsButton, _loc["ConfigureTools"]);
@@ -939,6 +948,7 @@ public partial class ChatPanelView : UserControl
         // 切到别的对话时上一份的后续提问药丸不再相关;各份的后续提问是即时算的,不做保留。
         ClearSuggestions();
         RequestAutoScroll(force: true);
+        UpdateJumpToBottomButton();
     }
 
     /// <summary>
@@ -1087,11 +1097,24 @@ public partial class ChatPanelView : UserControl
     /// </summary>
     private void OnChatScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
-        if (e.ExtentDelta.Y != 0)
+        // 只有"纯滚动"(内容尺寸没变)才更新粘底意图:流式期间内容增长引起的相对位移不算用户上滚。
+        if (e.ExtentDelta.Y == 0)
         {
-            return;
+            _autoScroll = ChatScroll.Offset.Y + ChatScroll.Viewport.Height >= ChatScroll.Extent.Height - 8;
         }
-        _autoScroll = ChatScroll.Offset.Y + ChatScroll.Viewport.Height >= ChatScroll.Extent.Height - 8;
+        // 但"跳到末尾"按钮的显隐要跟着每一次变化走 —— 包括新消息把内容顶长(此时离底更远了)。
+        UpdateJumpToBottomButton();
+    }
+
+    /// <summary>
+    /// "跳到末尾"圆钮的显隐:只有在聊天流可见、内容超出一屏、且当前不在底部时才显形。
+    /// 在底部(含流式粘底)时收起 —— 那会儿没有"跳"的必要。
+    /// </summary>
+    private void UpdateJumpToBottomButton()
+    {
+        bool hasOverflow = ChatScroll.Extent.Height > ChatScroll.Viewport.Height + 8;
+        bool atBottom = ChatScroll.Offset.Y + ChatScroll.Viewport.Height >= ChatScroll.Extent.Height - 8;
+        JumpToBottomButton.IsVisible = ChatScroll.IsVisible && hasOverflow && !atBottom;
     }
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/Loc.cs
@@ -112,6 +112,7 @@ public sealed class Loc(string locale)
         ["Interjected"] = ["You added", "你补充了", "你補充了", "追加した内容", "추가한 내용"],
         ["NewChat"] = ["New chat", "新会话", "新會話", "新規チャット", "새 채팅"],
         ["NewChatTip"] = ["Start a new conversation (discards the current one).", "开始新会话(丢弃当前对话)。", "開始新會話(丟棄當前對話)。", "新しい会話を開始します(現在の会話は破棄)。", "새 대화를 시작합니다(현재 대화는 삭제)."],
+        ["ScrollToBottom"] = ["Jump to latest", "跳到最新", "跳到最新", "最新へ移動", "최신으로 이동"],
         ["Settings"] = ["Settings", "设置", "設定", "設定", "설정"],
         ["ModelSettings"] = ["Models", "模型配置", "模型設定", "モデル設定", "모델 설정"],
         ["GlobalSettings"] = ["Global settings", "全局设置", "全域設定", "全体設定", "전역 설정"],

--- a/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Scroll.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ChatPanelViewUiTests.Scroll.cs
@@ -1,0 +1,52 @@
+using Avalonia;
+using Avalonia.Controls;
+using VelaShell.Plugin.Ai.Ui;
+using VelaShell.PluginSdk.Testing;
+
+namespace VelaShell.Plugin.Ai.Tests;
+
+/// <summary>
+/// "跳到末尾"圆钮:滚上去看旧消息时右下角显形,回到底部即收起。
+/// </summary>
+public sealed partial class ChatPanelViewUiTests
+{
+    [TestMethod]
+    public void JumpToBottom_ShowsWhenScrolledUp_HidesAtBottom()
+    {
+        OnUi(async () =>
+        {
+            using var context = new TestPluginContext();
+            (Window window, ChatPanelView panel) = await ShowAsync(context);
+            try
+            {
+                var scroll = Find<ScrollViewer>(panel, "ChatScroll");
+                var messages = (StackPanel)scroll.Content!;
+                Border jump = Find<Border>(panel, "JumpToBottomButton");
+
+                // 空对话、内容不超一屏:钮不该出现。
+                Assert.IsFalse(jump.IsVisible, "内容没超出一屏时不该显示跳到末尾");
+
+                // 塞进远超一屏(窗口 600px 高)的内容,让消息流可滚动。
+                for (int i = 0; i < 60; i++)
+                {
+                    messages.Children.Add(new TextBlock { Text = $"line {i}", MinHeight = 40 });
+                }
+                await PumpAsync();
+
+                // 滚到顶(离底很远):钮显形。
+                scroll.Offset = new Vector(0, 0);
+                await PumpAsync();
+                Assert.IsTrue(jump.IsVisible, "滚上去之后应显示跳到末尾");
+
+                // 回到底:钮收起。
+                scroll.ScrollToEnd();
+                await PumpAsync();
+                Assert.IsFalse(jump.IsVisible, "回到底部后跳到末尾应收起");
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+}


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

为聊天面板添加了“跳到末尾”圆形按钮：当消息区超出一屏且用户滚动查看旧消息时，右下角显示该按钮，点击可回到最新消息并恢复自动滚动。显隐逻辑在 ChatPanelView.axaml.cs 实现，并在切换会话、面板、滚动等场景下同步更新。样式和图标已在 ChatPanelView.axaml、AiTheme.axaml 补充，多语言提示“跳到最新”已加入 Loc.cs。新增 ChatPanelViewUiTests.Scroll.cs 单元测试，验证按钮显隐行为。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
