### PR TITLE
修复关闭文档导致 FTP 节点状态误熄灭问题

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1536,3 +1536,52 @@ banner。立刻注入会被这些输出盖住甚至吞掉,留一两秒才稳。`
 对话框保存时归一化 + 重开回显 + 自动展开高级选项、换成非 FTP 协议时整块不落盘,
 以及文件浏览器的两条 —— 配置路径优先于登录工作目录,以及路径打不开时回退且不留错误提示。
 文档已同步 velashell-docs `zh/host/交互与界面规格.md` §13.1 与 `en/` 镜像。
+
+## 39. 2026-09-04 文档型连接的树状态:关掉一个,别把还活着的另一个也熄了(用户反馈)
+
+现象:点太快对同一条 FTP 配置开出两个标签,关掉其中一个,资源管理器里那条的状态圆点就灭了
+—— 明明还有一个活着。
+
+### 一、根因与 #321 同形,只是那次只修了终端那一半
+
+树上一条配置只有**一个**节点,而名下可以同时开着好几条会话。#321 已经为终端标签定过纪律:
+节点状态是名下**所有**标签的合并结果(`RefreshSessionStatus`,Connected > Connecting > Error >
+Disconnected),不是最后一次变更的那个标签说了算。
+
+文档型连接(独立 SFTP / FTP / S3 等插件文件系统 / Redis 等工作台)漏在了外面,一直是
+"最后一次事件说了算":`CloseSftpDocumentCoreAsync` 按配置 Id **无条件写**「未连接」,
+`CloseWorkspaceDocumentAsync` 同样,`OnFtpSessionStateChanged` / `OnPluginSessionStateChanged`
+收到 `Closed` 也直接写「未连接」。四处都不看"这条配置名下还有没有别的活会话"。
+
+### 二、修法:把文档也纳入同一次合并
+
+新开一本 `_documentSessions`(会话 id → 配置 id + 当前状态),开文档时登记、关文档时摘掉;
+`RefreshSessionStatus` 从"只枚举 TabBar 里的终端标签"改成"终端标签 ∪ 该配置名下在册的文档会话"。
+于是四处关闭路径统一变成「摘掉这一条,然后重算」,谁也不再替别人做主。
+
+**不能拿 `Layout.AllDocuments()` 当这本册子**:`DockWorkspace.CloseDocument` 是先
+`RemoveDocument` 再触发 `DocumentClosed`,正在关的那个已经不在集合里了,而迟到的状态事件
+仍会引用它 —— 于是"还没关完就已经不算数"和"关完了还在算"两头都不对。单开一本反而没有歧义。
+
+顺带删掉 `_ftpSessionProfiles` / `_pluginSessionProfiles` / `_workspaceProfiles` 三本旧册子:
+它们的唯一用途就是这件事,新册子接手后三者只剩写入、无人读取。留着两本能互相打架的账,
+正是这类 bug 复发的温床。
+
+`UpdateDocumentSessionStatus` 对**不在册**的会话直接忽略,不复活它:文档关掉之后仍可能收到
+一条迟到的状态事件(FTP 的失效是在下一次操作时才暴露的),照单全收会把刚灭掉的圆点重新点亮。
+
+### 三、回归用例差点写成一条假绿
+
+第一版用例在"关掉一个之后断言节点仍为活跃",而状态更新是**异步**调度到主线程的 ——
+断言跑在更新之前,于是把修复整个撤掉它照样通过。这种用例比没有更糟。
+
+改成钉在两个确定的时点上:先 `await` 该文档的关闭任务(状态更新是在它的收尾里发起的,
+为此加了一个 `GetStandaloneSftpCloseTask` 测试探针,手法同 `SshTerminalBridge.DrainWritesAsync`),
+再往主线程调度器上压一道栅栏把排队的刷新冲掉。改完之后**验证过它会失败**:
+把 `ForgetDocumentSession` 换回"直接写未连接"的老语义,用例立刻红。
+
+### 四、验收
+
+`dotnet build VelaShell.slnx` 无警告;`dotnet test VelaShell.slnx` 全绿(2771 通过)。
+新增 1 条端到端用例(走环回 FTP 服务器,对同一条配置开两个文档、关一个、再关一个),
+并已反向验证它对老语义确实报错。

--- a/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
+++ b/src/VelaShell/ViewModels/ConnectionProfileViewModel.cs
@@ -1453,6 +1453,7 @@ public class ConnectionProfileViewModel : ReactiveObject, IDisposable
     {
         _protocolRegistry?.Changed -= OnProtocolsChanged;
         _copyFeedbackReset?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>把注册表里的协议页签同步到界面(打开对话框时调用)。</summary>

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -129,17 +129,22 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>工作台连接类型(Redis 等)的会话启动器;无插件宿主的单测里为 null。</summary>
     private readonly PluginWorkspaceLauncher? _workspaceLauncher;
 
-    /// <summary>FTP 会话标识 → 会话配置标识:状态事件只带会话标识,树上按配置标识定位节点。</summary>
-    private readonly ConcurrentDictionary<Guid, Guid> _ftpSessionProfiles = new();
-
-    /// <summary>插件协议会话标识 → 会话配置标识;用途同 <see cref="_ftpSessionProfiles" />。</summary>
-    private readonly ConcurrentDictionary<Guid, Guid> _pluginSessionProfiles = new();
-
-    /// <summary>工作台会话 id → 连接配置 id(树上的状态圆点按它定位)。</summary>
-    private readonly ConcurrentDictionary<Guid, Guid> _workspaceProfiles = new();
-
     /// <summary>工作台会话 id → 已打开的停靠文档(插件被停用时要按 id 找到它并关掉)。</summary>
     private readonly ConcurrentDictionary<Guid, PluginWorkspaceDocument> _workspaceDocuments = new();
+
+    /// <summary>
+    /// **活着的**文档型会话(独立 SFTP / FTP / S3 等插件文件系统 / Redis 等工作台):
+    /// 会话 id → (它属于哪条配置, 当前状态)。开文档时登记,关文档时摘掉。
+    /// <para>
+    /// 存在的理由是树上的状态圆点:一条配置可以同时开着好几个文档(点快了开出两个,
+    /// 或者有意开两个盯不同目录),而树上只有一个节点。没有这本册子就只能"最后一次事件说了算",
+    /// 于是关掉两个里的任意一个,节点就变成未连接 —— 明明还有一个活着。
+    /// 终端标签那边靠 <see cref="TabBar" /> 自己就能枚举(#321 已按这条纪律改过),
+    /// 文档没有等价的集合可枚举(<c>Layout.AllDocuments()</c> 在 DocumentClosed 触发时
+    /// 已经把正在关的那个摘掉了,但迟到的状态事件仍会引用它),所以单开一本。
+    /// </para>
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, (Guid ProfileId, SessionStatus Status)> _documentSessions = new();
 
     /// <summary>工作台会话 id → 为它建的隧道 id(文档关闭时要拆掉,否则本地端口一直占着)。</summary>
     private readonly ConcurrentDictionary<Guid, Guid> _workspaceTunnels = new();
@@ -179,7 +184,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// 标签关闭或连接断开时经 <see cref="EvictFileBrowser" /> 驱逐。
     /// </summary>
     private readonly Dictionary<Guid, FileBrowserViewModel> _fileBrowserCache = [];
-    private readonly object _fileBrowserPreferenceSaveSync = new();
+    private readonly Lock _fileBrowserPreferenceSaveSync = new();
     private Task _fileBrowserPreferenceSaveTail = Task.CompletedTask;
     private readonly Lock _sftpCloseTasksSync = new();
     private readonly Dictionary<SftpDocument, Task> _sftpCloseTasks = [];
@@ -2154,21 +2159,79 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// 按"最后一次变更"来更新会留下一个走不出去的状态(#321:在已连上的会话上再开一个
     /// 标签、趁它还在连接时立刻关掉,节点会永远停在「连接中」)。
     /// </para>
-    /// <para>没有任何标签属于该配置时归零为 Disconnected —— 最后一个标签关掉即回到未连接。</para>
+    /// <para>
+    /// 参与合并的不只有终端标签,还有该配置名下**活着的文档型会话**(独立 SFTP / FTP /
+    /// S3 等插件文件系统 / Redis 等工作台,见 <see cref="_documentSessions" />)。
+    /// 这些连接一样可以对同一条配置开好几个,而它们原先各自直接往树上写状态、最后一次说了算 ——
+    /// 于是"点快了开出两个 FTP 标签,关掉一个,树上的圆点就灭了"(明明还有一个活着)。
+    /// </para>
+    /// <para>没有任何标签或文档属于该配置时归零为 Disconnected —— 最后一个关掉即回到未连接。</para>
     /// </summary>
     private void RefreshSessionStatus(Guid profileId)
     {
         SessionStatus status = TabBar
             .Tabs.OfType<TerminalTabViewModel>()
             .Where(tab => tab.Profile?.Id == profileId)
+            .Select(tab => tab.ConnectionStatus)
+            .Concat(
+                _documentSessions
+                    .Values.Where(session => session.ProfileId == profileId)
+                    .Select(session => session.Status)
+            )
             .Aggregate(
                 SessionStatus.Disconnected,
-                (best, tab) =>
-                    SessionStatusRank(tab.ConnectionStatus) > SessionStatusRank(best)
-                        ? tab.ConnectionStatus
-                        : best
+                (best, candidate) =>
+                    SessionStatusRank(candidate) > SessionStatusRank(best) ? candidate : best
             );
         Sidebar.SessionTree?.SetSessionStatus(profileId, status);
+    }
+
+    /// <summary>
+    /// 登记一条刚建好的文档型会话并刷新它那条配置在树上的状态。
+    /// </summary>
+    /// <param name="sessionId">会话标识(摘除与状态更新都按它定位)。</param>
+    /// <param name="profileId">
+    /// 树上节点对应的配置标识。刻意由调用方给出**原始** profile 的 Id:登录弹窗可能换过
+    /// 文档里那份配置的字段,而树上的节点始终是按最初那条配置的 Id 建的。
+    /// </param>
+    /// <param name="status">初始状态(建出文档即已连上)。</param>
+    private void TrackDocumentSession(Guid sessionId, Guid profileId, SessionStatus status)
+    {
+        if (sessionId == Guid.Empty || profileId == Guid.Empty)
+        {
+            return;
+        }
+        _documentSessions[sessionId] = (profileId, status);
+        ScheduleSessionStatusRefresh(profileId);
+    }
+
+    /// <summary>
+    /// 更新一条在册文档型会话的状态(掉线 / 重新连上)并刷新树。
+    /// <para>
+    /// 不在册的会话**不复活**:文档已经关掉之后仍可能收到一条迟到的状态事件
+    /// (FTP 的失效是在下一次操作时才暴露的),照单全收会把刚灭掉的圆点重新点亮。
+    /// </para>
+    /// </summary>
+    private void UpdateDocumentSessionStatus(Guid sessionId, SessionStatus status)
+    {
+        if (!_documentSessions.TryGetValue(sessionId, out (Guid ProfileId, SessionStatus Status) tracked))
+        {
+            return;
+        }
+        _documentSessions[sessionId] = (tracked.ProfileId, status);
+        ScheduleSessionStatusRefresh(tracked.ProfileId);
+    }
+
+    /// <summary>
+    /// 摘掉一条已关闭的文档型会话并刷新树。幂等 —— 关闭路径与协议自己的 <c>Closed</c> 事件
+    /// 都会走到这里,谁先到都行。
+    /// </summary>
+    private void ForgetDocumentSession(Guid sessionId)
+    {
+        if (_documentSessions.TryRemove(sessionId, out (Guid ProfileId, SessionStatus Status) tracked))
+        {
+            ScheduleSessionStatusRefresh(tracked.ProfileId);
+        }
     }
 
     /// <summary>多标签合并时的状态优先级,数值越大越"活跃"(见 <see cref="RefreshSessionStatus" />)。</summary>
@@ -3159,7 +3222,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         QueryDefaultEditorPathAsync));
                 Layout.AddDocument(document);
                 // 与 FTP 同理:连接续体可能落在后台线程上,树节点是绑定属性,必须回主线程再改。
-                SetTreeSessionStatus(current.Id, SessionStatus.Connected);
+                TrackDocumentSession(session.SessionId, current.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -3250,11 +3313,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         settings.Transfer,
                         FileTransfer,
                         QueryDefaultEditorPathAsync));
-                // 用**原始** profile 的标识登记:登录弹窗可能换过 current 的字段,
-                // 但树上的节点始终是按最初那条配置的 Id 建的。
-                _ftpSessionProfiles[sessionId] = profile.Id;
                 Layout.AddDocument(document);
-                SetTreeSessionStatus(profile.Id, SessionStatus.Connected);
+                TrackDocumentSession(sessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -3375,11 +3435,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         _pluginProtocols.InvokeActionAsync(sessionId, actionId, path, CancellationToken.None);
                 }
                 var document = new SftpDocument(viewModel);
-                // 用**原始** profile 的标识登记:登录弹窗可能换过 current 的字段,
-                // 但树上的节点始终是按最初那条配置的 Id 建的。
-                _pluginSessionProfiles[sessionId] = profile.Id;
                 Layout.AddDocument(document);
-                SetTreeSessionStatus(profile.Id, SessionStatus.Connected);
+                TrackDocumentSession(sessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -3619,13 +3676,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 {
                     _workspaceTunnels[session.SessionId] = tunnelId;
                 }
-                // 用**原始** profile 的标识登记:登录弹窗可能换过 current 的字段,
-                // 但树上的节点始终是按最初那条配置的 Id 建的。
-                _workspaceProfiles[session.SessionId] = profile.Id;
                 _workspaceDocuments[session.SessionId] = document;
                 session.Document.StatusChanged += OnWorkspaceStatusChanged;
                 Layout.AddDocument(document);
-                SetTreeSessionStatus(profile.Id, SessionStatus.Connected);
+                TrackDocumentSession(session.SessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
@@ -3734,10 +3788,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         document.Workspace.StatusChanged -= OnWorkspaceStatusChanged;
         _workspaceDocuments.TryRemove(document.SessionId, out _);
         _workspaceLauncher?.Forget(document.SessionId);
-        if (_workspaceProfiles.TryRemove(document.SessionId, out Guid profileId))
-        {
-            SetTreeSessionStatus(profileId, SessionStatus.Disconnected);
-        }
+        // 摘掉这一条会话再重算,而不是直接把节点写成「未连接」:
+        // 同一条配置名下可能还开着别的文档或终端标签(#321 那条纪律的文档版)。
+        ForgetDocumentSession(document.SessionId);
         // 先关插件那边的连接,再拆隧道:反过来会让插件的关闭流程对着一条已经断掉的通道超时。
         await document.CloseAsync().ConfigureAwait(true);
         if (_workspaceTunnels.TryRemove(document.SessionId, out Guid tunnelId))
@@ -3880,11 +3933,11 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
         Guid sessionId = _workspaceDocuments
             .FirstOrDefault(pair => ReferenceEquals(pair.Value.Workspace, document)).Key;
-        if (sessionId == Guid.Empty || !_workspaceProfiles.TryGetValue(sessionId, out Guid profileId))
+        if (sessionId == Guid.Empty)
         {
             return;
         }
-        SetTreeSessionStatus(profileId, status.State switch
+        UpdateDocumentSessionStatus(sessionId, status.State switch
         {
             ProtocolSessionState.Connected => SessionStatus.Connected,
             ProtocolSessionState.Faulted => SessionStatus.Error,
@@ -3895,15 +3948,14 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>插件协议会话状态变化 → 资源管理器树的状态圆点(理由与线程约束同 FTP 侧)。</summary>
     private void OnPluginSessionStateChanged(object? sender, PluginProtocolSessionStateChange change)
     {
-        if (!_pluginSessionProfiles.TryGetValue(change.SessionId, out Guid profileId))
-        {
-            return;
-        }
         if (change.State == PluginProtocolSessionState.Closed)
         {
-            _pluginSessionProfiles.TryRemove(change.SessionId, out _);
+            // 会话没了就从册子上摘掉,而不是把节点写成「未连接」——
+            // 同一条配置的另一个文档可能还开着。
+            ForgetDocumentSession(change.SessionId);
+            return;
         }
-        SetTreeSessionStatus(profileId, change.State switch
+        UpdateDocumentSessionStatus(change.SessionId, change.State switch
         {
             PluginProtocolSessionState.Connected => SessionStatus.Connected,
             PluginProtocolSessionState.Faulted => SessionStatus.Error,
@@ -3944,33 +3996,35 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// </summary>
     private void OnFtpSessionStateChanged(object? sender, FtpSessionStateChange change)
     {
-        if (!_ftpSessionProfiles.TryGetValue(change.SessionId, out Guid profileId))
-        {
-            return;
-        }
         if (change.State == FtpSessionState.Closed)
         {
-            _ftpSessionProfiles.TryRemove(change.SessionId, out _);
+            // 会话没了就从册子上摘掉,而不是把节点写成「未连接」——
+            // 同一条配置的另一个 FTP 文档可能还开着(点快了开出两个,关掉其中一个)。
+            ForgetDocumentSession(change.SessionId);
+            return;
         }
-        SetTreeSessionStatus(profileId, change.State switch
+        UpdateDocumentSessionStatus(change.SessionId, change.State switch
         {
             FtpSessionState.Connected => SessionStatus.Connected,
             // 掉线显示为「离线」而不是「未连接」:文档还开着,用户需要看出是断了而不是没连过。
-            FtpSessionState.Faulted => SessionStatus.Error,
-            _ => SessionStatus.Disconnected,
+            _ => SessionStatus.Error,
         });
     }
 
     /// <summary>
-    /// 在主线程上更新树节点状态(绑定属性不得在后台线程改)。
+    /// 在主线程上重算并写回树节点状态(绑定属性不得在后台线程改)。
+    /// <para>
+    /// 重算而不是直接写一个状态进去:一条配置名下可能同时开着多个标签与多个文档,
+    /// 树上只有一个节点,谁都不该按自己那一份覆盖别人的(见 <see cref="RefreshSessionStatus" />)。
+    /// </para>
     /// <para>
     /// 用 <c>RxSchedulers.MainThreadScheduler</c> 而不是裸 <c>Dispatcher.UIThread.Post</c>:
     /// 与本类其它 VM 更新一致,并且在没有跑 Avalonia 消息循环的宿主(headless 测试)里也能落地
     /// —— 直接 Post 的作业在那种环境下永远不会被执行。
     /// </para>
     /// </summary>
-    private void SetTreeSessionStatus(Guid profileId, SessionStatus status) =>
-        RxSchedulers.MainThreadScheduler.Schedule(() => Sidebar.SessionTree?.SetSessionStatus(profileId, status));
+    private void ScheduleSessionStatusRefresh(Guid profileId) =>
+        RxSchedulers.MainThreadScheduler.Schedule(() => RefreshSessionStatus(profileId));
 
     /// <summary>FTP 缺少登录凭据时才需要弹登录框;匿名登录不需要用户名与口令。</summary>
     private static bool RequiresFtpCredentials(SessionProfile profile) =>
@@ -4662,6 +4716,22 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
     }
 
+    /// <summary>
+    /// 测试探针:取该文档正在进行的关闭任务;没有(尚未关闭或已收尾)则返回已完成任务。
+    /// <para>
+    /// <c>DocumentClosed</c> 的处理里是**同步**登记这个任务的,因此
+    /// <c>Layout.CloseDocument(doc)</c> 一返回就能取到它。测试借它等关闭真正跑完,
+    /// 而不是去猜一个毫秒数 —— 关闭是异步的,树上的状态又在关闭的收尾里才更新。
+    /// </para>
+    /// </summary>
+    internal Task GetStandaloneSftpCloseTask(SftpDocument document)
+    {
+        lock (_sftpCloseTasksSync)
+        {
+            return _sftpCloseTasks.TryGetValue(document, out Task? task) ? task : Task.CompletedTask;
+        }
+    }
+
     internal bool HasPendingStandaloneSftpDocuments()
     {
         lock (_sftpCloseTasksSync)
@@ -4676,14 +4746,19 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         try
         {
             await document.ViewModel.CloseAsync().ConfigureAwait(false);
-            await Dispatcher.UIThread.InvokeAsync(() =>
-                Sidebar.SessionTree?.SetSessionStatus(
-                    document.ViewModel.Profile.Id,
-                    SessionStatus.Disconnected));
         }
         catch (Exception ex)
         {
             await Dispatcher.UIThread.InvokeAsync(() => LastConnectionError = ex.Message);
+        }
+        finally
+        {
+            // 摘掉这一条会话再重算,而不是无条件把节点写成「未连接」——
+            // 用户点快了对同一条配置开出两个文档、关掉其中一个时,旧写法会把还活着的那条
+            // 也一起熄掉(树上只有一个节点,而这里按配置 Id 直接覆盖)。
+            // 放在 finally 里:关闭本身失败(服务器已经没影了)也必须把它从册子上摘掉,
+            // 否则那条会话永远"活着",节点再也回不到未连接。
+            ForgetDocumentSession(document.ViewModel.SessionId);
         }
     }
 

--- a/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
+++ b/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
@@ -1,8 +1,14 @@
 using Avalonia.Headless;
+using NSubstitute;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using VelaShell.Core.Data;
 using VelaShell.Core.Models;
 using VelaShell.Docking;
 using VelaShell.Infrastructure.Ftp;
 using VelaShell.Infrastructure.Tests.Ftp;
+using VelaShell.Presentation.ViewModels;
 using VelaShell.ViewModels;
 
 namespace VelaShell.Tests.Views;
@@ -91,5 +97,99 @@ public sealed class FtpConnectionFlowTests
         {
             // 临时目录删不掉不影响断言。
         }
+    }
+
+    /// <summary>
+    /// 用户反馈:点太快对同一条 FTP 配置开出两个标签,关掉其中一个,资源管理器里那条的状态
+    /// 圆点就灭了 —— 明明还有一个活着。
+    /// <para>
+    /// 根因与 #321(终端标签那次)同形:树上一条配置只有一个节点,而关闭路径按配置 Id
+    /// **直接写**「未连接」,不看同一条配置名下还有没有别的活会话。终端侧当时改成了
+    /// 「按名下所有标签重算」,文档型连接(SFTP / FTP / S3 / 工作台)漏在了外面。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task ClosingOneOfTwoFtpDocumentsForTheSameProfile_KeepsTheTreeNodeActive()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vela-ftp-dup-{Guid.NewGuid():N}");
+        using var server = new LoopbackFtpServer(root);
+        File.WriteAllText(Path.Combine(root, "deploy.sh"), "#!/bin/sh\n");
+
+        // 理由同上一条用例:连接链路全程 ConfigureAwait(true),在 headless UI 线程上等它会死锁。
+        await Task.Run(async () =>
+        {
+            var profile = new SessionProfile
+            {
+                Id = Guid.NewGuid(),
+                ConnectionType = ConnectionType.FTP,
+                Name = "外网FTP",
+                Host = "127.0.0.1",
+                Port = server.Port,
+                Username = "deploy",
+                Password = "secret123",
+                Ftp = new FtpSettings { EncryptionMode = FtpEncryptionMode.None, MaxConnections = 2 },
+            };
+            ISessionRepository repository = Substitute.For<ISessionRepository>();
+            repository.GetAllSessionsAsync().Returns(_ => Task.FromResult(new List<SessionProfile> { profile }));
+            repository.GetAllGroupsAsync().Returns(_ => Task.FromResult(new List<ServerGroup>()));
+
+            var ftp = new FtpFileService();
+            var vm = new MainWindowViewModel(sessionRepository: repository, sftpService: ftp, ftpSessionService: ftp);
+            SessionTreeViewModel tree = vm.Sidebar.SessionTree!;
+            await tree.LoadCommand.Execute().FirstAsync();
+            SessionTreeNodeViewModel node = tree.Nodes.Single(item => item.Id == profile.Id);
+
+            SftpDocument first = (await vm.OpenFtpDocumentForProfileAsync(profile))!;
+            SftpDocument second = (await vm.OpenFtpDocumentForProfileAsync(profile))!;
+            Assert.AreNotSame(first, second, "同一条配置开两次应得到两个各自独立的文档。");
+            Assert.IsTrue(
+                SpinWait.SpinUntil(() => node.Status == SessionStatus.Connected, TimeSpan.FromSeconds(5)),
+                "两个文档都开着,节点当然是「活跃」。");
+
+            Guid firstSessionId = first.ViewModel.SessionId;
+            vm.Layout.CloseDocument(first);
+
+            // 「关完之后节点仍是活跃」这条断言必须钉在一个确定的时点上,否则它会因为
+            // "状态更新还没来得及跑"而假通过 —— 那样即使把修复撤掉,用例照样绿。
+            // 两步:先等关闭任务真正跑完(状态更新是在它的收尾里发起的),
+            // 再往主线程调度器上压一道栅栏,把它前面排队的刷新全部冲掉。
+            await vm.GetStandaloneSftpCloseTask(first);
+            await DrainMainThreadAsync();
+
+            Assert.IsFalse(ftp.OwnsSession(firstSessionId), "关掉文档应连同它那条 FTP 会话一起断开。");
+            Assert.AreEqual(
+                SessionStatus.Connected,
+                node.Status,
+                "还有一个文档开着,节点不能因为关掉了另一个就变成未连接(用户反馈的正是这一幕)。");
+
+            vm.Layout.CloseDocument(second);
+            await vm.GetStandaloneSftpCloseTask(second);
+            await DrainMainThreadAsync();
+
+            Assert.AreEqual(
+                SessionStatus.Disconnected,
+                node.Status,
+                "最后一个文档也关掉了,节点必须回到未连接 —— 修复不能反过来让它永远亮着。");
+        });
+
+        try
+        {
+            Directory.Delete(root, true);
+        }
+        catch (IOException)
+        {
+            // 临时目录删不掉不影响断言。
+        }
+    }
+
+    /// <summary>
+    /// 在主线程调度器上压一道栅栏:它跑到时,此刻之前排队的作业(树上的状态刷新走的正是这条队)
+    /// 都已经跑完。用它替代"睡一会儿再看" —— 后者对时序有假设,而且失败时只会偶发。
+    /// </summary>
+    private static Task DrainMainThreadAsync()
+    {
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        RxSchedulers.MainThreadScheduler.Schedule(() => drained.SetResult());
+        return drained.Task;
     }
 }


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

原先关闭文档型连接会直接将节点状态设为未连接，未考虑同配置下可能有多个活跃会话，导致关闭一个文档会影响其他会话。现引入 _documentSessions 统一记录所有会话，关闭或状态变更时合并计算节点状态，仅全部关闭时才熄灭节点。移除旧的会话册子，状态刷新逻辑切换到新机制。新增端到端测试，确保多文档场景下节点状态正确，主线程栅栏保证断言时机。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
