### PR TITLE
统一代码风格，简化实现，优化可读性

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,33 @@
+# ============================================================================
+# VelaShell .editorconfig
+#
+# 分成两部分:
+#   1. 「通用部分」—— 与仓库无关的现代 C#(C# 12 ~ C# 15 / .NET 11)风格,可以整段复制到新项目当默认配置。
+#   2. 「仓库特定」—— 只对本仓库成立的分析器取舍(文件末尾,带 banner)。
+#
+# 严重级别的用法(这决定了 IDE 提示、代码清理和构建三处各看到什么):
+#   warning    代码已经全部符合,新写的不符合就该被看见。构建里要生效需在 MSBuild 打开
+#              EnforceCodeStyleInBuild;IDE 里始终生效。
+#   suggestion 想逐步推进的现代化写法:IDE 里显示「…」提示,代码清理会自动套用。
+#   silent     交给代码清理去套用、但不想在编辑器里看见任何提示的偏好。
+#   none       对本仓库是错的规则,代码清理也不会碰。
+# 同一条规则同时给了 `选项 = 值:级别` 和 `dotnet_diagnostic.IDExxxx.severity`,两边级别必须一致:
+# 两者都在时谁优先取决于工具(VS 看选项后缀,dotnet format 看 dotnet_diagnostic,.NET 9+ 的
+# EnforceCodeStyleInBuild 构建看选项后缀),写成一样就不用关心。命名规则(IDE1006)例外:
+# 不在全局给它 dotnet_diagnostic,那会把每条命名规则各自的级别压成同一个;代价是命名只在 IDE 里查,
+# 不进构建。
+# ============================================================================
+
 root = true
+
+# ============================================================================
+# 通用部分
+# ============================================================================
 
 [*]
 charset = utf-8
+# 仓库以 LF 入库(.gitattributes text=auto)。Windows 上 core.autocrlf=true 的工作区会是 CRLF,
+# 这是 git 在签出时转换的结果,不是风格问题;不要为此改成 crlf。
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
@@ -9,57 +35,139 @@ trim_trailing_whitespace = true
 [*.{cs,csx,vb,vbx}]
 indent_style = space
 indent_size = 4
+tab_width = 4
 
-[*.{json,xml,axaml,xaml}]
+# XML 系(项目文件、Avalonia 视图、资源)与 JSON 统一 2 空格:嵌套深,4 空格很快就顶到右边。
+[*.{json,jsonc,xml,axaml,xaml,resx,csproj,props,targets,slnx,nuspec,config,runsettings,manifest}]
 indent_style = space
 indent_size = 2
 
-# C# Code Style
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown 的行尾两个空格是硬换行,不能被 trim 掉。
+[*.md]
+trim_trailing_whitespace = false
+
+# 老式 .sln 由 VS 生成,用 Tab。
+[*.sln]
+indent_style = tab
+
+# 在 Linux runner 上执行的脚本必须是 LF,否则 shebang 变成 "/usr/bin/env^M"(与 .gitattributes 一致)。
+[*.{sh,spec,spec.in}]
+end_of_line = lf
+
+[AppRun]
+end_of_line = lf
+
+# Windows PowerShell 5.1 把无 BOM 的 .ps1 当 ANSI 读,非 ASCII 字符串直接乱码报错;pwsh 7 两者都认。
+[*.{ps1,psm1,psd1}]
+charset = utf-8-bom
+end_of_line = crlf
+
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# ----------------------------------------------------------------------------
+# C# —— 语言与表达式风格
+# ----------------------------------------------------------------------------
 [*.cs]
-# Organize usings
+
+# ---- using 与命名空间 ----
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
+csharp_using_directive_placement = outside_namespace:warning
+# 文件范围命名空间是 C# 10 起的默认形态;整仓已是如此,退回块作用域只会多一层缩进。
+csharp_style_namespace_declarations = file_scoped:warning
+# 命名空间与目录对应关系由人来定(插件目录、测试夹具都有例外),不让分析器改名。
+dotnet_style_namespace_match_folder = false
 
-# this. preferences
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# ---- this. 与内置类型 ----
+# 扩展方法调用(this.RaiseAndSetIfChanged / this.WhenAnyValue)语法上必须带 this,分析器不会碰它们。
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
 
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-# Parentheses preferences
+# ---- 括号 ----
+# 混合运算符时保留澄清用的括号;IDE0047 在仓库里已 NoWarn,保持 silent 免得两边打架。
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
 
-# Expression-level preferences
+# ---- 修饰符 ----
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
+# 顺序取自 Roslyn 默认,含 C# 11 的 file/required 与 C# 15 的 closed。
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,closed,sealed,override,readonly,unsafe,required,volatile,async:warning
+csharp_prefer_static_local_function = true:warning
+# 不捕获任何东西的 lambda 标成 static,避免误捕获 this;逐步推进。
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# ---- 表达式级偏好 ----
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
+# 集合表达式(C# 12)是整仓的主写法;loosely_match 让 List<T> 字段也能用 [] 初始化。
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
+# if/else 换三元是口味问题:仓库里 100+ 处 return 分支刻意写成 if/else,不让分析器和清理碰。
+dotnet_style_prefer_conditional_expression_over_assignment = false:silent
+dotnet_style_prefer_conditional_expression_over_return = false:silent
+# foreach 里的隐式向下转型看不见,强类型集合上禁止依赖它。
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:warning
+csharp_style_prefer_utf8_string_literals = true:warning
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# 丢弃未用返回值(`_ = list.Remove(x);`)整仓有 2400+ 处会被改写,纯噪声,关掉。
+csharp_style_unused_value_expression_statement_preference = discard_variable:none
+# 不需要的 lambda 包装(x => Foo(x))直接写方法组。
+csharp_style_prefer_method_group_conversion = true:suggestion
+# C# 14:lambda 参数带 ref/out/in 修饰符时可以省类型;C# 14:nameof(List<>)。
+csharp_style_prefer_implicitly_typed_lambda_expression = true:suggestion
+csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
+# C# 14:能用 field 关键字化简的属性访问器(IDE0360)。
+csharp_style_prefer_simple_property_accessors = true:suggestion
+# 预览语言特性:带标签的 break/continue 替代 goto(IDE0410);语言版本不支持时分析器不会触发。
+csharp_style_prefer_labeled_jump_statements = true:suggestion
+dotnet_prefer_system_hash_code = true:suggestion
 
-# Null-checking preferences
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+# ---- null 检查 ----
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
 
-# var preferences
+# ---- var ----
+# 内置类型与右侧看不出类型时写明类型,右侧已经是 new/强转/字面量时用 var。
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
-# Expression-bodied members
+# ---- 表达式体成员 ----
+# 一行放得下就用 =>。只让清理套用,不提示。
 csharp_style_expression_bodied_methods = when_on_single_line:silent
-csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_constructors = when_on_single_line:silent
 csharp_style_expression_bodied_operators = when_on_single_line:silent
 csharp_style_expression_bodied_properties = when_on_single_line:silent
 csharp_style_expression_bodied_indexers = when_on_single_line:silent
@@ -67,63 +175,299 @@ csharp_style_expression_bodied_accessors = when_on_single_line:silent
 csharp_style_expression_bodied_lambdas = when_on_single_line:silent
 csharp_style_expression_bodied_local_functions = when_on_single_line:silent
 
-# Pattern matching preferences
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# ---- 模式匹配 ----
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
 
-# Inlined variable declarations
-csharp_style_inlined_variable_declaration = true:suggestion
+# ---- 代码块 ----
+# 单语句体允许省花括号(`if (x) return;` 是仓库惯用写法),跨多行的语句体必须加。
+csharp_prefer_braces = when_multiline:silent
+csharp_prefer_simple_using_statement = true:warning
+# lock 语句一律用 System.Threading.Lock(C# 13),object 锁没有作用域检查。
+csharp_prefer_system_threading_lock = true:warning
+# 只做参数捕获的构造函数改主构造函数(C# 12);已有 350+ 处,余下的逐步推进。
+csharp_style_prefer_primary_constructors = true:suggestion
+# 顶级语句只在新建控制台程序时有意义,静默;已有显式 Main 的项目不受影响。
+csharp_style_prefer_top_level_statements = true:silent
 
-# C# expression-level preferences
-csharp_prefer_simple_default_expression = true:suggestion
+# ---- 参数与成员的使用情况 ----
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_remove_unnecessary_suppression_exclusions = none
 
-# C# null-checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
+# ---- 文件头 ----
+file_header_template = unset
 
-# Code block preferences
-csharp_prefer_braces = true:silent
+# ----------------------------------------------------------------------------
+# C# —— 排版(csharp_* 格式化选项,由 IDE0055 / 代码清理「设置文档格式」执行)
+# ----------------------------------------------------------------------------
+# 换行:Allman 风格,所有花括号独占一行。
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
-# Modifier preferences
-csharp_prefer_static_local_function = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# 缩进
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = true
 
-# Naming conventions
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+# 空格
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
 
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+# 换行保留:{ get; set; } 这类单行块保留;`try { x(); } catch { }`、`if (...) return;` 这类刻意写成一行的语句也保留,
+# 设成 false 会把整仓 140 多处这种写法强行拆行。
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+# 长条件折行时运算符放行首,一眼看出这一行是接上一行的。
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+# 空行纪律(IDE2000-IDE2006)。多余空行让清理删掉;`=>` 后换行(680+ 处)与单行嵌入语句是仓库惯用写法,放行。
+dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
 
-# Symbol specifications
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+# ----------------------------------------------------------------------------
+# C# —— 命名(IDE1006)。规则按书写顺序匹配,先具体后宽泛。
+# ----------------------------------------------------------------------------
+# 接口 IFoo
+dotnet_naming_rule.interfaces_begin_with_i.severity = warning
+dotnet_naming_rule.interfaces_begin_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_begin_with_i.style = begins_with_i
+# 类型参数 TFoo
+dotnet_naming_rule.type_parameters_begin_with_t.severity = warning
+dotnet_naming_rule.type_parameters_begin_with_t.symbols = type_parameters
+dotnet_naming_rule.type_parameters_begin_with_t.style = begins_with_t
+# 类型 PascalCase
+dotnet_naming_rule.types_pascal_case.severity = warning
+dotnet_naming_rule.types_pascal_case.symbols = types
+dotnet_naming_rule.types_pascal_case.style = pascal_case
+# 常量字段 PascalCase(任何可见性)。局部 const 归局部变量规则管:仓库里 `const double kb = 1024` 这类写法是 camelCase。
+dotnet_naming_rule.constants_pascal_case.severity = warning
+dotnet_naming_rule.constants_pascal_case.symbols = constants
+dotnet_naming_rule.constants_pascal_case.style = pascal_case
+# 私有 static readonly 字段 PascalCase —— 它们在用法上等同常量(Timeout、Gate、DefaultTypeface)
+dotnet_naming_rule.private_static_readonly_fields_pascal_case.severity = warning
+dotnet_naming_rule.private_static_readonly_fields_pascal_case.symbols = private_static_readonly_fields
+dotnet_naming_rule.private_static_readonly_fields_pascal_case.style = pascal_case
+# 其余私有/内部字段 _camelCase
+dotnet_naming_rule.private_fields_underscore_camel_case.severity = warning
+dotnet_naming_rule.private_fields_underscore_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_underscore_camel_case.style = underscore_camel_case
+# 公开字段 PascalCase(Avalonia 的 StyledProperty / AttachedProperty 就是这类)
+dotnet_naming_rule.public_fields_pascal_case.severity = warning
+dotnet_naming_rule.public_fields_pascal_case.symbols = public_fields
+dotnet_naming_rule.public_fields_pascal_case.style = pascal_case
+# 属性 / 方法 / 事件 PascalCase
+dotnet_naming_rule.members_pascal_case.severity = warning
+dotnet_naming_rule.members_pascal_case.symbols = members
+dotnet_naming_rule.members_pascal_case.style = pascal_case
+# 局部函数 PascalCase
+dotnet_naming_rule.local_functions_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_pascal_case.style = pascal_case
+# 局部变量与参数 camelCase
+dotnet_naming_rule.locals_and_parameters_camel_case.severity = suggestion
+dotnet_naming_rule.locals_and_parameters_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_and_parameters_camel_case.style = camel_case
 
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+# 符号
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum, delegate
+dotnet_naming_symbols.types.applicable_accessibilities = *
+dotnet_naming_symbols.constants.applicable_kinds = field
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+dotnet_naming_symbols.constants.required_modifiers = const
+dotnet_naming_symbols.private_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_symbols.private_static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.members.applicable_kinds = property, event, method
+dotnet_naming_symbols.members.applicable_accessibilities = *
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = *
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = local, parameter
+dotnet_naming_symbols.locals_and_parameters.applicable_accessibilities = *
 
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
+# 样式
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.begins_with_t.required_prefix = T
+dotnet_naming_style.begins_with_t.capitalization = pascal_case
 dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+# ----------------------------------------------------------------------------
+# IDE 诊断级别 —— 给编译器(EnforceCodeStyleInBuild)与 dotnet format 看的那一份,
+# 与上面各选项的级别一一对应。没列的 IDE 规则保持 Roslyn 默认。
+# ----------------------------------------------------------------------------
+# 简化 / 清理类:代码里不该留下这些
+# 名称与成员访问的化简(System.Text.Json.JsonValueKind.Null → JsonValueKind.Null)不能进构建,只做提示;仓库里现存约 90 处。
+dotnet_diagnostic.IDE0001.severity = suggestion
+dotnet_diagnostic.IDE0002.severity = suggestion
+dotnet_diagnostic.IDE0004.severity = warning
+# 未用的 using —— 需要 GenerateDocumentationFile=true 才能在构建期报出,本仓库已开。
+dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.IDE0035.severity = warning
+dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.IDE0052.severity = warning
+dotnet_diagnostic.IDE0059.severity = suggestion
+dotnet_diagnostic.IDE0060.severity = suggestion
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_diagnostic.IDE0080.severity = warning
+dotnet_diagnostic.IDE0100.severity = warning
+dotnet_diagnostic.IDE0110.severity = warning
+dotnet_diagnostic.IDE0240.severity = warning
+dotnet_diagnostic.IDE0241.severity = warning
+# 风格类
+dotnet_diagnostic.IDE0003.severity = warning
+dotnet_diagnostic.IDE0009.severity = warning
+dotnet_diagnostic.IDE0007.severity = suggestion
+dotnet_diagnostic.IDE0008.severity = suggestion
+dotnet_diagnostic.IDE0010.severity = silent
+dotnet_diagnostic.IDE0011.severity = silent
+dotnet_diagnostic.IDE0016.severity = warning
+dotnet_diagnostic.IDE0017.severity = suggestion
+dotnet_diagnostic.IDE0018.severity = warning
+dotnet_diagnostic.IDE0019.severity = warning
+dotnet_diagnostic.IDE0020.severity = warning
+dotnet_diagnostic.IDE0021.severity = silent
+dotnet_diagnostic.IDE0022.severity = silent
+dotnet_diagnostic.IDE0023.severity = silent
+dotnet_diagnostic.IDE0024.severity = silent
+dotnet_diagnostic.IDE0025.severity = silent
+dotnet_diagnostic.IDE0026.severity = silent
+dotnet_diagnostic.IDE0027.severity = silent
+dotnet_diagnostic.IDE0028.severity = suggestion
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_diagnostic.IDE0032.severity = suggestion
+dotnet_diagnostic.IDE0033.severity = suggestion
+dotnet_diagnostic.IDE0034.severity = warning
+dotnet_diagnostic.IDE0036.severity = warning
+dotnet_diagnostic.IDE0037.severity = suggestion
+dotnet_diagnostic.IDE0038.severity = warning
+dotnet_diagnostic.IDE0039.severity = suggestion
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_diagnostic.IDE0042.severity = suggestion
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_diagnostic.IDE0049.severity = warning
+dotnet_diagnostic.IDE0053.severity = silent
+dotnet_diagnostic.IDE0054.severity = suggestion
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_diagnostic.IDE0056.severity = suggestion
+dotnet_diagnostic.IDE0057.severity = suggestion
+dotnet_diagnostic.IDE0058.severity = none
+dotnet_diagnostic.IDE0061.severity = silent
+dotnet_diagnostic.IDE0062.severity = warning
+dotnet_diagnostic.IDE0063.severity = warning
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_diagnostic.IDE0066.severity = suggestion
+dotnet_diagnostic.IDE0070.severity = suggestion
+dotnet_diagnostic.IDE0071.severity = suggestion
+dotnet_diagnostic.IDE0072.severity = silent
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_diagnostic.IDE0075.severity = suggestion
+dotnet_diagnostic.IDE0078.severity = suggestion
+dotnet_diagnostic.IDE0082.severity = suggestion
+dotnet_diagnostic.IDE0083.severity = warning
+dotnet_diagnostic.IDE0090.severity = warning
+dotnet_diagnostic.IDE0120.severity = suggestion
+dotnet_diagnostic.IDE0130.severity = none
+dotnet_diagnostic.IDE0150.severity = warning
+dotnet_diagnostic.IDE0160.severity = none
+dotnet_diagnostic.IDE0161.severity = warning
+dotnet_diagnostic.IDE0170.severity = warning
+dotnet_diagnostic.IDE0180.severity = warning
+dotnet_diagnostic.IDE0200.severity = suggestion
+dotnet_diagnostic.IDE0210.severity = silent
+dotnet_diagnostic.IDE0211.severity = none
+dotnet_diagnostic.IDE0220.severity = warning
+dotnet_diagnostic.IDE0230.severity = warning
+dotnet_diagnostic.IDE0250.severity = warning
+dotnet_diagnostic.IDE0251.severity = warning
+dotnet_diagnostic.IDE0260.severity = warning
+dotnet_diagnostic.IDE0270.severity = warning
+dotnet_diagnostic.IDE0280.severity = suggestion
+dotnet_diagnostic.IDE0290.severity = suggestion
+dotnet_diagnostic.IDE0300.severity = suggestion
+dotnet_diagnostic.IDE0301.severity = suggestion
+dotnet_diagnostic.IDE0302.severity = suggestion
+dotnet_diagnostic.IDE0303.severity = suggestion
+dotnet_diagnostic.IDE0304.severity = suggestion
+dotnet_diagnostic.IDE0305.severity = suggestion
+dotnet_diagnostic.IDE0306.severity = suggestion
+dotnet_diagnostic.IDE0320.severity = suggestion
+dotnet_diagnostic.IDE0330.severity = warning
+dotnet_diagnostic.IDE0340.severity = suggestion
+dotnet_diagnostic.IDE0350.severity = suggestion
+dotnet_diagnostic.IDE0360.severity = suggestion
+# 多余的 !、unsafe、async 修饰符(Roslyn 5.x 新增)。
+dotnet_diagnostic.IDE0370.severity = suggestion
+dotnet_diagnostic.IDE0380.severity = suggestion
+dotnet_diagnostic.IDE0390.severity = suggestion
+dotnet_diagnostic.IDE0391.severity = suggestion
+dotnet_diagnostic.IDE0410.severity = suggestion
+dotnet_diagnostic.IDE1005.severity = warning
+dotnet_diagnostic.IDE2000.severity = suggestion
+dotnet_diagnostic.IDE2001.severity = silent
+dotnet_diagnostic.IDE2002.severity = silent
+dotnet_diagnostic.IDE2003.severity = silent
+dotnet_diagnostic.IDE2004.severity = silent
+dotnet_diagnostic.IDE2005.severity = silent
+dotnet_diagnostic.IDE2006.severity = silent
+
+# ============================================================================
+# 仓库特定
+# ============================================================================
 
 # ============================================================================
 # 性能分析器(CA1xxx)
@@ -177,6 +521,13 @@ dotnet_diagnostic.CA1863.severity = none
 # 数组/Span 以避免拷贝(终端网格、协议缓冲)。
 dotnet_diagnostic.CA1819.severity = none
 
+# ---- Win32 互操作结构体 ------------------------------------------------------
+
+# STARTUPINFOEX / PROCESS_INFORMATION 的字段名(cb、lpReserved、dwX、hProcess…)与 WM_* 消息常量
+# 照抄 Windows SDK,对着文档能一眼对上;这几个文件不套命名规则。
+[{src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs,src/VelaShell/Views/Win32WindowChrome.cs,src/VelaShell/Views/WindowMoveDrag.cs,src/VelaShell.PluginHost/PluginHostShellWindow.cs}]
+dotnet_diagnostic.IDE1006.severity = none
+
 # ---- 测试项目的放宽 --------------------------------------------------------
 
 [tests/**.cs]
@@ -184,3 +535,5 @@ dotnet_diagnostic.CA1819.severity = none
 # Assert.AreSequenceEqual(new[] { "a", "b" }, actual) 就该这么写 —— 把期望值搬到类字段上,
 # 读的人要来回跳才能知道这条断言在比什么,而"重复调用重复分配"在只跑一次的用例里不存在。
 dotnet_diagnostic.CA1861.severity = none
+# 测试里的命名更自由(headless 会话助手 `_session` 属性、下划线分隔的用例名),只提示不告警。
+dotnet_diagnostic.IDE1006.severity = suggestion

--- a/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
+++ b/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
@@ -22,15 +22,13 @@ public sealed class AiPlugin : IVelaPlugin
     private IPluginPanel? _panel;
     private IPluginPanel? _collaborationPanel;
     private ChatPanelView? _view;
-    private BridgeService? _bridge;
-    private McpEndpoint? _mcpServer;
     private readonly List<IDisposable> _commands = [];
 
     /// <summary>IM 桥接(设置页保存后调它的 <c>ReloadAsync</c>)。</summary>
-    public BridgeService? Bridge => _bridge;
+    public BridgeService? Bridge { get; private set; }
 
     /// <summary>对外的 MCP 服务端(设置页保存后调它的 <c>ReloadAsync</c>)。</summary>
-    public McpEndpoint? McpServer => _mcpServer;
+    public McpEndpoint? McpServer { get; private set; }
 
     /// <inheritdoc />
     public Task ActivateAsync(IPluginContext context, CancellationToken cancellationToken)
@@ -55,13 +53,13 @@ public sealed class AiPlugin : IVelaPlugin
     /// </remarks>
     private void StartServices(IPluginContext context, CancellationToken cancellationToken)
     {
-        _bridge = new BridgeService(context, _store!);
-        _mcpServer = new McpEndpoint(context, new McpServerSettingsStore(context));
+        Bridge = new BridgeService(context, _store!);
+        McpServer = new McpEndpoint(context, new McpServerSettingsStore(context));
         _ = Task.Run(async () =>
         {
             try
             {
-                await _bridge.ReloadAsync(cancellationToken);
+                await Bridge.ReloadAsync(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -69,7 +67,7 @@ public sealed class AiPlugin : IVelaPlugin
             }
             try
             {
-                await _mcpServer.ReloadAsync(cancellationToken);
+                await McpServer.ReloadAsync(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -86,15 +84,15 @@ public sealed class AiPlugin : IVelaPlugin
         _view = null;
         _panel = null;
         _commands.Clear();
-        if (_bridge is { } bridge)
+        if (Bridge is { } bridge)
         {
             await bridge.DisposeAsync();
-            _bridge = null;
+            Bridge = null;
         }
-        if (_mcpServer is { } mcp)
+        if (McpServer is { } mcp)
         {
             await mcp.DisposeAsync();
-            _mcpServer = null;
+            McpServer = null;
         }
         _context = null;
     }
@@ -146,18 +144,18 @@ public sealed class AiPlugin : IVelaPlugin
                 WindowWidth = 860,
                 WindowHeight = 780
             },
-            () => new CollaborationView(context, loc, RestartServicesAsync, _bridge));
+            () => new CollaborationView(context, loc, RestartServicesAsync, Bridge));
         _collaborationPanel.Closed += () => _collaborationPanel = null;
     }
 
     /// <summary>设置页保存后按新配置重起两条服务。</summary>
     private async Task RestartServicesAsync()
     {
-        if (_bridge is { } bridge)
+        if (Bridge is { } bridge)
         {
             await bridge.ReloadAsync();
         }
-        if (_mcpServer is { } mcp)
+        if (McpServer is { } mcp)
         {
             await mcp.ReloadAsync();
         }

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Editing.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Microsoft.Extensions.AI;
 
@@ -44,10 +43,6 @@ public partial class ChatPanelView
     }
 
     /// <summary>删除这条用户消息及其之后的一切。</summary>
-    [SuppressMessage("Performance", "CA1859:使用具体类型以提高性能",
-        Justification = "把 Task<bool> 当 Task 返回本就是零成本的引用向上转换,没有装箱也没有包装;" +
-                        "而改成 Task<bool> 等于对外声明一个没有任何调用方在意的返回值。" +
-                        "本方法是点击处理器,一次交互调一次。")]
     private Task DeleteFromAsync(Control bubble) => TruncateAtAsync(bubble);
 
     /// <summary>

--- a/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/CollaborationView.Grants.cs
@@ -143,20 +143,29 @@ public partial class CollaborationView
         Grid.SetColumn(remove, 2);
         head.Children.Add(remove);
 
-        var scope = new ComboBox { MinWidth = 190 };
-        scope.ItemsSource = new[] { _loc["ScopeAll"], _loc["ScopeLimited"] };
-        scope.SelectedIndex = grant.Scope.IsUnrestricted ? 0 : 1;
-
-        var mode = new ComboBox { MinWidth = 130 };
-        mode.ItemsSource = new[] { _loc["GrantFollowGlobal"], _loc["ModeChat"], _loc["ModePlan"], _loc["ModeAgent"] };
-        mode.SelectedIndex = grant.Mode is { } m ? (int)m + 1 : 0;
-
-        var approval = new ComboBox { MinWidth = 130 };
-        approval.ItemsSource = new[]
+        var scope = new ComboBox
         {
-            _loc["GrantFollowGlobal"], _loc["ApprovalAsk"], _loc["ApprovalReadOnly"], _loc["ApprovalBypass"]
+            MinWidth = 190,
+            ItemsSource = new[] { _loc["ScopeAll"], _loc["ScopeLimited"] },
+            SelectedIndex = grant.Scope.IsUnrestricted ? 0 : 1
         };
-        approval.SelectedIndex = grant.Approval is { } a ? (int)a + 1 : 0;
+
+        var mode = new ComboBox
+        {
+            MinWidth = 130,
+            ItemsSource = new[] { _loc["GrantFollowGlobal"], _loc["ModeChat"], _loc["ModePlan"], _loc["ModeAgent"] },
+            SelectedIndex = grant.Mode is { } m ? (int)m + 1 : 0
+        };
+
+        var approval = new ComboBox
+        {
+            MinWidth = 130,
+            ItemsSource = new[]
+            {
+                _loc["GrantFollowGlobal"], _loc["ApprovalAsk"], _loc["ApprovalReadOnly"], _loc["ApprovalBypass"]
+            },
+            SelectedIndex = grant.Approval is { } a ? (int)a + 1 : 0
+        };
 
         var controls = new WrapPanel { ItemSpacing = 12, LineSpacing = 8, Margin = new Thickness(0, 8, 0, 0) };
         controls.Children.Add(Labelled(_loc["ScopeLabel"], scope));

--- a/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/SettingsView.axaml.cs
@@ -21,10 +21,6 @@ public sealed class ProviderNavItem(
     int modelCount = 0, bool expanded = false, string toggleTip = "")
     : System.ComponentModel.INotifyPropertyChanged
 {
-    private Geometry? _icon;
-    private IBrush? _dot;
-    private IBrush? _tint;
-    private string _dotTip = "";
 
     /// <summary>这一行所属的供应商(模型行也指向它的父供应商)。</summary>
     public AiProvider Provider { get; } = provider;
@@ -47,8 +43,8 @@ public sealed class ProviderNavItem(
     /// </summary>
     public Geometry? Icon
     {
-        get => _icon;
-        set => Set(ref _icon, value, nameof(Icon));
+        get;
+        set => Set(ref field, value, nameof(Icon));
     }
 
     /// <summary>
@@ -58,8 +54,8 @@ public sealed class ProviderNavItem(
     /// </summary>
     public IBrush? Tint
     {
-        get => _tint;
-        set => Set(ref _tint, value, nameof(Tint));
+        get;
+        set => Set(ref field, value, nameof(Tint));
     }
 
     /// <summary>是不是供应商行。</summary>
@@ -86,16 +82,16 @@ public sealed class ProviderNavItem(
     /// <summary>状态点的颜色:灰 = 本次窗口内没测过,绿 = 通过,红 = 失败。</summary>
     public IBrush? Dot
     {
-        get => _dot;
-        set => Set(ref _dot, value, nameof(Dot));
+        get;
+        set => Set(ref field, value, nameof(Dot));
     }
 
     /// <summary>状态点的悬停说明。</summary>
     public string DotTip
     {
-        get => _dotTip;
-        set => Set(ref _dotTip, value, nameof(DotTip));
-    }
+        get;
+        set => Set(ref field, value, nameof(DotTip));
+    } = "";
 
     /// <summary>图标/状态点变化时通知绑定(<see cref="Icon" /> / <see cref="Dot" /> / <see cref="DotTip" /> / <see cref="Tint" />)。</summary>
     public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;

--- a/src/VelaShell.Controls/Controls/LucideIcon.cs
+++ b/src/VelaShell.Controls/Controls/LucideIcon.cs
@@ -20,10 +20,7 @@ public class LucideIcon : Control
     public static readonly StyledProperty<IBrush?> ForegroundProperty =
         AvaloniaProperty.Register<LucideIcon, IBrush?>(nameof(Foreground));
 
-    static LucideIcon()
-    {
-        AffectsRender<LucideIcon>(DataProperty, ForegroundProperty);
-    }
+    static LucideIcon() => AffectsRender<LucideIcon>(DataProperty, ForegroundProperty);
 
     /// <summary>要绘制的 lucide 路径几何(以其原生 24×24 视图框为准)。</summary>
     public Geometry? Data

--- a/src/VelaShell.Controls/Controls/TimeSeriesChart.cs
+++ b/src/VelaShell.Controls/Controls/TimeSeriesChart.cs
@@ -31,10 +31,7 @@ public sealed class ChartSeries : Control
     public static readonly StyledProperty<bool> MirrorProperty =
         AvaloniaProperty.Register<ChartSeries, bool>(nameof(Mirror));
 
-    static ChartSeries()
-    {
-        AffectsRender<ChartSeries>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, MirrorProperty);
-    }
+    static ChartSeries() => AffectsRender<ChartSeries>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, MirrorProperty);
 
     /// <inheritdoc cref="ValuesProperty" />
     public IReadOnlyList<double>? Values

--- a/src/VelaShell.Core/Services/BackgroundActivityService.cs
+++ b/src/VelaShell.Core/Services/BackgroundActivityService.cs
@@ -67,7 +67,6 @@ public sealed class BackgroundActivityService : IBackgroundActivityService, IDis
     private readonly List<Entry> _entries = [];
     private readonly Lock _gate = new();
     private readonly Timer _coalesce;
-    private IReadOnlyList<BackgroundActivitySnapshot> _snapshot = [];
     private long _nextId;
     private bool _coalescePending;
     private bool _disposed;
@@ -84,10 +83,12 @@ public sealed class BackgroundActivityService : IBackgroundActivityService, IDis
         {
             lock (_gate)
             {
-                return _snapshot;
+                return field;
             }
         }
-    }
+
+        private set;
+    } = [];
 
     /// <inheritdoc />
     public event Action? Changed;
@@ -121,7 +122,7 @@ public sealed class BackgroundActivityService : IBackgroundActivityService, IDis
             }
             _disposed = true;
             _entries.Clear();
-            _snapshot = [];
+            Activities = [];
         }
         _coalesce.Dispose();
     }
@@ -131,7 +132,7 @@ public sealed class BackgroundActivityService : IBackgroundActivityService, IDis
 
     /// <summary>在锁内重建不可变快照。</summary>
     private void Rebuild() =>
-        _snapshot = [.. _entries.Select(e => new BackgroundActivitySnapshot(e.Id, e.Title, e.Detail, e.Progress))];
+        Activities = [.. _entries.Select(e => new BackgroundActivitySnapshot(e.Id, e.Title, e.Detail, e.Progress))];
 
     private void Remove(Entry entry)
     {

--- a/src/VelaShell.Core/Services/SettingsPreviewService.cs
+++ b/src/VelaShell.Core/Services/SettingsPreviewService.cs
@@ -48,10 +48,7 @@ public sealed class SettingsPreviewService : ISettingsPreviewService
     public event Action<int>? WindowOpacityPreviewRequested;
 
     /// <inheritdoc />
-    public void PreviewWindowOpacity(int percent)
-    {
-        WindowOpacityPreviewRequested?.Invoke(Math.Clamp(percent, 10, 100));
-    }
+    public void PreviewWindowOpacity(int percent) => WindowOpacityPreviewRequested?.Invoke(Math.Clamp(percent, 10, 100));
 
     /// <inheritdoc />
     public event Action<(int Image, int Content)>? BackgroundOpacityPreviewRequested;

--- a/src/VelaShell.Core/XYModem/Protocol/XYModemReceiver.cs
+++ b/src/VelaShell.Core/XYModem/Protocol/XYModemReceiver.cs
@@ -184,7 +184,7 @@ public sealed class XYModemReceiver(
         var item = new FileTransferItem { FileName = metadata.FileName, Size = metadata.Size };
         session.AddItem(item);
 
-        (TransferFileDisposition disposition, long _) =
+        (TransferFileDisposition disposition, _) =
             await _sink.OnFileOfferedAsync(metadata, item, ct).ConfigureAwait(false);
         if (disposition != TransferFileDisposition.Accept)
         {
@@ -252,7 +252,6 @@ public sealed class XYModemReceiver(
                         await _sink.WriteAsync(item, deferred.AsMemory(0, trimmed), ct).ConfigureAwait(false);
                         written += trimmed;
                     }
-                    deferred = null;
                 }
                 await WriteAsync([XYModemConstants.ACK], ct).ConfigureAwait(false);
                 item.BytesTransferred = written;

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -357,7 +357,9 @@ public static class InfrastructureServiceCollectionExtensions
 
             if (verification == HostKeyVerification.Trusted
                 || HostTrustOnceCache.IsTrusted(host, port, fingerprint))
+            {
                 return true;
+            }
 
             HostKeyDecision decision;
             if (verification == HostKeyVerification.Unknown)
@@ -383,17 +385,21 @@ public static class InfrastructureServiceCollectionExtensions
             {
                 await hostKey.TrustHostKeyAsync(host, port, keyType, fingerprint, ct);
                 if (verification == HostKeyVerification.Changed && alerts is not null)
+                {
                     await alerts.RaiseAsync("hostkey-changed-accepted",
                         Strings.Format("KeySvc_AlertChangedAccepted", target, fingerprint));
+                }
             }
             else if (decision == HostKeyDecision.TrustOnce)
             {
                 HostTrustOnceCache.Remember(host, port, fingerprint);
                 if (alerts is not null)
+                {
                     await alerts.RaiseAsync("hostkey-trusted-once",
                         verification == HostKeyVerification.Changed
                             ? Strings.Format("KeySvc_AlertChangedTrustOnce", target, fingerprint)
                             : Strings.Format("KeySvc_AlertFirstTrustOnce", target, fingerprint));
+                }
             }
             return true;
         };

--- a/src/VelaShell.Infrastructure/Plugins/Capabilities/ProtectedSecretsCapability.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Capabilities/ProtectedSecretsCapability.cs
@@ -111,7 +111,7 @@ internal sealed class ProtectedSecretsCapability(string dataDirectory, ISecretPr
 internal sealed class UnavailableSecrets : ISecretsApi
 {
     private static InvalidOperationException Unavailable() =>
-        new InvalidOperationException("Secrets capability is unavailable in this host (no secret protector).");
+        new("Secrets capability is unavailable in this host (no secret protector).");
 
     public Task<string?> GetAsync(string name, CancellationToken cancellationToken = default) => Task.FromException<string?>(Unavailable());
     public Task SetAsync(string name, string value, CancellationToken cancellationToken = default) => Task.FromException(Unavailable());
@@ -122,7 +122,7 @@ internal sealed class UnavailableSecrets : ISecretsApi
 internal sealed class UnavailableClipboard : PluginSdk.Clipboard.IClipboardApi
 {
     private static InvalidOperationException Unavailable() =>
-        new InvalidOperationException("Clipboard capability is unavailable in this host.");
+        new("Clipboard capability is unavailable in this host.");
 
     public Task<string?> GetTextAsync(CancellationToken cancellationToken = default) => Task.FromException<string?>(Unavailable());
     public Task SetTextAsync(string text, CancellationToken cancellationToken = default) => Task.FromException(Unavailable());
@@ -132,7 +132,7 @@ internal sealed class UnavailableClipboard : PluginSdk.Clipboard.IClipboardApi
 internal sealed class UnavailableTerminal : PluginSdk.Terminal.ITerminalApi
 {
     private static InvalidOperationException Unavailable() =>
-        new InvalidOperationException("Terminal capability is unavailable in this host.");
+        new("Terminal capability is unavailable in this host.");
 
     public Task<string> GetOutputAsync(string sessionId, int maxLines = 1000, CancellationToken cancellationToken = default)
         => Task.FromException<string>(Unavailable());

--- a/src/VelaShell.Infrastructure/Ssh/SshConnectionService.cs
+++ b/src/VelaShell.Infrastructure/Ssh/SshConnectionService.cs
@@ -70,14 +70,12 @@ public class SshConnectionService(
     /// 根据连接信息异步建立一条新的 SSH 会话。建连过程在线程池中执行,
     /// 多条连接可并发建立,单条慢连接不会阻塞其它连接。
     /// </summary>
-    public Task<SshSession> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken = default)
-    {
+    public Task<SshSession> ConnectAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken = default) =>
         // Tmds.Ssh 建连前的同步前缀(设置构建、凭据包装)均为纯内存操作(无 I/O),
         // 无需 Task.Run 调度;真正的网络 I/O 在 ConnectInternalAsync 的 await 里。
         // Task.Run(action, cancellationToken) 会导致外层任务取消时内层仍运行,
         // 产生大量未观察的异常并造成调试器输出洪流。
-        return ConnectInternalAsync(connectionInfo, cancellationToken);
-    }
+        ConnectInternalAsync(connectionInfo, cancellationToken);
 
     /// <summary>
     /// 异步断开指定标识的 SSH 会话,拆除底层网络连接并将会话状态置为已断开。

--- a/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/TmdsSftpClientWrapper.cs
@@ -434,10 +434,7 @@ public sealed class TmdsSftpClientWrapper(Func<Task<SftpClient>> clientFactory) 
         catch (Exception ex) when (TmdsSshInterop.Translate(ex, ct) is { } t) { throw t; }
     }
 
-    private async Task GuardedAsync(Func<Task> op, CancellationToken ct = default)
-    {
-        await GuardedAsync(async () => { await op().ConfigureAwait(false); return true; }, ct).ConfigureAwait(false);
-    }
+    private async Task GuardedAsync(Func<Task> op, CancellationToken ct = default) => await GuardedAsync(async () => { await op().ConfigureAwait(false); return true; }, ct).ConfigureAwait(false);
 
     private bool IsTornDown() { if (_disposed) return true; try { return _client is null; } catch { return true; } }
 

--- a/src/VelaShell.PluginHost/PluginHostApp.cs
+++ b/src/VelaShell.PluginHost/PluginHostApp.cs
@@ -13,10 +13,7 @@ namespace VelaShell.PluginHost;
 internal sealed class PluginHostApp : Application
 {
     /// <inheritdoc />
-    public override void Initialize()
-    {
-        Styles.Add(new FluentTheme());
-    }
+    public override void Initialize() => Styles.Add(new FluentTheme());
 
     /// <summary>
     /// 把宿主的明暗基底应用到本进程(任意线程可调)。

--- a/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/SessionImportViewModel.cs
@@ -31,7 +31,7 @@ public sealed class SessionImportViewModel : ReactiveObject
         RescanAllCommand = ReactiveCommand.CreateFromTask(RescanAllAsync, notBusy);
 
         IObservable<bool> canImport = this.WhenAnyValue(x => x.SelectedCount, x => x.IsBusy)
-            .Select(static t => t.Item1 > 0 && !t.Item2);
+            .Select(static t => t.Value1 > 0 && !t.Value2);
         ImportCommand = ReactiveCommand.CreateFromTask(ImportSelectedAsync, canImport);
 
         SelectAllCommand = ReactiveCommand.Create(() => SetAllSelected(true));

--- a/src/VelaShell.Terminal/Emulation/TerminalCell.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalCell.cs
@@ -177,17 +177,11 @@ public struct TerminalCell : IEquatable<TerminalCell>
     /// <param name="left">左操作数。</param>
     /// <param name="right">右操作数。</param>
     /// <returns>相等时返回 true。</returns>
-    public static bool operator ==(TerminalCell left, TerminalCell right)
-    {
-        return left.Equals(right);
-    }
+    public static bool operator ==(TerminalCell left, TerminalCell right) => left.Equals(right);
 
     /// <summary>判断两个单元格是否不相等。</summary>
     /// <param name="left">左操作数。</param>
     /// <param name="right">右操作数。</param>
     /// <returns>不相等时返回 true。</returns>
-    public static bool operator !=(TerminalCell left, TerminalCell right)
-    {
-        return !(left == right);
-    }
+    public static bool operator !=(TerminalCell left, TerminalCell right) => !(left == right);
 }

--- a/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalEmulator.cs
@@ -1172,10 +1172,12 @@ public sealed class TerminalEmulator : IVtActions
     {
         var cell = new TerminalCell { Rune = 'E', Foreground = _fg, Background = _bg, Flags = _flags };
         for (int y = 0; y < Screen.Rows; y++)
+        {
             for (int x = 0; x < Screen.Columns; x++)
             {
                 Screen.SetCell(x, y, cell);
             }
+        }
     }
 
     private void SoftReset()

--- a/src/VelaShell.Terminal/Emulation/TerminalPalette.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalPalette.cs
@@ -100,11 +100,15 @@ public sealed class TerminalPalette
         ReadOnlySpan<byte> steps = [0x00, 0x5F, 0x87, 0xAF, 0xD7, 0xFF];
         int i = 16;
         foreach (byte r in steps)
+        {
             foreach (byte g in steps)
+            {
                 foreach (byte b in steps)
                 {
                     _colors[i++] = Rgba.FromRgb(r, g, b);
                 }
+            }
+        }
     }
 
     private void InitializeGrayscale()

--- a/src/VelaShell.Terminal/Emulation/Utf8Sink.cs
+++ b/src/VelaShell.Terminal/Emulation/Utf8Sink.cs
@@ -15,10 +15,7 @@ public sealed class Utf8Sink(Encoding? encoding = null)
     /// <summary>
     /// 切换解码所用的字符编码,并重置解码器状态(丢弃任何未完成的多字节前缀)。
     /// </summary>
-    public void SetEncoding(Encoding encoding)
-    {
-        _decoder = CreateDecoder(encoding);
-    }
+    public void SetEncoding(Encoding encoding) => _decoder = CreateDecoder(encoding);
 
     private static Decoder CreateDecoder(Encoding? encoding)
     {

--- a/src/VelaShell.Terminal/ScrollbackBuffer.cs
+++ b/src/VelaShell.Terminal/ScrollbackBuffer.cs
@@ -61,24 +61,15 @@ public class ScrollbackBuffer
 
     /// <summary>将视口滚动到指定绝对行号,超出范围时自动夹取到有效区间。</summary>
     /// <param name="absoluteRow">目标绝对行号。</param>
-    public void ScrollTo(int absoluteRow)
-    {
-        ViewportRow = Math.Clamp(absoluteRow, 0, Math.Max(0, ScrollbackLineCount));
-    }
+    public void ScrollTo(int absoluteRow) => ViewportRow = Math.Clamp(absoluteRow, 0, Math.Max(0, ScrollbackLineCount));
 
     /// <summary>向上滚动指定行数(朝更早的历史方向)。</summary>
     /// <param name="lines">要向上滚动的行数。</param>
-    public void ScrollUp(int lines)
-    {
-        ScrollTo(ViewportRow - lines);
-    }
+    public void ScrollUp(int lines) => ScrollTo(ViewportRow - lines);
 
     /// <summary>向下滚动指定行数(朝更新的内容方向)。</summary>
     /// <param name="lines">要向下滚动的行数。</param>
-    public void ScrollDown(int lines)
-    {
-        ScrollTo(ViewportRow + lines);
-    }
+    public void ScrollDown(int lines) => ScrollTo(ViewportRow + lines);
 
     /// <summary>在回滚历史行内按序查找指定文本的全部匹配项(区分大小写)。</summary>
     /// <param name="query">要搜索的文本;为空时返回空结果。</param>

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -566,10 +566,7 @@ public class App : Application
         }
     }
 
-    private void OnThemeChanged(string themeName)
-    {
-        ApplyThemeVariant(themeName);
-    }
+    private void OnThemeChanged(string themeName) => ApplyThemeVariant(themeName);
 
     /// <summary>
     /// 应用一套具名主题:先定明暗基底(Fluent 控件与 axaml 里的 ThemeDictionaries 跟着它走),

--- a/src/VelaShell/Controls/ReparentingHost.cs
+++ b/src/VelaShell/Controls/ReparentingHost.cs
@@ -18,10 +18,7 @@ public sealed class ReparentingHost : Decorator
     public static readonly StyledProperty<Control?> TargetProperty =
         AvaloniaProperty.Register<ReparentingHost, Control?>(nameof(Target));
 
-    static ReparentingHost()
-    {
-        TargetProperty.Changed.AddClassHandler<ReparentingHost>((host, _) => host.Reattach());
-    }
+    static ReparentingHost() => TargetProperty.Changed.AddClassHandler<ReparentingHost>((host, _) => host.Reattach());
 
     /// <summary>
     /// 需要被独占托管的共享控件(如实时终端画面)。设置后本宿主会先将其从原父级

--- a/src/VelaShell/Docking/Controls/DockWorkspaceControl.cs
+++ b/src/VelaShell/Docking/Controls/DockWorkspaceControl.cs
@@ -32,16 +32,10 @@ public sealed class DockWorkspaceControl : Panel
     /// </summary>
     private readonly List<(DockNode Node, DefinitionBase Definition, bool Horizontal)> _observedTracks = [];
 
-    static DockWorkspaceControl()
-    {
-        WorkspaceProperty.Changed.AddClassHandler<DockWorkspaceControl>((control, e) => control.OnWorkspaceChanged(e));
-    }
+    static DockWorkspaceControl() => WorkspaceProperty.Changed.AddClassHandler<DockWorkspaceControl>((control, e) => control.OnWorkspaceChanged(e));
 
     /// <summary>构造工作区控件,并初始化其标签拖拽控制器。</summary>
-    public DockWorkspaceControl()
-    {
-        DragController = new DockDragController(this);
-    }
+    public DockWorkspaceControl() => DragController = new DockDragController(this);
 
     /// <summary>当前渲染的停靠布局树;赋值后整树重建视图。</summary>
     public DockWorkspace? Workspace

--- a/src/VelaShell/Services/KeyboardShortcutService.cs
+++ b/src/VelaShell/Services/KeyboardShortcutService.cs
@@ -84,8 +84,5 @@ public class KeyboardShortcutService : IKeyboardShortcutService
         Map(KeyModifiers.Ctrl | KeyModifiers.Shift, KeyCode.Tab, ShortcutContext.Global, ShortcutAction.PreviousTab);
     }
 
-    private void Map(KeyModifiers modifiers, KeyCode key, ShortcutContext context, ShortcutAction action)
-    {
-        _mappings[(modifiers, key, context)] = action;
-    }
+    private void Map(KeyModifiers modifiers, KeyCode key, ShortcutContext context, ShortcutAction action) => _mappings[(modifiers, key, context)] = action;
 }

--- a/src/VelaShell/Services/SessionLogService.cs
+++ b/src/VelaShell/Services/SessionLogService.cs
@@ -81,10 +81,7 @@ public sealed class SessionLogWriter : IDisposable
 
     /// <summary>以追加模式打开日志文件,准备写入会话原始输出。</summary>
     /// <param name="path">日志文件的完整路径。</param>
-    internal SessionLogWriter(string path)
-    {
-        _stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read);
-    }
+    internal SessionLogWriter(string path) => _stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read);
 
     /// <summary>刷新并关闭底层日志文件流。</summary>
     public void Dispose()

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -925,7 +925,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 "app.palette",
                 Strings.Get("Cmd_CommandPalette"),
                 Strings.Get("CmdCat_Search"),
-                () => CommandPalette.Open(),
+                CommandPalette.Open,
                 Shortcut: "Ctrl+P",
                 Icon: "Icon.zap"
             )
@@ -1408,10 +1408,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// 由 <see cref="RebindFileBrowser" /> 按标签自己的状态决定(首次连接取设置
     /// 「连接后自动打开文件浏览器」的当前值,断线重连沿用标签生命周期内的记忆)。
     /// </summary>
-    private void ShowFileBrowserForActiveSession()
-    {
-        RebindFileBrowser();
-    }
+    private void ShowFileBrowserForActiveSession() => RebindFileBrowser();
 
     /// <summary>
     /// 用户通过菜单/面板请求终端内搜索时触发;窗口将其转发到活动终端视图的搜索栏(§5.3)。
@@ -3308,7 +3305,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     new SftpDocumentViewModel(
                         current,
                         sessionId,
-                        (id, token) => _ftpSessionService.CloseSessionAsync(id, token),
+                        _ftpSessionService.CloseSessionAsync,
                         _sftpService,
                         settings.Transfer,
                         FileTransfer,
@@ -3421,7 +3418,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 var viewModel = new SftpDocumentViewModel(
                     current,
                     sessionId,
-                    (id, token) => _pluginProtocols.CloseSessionAsync(id, token),
+                    _pluginProtocols.CloseSessionAsync,
                     _sftpService,
                     settings.Transfer,
                     FileTransfer,

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -101,10 +101,7 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
 
     /// <summary>创建一个标签并立即挂载实时传输(已建立连接的场景)。</summary>
     public TerminalTabViewModel(ITerminalEmulator terminalEmulator, IShellStreamWrapper shellStream)
-        : this(terminalEmulator)
-    {
-        AttachTransport(shellStream ?? throw new ArgumentNullException(nameof(shellStream)));
-    }
+        : this(terminalEmulator) => AttachTransport(shellStream ?? throw new ArgumentNullException(nameof(shellStream)));
 
     /// <summary>该标签所属会话的唯一标识,用于与宿主的会话管理关联。</summary>
     public Guid SessionId { get; set; }
@@ -966,14 +963,8 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     }
 
     /// <summary>自动重连尝试计数加一。</summary>
-    public void IncrementReconnectAttempt()
-    {
-        ReconnectAttempts++;
-    }
+    public void IncrementReconnectAttempt() => ReconnectAttempts++;
 
     /// <summary>把自动重连尝试计数归零(连接成功后调用)。</summary>
-    public void ResetReconnectAttempts()
-    {
-        ReconnectAttempts = 0;
-    }
+    public void ResetReconnectAttempts() => ReconnectAttempts = 0;
 }

--- a/src/VelaShell/ViewModels/TunnelPanelViewModel.cs
+++ b/src/VelaShell/ViewModels/TunnelPanelViewModel.cs
@@ -331,7 +331,11 @@ public class TunnelPanelViewModel : ReactiveObject, IDisposable
         {
             SelectedServer = preferred;
         }
-        else SelectedServer ??= Servers.FirstOrDefault();
+        else
+        {
+            SelectedServer ??= Servers.FirstOrDefault();
+        }
+
         RefreshServerStatus();
     }
 

--- a/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
+++ b/src/VelaShell/Views/AuthenticationDialogView.axaml.cs
@@ -28,8 +28,8 @@ public partial class AuthenticationDialogView : Window
         }
         // 登录/取消命令由按钮点击触发,回调仍在输入事件栈内:推迟关闭,避免后续路由
         // 打到已销毁的窗口刷 "PlatformImpl is null" 警告。
-        viewModel.LoginCommand.Subscribe(result => this.PostClose(result));
-        viewModel.CancelCommand.Subscribe(result => this.PostClose(result));
+        viewModel.LoginCommand.Subscribe(this.PostClose);
+        viewModel.CancelCommand.Subscribe(this.PostClose);
     }
 
     /// <summary>Esc 等价于点击取消:经 CancelCommand 走与取消按钮完全相同的关闭路径(结果为 null)。</summary>

--- a/src/VelaShell/Views/ConnectionProfileView.axaml.cs
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml.cs
@@ -236,9 +236,9 @@ public partial class ConnectionProfileView : Window
         UpdateProtoTabIndicator();
         // 保存/连接/取消命令由按钮点击触发,回调仍在输入事件栈内:推迟关闭,避免后续路由
         // 打到已销毁的窗口刷 "PlatformImpl is null" 警告。
-        viewModel.SaveCommand.Subscribe(result => this.PostClose(result));
-        viewModel.ConnectCommand.Subscribe(result => this.PostClose(result));
-        viewModel.CancelCommand.Subscribe(result => this.PostClose(result));
+        viewModel.SaveCommand.Subscribe(this.PostClose);
+        viewModel.ConnectCommand.Subscribe(this.PostClose);
+        viewModel.CancelCommand.Subscribe(this.PostClose);
         await viewModel.LoadGroupsAsync();
     }
 

--- a/src/VelaShell/Views/MessageDialog.axaml.cs
+++ b/src/VelaShell/Views/MessageDialog.axaml.cs
@@ -33,10 +33,7 @@ public enum MessageDialogKind
 public partial class MessageDialog : Window
 {
     /// <summary>供 XAML 加载器调用的无参构造:初始化可视化组件。</summary>
-    public MessageDialog()
-    {
-        InitializeComponent();
-    }
+    public MessageDialog() => InitializeComponent();
 
     /// <summary>纯消息:仅一个"确定"按钮。</summary>
     public static Task ShowMessageAsync(Window owner,

--- a/src/VelaShell/Views/QuickCommandsView.axaml.cs
+++ b/src/VelaShell/Views/QuickCommandsView.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views;
 public partial class QuickCommandsView : UserControl
 {
     /// <summary>初始化快捷命令视图并加载 XAML 组件。</summary>
-    public QuickCommandsView()
-    {
-        InitializeComponent();
-    }
+    public QuickCommandsView() => InitializeComponent();
 }

--- a/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
+++ b/src/VelaShell/Views/RemoteFileEditorView.axaml.cs
@@ -23,10 +23,7 @@ public partial class RemoteFileEditorView : Window
     /// <summary>
     /// 供设计器/XAML 使用的无参构造函数。
     /// </summary>
-    public RemoteFileEditorView()
-    {
-        InitializeComponent();
-    }
+    public RemoteFileEditorView() => InitializeComponent();
 
     /// <summary>
     /// 创建编辑器窗口并加载本地临时副本内容。

--- a/src/VelaShell/Views/Settings/AboutPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/AboutPage.axaml.cs
@@ -7,10 +7,7 @@ namespace VelaShell.Views.Settings;
 public partial class AboutPage : UserControl
 {
     /// <summary>初始化关于页并加载 XAML 组件。</summary>
-    public AboutPage()
-    {
-        InitializeComponent();
-    }
+    public AboutPage() => InitializeComponent();
 
     /// <summary>点击依赖项目名/许可证时,用系统默认浏览器打开对应链接(URL 存放在控件 Tag)。</summary>
     private async void OnOpenLink(object? sender, RoutedEventArgs e)

--- a/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/AppearanceSettingsPage.axaml.cs
@@ -10,10 +10,7 @@ namespace VelaShell.Views.Settings;
 public partial class AppearanceSettingsPage : UserControl
 {
     /// <summary>初始化外观设置页并加载 XAML 组件。</summary>
-    public AppearanceSettingsPage()
-    {
-        InitializeComponent();
-    }
+    public AppearanceSettingsPage() => InitializeComponent();
 
     /// <summary>“浏览…”:选一张本地图片作为应用背景;写入 Appearance.BackgroundImagePath(触发即时预览与保存)。</summary>
     private async void PickBackgroundImage_Click(object? sender, RoutedEventArgs e)

--- a/src/VelaShell/Views/Settings/DonatePage.axaml.cs
+++ b/src/VelaShell/Views/Settings/DonatePage.axaml.cs
@@ -12,10 +12,7 @@ public partial class DonatePage : UserControl
     private const string WiseLink = "https://wise.com/pay/me/yud162";
 
     /// <summary>初始化捐赠页并加载 XAML 组件。</summary>
-    public DonatePage()
-    {
-        InitializeComponent();
-    }
+    public DonatePage() => InitializeComponent();
 
     /// <summary>点击链接文本:在系统默认浏览器中打开 Wise 付款页。</summary>
     private async void WiseLink_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/GeneralSettingsPage.axaml.cs
@@ -11,10 +11,7 @@ namespace VelaShell.Views.Settings;
 public partial class GeneralSettingsPage : UserControl
 {
     /// <summary>初始化常规设置页并加载 XAML 组件。</summary>
-    public GeneralSettingsPage()
-    {
-        InitializeComponent();
-    }
+    public GeneralSettingsPage() => InitializeComponent();
 
     private async void ExportSettings_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/VelaShell/Views/Settings/KeyManagementPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/KeyManagementPage.axaml.cs
@@ -12,10 +12,7 @@ namespace VelaShell.Views.Settings;
 public partial class KeyManagementPage : UserControl
 {
     /// <summary>初始化密钥管理设置页并加载 XAML 组件。</summary>
-    public KeyManagementPage()
-    {
-        InitializeComponent();
-    }
+    public KeyManagementPage() => InitializeComponent();
 
     private async void ImportKey_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/VelaShell/Views/Settings/ProxySettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/ProxySettingsPage.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views.Settings;
 public partial class ProxySettingsPage : UserControl
 {
     /// <summary>初始化代理设置页并加载 XAML 组件。</summary>
-    public ProxySettingsPage()
-    {
-        InitializeComponent();
-    }
+    public ProxySettingsPage() => InitializeComponent();
 }

--- a/src/VelaShell/Views/Settings/SecurityAuditPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/SecurityAuditPage.axaml.cs
@@ -12,10 +12,7 @@ namespace VelaShell.Views.Settings;
 public partial class SecurityAuditPage : UserControl
 {
     /// <summary>初始化安全审计设置页并加载 XAML 组件。</summary>
-    public SecurityAuditPage()
-    {
-        InitializeComponent();
-    }
+    public SecurityAuditPage() => InitializeComponent();
 
     /// <summary>打开会话录制回放中心(设计 NceE6),非模态独立窗口。</summary>
     private void OpenRecordingPlayer_Click(object? sender, RoutedEventArgs e)

--- a/src/VelaShell/Views/Settings/ShortcutsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/ShortcutsPage.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views.Settings;
 public partial class ShortcutsPage : UserControl
 {
     /// <summary>初始化快捷键设置页并加载 XAML 组件。</summary>
-    public ShortcutsPage()
-    {
-        InitializeComponent();
-    }
+    public ShortcutsPage() => InitializeComponent();
 }

--- a/src/VelaShell/Views/Settings/SnippetsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/SnippetsPage.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views.Settings;
 public partial class SnippetsPage : UserControl
 {
     /// <summary>初始化代码片段设置页并加载 XAML 组件。</summary>
-    public SnippetsPage()
-    {
-        InitializeComponent();
-    }
+    public SnippetsPage() => InitializeComponent();
 }

--- a/src/VelaShell/Views/Settings/SyncPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/SyncPage.axaml.cs
@@ -7,10 +7,7 @@ namespace VelaShell.Views.Settings;
 public partial class SyncPage : UserControl
 {
     /// <summary>初始化同步设置页并加载 XAML 组件。</summary>
-    public SyncPage()
-    {
-        InitializeComponent();
-    }
+    public SyncPage() => InitializeComponent();
 
     /// <summary>指引卡片中的链接:Tag 即 URL,点击在系统默认浏览器打开。</summary>
     private async void OpenLink_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml.cs
+++ b/src/VelaShell/Views/Settings/TerminalSettingsPage.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views.Settings;
 public partial class TerminalSettingsPage : UserControl
 {
     /// <summary>初始化终端设置页并加载 XAML 组件。</summary>
-    public TerminalSettingsPage()
-    {
-        InitializeComponent();
-    }
+    public TerminalSettingsPage() => InitializeComponent();
 }

--- a/src/VelaShell/Views/SidebarView.axaml.cs
+++ b/src/VelaShell/Views/SidebarView.axaml.cs
@@ -112,10 +112,7 @@ public partial class SidebarView : UserControl
         CollapsedRail.IsVisible = collapsed;
     }
 
-    private void ExpandSidebar_Click(object? sender, RoutedEventArgs e)
-    {
-        _viewModel?.IsCollapsed = false;
-    }
+    private void ExpandSidebar_Click(object? sender, RoutedEventArgs e) => _viewModel?.IsCollapsed = false;
 
     /// <summary>
     /// 折叠态细条贴哪一边(随设置 → 外观 → 侧边栏位置)。
@@ -132,30 +129,15 @@ public partial class SidebarView : UserControl
             : Avalonia.Layout.HorizontalAlignment.Left;
 
     /// <summary>工具栏折叠按钮。只出现在展开态,所以直接置位而不是取反。</summary>
-    private void CollapseSidebar_Click(object? sender, RoutedEventArgs e)
-    {
-        _viewModel?.IsCollapsed = true;
-    }
+    private void CollapseSidebar_Click(object? sender, RoutedEventArgs e) => _viewModel?.IsCollapsed = true;
 
-    private void OpenConnectionProfile_Click(object? sender, RoutedEventArgs e)
-    {
-        OpenConnectionProfileRequested?.Invoke(this, EventArgs.Empty);
-    }
+    private void OpenConnectionProfile_Click(object? sender, RoutedEventArgs e) => OpenConnectionProfileRequested?.Invoke(this, EventArgs.Empty);
 
-    private void OpenSettings_Click(object? sender, RoutedEventArgs e)
-    {
-        SettingsRequested?.Invoke(this, EventArgs.Empty);
-    }
+    private void OpenSettings_Click(object? sender, RoutedEventArgs e) => SettingsRequested?.Invoke(this, EventArgs.Empty);
 
-    private void OpenPlugins_Click(object? sender, RoutedEventArgs e)
-    {
-        PluginsRequested?.Invoke(this, EventArgs.Empty);
-    }
+    private void OpenPlugins_Click(object? sender, RoutedEventArgs e) => PluginsRequested?.Invoke(this, EventArgs.Empty);
 
-    private void ImportSessions_Click(object? sender, RoutedEventArgs e)
-    {
-        ImportSessionsRequested?.Invoke(this, EventArgs.Empty);
-    }
+    private void ImportSessions_Click(object? sender, RoutedEventArgs e) => ImportSessionsRequested?.Invoke(this, EventArgs.Empty);
 
     private void ToggleQuickCommands_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/VelaShell/Views/StatusBarView.axaml.cs
+++ b/src/VelaShell/Views/StatusBarView.axaml.cs
@@ -6,8 +6,5 @@ namespace VelaShell.Views;
 public partial class StatusBarView : UserControl
 {
     /// <summary>初始化 <see cref="StatusBarView"/> 并加载 XAML 组件。</summary>
-    public StatusBarView()
-    {
-        InitializeComponent();
-    }
+    public StatusBarView() => InitializeComponent();
 }

--- a/src/VelaShell/Views/TunnelHelpDialog.axaml.cs
+++ b/src/VelaShell/Views/TunnelHelpDialog.axaml.cs
@@ -8,10 +8,7 @@ namespace VelaShell.Views;
 public partial class TunnelHelpDialog : Window
 {
     /// <summary>初始化可视化组件。</summary>
-    public TunnelHelpDialog()
-    {
-        InitializeComponent();
-    }
+    public TunnelHelpDialog() => InitializeComponent();
 
     // 推迟关闭:同步 Close 会让本轮点击/按键的后续路由打到已销毁的窗口刷
     // "PlatformImpl is null" 警告(见 WindowCloseExtensions)。

--- a/tests/VelaShell.Core.Tests/Models/ProxyDefaultsTests.cs
+++ b/tests/VelaShell.Core.Tests/Models/ProxyDefaultsTests.cs
@@ -17,10 +17,7 @@ namespace VelaShell.Core.Tests.Models;
 public class ProxyDefaultsTests
 {
     [TestMethod]
-    public void FreshSettings_FollowTheSystemProxy()
-    {
-        Assert.AreEqual("system", new AppSettings().Proxy.Type);
-    }
+    public void FreshSettings_FollowTheSystemProxy() => Assert.AreEqual("system", new AppSettings().Proxy.Type);
 
     [TestMethod]
     public void NullType_FallsBackToSystemRatherThanForcingDirect()

--- a/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
+++ b/tests/VelaShell.Core.Tests/Resources/LocalizationTests.cs
@@ -10,10 +10,7 @@ public class LocalizationTests : IDisposable
 {
     private readonly CultureInfo _originalCulture;
 
-    public LocalizationTests()
-    {
-        _originalCulture = CultureInfo.CurrentUICulture;
-    }
+    public LocalizationTests() => _originalCulture = CultureInfo.CurrentUICulture;
 
     public void Dispose()
     {

--- a/tests/VelaShell.Core.Tests/Services/SettingsPreviewServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Services/SettingsPreviewServiceTests.cs
@@ -9,16 +9,13 @@ public sealed class SettingsPreviewServiceTests
     private SettingsPreviewService _sut = null!;
 
     [TestInitialize]
-    public void Setup()
-    {
-        _sut = new SettingsPreviewService();
-    }
+    public void Setup() => _sut = new SettingsPreviewService();
 
     [TestMethod]
     public void PreviewWindowOpacity_InvokeOnce_EmitsExactlyOneEvent()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(50);
 
@@ -30,7 +27,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_InvokeMultiple_EmitsInOrder()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(30);
         _sut.PreviewWindowOpacity(60);
@@ -43,7 +40,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_BelowMin_ClampsTo10()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(0);
 
@@ -55,7 +52,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_AboveMax_ClampsTo100()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(150);
 
@@ -67,7 +64,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_Boundary10_PassesThrough()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(10);
 
@@ -79,7 +76,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_Boundary100_PassesThrough()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(100);
 
@@ -93,8 +90,8 @@ public sealed class SettingsPreviewServiceTests
         var opacityReceived = new List<int>();
         var snapshotReceived = new List<AppSettings>();
 
-        _sut.WindowOpacityPreviewRequested += v => opacityReceived.Add(v);
-        _sut.PreviewRequested += s => snapshotReceived.Add(s);
+        _sut.WindowOpacityPreviewRequested += opacityReceived.Add;
+        _sut.PreviewRequested += snapshotReceived.Add;
 
         var settings = new AppSettings();
         _sut.Preview(settings);
@@ -110,7 +107,7 @@ public sealed class SettingsPreviewServiceTests
     public void PreviewWindowOpacity_NegativeValue_ClampsTo10()
     {
         var received = new List<int>();
-        _sut.WindowOpacityPreviewRequested += v => received.Add(v);
+        _sut.WindowOpacityPreviewRequested += received.Add;
 
         _sut.PreviewWindowOpacity(-5);
 
@@ -119,17 +116,15 @@ public sealed class SettingsPreviewServiceTests
     }
 
     [TestMethod]
-    public void PreviewWindowOpacity_NoSubscribers_DoesNotThrow()
-    {
+    public void PreviewWindowOpacity_NoSubscribers_DoesNotThrow() =>
         // No subscribers attached — should not throw.
         _sut.PreviewWindowOpacity(50);
-    }
 
     [TestMethod]
     public void Preview_SnapshotStillWorks_Unchanged()
     {
         var snapshotReceived = new List<AppSettings>();
-        _sut.PreviewRequested += s => snapshotReceived.Add(s);
+        _sut.PreviewRequested += snapshotReceived.Add;
 
         var settings = new AppSettings();
         _sut.Preview(settings);

--- a/tests/VelaShell.Core.Tests/Sftp/SerializedSftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SerializedSftpServiceTests.cs
@@ -294,10 +294,7 @@ public sealed class SerializedSftpServiceTests
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-        private async Task InvokeAsync(string operationName, Guid sessionId, CancellationToken cancellationToken)
-        {
-            _ = await InvokeAsync(operationName, sessionId, true, cancellationToken);
-        }
+        private async Task InvokeAsync(string operationName, Guid sessionId, CancellationToken cancellationToken) => _ = await InvokeAsync(operationName, sessionId, true, cancellationToken);
 
         private async Task<T> InvokeAsync<T>(string operationName, Guid sessionId, T result, CancellationToken cancellationToken)
         {

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -293,7 +293,7 @@ public class SftpServiceTests
 
         // Act
         await _sftpService.UploadFileAsync(_sessionId, localPath, remotePath,
-            new SynchronousProgress<TransferProgress>(p => progressReports.Add(p)));
+            new SynchronousProgress<TransferProgress>(progressReports.Add));
 
         // Assert
         await _sftpClient.Received(1).UploadAsync(Arg.Any<Stream>(),
@@ -334,7 +334,7 @@ public class SftpServiceTests
 
         // Act
         await _sftpService.DownloadFileAsync(_sessionId, remotePath, localPath,
-            new SynchronousProgress<TransferProgress>(p => progressReports.Add(p)));
+            new SynchronousProgress<TransferProgress>(progressReports.Add));
 
         // Assert
         await _sftpClient.Received(1).DownloadAsync(remotePath,
@@ -568,7 +568,7 @@ public class SftpServiceTests
 
         // Act
         await _sftpService.UploadFileAsync(_sessionId, localPath, remotePath,
-            new SynchronousProgress<TransferProgress>(p => progressReports.Add(p)));
+            new SynchronousProgress<TransferProgress>(progressReports.Add));
 
         // Assert —— 进度上报按时间片节流(见 Core/Sftp/TransferProgressThrottle.cs),因此不保证
         // "每个底层回调都对应一次上报"。这里断言的是真正的契约:立刻有首帧、单调不回退、
@@ -608,7 +608,7 @@ public class SftpServiceTests
                    .Returns(Task.CompletedTask);
 
         await _sftpService.UploadFileAsync(_sessionId, localPath, remotePath,
-            new SynchronousProgress<TransferProgress>(p => progressReports.Add(p)));
+            new SynchronousProgress<TransferProgress>(progressReports.Add));
 
         // 十万次回调必须被压到极少数几次(首帧 + 每 100ms 一帧 + 收尾),绝不是十万次。
         Assert.IsLessThan(100, progressReports.Count,

--- a/tests/VelaShell.Core.Tests/Sftp/TransferManagerTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/TransferManagerTests.cs
@@ -115,10 +115,7 @@ public class TransferManagerTests
         Assert.AreEqual(5, manager.MaxConcurrentTransfers);
     }
 
-    private static TransferExecutor SlowExecutor(int delayMs = 2000)
-    {
-        return async (task, progress, ct) => { await Task.Delay(delayMs, ct); };
-    }
+    private static TransferExecutor SlowExecutor(int delayMs = 2000) => async (task, progress, ct) => { await Task.Delay(delayMs, ct); };
 
     private static TransferTask CreateTransferTask(TransferType type)
     {

--- a/tests/VelaShell.Core.Tests/Ssh/TmdsSshInteropTests.cs
+++ b/tests/VelaShell.Core.Tests/Ssh/TmdsSshInteropTests.cs
@@ -55,10 +55,7 @@ public sealed class TmdsSshInteropTests
     }
 
     [TestMethod]
-    public void Translate_UnknownException_ReturnsNull()
-    {
-        Assert.IsNull(TmdsSshInterop.Translate(new InvalidOperationException("boom")));
-    }
+    public void Translate_UnknownException_ReturnsNull() => Assert.IsNull(TmdsSshInterop.Translate(new InvalidOperationException("boom")));
 
     [TestMethod]
     public void Translate_PreservesInnerException()

--- a/tests/VelaShell.Core.Tests/ZModem/CrcTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/CrcTests.cs
@@ -17,21 +17,16 @@ public class CrcTests
     }
 
     [TestMethod]
-    public void Crc16Xmodem_Empty_IsZero()
-    {
-        Assert.AreEqual((ushort)0x0000, Crc16Xmodem.Compute([]));
-    }
+    public void Crc16Xmodem_Empty_IsZero() => Assert.AreEqual((ushort)0x0000, Crc16Xmodem.Compute([]));
 
     [TestMethod]
-    public void Crc16Xmodem_MatchesRealLrzszWireValue()
-    {
+    public void Crc16Xmodem_MatchesRealLrzszWireValue() =>
         // 地面真值:真实 Ubuntu 22.04 lrzsz sz 对 ZNAK 帧头 [06 00 00 00 00] 上链的 CRC 是 0xCD85
         // (2026-07-16 实测抓包 "**\x18B0600000000cd85")。lrzsz zm.c 的 updcrc 是旧式 XMODEM 算法,
         // 其「补两个零字节」收尾与本实现的现代查表算法数学等价 —— 增广已内建,绝不能再补。
         // 此前这里断言过 Augment("123456789")==0xDF8B 并声称"已对照 lrzsz 源码验证",实为双重增广:
         // 它让收发两侧自洽地一起错,与真实 sz/rz 的每一个非全零帧头互相报 CRC 错,握手永远谈不拢。
         Assert.AreEqual((ushort)0xCD85, Crc16Xmodem.Compute([0x06, 0x00, 0x00, 0x00, 0x00]));
-    }
 
     [TestMethod]
     public void Crc16Xmodem_ChunkedUpdate_EqualsSinglePass()

--- a/tests/VelaShell.Core.Tests/ZModem/ZdleCodecTests.cs
+++ b/tests/VelaShell.Core.Tests/ZModem/ZdleCodecTests.cs
@@ -14,20 +14,14 @@ public class ZdleCodecTests
     [DataRow((byte)0x90)]
     [DataRow((byte)0x91)]
     [DataRow((byte)0x93)]
-    public void NeedsEscape_RequiredBytes_ReturnsTrue(byte value)
-    {
-        Assert.IsTrue(ZdleCodec.NeedsEscape(value));
-    }
+    public void NeedsEscape_RequiredBytes_ReturnsTrue(byte value) => Assert.IsTrue(ZdleCodec.NeedsEscape(value));
 
     [TestMethod]
     [DataRow((byte)0x00)]
     [DataRow((byte)0x41)] // 'A'
     [DataRow((byte)0x7F)]
     [DataRow((byte)0xFF)]
-    public void NeedsEscape_OrdinaryBytes_ReturnsFalse(byte value)
-    {
-        Assert.IsFalse(ZdleCodec.NeedsEscape(value));
-    }
+    public void NeedsEscape_OrdinaryBytes_ReturnsFalse(byte value) => Assert.IsFalse(ZdleCodec.NeedsEscape(value));
 
     [TestMethod]
     public void EscapeByte_Zdle_ProducesEscapedPair()
@@ -103,9 +97,7 @@ public class ZdleCodecTests
     }
 
     [TestMethod]
-    public void ClassifyEscaped_IllegalByte_ReportsInvalid()
-    {
+    public void ClassifyEscaped_IllegalByte_ReportsInvalid() =>
         // 0x00 after ZDLE is not a legal escape (fails the (b & 0x60) == 0x40 test).
         Assert.AreEqual(ZdleTokenKind.Invalid, ZdleCodec.ClassifyEscaped(0x00).Kind);
-    }
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/DevPluginRootTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/DevPluginRootTests.cs
@@ -59,11 +59,9 @@ public class DevPluginRootTests
     }
 
     [TestMethod]
-    public void Resolve_NoListFileAndNoEnvironment_IsEmpty()
-    {
+    public void Resolve_NoListFileAndNoEnvironment_IsEmpty() =>
         // 生产路径:两个来源都空 → 发现期一个额外目录都不扫。
         Assert.IsEmpty(DevPluginRootResolver.Resolve(_base, readFile: _ => null));
-    }
 
     [TestMethod]
     public void Resolve_MalformedLine_DoesNotThrow()

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/HostRegistryTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/HostRegistryTests.cs
@@ -112,14 +112,8 @@ public class HostRegistryTests
     }
 
     [TestMethod]
-    public void Read_MissingFile_ReturnsEmpty()
-    {
-        Assert.IsEmpty(HostRegistry.List(Path.Combine(_base, "nope", HostRegistry.FileName)));
-    }
+    public void Read_MissingFile_ReturnsEmpty() => Assert.IsEmpty(HostRegistry.List(Path.Combine(_base, "nope", HostRegistry.FileName)));
 
     [TestMethod]
-    public void Upsert_WithoutExePath_IsRejected()
-    {
-        Assert.IsFalse(HostRegistry.Upsert(new() { Version = "1.0.0" }, _registry));
-    }
+    public void Upsert_WithoutExePath_IsRejected() => Assert.IsFalse(HostRegistry.Upsert(new() { Version = "1.0.0" }, _registry));
 }

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/PluginWorkspaceTests.cs
@@ -512,7 +512,7 @@ public sealed class PluginWorkspaceTests
 
         public event EventHandler<WorkspaceStatus>? StatusChanged;
 
-        public object CreateView() => new object();
+        public object CreateView() => new();
 
         public Task ReconnectAsync(CancellationToken cancellationToken = default)
         {

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TerminalViewCapabilityTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TerminalViewCapabilityTests.cs
@@ -64,7 +64,7 @@ public class TerminalViewCapabilityTests
     {
         var view = new FakeTerminalView();
         List<byte[]> seen = [];
-        view.UserInput += bytes => seen.Add(bytes);
+        view.UserInput += seen.Add;
 
         view.SimulateUserInput("ls -l\n");
 

--- a/tests/VelaShell.Infrastructure.Tests/Startup/XshellLaunchParserTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Startup/XshellLaunchParserTests.cs
@@ -198,10 +198,7 @@ public class XshellLaunchParserTests
     }
 
     [TestMethod]
-    public void Parse_MissingSessionFile_ReturnsNullInsteadOfThrowing()
-    {
-        Assert.IsNull(XshellLaunchParser.TryParse(["-f", Path.Combine(Path.GetTempPath(), "no-such-file.xsh")]));
-    }
+    public void Parse_MissingSessionFile_ReturnsNullInsteadOfThrowing() => Assert.IsNull(XshellLaunchParser.TryParse(["-f", Path.Combine(Path.GetTempPath(), "no-such-file.xsh")]));
 
     [TestMethod]
     public void TrustKey_IncludesUserAndPort_AndIgnoresHostCase()

--- a/tests/VelaShell.Plugin.Ai.Tests/ContextBuilderTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ContextBuilderTests.cs
@@ -115,11 +115,9 @@ public sealed class ContextBuilderTests
     }
 
     [TestMethod]
-    public void Estimate_CountsWideCharactersHeavierThanAscii()
-    {
+    public void Estimate_CountsWideCharactersHeavierThanAscii() =>
         // 同样 12 个字符:ASCII 约 3 token,中文约 8 token
         Assert.IsLessThan(ContextBuilder.Estimate("你好世界你好世界你好世界"), ContextBuilder.Estimate("abcdefghijkl"));
-    }
 
     [TestMethod]
     public void Estimate_IncludesToolCallsAndResults()

--- a/tests/VelaShell.Plugin.Ai.Tests/FileReferenceTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/FileReferenceTests.cs
@@ -129,10 +129,7 @@ public sealed class FileReferenceTests
     }
 
     [TestMethod]
-    public void Parse_IgnoresUnterminatedQuote()
-    {
-        Assert.IsEmpty(FileReference.Parse("@\"/opt/still typing"));
-    }
+    public void Parse_IgnoresUnterminatedQuote() => Assert.IsEmpty(FileReference.Parse("@\"/opt/still typing"));
 
     [TestMethod]
     public void Expand_ResolvesHome() => Assert.AreEqual("/home/tester/a.txt", FileReference.Expand("~/a.txt", "/home/tester/"));

--- a/tests/VelaShell.Plugin.Ai.Tests/ModelsDevCatalogTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/ModelsDevCatalogTests.cs
@@ -176,11 +176,9 @@ public sealed class ModelsDevCatalogTests
     }
 
     [TestMethod]
-    public void Parse_KeepsBetaModels()
-    {
+    public void Parse_KeepsBetaModels() =>
         // beta 是能用的,别跟着 deprecated 一起筛掉
         Assert.Contains(m => m.Id == "gpt-5.6-beta", ModelsDevCatalog.Parse(NoisyShape)["openai"]);
-    }
 
     [TestMethod]
     public void Parse_DropsModelsThatCannotProduceChatOutput()
@@ -329,11 +327,9 @@ public sealed class ModelsDevCatalogTests
     }
 
     [TestMethod]
-    public void ChooseDefault_FallsBackToTheFirstWhenNothingIsEvenClose()
-    {
+    public void ChooseDefault_FallsBackToTheFirstWhenNothingIsEvenClose() =>
         // 前缀只对上两三个字母说明根本不是一族,别硬凑
         Assert.AreEqual("aardvark", ModelsDevCatalog.ChooseDefault("zzz-9", Specs("aardvark", "beta"))!.Id);
-    }
 
     [TestMethod]
     public void ChooseDefault_WithNothingPulled_IsNull()

--- a/tests/VelaShell.Presentation.Tests/Services/TunnelWorkflowServiceTests.cs
+++ b/tests/VelaShell.Presentation.Tests/Services/TunnelWorkflowServiceTests.cs
@@ -36,10 +36,7 @@ public sealed class TunnelWorkflowServiceTests
 
     [TestMethod]
     [TestCategory("TunnelWorkflow")]
-    public void Constructor_NullService_Throws()
-    {
-        Assert.ThrowsExactly<ArgumentNullException>(() => new TunnelWorkflowService(null!));
-    }
+    public void Constructor_NullService_Throws() => Assert.ThrowsExactly<ArgumentNullException>(() => new TunnelWorkflowService(null!));
 
     [TestMethod]
     [TestCategory("TunnelWorkflow")]

--- a/tests/VelaShell.Terminal.Tests/Emulation/Osc7WorkingDirectoryTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Emulation/Osc7WorkingDirectoryTests.cs
@@ -23,33 +23,19 @@ public class Osc7WorkingDirectoryTests
     }
 
     [TestMethod]
-    public void Osc7_WithHost_StTerminator_ExtractsPath()
-    {
+    public void Osc7_WithHost_StTerminator_ExtractsPath() =>
         // ESC ] 7 ; file://host/root/temp ESC \
         Assert.AreEqual("/root/temp", CaptureCwd("\e]7;file://myhost/root/temp\e\\"));
-    }
 
     [TestMethod]
-    public void Osc7_EmptyHost_ExtractsPath()
-    {
-        Assert.AreEqual("/var/log", CaptureCwd("\e]7;file:///var/log\e\\"));
-    }
+    public void Osc7_EmptyHost_ExtractsPath() => Assert.AreEqual("/var/log", CaptureCwd("\e]7;file:///var/log\e\\"));
 
     [TestMethod]
-    public void Osc7_PercentEncoded_IsDecoded()
-    {
-        Assert.AreEqual("/a b/c", CaptureCwd("\e]7;file://h/a%20b/c\e\\"));
-    }
+    public void Osc7_PercentEncoded_IsDecoded() => Assert.AreEqual("/a b/c", CaptureCwd("\e]7;file://h/a%20b/c\e\\"));
 
     [TestMethod]
-    public void Osc7_NonFileScheme_DoesNotFire()
-    {
-        Assert.IsNull(CaptureCwd("\e]7;http://example.com/x\e\\"));
-    }
+    public void Osc7_NonFileScheme_DoesNotFire() => Assert.IsNull(CaptureCwd("\e]7;http://example.com/x\e\\"));
 
     [TestMethod]
-    public void Osc7_MalformedNoPath_DoesNotFire()
-    {
-        Assert.IsNull(CaptureCwd("\e]7;file://host\e\\"));
-    }
+    public void Osc7_MalformedNoPath_DoesNotFire() => Assert.IsNull(CaptureCwd("\e]7;file://host\e\\"));
 }

--- a/tests/VelaShell.Terminal.Tests/Input/TerminalKeyRouterTests.cs
+++ b/tests/VelaShell.Terminal.Tests/Input/TerminalKeyRouterTests.cs
@@ -31,23 +31,15 @@ public class TerminalKeyRouterTests
     }
 
     [TestMethod]
-    public void CtrlShiftC_CopiesSelection()
-    {
-        Assert.AreEqual(TerminalKeyActionKind.CopySelection, Classify(Key.C, KeyModifiers.Control | KeyModifiers.Shift).Kind);
-    }
+    public void CtrlShiftC_CopiesSelection() => Assert.AreEqual(TerminalKeyActionKind.CopySelection, Classify(Key.C, KeyModifiers.Control | KeyModifiers.Shift).Kind);
 
     [TestMethod]
-    public void CtrlShiftV_Pastes()
-    {
-        Assert.AreEqual(TerminalKeyActionKind.PasteClipboard, Classify(Key.V, KeyModifiers.Control | KeyModifiers.Shift).Kind);
-    }
+    public void CtrlShiftV_Pastes() => Assert.AreEqual(TerminalKeyActionKind.PasteClipboard, Classify(Key.V, KeyModifiers.Control | KeyModifiers.Shift).Kind);
 
     [TestMethod]
-    public void ShiftInsert_Pastes_InsteadOfEncodingCsi2Tilde()
-    {
+    public void ShiftInsert_Pastes_InsteadOfEncodingCsi2Tilde() =>
         // 必须在编码器之前拦截,否则会被编成 CSI 2~ 发往主机。
         Assert.AreEqual(TerminalKeyActionKind.PasteClipboard, Classify(Key.Insert, KeyModifiers.Shift).Kind);
-    }
 
     [TestMethod]
     public void PageUp_OnMainScreenWithScrollback_ScrollsHistoryUp()
@@ -100,11 +92,9 @@ public class TerminalKeyRouterTests
     }
 
     [TestMethod]
-    public void PlainCharacterKey_ProducesNoAction_TextArrivesViaTextInput()
-    {
+    public void PlainCharacterKey_ProducesNoAction_TextArrivesViaTextInput() =>
         // 无修饰的字符键交给 TextInput 管线(IME/大小写/布局都在那边处理)。
         Assert.AreEqual(TerminalKeyActionKind.None, Classify(Key.A, KeyModifiers.None).Kind);
-    }
 
     [TestMethod]
     public void Backspace_EncodesDelete()

--- a/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LocalEchoTests.cs
@@ -17,10 +17,7 @@ public class LocalEchoTests
         Encoding.ASCII.GetString(LocalEcho.Compute(Encoding.ASCII.GetBytes(input), newLineMode));
 
     [TestMethod]
-    public void PrintableText_IsEchoedVerbatim()
-    {
-        Assert.AreEqual("ls -la", Echo("ls -la"));
-    }
+    public void PrintableText_IsEchoedVerbatim() => Assert.AreEqual("ls -la", Echo("ls -la"));
 
     [TestMethod]
     public void Utf8MultiByte_SurvivesRoundTrip()
@@ -40,10 +37,7 @@ public class LocalEchoTests
 
     /// <summary>含 ESC 时整段丢弃,不做"挑出可打印部分"的小聪明 —— 那会把序列拆碎得更难看。</summary>
     [TestMethod]
-    public void PayloadContainingEscape_IsDroppedEntirely()
-    {
-        Assert.AreEqual("", Echo("abc\e[Adef"));
-    }
+    public void PayloadContainingEscape_IsDroppedEntirely() => Assert.AreEqual("", Echo("abc\e[Adef"));
 
     [TestMethod]
     public void Backspace_EchoesVisibleErase()
@@ -67,33 +61,24 @@ public class LocalEchoTests
     }
 
     [TestMethod]
-    public void EmptyInput_ProducesNothing()
-    {
-        Assert.AreEqual("", Echo(""));
-    }
+    public void EmptyInput_ProducesNothing() => Assert.AreEqual("", Echo(""));
 
     // ---- 开关语义 ----------------------------------------------------
 
     [TestMethod]
-    public void Disabled_WhenUserOffAndSrmSet()
-    {
+    public void Disabled_WhenUserOffAndSrmSet() =>
         // SRM 置位(默认)= 主机负责回显 → 不本地回显。SSH 的常态。
         Assert.IsFalse(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: true));
-    }
 
     [TestMethod]
-    public void Enabled_WhenUserTurnsItOn()
-    {
+    public void Enabled_WhenUserTurnsItOn() =>
         // Telnet/串口:主机不回显也不会发 SRM,只能靠用户设置。
         Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: true, sendReceiveMode: true));
-    }
 
     [TestMethod]
-    public void Enabled_WhenHostResetsSrm()
-    {
+    public void Enabled_WhenHostResetsSrm() =>
         // CSI 12 l:主机显式要求终端自行回显。
         Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: false));
-    }
 
     // ---- 对端自己回显时强制关闭(SSH / 本地 ConPTY)------------------
 
@@ -122,18 +107,12 @@ public class LocalEchoTests
     /// (它自己会相应停止),无视它会让用户打字完全看不见。
     /// </summary>
     [TestMethod]
-    public void ExplicitSrmReset_StillWins_OverPeerEchoes()
-    {
-        Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: false, peerEchoes: true));
-    }
+    public void ExplicitSrmReset_StillWins_OverPeerEchoes() => Assert.IsTrue(LocalEcho.IsEnabled(userEnabled: false, sendReceiveMode: false, peerEchoes: true));
 
     // ---- SRM 在引擎里的解析 ------------------------------------------
 
     [TestMethod]
-    public void Srm_DefaultsToHostEcho()
-    {
-        Assert.IsTrue(new TerminalModes().SendReceive, "默认必须是 12h(不本地回显),否则 SSH 会话会双字符。");
-    }
+    public void Srm_DefaultsToHostEcho() => Assert.IsTrue(new TerminalModes().SendReceive, "默认必须是 12h(不本地回显),否则 SSH 会话会双字符。");
 
     [TestMethod]
     public void Srm_IsParsedFromAnsiMode12()

--- a/tests/VelaShell.Terminal.Tests/ScrollOffsetTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ScrollOffsetTests.cs
@@ -7,43 +7,29 @@ namespace VelaShell.Terminal.Tests;
 public class ScrollOffsetTests
 {
     [TestMethod]
-    public void AtLiveBottom_AlwaysStaysAtBottom()
-    {
+    public void AtLiveBottom_AlwaysStaysAtBottom() =>
         // Offset 0 means "following output"; new lines must keep it at the bottom.
         Assert.AreEqual(0, VelaTerminalControl.PinScrollOffset(0, 10, 25));
-    }
 
     [TestMethod]
-    public void ScrolledUp_PinsViewByGrowingWithScrollback()
-    {
+    public void ScrolledUp_PinsViewByGrowingWithScrollback() =>
         // Viewing history 5 lines up; scrollback grew 10 -> 13, so the same content is now
         // 8 lines up. Without this the view would drift down toward the live output.
         Assert.AreEqual(8, VelaTerminalControl.PinScrollOffset(5, 10, 13));
-    }
 
     [TestMethod]
-    public void ScrolledUp_NoGrowth_KeepsOffset()
-    {
-        Assert.AreEqual(5, VelaTerminalControl.PinScrollOffset(5, 10, 10));
-    }
+    public void ScrolledUp_NoGrowth_KeepsOffset() => Assert.AreEqual(5, VelaTerminalControl.PinScrollOffset(5, 10, 10));
 
     [TestMethod]
-    public void ScrolledUp_ClampsToNewScrollback()
-    {
+    public void ScrolledUp_ClampsToNewScrollback() =>
         // Can never scroll past the top of the available history.
         Assert.AreEqual(12, VelaTerminalControl.PinScrollOffset(100, 10, 12));
-    }
 
     [TestMethod]
-    public void ScrollbackShrank_ClampsDown()
-    {
+    public void ScrollbackShrank_ClampsDown() =>
         // Alt-screen exit / clear can shrink scrollback; the pinned offset clamps to fit.
         Assert.AreEqual(4, VelaTerminalControl.PinScrollOffset(5, 10, 4));
-    }
 
     [TestMethod]
-    public void EmptyScrollback_ReturnsZero()
-    {
-        Assert.AreEqual(0, VelaTerminalControl.PinScrollOffset(5, 10, 0));
-    }
+    public void EmptyScrollback_ReturnsZero() => Assert.AreEqual(0, VelaTerminalControl.PinScrollOffset(5, 10, 0));
 }

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -294,7 +294,7 @@ public class TerminalBridgeTests
         _shellStream.CanRead.Returns(false);
         _shellStream.CanWrite.Returns(true);
 
-        object gate = new object();
+        object gate = new();
         int inFlight = 0, maxInFlight = 0;
         var received = new MemoryStream();
         _shellStream.WriteAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())

--- a/tests/VelaShell.Terminal.Tests/TransferCommandParserTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TransferCommandParserTests.cs
@@ -60,10 +60,7 @@ public class TransferCommandParserTests
     /// <c>--</c> 之后是文件名而不是开关:名为 <c>-X</c> 的文件不得把协议改掉。
     /// </summary>
     [TestMethod]
-    public void FlagsAfterDoubleDash_AreNotParsed()
-    {
-        AssertIntent("sz -- -X", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
-    }
+    public void FlagsAfterDoubleDash_AreNotParsed() => AssertIntent("sz -- -X", TerminalTransferProtocol.ZModem, FileTransferDirection.Receive);
 
     /// <summary>
     /// 误判的代价是把终端交给引擎最多 30 秒,所以宁可漏认也不能错认:

--- a/tests/VelaShell.Tests/Behaviors/NumericInputGuardUiTests.cs
+++ b/tests/VelaShell.Tests/Behaviors/NumericInputGuardUiTests.cs
@@ -412,20 +412,18 @@ public sealed class NumericInputGuardUiTests
 
     private sealed class DelayModel : INotifyPropertyChanged
     {
-        private int _delaySeconds;
-
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public int DelaySeconds
         {
-            get => _delaySeconds;
+            get;
             set
             {
-                if (_delaySeconds == value)
+                if (field == value)
                 {
                     return;
                 }
-                _delaySeconds = value;
+                field = value;
                 PropertyChanged?.Invoke(this, new(nameof(DelaySeconds)));
             }
         }

--- a/tests/VelaShell.Tests/Integration/HeadlessUiTests.cs
+++ b/tests/VelaShell.Tests/Integration/HeadlessUiTests.cs
@@ -71,7 +71,7 @@ public class HeadlessUiTests
     {
         var themeService = new ThemeService();
         var events = new List<string>();
-        themeService.ThemeChanged += name => events.Add(name);
+        themeService.ThemeChanged += events.Add;
         themeService.SetTheme("light");
         themeService.SetTheme("dark");
         themeService.SetTheme("light");

--- a/tests/VelaShell.Tests/Localization/LocalizedKeyUsageTests.cs
+++ b/tests/VelaShell.Tests/Localization/LocalizedKeyUsageTests.cs
@@ -31,16 +31,10 @@ public partial class LocalizedKeyUsageTests
     private static partial Regex CodeKey { get; }
 
     [TestMethod]
-    public void EveryLocalizeKeyUsedInXaml_ExistsInResources()
-    {
-        AssertAllKeysDefined("*.axaml", XamlKey, minimumExpected: 100);
-    }
+    public void EveryLocalizeKeyUsedInXaml_ExistsInResources() => AssertAllKeysDefined("*.axaml", XamlKey, minimumExpected: 100);
 
     [TestMethod]
-    public void EveryLocalizeKeyUsedInCode_ExistsInResources()
-    {
-        AssertAllKeysDefined("*.cs", CodeKey, minimumExpected: 50);
-    }
+    public void EveryLocalizeKeyUsedInCode_ExistsInResources() => AssertAllKeysDefined("*.cs", CodeKey, minimumExpected: 50);
 
     /// <summary>
     /// 扫 src 下所有匹配文件里的键,逐个比对中性资源。

--- a/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
+++ b/tests/VelaShell.Tests/Services/PackageVersionsTests.cs
@@ -50,33 +50,21 @@ public partial class PackageVersionsTests
     }
 
     [TestMethod]
-    public void Of_UnknownPackage_ReturnsNull()
-    {
-        Assert.IsNull(PackageVersions.Of("No.Such.Package"));
-    }
+    public void Of_UnknownPackage_ReturnsNull() => Assert.IsNull(PackageVersions.Of("No.Such.Package"));
 
     /// <summary>没有任何包版本元数据的程序集:返回空表而不是抛。</summary>
     [TestMethod]
-    public void Read_AssemblyWithoutMetadata_ReturnsEmpty()
-    {
-        Assert.IsEmpty(PackageVersions.Read(typeof(object).Assembly));
-    }
+    public void Read_AssemblyWithoutMetadata_ReturnsEmpty() => Assert.IsEmpty(PackageVersions.Read(typeof(object).Assembly));
 
     /// <summary>
     /// 关于页真正显示出来的文本 —— 这才是用户看到的东西,也是原先写死、并且已经漂移过的地方
     /// (曾停留在 "Avalonia UI 12.0.5",而实际引用早已是 12.1.0)。
     /// </summary>
     [TestMethod]
-    public void AboutFramework_ShowsTheReferencedAvaloniaVersion()
-    {
-        Assert.AreEqual($"Avalonia UI {PackageVersions.Of("Avalonia")}", SettingsViewModel.AboutFramework);
-    }
+    public void AboutFramework_ShowsTheReferencedAvaloniaVersion() => Assert.AreEqual($"Avalonia UI {PackageVersions.Of("Avalonia")}", SettingsViewModel.AboutFramework);
 
     [TestMethod]
-    public void AboutSshLibrary_ShowsTheReferencedSshLibraryVersion()
-    {
-        Assert.AreEqual($"Tmds.Ssh {PackageVersions.Of("Tmds.Ssh")}", SettingsViewModel.AboutSshLibrary);
-    }
+    public void AboutSshLibrary_ShowsTheReferencedSshLibraryVersion() => Assert.AreEqual($"Tmds.Ssh {PackageVersions.Of("Tmds.Ssh")}", SettingsViewModel.AboutSshLibrary);
 
     /// <summary>关于页不该再出现写死的版本号 —— 这条盯的就是当初那个漂移。</summary>
     [TestMethod]

--- a/tests/VelaShell.Tests/Services/SyntaxHighlightingTests.cs
+++ b/tests/VelaShell.Tests/Services/SyntaxHighlightingTests.cs
@@ -74,11 +74,9 @@ public class SyntaxHighlightingTests
         Assert.AreEqual(expected, FileTypeDetector.Detect("deploy", firstLine));
 
     [TestMethod]
-    public void Detect_ExtensionWinsOverShebang()
-    {
+    public void Detect_ExtensionWinsOverShebang() =>
         // 扩展名是更强的信号;shebang 只是无扩展名时的兜底。
         Assert.AreEqual("Python", FileTypeDetector.Detect("tool.py", "#!/bin/bash"));
-    }
 
     [TestMethod]
     [DataRow("notes", null)]

--- a/tests/VelaShell.Tests/Services/ThemeServiceSwitchTests.cs
+++ b/tests/VelaShell.Tests/Services/ThemeServiceSwitchTests.cs
@@ -115,7 +115,7 @@ public class ThemeServiceSwitchTests
     {
         var sut = new ThemeService("dark");
         var events = new List<string>();
-        sut.ThemeChanged += name => events.Add(name);
+        sut.ThemeChanged += events.Add;
 
         sut.SetTheme("light");
         sut.SetTheme("dark");

--- a/tests/VelaShell.Tests/Services/UpdateApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateApplierTests.cs
@@ -213,10 +213,7 @@ public class UpdateApplierTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public void SwapFromPayload_WithoutStage_Throws()
-    {
-        Assert.ThrowsExactly<InvalidOperationException>(_applier.SwapFromPayload);
-    }
+    public void SwapFromPayload_WithoutStage_Throws() => Assert.ThrowsExactly<InvalidOperationException>(_applier.SwapFromPayload);
 
     [TestMethod]
     [TestCategory("Update")]
@@ -429,10 +426,7 @@ public class UpdateApplierTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public void TryFinalizeStartup_NothingPending_ReturnsTrue()
-    {
-        Assert.IsTrue(_applier.TryFinalizeStartup());
-    }
+    public void TryFinalizeStartup_NothingPending_ReturnsTrue() => Assert.IsTrue(_applier.TryFinalizeStartup());
 
     // ———————————————————— 自愈 ————————————————————
 
@@ -472,10 +466,7 @@ public class UpdateApplierTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public void IsApplicationDirectoryWritable_TempDir_IsTrue()
-    {
-        Assert.IsTrue(_applier.IsApplicationDirectoryWritable());
-    }
+    public void IsApplicationDirectoryWritable_TempDir_IsTrue() => Assert.IsTrue(_applier.IsApplicationDirectoryWritable());
 
     [TestMethod]
     [TestCategory("Update")]

--- a/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateManifestTests.cs
@@ -77,9 +77,7 @@ public class UpdateManifestTests
 
     [TestMethod]
     [TestCategory("Update")]
-    public void Parse_MalformedJson_Throws()
-    {
+    public void Parse_MalformedJson_Throws() =>
         // JsonReaderException 等派生类也算,用非严格断言。
         Assert.Throws<JsonException>(() => UpdateManifest.Parse("not json"));
-    }
 }

--- a/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateServiceTests.cs
@@ -77,17 +77,11 @@ public class UpdateServiceTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public void AvailableVersion_Initially_IsNull()
-    {
-        Assert.IsNull(CreateService().AvailableVersion);
-    }
+    public void AvailableVersion_Initially_IsNull() => Assert.IsNull(CreateService().AvailableVersion);
 
     [TestMethod]
     [TestCategory("Update")]
-    public void CanSelfUpdate_WritableTempDir_IsTrue()
-    {
-        Assert.IsTrue(CreateService().CanSelfUpdate);
-    }
+    public void CanSelfUpdate_WritableTempDir_IsTrue() => Assert.IsTrue(CreateService().CanSelfUpdate);
 
     [TestMethod]
     [TestCategory("Update")]
@@ -156,10 +150,7 @@ public class UpdateServiceTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public async Task DownloadUpdateAsync_WithoutCheck_CompletesWithoutError()
-    {
-        await CreateService().DownloadUpdateAsync();
-    }
+    public async Task DownloadUpdateAsync_WithoutCheck_CompletesWithoutError() => await CreateService().DownloadUpdateAsync();
 
     [TestMethod]
     [TestCategory("Update")]
@@ -194,7 +185,7 @@ public class UpdateServiceTests : IDisposable
         string staging = Path.Combine(_appDir, UpdateApplier.StagingDirectoryName);
         Assert.IsEmpty(Directory.GetFiles(staging), "校验失败的下载必须删除");
         // 校验失败后不允许进入换版。
-        Assert.ThrowsExactly<InvalidOperationException>(() => service.ApplyUpdateAndRestart());
+        Assert.ThrowsExactly<InvalidOperationException>(service.ApplyUpdateAndRestart);
     }
 
     [TestMethod]
@@ -351,31 +342,19 @@ public class UpdateServiceTests : IDisposable
 
     [TestMethod]
     [TestCategory("Update")]
-    public void ApplyUpdateAndRestart_WithoutDownload_ThrowsInvalidOperation()
-    {
-        Assert.ThrowsExactly<InvalidOperationException>(() => CreateService().ApplyUpdateAndRestart());
-    }
+    public void ApplyUpdateAndRestart_WithoutDownload_ThrowsInvalidOperation() => Assert.ThrowsExactly<InvalidOperationException>(() => CreateService().ApplyUpdateAndRestart());
 
     [TestMethod]
     [TestCategory("Update")]
-    public void Constructor_WithNullSource_ThrowsArgumentNullException()
-    {
-        Assert.ThrowsExactly<ArgumentNullException>(() => _ = new UpdateService((IUpdateSource)null!));
-    }
+    public void Constructor_WithNullSource_ThrowsArgumentNullException() => Assert.ThrowsExactly<ArgumentNullException>(() => _ = new UpdateService((IUpdateSource)null!));
 
     [TestMethod]
     [TestCategory("Update")]
-    public void Constructor_WithInvalidRepositoryUrl_Throws()
-    {
-        Assert.ThrowsExactly<ArgumentException>(() => _ = new UpdateService("https://github.com/only-owner"));
-    }
+    public void Constructor_WithInvalidRepositoryUrl_Throws() => Assert.ThrowsExactly<ArgumentException>(() => _ = new UpdateService("https://github.com/only-owner"));
 
     [TestMethod]
     [TestCategory("Update")]
-    public void ImplementsIUpdateService()
-    {
-        Assert.IsInstanceOfType<IUpdateService>(CreateService());
-    }
+    public void ImplementsIUpdateService() => Assert.IsInstanceOfType<IUpdateService>(CreateService());
 
     /// <summary>同步回调的进度器(Progress&lt;T&gt; 经同步上下文投递,测试里改用直呼)。</summary>
     private sealed class SynchronousProgress(Action<int> handler) : IProgress<int>

--- a/tests/VelaShell.Tests/Services/UpdateVersionTests.cs
+++ b/tests/VelaShell.Tests/Services/UpdateVersionTests.cs
@@ -31,10 +31,7 @@ public class UpdateVersionTests
     [DataRow("1.2.3.4.5")]
     [DataRow("1.-2.3")]
     [DataRow("1.2.3-")]
-    public void TryParse_InvalidInput_Fails(string? text)
-    {
-        Assert.IsFalse(UpdateVersion.TryParse(text, out _));
-    }
+    public void TryParse_InvalidInput_Fails(string? text) => Assert.IsFalse(UpdateVersion.TryParse(text, out _));
 
     [TestMethod]
     [TestCategory("Update")]

--- a/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectionProfileViewModelTests.cs
@@ -365,13 +365,11 @@ public sealed class ConnectionProfileViewModelTests
     }
 
     [TestMethod]
-    public void ChoiceItem_StringifiesToTheStoredValue()
-    {
+    public void ChoiceItem_StringifiesToTheStoredValue() =>
         // 可编辑下拉在用户选中一项时,会拿 item.ToString() 去填那个文本框 ——
         // 而那就是接下来落盘的值。返回展示文案的话,存进配置的会是
         // "USB-SERIAL CH340 (COM3)" 这种打不开的东西。
         Assert.AreEqual("COM3", new PluginChoiceItem("COM3", "USB-SERIAL CH340 (COM3)").ToString());
-    }
 
     /// <summary>
     /// 声明了显示条件的字段只在条件成立时出现,并且**改一下就跟着变** ——

--- a/tests/VelaShell.Tests/ViewModels/InteractiveAuthFlowTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/InteractiveAuthFlowTests.cs
@@ -103,5 +103,4 @@ public sealed class InteractiveAuthFlowTests
         // 所以断言的是「本地化文案 + \n + 原因」,不是裸文案。
         Assert.AreEqual($"{Strings.Format("Msg_AuthFailed", "root@h:22")}\ndenied", vm.LastConnectionError);
     }
-
 }

--- a/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ProcessManagerViewModelTests.cs
@@ -12,10 +12,7 @@ public class ProcessManagerViewModelTests
     private readonly FakeProcessService _service = new();
     private readonly ProcessManagerViewModel _vm;
 
-    public ProcessManagerViewModelTests()
-    {
-        _vm = new(_service, Guid.NewGuid(), "生产数据库");
-    }
+    public ProcessManagerViewModelTests() => _vm = new(_service, Guid.NewGuid(), "生产数据库");
 
     [TestMethod]
     public async Task Refresh_WithoutData_KeepsThePlaceholderVisible()

--- a/tests/VelaShell.Tests/ViewModels/PromptCommandExtractionTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/PromptCommandExtractionTests.cs
@@ -36,10 +36,7 @@ public class PromptCommandExtractionTests
     }
 
     [TestMethod]
-    public void EmptyCommand_ReturnsNull()
-    {
-        Assert.IsNull(TerminalTabViewModel.ExtractCommandAfterPrompt("pi@NanoPi-R2S:~$ "));
-    }
+    public void EmptyCommand_ReturnsNull() => Assert.IsNull(TerminalTabViewModel.ExtractCommandAfterPrompt("pi@NanoPi-R2S:~$ "));
 
     [TestMethod]
     public void DollarInsideCommand_UsesEarliestPromptMarker()

--- a/tests/VelaShell.Tests/ViewModels/RemotePathInputTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/RemotePathInputTests.cs
@@ -62,11 +62,9 @@ public class RemotePathInputTests
     }
 
     [TestMethod]
-    public void Backslash_IsAFileNameChar_NotASeparator()
-    {
+    public void Backslash_IsAFileNameChar_NotASeparator() =>
         // POSIX 下 \ 是合法文件名字符;若当成分隔符替换,带反斜杠的目录将永远打不开。
         Assert.AreEqual("/tmp/a\\b", RemotePathInput.Normalize("/tmp/a\\b", "/", null));
-    }
 
     [TestMethod]
     public void BlankInput_MeansNoNavigation()

--- a/tests/VelaShell.Tests/ViewModels/SecretPromptDetectionTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SecretPromptDetectionTests.cs
@@ -37,11 +37,9 @@ public class SecretPromptDetectionTests
     }
 
     [TestMethod]
-    public void CommandContainingPasswordWord_IsNotSecret()
-    {
+    public void CommandContainingPasswordWord_IsNotSecret() =>
         // 命令文本里出现 password 不算:剥掉回显输入后提示是 "$" 结尾。
         Assert.IsFalse(TerminalTabView.IsSecretPrompt("pi@host:~$ grep password /etc/x", "grep password /etc/x"));
-    }
 
     [TestMethod]
     public void ColonWithoutKeyword_IsNotSecret()

--- a/tests/VelaShell.Tests/ViewModels/SessionTreeStatusFromTabsTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SessionTreeStatusFromTabsTests.cs
@@ -100,7 +100,7 @@ public sealed class SessionTreeStatusFromTabsTests
     [TestMethod]
     public async Task OtherProfileTabs_DoNotAffectNode()
     {
-        (MainWindowViewModel vm, SessionProfile profile, SessionTreeNodeViewModel node) =
+        (MainWindowViewModel vm, _, SessionTreeNodeViewModel node) =
             await CreateLoadedAsync();
 
         vm.TabBar.AddTab(CreateTab(new SessionProfile { Id = Guid.NewGuid(), Name = "other" }, SessionStatus.Connected));

--- a/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/SettingsViewModelTests.cs
@@ -31,8 +31,8 @@ public class SettingsViewModelTests
         ISettingsPreviewService preview = new SettingsPreviewService();
         var opacityValues = new List<int>();
         var snapshots = new List<AppSettings>();
-        preview.WindowOpacityPreviewRequested += value => opacityValues.Add(value);
-        preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+        preview.WindowOpacityPreviewRequested += opacityValues.Add;
+        preview.PreviewRequested += snapshots.Add;
         _settingsService.GetSettingsAsync().Returns(new AppSettings());
 
         SettingsViewModel vm = CreateVm(preview);
@@ -53,7 +53,7 @@ public class SettingsViewModelTests
     {
         ISettingsPreviewService preview = new SettingsPreviewService();
         var snapshots = new List<AppSettings>();
-        preview.PreviewRequested += snapshot => snapshots.Add(snapshot);
+        preview.PreviewRequested += snapshots.Add;
         var baseline = new AppSettings { Appearance = new() { WindowOpacityPercent = 80 } };
         _settingsService.GetSettingsAsync().Returns(baseline);
 

--- a/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
+++ b/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
@@ -53,17 +53,11 @@ public sealed class BreadcrumbUnderscoreUiTests
 
     /// <summary>本地面板(双栏左侧)的面包屑走同一套样式。</summary>
     [TestMethod]
-    public void LocalPaneBreadcrumb_KeepsUnderscoreInsteadOfEatingItAsAccessKey()
-    {
-        RunLocalPaneCase(vm => new LocalFilePaneView { DataContext = vm });
-    }
+    public void LocalPaneBreadcrumb_KeepsUnderscoreInsteadOfEatingItAsAccessKey() => RunLocalPaneCase(vm => new LocalFilePaneView { DataContext = vm });
 
     /// <summary>本地路径选择器对话框的面包屑同理。</summary>
     [TestMethod]
-    public void LocalPathPickerBreadcrumb_KeepsUnderscoreInsteadOfEatingItAsAccessKey()
-    {
-        RunLocalPaneCase(vm => new LocalPathPickerDialog(vm, loadInitial: false));
-    }
+    public void LocalPathPickerBreadcrumb_KeepsUnderscoreInsteadOfEatingItAsAccessKey() => RunLocalPaneCase(vm => new LocalPathPickerDialog(vm, loadInitial: false));
 
     /// <summary>
     /// 在一个名字带下划线的真实临时目录上起本地面板视图模型,交给 <paramref name="createView" />

--- a/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
+++ b/tests/VelaShell.Tests/Views/FtpConnectionFlowTests.cs
@@ -189,7 +189,7 @@ public sealed class FtpConnectionFlowTests
     private static Task DrainMainThreadAsync()
     {
         var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        RxSchedulers.MainThreadScheduler.Schedule(() => drained.SetResult());
+        RxSchedulers.MainThreadScheduler.Schedule(drained.SetResult);
         return drained.Task;
     }
 }

--- a/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
@@ -17,10 +17,7 @@ public sealed class LocalFilePaneViewUiTests
     private static HeadlessUnitTestSession _session = null!;
 
     [ClassInitialize]
-    public static void Init(TestContext _)
-    {
-        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(LocalFilePaneViewUiTests).Assembly);
-    }
+    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(LocalFilePaneViewUiTests).Assembly);
 
     [TestMethod]
     public async Task InaccessibleRootSelectionRestoresPreviousSelection()


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

本次提交聚焦于代码风格和一致性优化，包括：
- 大量方法、属性、事件等改为表达式体，提升简洁度
- 统一事件订阅、委托、回调等写法，减少冗余 lambda
- 优化属性为自动属性或表达式体，精简 setter/字段
- 构造函数、辅助方法等能用表达式体的均已简化
- 测试代码断言、初始化等精简为单行表达式
- .editorconfig 重构，细化 C# 风格、命名、诊断规则，区分通用与特定部分
- 局部变量、参数、字段命名更严格，部分文件关闭命名警告
- 少量逻辑微调以配合风格统一
- 移除冗余 using、SuppressMessage、空实现等

整体提升代码一致性、现代化和可维护性，减少样板和视觉噪音。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
