### PR TITLE
修复快捷命令目标选择浮层外圈黑边

### DIFF
--- a/src/VelaShell/Views/QuickCommandsView.axaml
+++ b/src/VelaShell/Views/QuickCommandsView.axaml
@@ -88,7 +88,10 @@
     <!-- 目标多选器:未勾选时由 VM 回退当前活动终端。 -->
     <Button Grid.Row="0" Classes="target-button" Margin="8,6,8,4">
       <Button.Flyout>
-        <Flyout Placement="BottomEdgeAlignedLeft">
+        <!-- 外观由内容这层 Border 自己画。bare 类把 presenter 自带的底色/描边/内边距/圆角
+             剥掉(见 DockStyles),否则 Border 外面还套一圈 presenter 的框,圆角处露出
+             一圈黑边 —— 与侧栏会话浮层(SidebarView)同一处理。 -->
+        <Flyout Placement="BottomEdgeAlignedLeft" FlyoutPresenterClasses="bare">
           <Border Width="250" MaxHeight="300" Padding="10"
                   Background="{DynamicResource VelaBgSurface}"
                   BorderBrush="{DynamicResource VelaBorderSecondary}"


### PR DESCRIPTION
## 问题

快捷命令面板的"选择执行终端"浮层外圈有一圈黑边。

## 原因

浮层内容自带一层 `Border` 画底色和描边,但默认的 `FlyoutPresenter` 又套了一层自己的底色/描边/内边距/圆角。两层框叠在一起,圆角处露出 presenter 的深色底,形成黑边。

## 修复

给 `Flyout` 挂上 `FlyoutPresenterClasses="bare"`。这个类在 `DockStyles.axaml` 里已经存在,会把 presenter 剥成纯定位容器,外观完全交给内容自己的 `Border`。侧栏会话浮层(`SidebarView`)此前已用同样方式修过,这里保持一致。

## 验证

- `dotnet build src/VelaShell/VelaShell.csproj`:0 警告 0 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01578Yb3rxDP8FhTSSsNyqxg