### PR TITLE
数字输入框删空后给人话提示,不再甩转换异常

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1585,3 +1585,70 @@ Disconnected),不是最后一次变更的那个标签说了算。
 `dotnet build VelaShell.slnx` 无警告;`dotnet test VelaShell.slnx` 全绿(2771 通过)。
 新增 1 条端到端用例(走环回 FTP 服务器,对同一条配置开两个文档、关一个、再关一个),
 并已反向验证它对老语义确实报错。
+
+## 40. 2026-09-04 数字输入框删空后别再甩一句转换异常(用户反馈)
+
+现象:连接配置 → 高级选项 → 「认证后执行命令」右边那个「延迟(秒)」,把里面的数字删掉,
+框旁边立刻冒出一整段红字 **`System.InvalidCastException: Could not convert '(null)' (null)
+to System.Int32.`**,同时把同排的命令输入框挤成一条缝。
+
+### 一、根因:空框直接撞在绑定的类型转换上
+
+`NumericUpDown.Value` 是 `decimal?`,而目标属性(设置项、连接配置)是 `int` / `double`。
+用户按退格删空的那一刻控件把 Value 置成 `null`,绑定引擎转换不了,把**异常对象本身**当作
+校验错误交给 `DataValidationErrors` —— 界面于是原样显示异常的 `ToString()`。
+全项目 20 处 `NumericUpDown` 无一例外(端口、超时、保活、日志留存、行高、内边距、回滚行数、
+并发数、限速……),因为这是控件与绑定的默认组合行为,不是哪一处写错了。
+
+布局被挤的那一半是同一件事的副作用:数字框统统长在 `"*,Auto"` 两栏的 Auto 一侧,
+Fluent 默认把整段错误文字排进布局,一段几十字的异常把 Auto 列撑开,`*` 那一栏就被压没了。
+
+### 二、修法:文案、状态、呈现三件事分开
+
+**文案** —— `Behaviors/NumericInputGuard.cs` 用 `DataValidationErrors.ErrorConverter` 把任何
+错误换成一句人话:「请输入 0 到 60 之间的数字」。区间直接读控件自己的 `Minimum` / `Maximum`
+(延迟是 0–60、端口 1–65535、行高 0.8–2.0),按控件的 `FormatString` 渲染 —— 一位小数的
+行高框才不会被写成「0.8 到 2」让人以为上界是整数。两端没有界时退回「请输入数字」。
+五份 resx 各加 `Validation_NumberRange` / `Validation_NumberRequired` 两条。
+
+**状态** —— 同一个行为在 `LostFocus` 上兜底:值还是空的就恢复成上一个有效值。清空只是编辑
+过程中的中间态,人走开之后不该留一个红着的空框 —— 那时视图模型里其实一直是旧值,空框在说谎。
+恢复走 `SetCurrentValue` 而不是直接赋值:直接赋值写的是本地值,优先级高过绑定,会把这个框与
+视图模型的双向绑定就地掐断,此后改设置再也传不回去(已有回归用例钉住)。
+
+**呈现** —— `Themes/DockStyles.axaml` 把 `DataValidationErrors.ErrorTemplate` 换成 14px 的红色
+警告图标 + 悬停提示(文案经 `Converters/ValidationErrorTextConverter` 拼成一段)。占位恒定,
+布局纹丝不动,文案一个字没少。
+
+兜底挂在全局那条 `Style Selector="NumericUpDown"` 上,新加的数字框自动带上,不需要谁记得
+在每个 axaml 里补一句 —— 有一条用例专门守这个。
+
+### 三、顺手改掉两个用 TextBox 装端口的地方
+
+隧道面板的「本地端口」「端口」绑的是 `int NewLocalPort` / `NewRemotePort`,却用的是 `TextBox`,
+删空或输入字母同样会把 `Could not convert '' (System.String) to System.Int32` 摆进表单。
+改成 `NumericUpDown`(1–65535,不显示微调钮),外观照抄本视图那条 TextBox 样式,与旁边的
+主机框逐像素一致(已用 headless 截图核对)。全项目再无绑到数值属性的可编辑 `TextBox`。
+
+顺带一提,输入字母这条路其实**到不了绑定**:控件解析不了的文本自己就拦下了,`Value` 不动,
+失焦时文本回滚。真正会漏到绑定上的只有"清空"。有一条用例把这个前提钉住,免得日后有人以为
+提示丢了。
+
+### 四、设置窗口整卷扫一遍
+
+设置窗口是数字框最密的地方,所以不靠"我改的是全局样式,应该都覆盖到了"这句话交差,
+而是把它整个架起来逐页逐框走一遍(`Every_number_box_in_the_settings_window_is_covered`):
+翻遍 12 个分页、把跟在开关后面的字段(自动重连的间隔与重试、限速上下行、日志留存与目录、
+代理那一整组)全拨出来,**17 个数字框**逐个清空 → 核对提示是区间不是异常 → 挪走焦点 →
+核对值回到原样、红标消失。17 = 常规 7 + 外观 1 + 终端 4 + 传输 4 + 代理 1,与静态清点一致。
+
+同一扇窗里剩下的 **22 个纯文本框**另有一条用例:逐个清空,断言不许冒出异常原文 ——
+真冒出来就说明又有人把数值属性绑到了 `TextBox` 上(隧道面板那两个端口原本就是这么写的)。
+两条都带扫描数量下限,免得哪天页面结构一变,扫不到控件却一路绿。
+
+### 五、验收
+
+`dotnet build VelaShell.slnx` 无警告;`dotnet test VelaShell.slnx` 全绿(2781 通过)。
+新增 10 条 headless UI 用例(`NumericInputGuardUiTests`):全局样式是否挂上、提示文案是否是
+区间而不是异常、失焦是否恢复、恢复后绑定是否还活着、提示是不是定宽图标且文案在悬停里、
+字母输入是否根本到不了绑定、无界与小数框的文案,以及上面那两条设置窗口整卷扫描。

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -4195,4 +4195,10 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Recorder_CleanupFailed" xml:space="preserve">
     <value>クリーンアップに失敗しました: {0}</value>
   </data>
+  <data name="Validation_NumberRange" xml:space="preserve">
+    <value>{0}～{1} の数値を入力してください</value>
+  </data>
+  <data name="Validation_NumberRequired" xml:space="preserve">
+    <value>数値を入力してください</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -4195,4 +4195,10 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Recorder_CleanupFailed" xml:space="preserve">
     <value>정리 실패: {0}</value>
   </data>
+  <data name="Validation_NumberRange" xml:space="preserve">
+    <value>{0}~{1} 사이의 숫자를 입력하세요</value>
+  </data>
+  <data name="Validation_NumberRequired" xml:space="preserve">
+    <value>숫자를 입력하세요</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -4196,4 +4196,10 @@ Choose how much to clean up. Every option rebuilds the store so the space is gen
   <data name="Recorder_CleanupFailed" xml:space="preserve">
     <value>Cleanup failed: {0}</value>
   </data>
+  <data name="Validation_NumberRange" xml:space="preserve">
+    <value>Enter a number between {0} and {1}</value>
+  </data>
+  <data name="Validation_NumberRequired" xml:space="preserve">
+    <value>Enter a number</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -4606,4 +4606,10 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Recorder_CleanupFailed" xml:space="preserve">
     <value>清理失败:{0}</value>
   </data>
+  <data name="Validation_NumberRange" xml:space="preserve">
+    <value>请输入 {0} 到 {1} 之间的数字</value>
+  </data>
+  <data name="Validation_NumberRequired" xml:space="preserve">
+    <value>请输入数字</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -4606,4 +4606,10 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Recorder_CleanupFailed" xml:space="preserve">
     <value>清理失敗:{0}</value>
   </data>
+  <data name="Validation_NumberRange" xml:space="preserve">
+    <value>請輸入 {0} 到 {1} 之間的數字</value>
+  </data>
+  <data name="Validation_NumberRequired" xml:space="preserve">
+    <value>請輸入數字</value>
+  </data>
 </root>

--- a/src/VelaShell/Behaviors/NumericInputGuard.cs
+++ b/src/VelaShell/Behaviors/NumericInputGuard.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using VelaShell.Core.Resources;
+
+namespace VelaShell.Behaviors;
+
+/// <summary>
+/// 数字输入框的兜底:内容被清空时把界面上的类型转换异常换成一句人话,并在焦点离开时
+/// 把值恢复成上一个有效值。全局挂在 <c>NumericUpDown</c> 样式上(见 Themes/DockStyles.axaml),
+/// 无需逐个输入框声明。
+/// </summary>
+/// <remarks>
+/// <c>NumericUpDown.Value</c> 是 <c>decimal?</c>,而设置项与连接配置里的目标属性是
+/// <c>int</c> / <c>double</c>。用户按退格把框删空的那一瞬间,控件把 Value 置成 null,
+/// 绑定引擎转换不了,就把异常对象本身当成校验错误摆到界面上 —— 那正是用户看到的
+/// "System.InvalidCastException: Could not convert '(null)' (null) to System.Int32."。
+/// <para>
+/// 两件事分开修。文案:<see cref="DataValidationErrors.ErrorConverterProperty" /> 把任何错误
+/// 换成"请输入 0 到 60 之间的数字",范围直接取控件自己的 Minimum / Maximum,不必逐处配文案。
+/// 状态:焦点离开时空值自动回到上一个有效值 —— 清空只是编辑过程中的一个中间态,
+/// 不该在用户走开之后还留一个红着的空框(那时目标属性其实一直是旧值,界面在说谎)。
+/// </para>
+/// <para>
+/// 提示怎么显示是另一件事,不在这里:文案挂在 DockStyles.axaml 那条 <c>DataValidationErrors</c>
+/// 的错误模板上(红色警告图标 + 悬停提示),换成图标是因为整段文字会把输入框那一列撑开。
+/// </para>
+/// </remarks>
+public static class NumericInputGuard
+{
+    /// <summary>每个输入框上一个能用的值;控件回收时随之释放。</summary>
+    private static readonly ConditionalWeakTable<NumericUpDown, LastValidValue> LastValid = [];
+
+    /// <summary>附加在 <see cref="NumericUpDown" /> 上:是否接管空值的提示文案与恢复。</summary>
+    public static readonly AttachedProperty<bool> EnabledProperty =
+        AvaloniaProperty.RegisterAttached<NumericUpDown, bool>("Enabled", typeof(NumericInputGuard));
+
+    static NumericInputGuard() =>
+        EnabledProperty.Changed.AddClassHandler<NumericUpDown>(OnEnabledChanged);
+
+    /// <summary>读取某个数字输入框是否启用了空值兜底。</summary>
+    public static bool GetEnabled(NumericUpDown box) => box.GetValue(EnabledProperty);
+
+    /// <summary>开启或关闭某个数字输入框的空值兜底。</summary>
+    public static void SetEnabled(NumericUpDown box, bool value) => box.SetValue(EnabledProperty, value);
+
+    /// <summary>
+    /// 该输入框当前该显示的提示文案:两端都有界时报出区间,否则只说"请输入数字"。
+    /// 边界按控件的 <c>FormatString</c> 渲染,小数框(行高 0.8–2.0)才不会被显示成 "0.8 到 2"。
+    /// </summary>
+    internal static string Hint(NumericUpDown box) =>
+        box.Minimum > decimal.MinValue && box.Maximum < decimal.MaxValue
+            ? Strings.Format("Validation_NumberRange", Display(box, box.Minimum), Display(box, box.Maximum))
+            : Strings.Get("Validation_NumberRequired");
+
+    private static void OnEnabledChanged(NumericUpDown box, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.NewValue is true)
+        {
+            // 闭包捕获控件本身:错误转换器签名里拿不到目标控件,而提示文案要用它的 Minimum/Maximum。
+            DataValidationErrors.SetErrorConverter(box, _ => Hint(box));
+            box.PropertyChanged += OnBoxPropertyChanged;
+            box.LostFocus += OnLostFocus;
+            Remember(box);
+        }
+        else
+        {
+            box.LostFocus -= OnLostFocus;
+            box.PropertyChanged -= OnBoxPropertyChanged;
+            DataValidationErrors.SetErrorConverter(box, null);
+        }
+    }
+
+    private static void OnBoxPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == NumericUpDown.ValueProperty && sender is NumericUpDown box)
+        {
+            Remember(box);
+        }
+    }
+
+    private static void Remember(NumericUpDown box)
+    {
+        if (box.Value is { } value)
+        {
+            LastValid.GetValue(box, static _ => new LastValidValue()).Value = value;
+        }
+    }
+
+    private static void OnLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not NumericUpDown box || box.Value is not null)
+        {
+            return;
+        }
+
+        // SetCurrentValue 而不是直接赋值:直接赋值写的是本地值,优先级高过绑定,
+        // 会把这个框和视图模型的双向绑定就地掐断,此后改设置再也传不回去。
+        LastValid.TryGetValue(box, out LastValidValue? last);
+        decimal fallback = last?.Value ?? 0m;
+        box.SetCurrentValue(NumericUpDown.ValueProperty,
+                            box.Minimum <= box.Maximum ? Math.Clamp(fallback, box.Minimum, box.Maximum) : fallback);
+    }
+
+    private static string Display(NumericUpDown box, decimal value)
+    {
+        if (string.IsNullOrEmpty(box.FormatString))
+        {
+            return value.ToString(CultureInfo.CurrentCulture);
+        }
+        try
+        {
+            return value.ToString(box.FormatString, CultureInfo.CurrentCulture);
+        }
+        catch (FormatException)
+        {
+            // FormatString 是可以从 XAML 随便写的字符串;它不合法时提示文案照样得出得来。
+            return value.ToString(CultureInfo.CurrentCulture);
+        }
+    }
+
+    private sealed class LastValidValue
+    {
+        internal decimal Value { get; set; }
+    }
+}

--- a/src/VelaShell/Converters/ValidationErrorTextConverter.cs
+++ b/src/VelaShell/Converters/ValidationErrorTextConverter.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace VelaShell.Converters;
+
+/// <summary>
+/// 一组校验错误 → 一段可直接显示的文字(多条按行拼接)。
+/// 校验提示的呈现是个只有图标的小三角,文案挂在它的悬停提示上;
+/// 悬停提示要的是一个字符串,而 <c>DataValidationErrors.Errors</c> 给的是一串对象。
+/// </summary>
+public sealed class ValidationErrorTextConverter : IValueConverter
+{
+    /// <summary>可在 XAML 中直接引用的共享单例。</summary>
+    public static readonly ValidationErrorTextConverter Instance = new();
+
+    /// <summary>把错误集合拼成多行文本;空集合返回 null,悬停提示自然不出现。</summary>
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not IEnumerable errors || value is string)
+        {
+            return value?.ToString();
+        }
+
+        string text = string.Join(Environment.NewLine,
+                                  errors.Cast<object?>()
+                                        .Select(error => error?.ToString())
+                                        .Where(line => !string.IsNullOrWhiteSpace(line)));
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
+    /// <summary>不支持反向转换,调用即抛出 <see cref="NotSupportedException" />。</summary>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -1,7 +1,10 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dockc="using:VelaShell.Docking.Controls"
-        xmlns:shapes="using:Avalonia.Controls.Shapes">
+        xmlns:shapes="using:Avalonia.Controls.Shapes"
+        xmlns:behaviors="using:VelaShell.Behaviors"
+        xmlns:conv="using:VelaShell.Converters"
+        xmlns:pc="using:VelaShell.Controls.Controls">
 
     <!-- 终端工作区(自研 VelaDock)底色 + 全局通用样式。标签本身的视觉
          (36px 条 / 32px 标签 / 状态点 / accent 顶线 / 关闭钮)内联在
@@ -20,8 +23,31 @@
     <Style Selector="TextBox[AcceptsReturn=True]">
         <Setter Property="VerticalContentAlignment" Value="Top" />
     </Style>
+    <!-- 数字框全局挂上空值兜底:删空时提示"请输入 x 到 y 之间的数字"而不是绑定抛出的
+         InvalidCastException,离开输入框后自动回到上一个有效值。理由见 NumericInputGuard。 -->
     <Style Selector="NumericUpDown">
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="behaviors:NumericInputGuard.Enabled" Value="True" />
+    </Style>
+
+    <!-- 校验提示的呈现:Fluent 默认把整段红色错误文字排进布局里。数字框全长在 "*,Auto"
+         两栏的 Auto 那一侧(设置页每一行、连接配置的"延迟(秒)"都是),一段几十字的文字进来
+         就把 Auto 列撑开,同排的输入框被挤成一条缝 —— 截图里"延迟(秒)"变成一个黑方块,
+         就是旁边那句 InvalidCastException 撑的。换成 14px 的红色警告图标 + 悬停提示:
+         占位恒定,布局纹丝不动,文案一个字没少。 -->
+    <Style Selector="DataValidationErrors">
+        <Setter Property="ErrorTemplate">
+            <DataTemplate>
+                <Border Margin="4,2,0,0" Background="Transparent"
+                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                        ToolTip.Placement="Top" ToolTip.ShowDelay="0"
+                        ToolTip.Tip="{Binding Converter={x:Static conv:ValidationErrorTextConverter.Instance}}">
+                    <pc:LucideIcon Width="14" Height="14"
+                                   Data="{DynamicResource Icon.triangle-alert}"
+                                   Foreground="{DynamicResource VelaError}" />
+                </Border>
+            </DataTemplate>
+        </Setter>
     </Style>
     <Style Selector="Button">
         <Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/VelaShell/Views/TunnelPanelView.axaml
+++ b/src/VelaShell/Views/TunnelPanelView.axaml
@@ -26,6 +26,20 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="3" />
     </Style>
+    <!-- 端口两栏用 NumericUpDown 而不是 TextBox:目标属性是 int,用文本框绑定时清空或输入字母
+         会把 "Could not convert '' (System.String) to System.Int32" 直接摆在表单里(见
+         Behaviors/NumericInputGuard)。外观照抄上面那条 TextBox —— 内部编辑框本就吃同一条样式,
+         这里只补外壳,视觉与旁边的主机框保持一致。 -->
+    <Style Selector="NumericUpDown">
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="MinHeight" Value="26" />
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="CornerRadius" Value="3" />
+      <Setter Property="ShowButtonSpinner" Value="False" />
+    </Style>
     <Style Selector="TextBlock.form-label">
       <Setter Property="Foreground" Value="{DynamicResource VelaTextMuted}" />
       <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
@@ -302,7 +316,8 @@
              取消勾选可填服务器可达的内网第三方主机。 -->
         <Grid ColumnDefinitions="80,8,*,8,56" RowDefinitions="Auto,4,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Classes="form-label" Text="{loc:Localize LocalPort}" />
-          <TextBox   Grid.Row="2" Grid.Column="0" Text="{Binding NewLocalPort}" PlaceholderText="27017" />
+          <NumericUpDown Grid.Row="2" Grid.Column="0" Value="{Binding NewLocalPort}" PlaceholderText="27017"
+                         Minimum="1" Maximum="65535" Increment="1" FormatString="0" />
           <TextBlock Grid.Row="0" Grid.Column="2" Classes="form-label" Text="{loc:Localize Tunnel_TargetHostLabel}"
                      IsVisible="{Binding IsRemoteTargetVisible}" />
           <TextBox   Grid.Row="2" Grid.Column="2"
@@ -312,8 +327,9 @@
                      IsVisible="{Binding IsRemoteTargetVisible}" />
           <TextBlock Grid.Row="0" Grid.Column="4" Classes="form-label" Text="{loc:Localize Port}"
                      IsVisible="{Binding IsRemoteTargetVisible}" />
-          <TextBox   Grid.Row="2" Grid.Column="4" Text="{Binding NewRemotePort}" PlaceholderText="27017"
-                     IsVisible="{Binding IsRemoteTargetVisible}" />
+          <NumericUpDown Grid.Row="2" Grid.Column="4" Value="{Binding NewRemotePort}" PlaceholderText="27017"
+                         Minimum="1" Maximum="65535" Increment="1" FormatString="0"
+                         IsVisible="{Binding IsRemoteTargetVisible}" />
         </Grid>
 
         <CheckBox IsChecked="{Binding ForwardToServerLoopback}"

--- a/tests/VelaShell.Tests/Behaviors/NumericInputGuardUiTests.cs
+++ b/tests/VelaShell.Tests/Behaviors/NumericInputGuardUiTests.cs
@@ -1,0 +1,434 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless;
+using Avalonia.Interactivity;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Behaviors;
+using VelaShell.Controls.Controls;
+using NSubstitute;
+using ReactiveUI.Primitives;
+using VelaShell.Core.Data;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.Localization;
+using VelaShell.ViewModels;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Behaviors;
+
+/// <summary>
+/// 数字输入框被清空时界面上出现的是人话,而不是绑定抛出的
+/// "System.InvalidCastException: Could not convert '(null)' (null) to System.Int32."。
+/// </summary>
+/// <remarks>
+/// 这条守的是用户真的会做的操作:选中"延迟(秒)"按退格删空。控件的 Value 是 decimal?,
+/// 目标属性是 int,清空那一刻绑定转换失败,默认行为是把异常对象原样摆到输入框旁边 ——
+/// 既没人看得懂,又把 80px 宽的框挤成一条缝。
+/// </remarks>
+[TestClass]
+[TestCategory("NumericInputGuardUi")]
+public sealed class NumericInputGuardUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(NumericInputGuardUiTests).Assembly);
+        LocalizedStrings.Instance.Attach(new LocalizationService());
+    }
+
+    [TestMethod]
+    public void Every_number_box_gets_the_guard_from_the_global_style()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+
+            // 兜底挂在 DockStyles.axaml 的 NumericUpDown 样式上:新加的数字框自动带上,
+            // 不需要谁记得在每个 axaml 里补一句。
+            Assert.IsTrue(NumericInputGuard.GetEnabled(fixture.Box),
+                          "全局样式没把空值兜底挂上,新增的数字框会退回显示转换异常。");
+        });
+    }
+
+    [TestMethod]
+    public void Clearing_the_box_reports_the_allowed_range_instead_of_the_cast_exception()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+
+            fixture.Box.Text = "";
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.IsTrue(DataValidationErrors.GetHasErrors(fixture.Box),
+                          "清空之后绑定确实失败了,界面本就该给出提示。");
+            List<string> messages = [.. DataValidationErrors.GetErrors(fixture.Box)!
+                .Select(error => error?.ToString() ?? "")];
+
+            Assert.HasCount(1, messages);
+            Assert.DoesNotContain("Exception", messages[0], StringComparison.Ordinal);
+            Assert.Contains("0", messages[0], StringComparison.Ordinal);
+            Assert.Contains("3600", messages[0], StringComparison.Ordinal);
+            Assert.AreEqual(NumericInputGuard.Hint(fixture.Box), messages[0]);
+        });
+    }
+
+    [TestMethod]
+    public void Leaving_an_emptied_box_restores_the_last_value_and_clears_the_complaint()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+            Assert.IsTrue(fixture.Editor.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            fixture.Box.Text = "";
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsNull(fixture.Box.Value);
+
+            Assert.IsTrue(fixture.Elsewhere.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            // 清空只是编辑中的一个中间态。人走开之后不该留一个红着的空框 ——
+            // 那时视图模型里其实一直是旧值,空框是在说谎。
+            Assert.AreEqual(30m, fixture.Box.Value);
+            Assert.AreEqual(30, fixture.Model.DelaySeconds);
+            Assert.IsFalse(DataValidationErrors.GetHasErrors(fixture.Box));
+        });
+    }
+
+    [TestMethod]
+    public void Restoring_keeps_the_two_way_binding_alive()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+            Assert.IsTrue(fixture.Editor.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            fixture.Box.Text = "";
+            Dispatcher.UIThread.RunJobs();
+            Assert.IsTrue(fixture.Elsewhere.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            // 恢复走的是 SetCurrentValue:写本地值会把绑定压住,此后改设置再也传不回视图模型。
+            fixture.Box.Text = "12";
+            Dispatcher.UIThread.RunJobs();
+            Assert.AreEqual(12, fixture.Model.DelaySeconds);
+        });
+    }
+
+    [TestMethod]
+    public void The_complaint_is_a_fixed_size_icon_not_a_block_of_text_beside_the_field()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+            double clean = fixture.Box.Bounds.Width;
+
+            fixture.Box.Text = "";
+            fixture.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            // Fluent 默认把错误文字贴在控件右侧,设置页每行只有 80–110px,一段文字进来
+            // 就把输入框压成一条缝(截图里"延迟(秒)"变成了一个黑方块)。
+            LucideIcon icon = fixture.Box.GetVisualDescendants().OfType<LucideIcon>().Single();
+            Assert.IsLessThanOrEqualTo(clean + 24, fixture.Box.Bounds.Width,
+                                       "校验提示把输入框挤宽了 —— 图标之外又冒出了整段文字。");
+
+            // 话没丢,只是挪进了悬停提示里 —— 这条一旦断了,界面上就只剩一个没人看得懂的红三角。
+            Assert.AreEqual(NumericInputGuard.Hint(fixture.Box),
+                            ToolTip.GetTip((Control)icon.Parent!) as string);
+        });
+    }
+
+    [TestMethod]
+    public void Typing_letters_never_reaches_the_binding_at_all()
+    {
+        OnUi(() =>
+        {
+            using var fixture = Fixture.Show();
+            Assert.IsTrue(fixture.Editor.Focus());
+            Dispatcher.UIThread.RunJobs();
+
+            fixture.Box.Text = "abc";
+            Dispatcher.UIThread.RunJobs();
+
+            // 解析不了的文本控件自己就拦下了,Value 不动 —— 所以这一路从来不会有转换异常;
+            // 真正会漏到绑定上的只有"清空"。这条钉住这个前提,免得日后有人以为提示丢了。
+            Assert.AreEqual(30m, fixture.Box.Value);
+            Assert.IsFalse(DataValidationErrors.GetHasErrors(fixture.Box));
+
+            Assert.IsTrue(fixture.Elsewhere.Focus());
+            Dispatcher.UIThread.RunJobs();
+            Assert.AreEqual("30", fixture.Box.Text);
+        });
+    }
+
+    [TestMethod]
+    public void An_unbounded_box_just_asks_for_a_number()
+    {
+        OnUi(() =>
+        {
+            var box = new NumericUpDown();
+            string hint = NumericInputGuard.Hint(box);
+
+            // 没设上下界时说不出区间;那就别硬拼一句 "-79228162514264337593543950335 到 …"。
+            Assert.DoesNotContain("79228162514264337593543950335", hint, StringComparison.Ordinal);
+            Assert.IsNotEmpty(hint);
+        });
+    }
+
+    [TestMethod]
+    public void A_decimal_box_states_its_bounds_the_way_it_shows_them()
+    {
+        OnUi(() =>
+        {
+            // 终端行高就是这么配的:0.8–2.0,一位小数。提示里写成 "0.8 到 2" 会让人以为上界是整数。
+            var box = new NumericUpDown { Minimum = 0.8m, Maximum = 2.0m, FormatString = "0.0" };
+
+            Assert.Contains("0.8", NumericInputGuard.Hint(box), StringComparison.Ordinal);
+            Assert.Contains("2.0", NumericInputGuard.Hint(box), StringComparison.Ordinal);
+        });
+    }
+
+    /// <summary>
+    /// 设置窗口是数字输入框最密的地方(端口、超时、保活、日志留存、界面字号、行高、内边距、
+    /// 回滚行数、并发数、限速、重试次数……)。逐个清空,逐个核对:提示是区间而不是异常,
+    /// 失焦之后值回到原样。
+    /// </summary>
+    /// <remarks>
+    /// 单独列这一条,是因为兜底靠的是全局样式选择器。哪天有人给某个页面加一条更靠后的
+    /// <c>NumericUpDown</c> 样式、或者把某个框换成别的控件,这里会立刻红 —— 而只测一个
+    /// 孤立的数字框永远发现不了。
+    /// </remarks>
+    [TestMethod]
+    public void Every_number_box_in_the_settings_window_is_covered()
+    {
+        OnSettingsWindow((window, viewModel) =>
+        {
+            int swept = 0;
+            foreach (int _ in EachPage(window, viewModel))
+            {
+                foreach (NumericUpDown box in Live<NumericUpDown>(window))
+                {
+                    SweepOne(window, box);
+                    swept++;
+                }
+            }
+
+            // 没有这道下限,哪天页面结构一变扫不到控件,这条就悄悄变成一个永远通过的空壳。
+            // 17 = 常规 7 + 外观 1 + 终端 4 + 传输 4 + 代理 1。
+            Assert.IsGreaterThanOrEqualTo(17, swept,
+                                          $"设置窗口里只扫到 {swept} 个数字框,远低于预期 —— 扫描八成失效了。");
+        });
+    }
+
+    /// <summary>
+    /// 设置窗口里剩下的可编辑字段(纯文本框)清空之后也不许冒出转换异常 ——
+    /// 那意味着又有人把数值属性绑到了 <see cref="TextBox" /> 上(隧道面板的端口原本就是这么写的)。
+    /// </summary>
+    [TestMethod]
+    public void Emptying_any_text_field_in_the_settings_window_never_surfaces_an_exception()
+    {
+        OnSettingsWindow((window, viewModel) =>
+        {
+            int swept = 0;
+            foreach (int _ in EachPage(window, viewModel))
+            {
+                // 数字框模板里也有一个 TextBox,那条路上面那条用例已经管了,这里跳过。
+                foreach (TextBox field in Live<TextBox>(window)
+                             .Where(field => !field.GetVisualAncestors().OfType<NumericUpDown>().Any()))
+                {
+                    string? original = field.Text;
+                    field.Text = "";
+                    Dispatcher.UIThread.RunJobs();
+
+                    foreach (object? error in DataValidationErrors.GetErrors(field) ?? [])
+                    {
+                        Assert.DoesNotContain("Exception", error?.ToString() ?? "", StringComparison.Ordinal,
+                                              $"清空文本框「{original}」后冒出了异常原文 —— 它八成绑在一个数值属性上,改用 NumericUpDown。");
+                    }
+
+                    field.Text = original;
+                    Dispatcher.UIThread.RunJobs();
+                    swept++;
+                }
+            }
+
+            Assert.IsGreaterThanOrEqualTo(20, swept,
+                                          $"设置窗口里只扫到 {swept} 个文本框,远低于预期 —— 扫描八成失效了。");
+        });
+    }
+
+    /// <summary>把设置窗口连同视图模型架起来交给用例;窗口在用例跑完后关掉。</summary>
+    private static void OnSettingsWindow(Action<SettingsView, SettingsViewModel> body) =>
+        _session.Dispatch(async () =>
+        {
+            ISettingsService settings = Substitute.For<ISettingsService>();
+            IThemeService theme = Substitute.For<IThemeService>();
+            settings.GetSettingsAsync().Returns(new AppSettings());
+            var viewModel = new SettingsViewModel(settings, theme);
+            await viewModel.LoadCommand.Execute().FirstAsync();
+
+            // 有几个字段跟在开关后面(自动重连的间隔与重试、限速的上下行、日志留存与目录、
+            // 代理那一整组)。开关不打开它们根本不出现,扫描就会漏掉一半 —— 全部拨到"露出来"。
+            viewModel.General.AutoReconnect = true;
+            viewModel.General.SessionLogging = true;
+            viewModel.Transfer.BandwidthLimitEnabled = true;
+            viewModel.Transfer.TransferLogging = true;
+            viewModel.ProxyTypeIndex = 2;
+
+            var window = new SettingsView { DataContext = viewModel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            body(window, viewModel);
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>逐页翻过去:各页默认收着,只有当页可见,里面的控件才有模板、才能拿焦点。</summary>
+    private static IEnumerable<int> EachPage(SettingsView window, SettingsViewModel viewModel)
+    {
+        for (int section = 0; section <= 11; section++)
+        {
+            viewModel.SelectedSectionIndex = section;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            yield return section;
+        }
+    }
+
+    /// <summary>当页上真的能让用户动手的那些控件。</summary>
+    private static List<T> Live<T>(Visual root) where T : Control =>
+        [.. root.GetVisualDescendants().OfType<T>()
+                .Where(control => control.IsEffectivelyVisible && control.IsEffectivelyEnabled)];
+
+    /// <summary>清空一个数字框,核对提示,再把焦点挪走,核对它自己恢复了。</summary>
+    private static void SweepOne(Visual root, NumericUpDown box)
+    {
+        decimal? before = box.Value;
+        Assert.IsTrue(NumericInputGuard.GetEnabled(box), $"{Describe(box)} 没挂上空值兜底。");
+
+        box.Text = "";
+        Dispatcher.UIThread.RunJobs();
+
+        foreach (string message in DataValidationErrors.GetErrors(box)?
+                     .Select(error => error?.ToString() ?? "") ?? [])
+        {
+            Assert.DoesNotContain("Exception", message, StringComparison.Ordinal,
+                                  $"{Describe(box)} 清空后仍在显示异常原文:{message}");
+            Assert.AreEqual(NumericInputGuard.Hint(box), message, Describe(box));
+        }
+
+        // 走真实的焦点通道:LostFocus 带的是 FocusChangedEventArgs,自己 RaiseEvent 一个裸
+        // RoutedEventArgs 会把别人挂的强类型处理器炸掉,测的也就不是真事了。
+        Assert.IsTrue(box.GetVisualDescendants().OfType<TextBox>().First().Focus(), Describe(box));
+        Dispatcher.UIThread.RunJobs();
+        Assert.IsTrue(Elsewhere(root, box).Focus(), $"{Describe(box)} 那一页找不到能接走焦点的控件。");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.AreEqual(before, box.Value, $"{Describe(box)} 失焦后没回到原值。");
+        Assert.IsFalse(DataValidationErrors.GetHasErrors(box), $"{Describe(box)} 失焦后还红着。");
+    }
+
+    /// <summary>当页上任意一个能接走焦点的控件,但不能是被测框自己(它的编辑框就在它肚子里)。</summary>
+    private static Control Elsewhere(Visual root, NumericUpDown box) =>
+        root.GetVisualDescendants()
+            .OfType<Control>()
+            .First(control => control is TextBox or Button or CheckBox or ToggleSwitch or ComboBox
+                              && control.IsEffectivelyVisible
+                              && control.Focusable
+                              && !control.GetVisualAncestors().Contains(box));
+
+    /// <summary>断言失败时能指认是哪一个框:设置页的框没有名字,用区间当身份。</summary>
+    private static string Describe(NumericUpDown box) =>
+        $"数字框[{box.Minimum}–{box.Maximum}]";
+
+    private static void OnUi(Action action) =>
+        _session.Dispatch(() =>
+        {
+            action();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>一个绑到 int 属性的数字框 + 一个用来抢焦点的输入框,照搬连接配置里"延迟(秒)"那一处。</summary>
+    private sealed class Fixture : IDisposable
+    {
+        private Fixture(Window window, NumericUpDown box, TextBox elsewhere, DelayModel model)
+        {
+            Window = window;
+            Box = box;
+            Elsewhere = elsewhere;
+            Model = model;
+        }
+
+        internal Window Window { get; }
+        internal NumericUpDown Box { get; }
+        internal TextBox Elsewhere { get; }
+        internal DelayModel Model { get; }
+
+        /// <summary>数字框模板里那个真正接收键盘与焦点的输入框 —— NumericUpDown 本身不可聚焦。</summary>
+        internal TextBox Editor => Box.GetVisualDescendants().OfType<TextBox>().First();
+
+        internal static Fixture Show()
+        {
+            var model = new DelayModel { DelaySeconds = 30 };
+            var box = new NumericUpDown
+            {
+                Minimum = 0,
+                Maximum = 3600,
+                Increment = 1,
+                FormatString = "0",
+                ShowButtonSpinner = false,
+            };
+            box.Bind(NumericUpDown.ValueProperty,
+                     new Binding(nameof(DelayModel.DelaySeconds))
+                     {
+                         Source = model,
+                         Mode = BindingMode.TwoWay,
+                     });
+            var elsewhere = new TextBox();
+            var window = new Window { Content = new StackPanel { Children = { box, elsewhere } } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            return new(window, box, elsewhere, model);
+        }
+
+        public void Dispose()
+        {
+            Window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private sealed class DelayModel : INotifyPropertyChanged
+    {
+        private int _delaySeconds;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int DelaySeconds
+        {
+            get => _delaySeconds;
+            set
+            {
+                if (_delaySeconds == value)
+                {
+                    return;
+                }
+                _delaySeconds = value;
+                PropertyChanged?.Invoke(this, new(nameof(DelaySeconds)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 现象

连接配置 → 高级选项 →「认证后执行命令」右边的「延迟(秒)」,把里面的数字删掉,框旁边立刻冒出一整段红字 **`System.InvalidCastException: Could not convert '(null)' (null) to System.Int32.`**,同时把同排的命令输入框挤成一条缝。

## 根因

`NumericUpDown.Value` 是 `decimal?`,而目标属性(设置项、连接配置)是 `int` / `double`。按退格删空的那一刻控件把 Value 置成 `null`,绑定引擎转换不了,把**异常对象本身**当作校验错误交给 `DataValidationErrors` —— 界面于是原样显示异常的 `ToString()`。全项目 20 处 `NumericUpDown` 无一例外,这是控件与绑定的默认组合行为,不是哪一处写错了。

布局被挤是同一件事的副作用:数字框统统长在 `"*,Auto"` 两栏的 Auto 一侧,Fluent 默认把整段错误文字排进布局,几十字的异常把 Auto 列撑开,`*` 那栏就被压没了。

## 修法:文案、状态、呈现三件事分开

**文案** — 新增 `Behaviors/NumericInputGuard.cs`,用 `DataValidationErrors.ErrorConverter` 把任何错误换成一句人话:「请输入 0 到 60 之间的数字」。区间直接读控件自己的 `Minimum` / `Maximum`(延迟 0–60、端口 1–65535、行高 0.8–2.0),按控件的 `FormatString` 渲染 —— 一位小数的行高框才不会被写成「0.8 到 2」让人以为上界是整数。两端没有界时退回「请输入数字」。五份 resx 各加 `Validation_NumberRange` / `Validation_NumberRequired`。

**状态** — 同一个行为在 `LostFocus` 上兜底:值还是空的就恢复成上一个有效值。清空只是编辑中的中间态,人走开之后不该留一个红着的空框 —— 那时视图模型里其实一直是旧值,空框在说谎。恢复走 `SetCurrentValue` 而不是直接赋值:直接赋值写的是本地值,优先级高过绑定,会把这个框与视图模型的双向绑定就地掐断。

**呈现** — `Themes/DockStyles.axaml` 把 `DataValidationErrors.ErrorTemplate` 换成 14px 红色警告图标 + 悬停提示(文案经新增的 `Converters/ValidationErrorTextConverter` 拼成一段)。占位恒定,布局纹丝不动,文案一个字没少。

兜底挂在全局那条 `Style Selector="NumericUpDown"` 上,新加的数字框自动带上,不需要谁记得在每个 axaml 里补一句。

## 顺带:两个用 TextBox 装端口的地方

隧道面板的「本地端口」「端口」绑的是 `int NewLocalPort` / `NewRemotePort`,却用的 `TextBox`,删空或输入字母同样会把 `Could not convert '' (System.String) to System.Int32` 摆进表单。改成 `NumericUpDown`(1–65535,不显示微调钮),外观照抄本视图那条 TextBox 样式,与旁边的主机框逐像素一致(已用 headless 截图核对)。**全项目再无绑到数值属性的可编辑 `TextBox`。**

另外查证:输入字母这条路其实**到不了绑定** —— 控件解析不了的文本自己就拦下了,`Value` 不动,失焦时文本回滚。真正会漏到绑定上的只有"清空"。有一条用例把这个前提钉住。

## 设置窗口整卷扫过

不靠"改的是全局样式,应该都覆盖到了"这句话交差,而是把设置窗口整个架起来逐页逐框走一遍:翻遍 12 个分页,把跟在开关后面的字段(自动重连的间隔与重试、限速上下行、日志留存与目录、代理那一整组)全拨出来,**17 个数字框**逐个清空 → 核对提示是区间不是异常 → 挪走焦点 → 核对值回到原样、红标消失。17 = 常规 7 + 外观 1 + 终端 4 + 传输 4 + 代理 1,与静态清点一致。

同一扇窗里剩下的 **22 个纯文本框**另有一条用例:逐个清空,断言不许冒出异常原文 —— 真冒出来就说明又有人把数值属性绑到了 `TextBox` 上。两条都带扫描数量下限,免得哪天页面结构一变,扫不到控件却一路绿。

## 验收

- `dotnet build VelaShell.slnx` 无警告
- `dotnet test VelaShell.slnx` 全绿(2781 通过)
- 新增 10 条 headless UI 用例(`NumericInputGuardUiTests`)
- 进展记录见 `plan.md` §40

文档侧无需同步:`velashell-docs` 的「交互与界面规格」没有规定校验提示的呈现形式,隧道表单那一条写的是「本地端口 输入」,`NumericUpDown` 照样满足。

> 本 PR 基于 `main`,与 #369(快捷命令浮层黑边)互不重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASUwXM5wNV3k5rSyAyJUiP
