### PR TITLE
fix(ssh): 远端 exit 之后别再自动连回来 (#383)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1782,3 +1782,67 @@ MCP 默认 **`ScopeKind.All` = 允许全部**,与 IM 授权「空 = 一个都不
 在一块 320px 高的矮屏上确认表单确实需要滚动、而滚动条仍是收起的 —— 把
 `AllowAutoHide="False"` 贴回去,这条会红。`DESIGN.md` 5.8 补了两条:展开时机,以及
 "`AllowAutoHide=false` 等于常驻展开,不要拿它当'让人看见能滚'的手段"。
+
+## 44. 2026-09-06 exit 之后不该被自动连回来;SFTP 通道跟着 SSH 一起收(#383)
+
+用户反馈:建立连接后用 `exit` 正常退出,自动重连立刻把它连了回来 —— 换句话说,
+**开着自动重连就退不掉**。
+
+### 一、根因:「用户不想连了」只认了一个入口
+
+`ReconnectPolicy.ShouldReconnect` 的四个条件里,代表用户意图的只有
+`userRequestedDisconnect`,而它**只**由工具栏「断开」按钮置位。在远端敲 `exit`
+说的是同一句话,却走的是另一条路:远端 shell 退出 → 通道关闭 → 桥 `Closed`
+→ `MarkDisconnected`,全程没人把这层意思记下来,于是判定里它和掉线毫无区别。
+
+更下面一层还丢了一次信息。SSH 协议本来把这两件事分得很清楚:
+
+- 远端 shell 退出 → 对端发 `SSH_MSG_CHANNEL_CLOSE` → 读端拿到一次**干净的 EOF**;
+- 连接中断(RST / 超时 / sshd 没了)→ 通道读**抛异常**(走 `ReadAsStream` 时是包着
+  `Ssh*ClosedException` 的 `IOException`)。
+
+但 `ShellStreamWrapper.ReadAsync` 把两者一律归一成"返回 0"(这个归一本身是对的 ——
+掉线不是崩溃,抛出去只会让读循环带着异常收尾),原因就此蒸发。桥只看得到"读到 0",
+宿主只看得到"断了"。
+
+### 二、修法:结论仍是 EOF,原因单独留一份
+
+- 新增 `ShellCloseReason`(`Unknown` / `RemoteExited` / `ConnectionLost` / `LocalTeardown`),
+  `IShellStreamWrapper.CloseReason` 交代读端为什么走到头。`ShellStreamWrapper` 按上面那条
+  协议事实填写:没抛而读到 0 = `RemoteExited`,抛了 = `ConnectionLost`,我们自己在拆 =
+  `LocalTeardown`。`ConPtyShellStream` 只有一种收场(`RemoteExited`);
+  `PluginTerminalShellStream` 报 `Unknown` —— 插件的传输层什么都可能抛,宿主分不出也不该猜,
+  按连接中断处理即与改动前完全一致。
+- `SshTerminalBridge.Closed` 由 `Action` 改成 `Action<ShellCloseReason>`,只负责转述,不做判断。
+- `TerminalTabViewModel.RemoteShellExited` 记住这次是不是远端自己退的,在 `AttachTransport`
+  里与 `UserRequestedDisconnect` 一起复位(否则一次 exit 会永久禁掉该标签的自动重连)。
+- `ReconnectPolicy.ShouldReconnect` 加第五个条件 `remoteShellExited`,**不给默认值** ——
+  这个类存在的理由就是"两处判定必须一致",能被忘掉的参数等于没加。三处消费点一并补齐:
+  掉线后的排程、倒计时到点时的复查、睡眠唤醒后的批量重连。
+
+### 三、顺带:SFTP 的生命周期挂到 SSH 上,而不是挂在调用方的记性上
+
+SFTP **复用主 SSH 连接**(DI 注册处 `inner.OpenSftpClientAsync()`,刻意不在主连接之外另开
+一条:那样的连接无人持有、无人释放,还绕过用户可见的连接生命周期)。既然是同一条连接上的
+通道,SSH 一断,缓存里的 SFTP 客户端就只是个还占着句柄的死物。
+
+原先靠 `MainWindowViewModel` 在断开/关标签时记得调一次 `CloseSftpForTab` —— 主路径是对的,
+但断开的入口不止一个(标签断开、关标签、隧道面板直接 `DisconnectAsync`、退出应用),
+靠约定维持不变量迟早漏一个。改为 `SftpService` 订阅
+`ISshConnectionService.SessionDisconnected`,在服务层收口;`DisposeAsync` 里退订。
+VM 里那次调用保留 —— 它还顺手驱逐文件面板(`EvictFileBrowser`),两者职责不同,
+且 `CloseSessionAsync` 本就是幂等的。
+
+### 四、验收
+
+`dotnet test VelaShell.slnx` 全绿。新增用例:
+
+- `ReconnectPolicyTests.ARemoteShellThatExitedIsNotDraggedBack` 钉住新条件;
+- `TerminalTabViewModelTests` 三条走**真实链路**(替身流 → 桥 → 标签):exit 被记住、
+  掉线不被误认成 exit、重连挂上新传输后标志复位。把 `OnBridgeClosed` 里那行改成
+  `RemoteShellExited = false`,第一条与第三条会红;
+- `TerminalBridgeTests` 两条钉住桥如实转述原因、抛异常那条路一律报 `ConnectionLost`;
+- `SftpServiceTests.ASshDisconnect_TakesTheSftpChannelWithIt` 钉住服务层收口。
+
+文档同步:velashell-docs `zh/host/交互与界面规格.md` 与 `en/host/interaction-and-ui-specs.md`
+的「断开连接状态」补上自动重连的适用边界(只救没人要它结束的断开,四种例外)。

--- a/src/VelaShell.Core/Sftp/SftpService.cs
+++ b/src/VelaShell.Core/Sftp/SftpService.cs
@@ -12,19 +12,56 @@ namespace VelaShell.Core.Sftp;
 /// 基于 SSH 会话的 SFTP 文件操作服务:按会话缓存并复用 SFTP 客户端,提供目录浏览、
 /// 上传/下载、删除、重命名、权限设置等远端文件系统操作。
 /// </summary>
-public class SftpService(
-    ISshConnectionService connectionService,
-    Func<SshSession, ISftpClientWrapper>? sftpClientFactory = null,
-    ISettingsService? settingsService = null) : ISftpService
+public class SftpService : ISftpService
 {
-    private readonly ISshConnectionService _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
+    private readonly ISshConnectionService _connectionService;
+    private readonly Func<SshSession, ISftpClientWrapper>? _sftpClientFactory;
+    private readonly ISettingsService? _settingsService;
     private readonly ConcurrentDictionary<Guid, ISftpClientWrapper> _sftpClients = new();
 
     /// <summary>属主/属组的数字 id → 名称翻译(按会话缓存,见 RemoteIdentityResolver)。</summary>
-    private readonly RemoteIdentityResolver _identities = new(connectionService);
+    private readonly RemoteIdentityResolver _identities;
 
     /// <summary>SFTP 客户端创建的按会话单飞闸(见 GetOrCreateSftpClientAsync)。</summary>
     private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _clientGates = new();
+
+    /// <summary>
+    /// 构造服务,并把 SFTP 通道的生命周期挂到 SSH 会话的生命周期上。
+    /// </summary>
+    /// <remarks>
+    /// SFTP 不是一条独立的连接:它是**主 SSH 连接上的一个通道**
+    /// (见 DI 注册处的 <c>OpenSftpClientAsync</c> —— 刻意复用主连接,
+    /// 不在主连接之外偷偷另开一条)。既然如此,SSH 一断,这边缓存的客户端就已经是个
+    /// 死物,只是还占着字典与非托管句柄。
+    /// <para>
+    /// 因此清理在这里订阅 <see cref="ISshConnectionService.SessionDisconnected" />,
+    /// 而不是靠每个断开入口自己记得调一次 <see cref="CloseSessionAsync" /> ——
+    /// 断开的入口不止一个(标签断开、关标签、隧道面板、退出应用),
+    /// 靠约定去维持这个不变量,迟早会漏掉一个。
+    /// </para>
+    /// </remarks>
+    public SftpService(
+        ISshConnectionService connectionService,
+        Func<SshSession, ISftpClientWrapper>? sftpClientFactory = null,
+        ISettingsService? settingsService = null)
+    {
+        _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
+        _sftpClientFactory = sftpClientFactory;
+        _settingsService = settingsService;
+        _identities = new(connectionService);
+        _connectionService.SessionDisconnected += OnSshSessionDisconnected;
+    }
+
+    /// <summary>
+    /// SSH 会话断了 —— 连它上面那条 SFTP 通道一起收掉。
+    /// </summary>
+    /// <remarks>
+    /// 即发即忘:这是断开路径上的清理,拖慢它没有意义,失败也没有可补救的动作
+    /// (要关的东西已经跟着连接一起没了)。<see cref="CloseSessionAsync" /> 内部
+    /// 对已死的客户端本就是尽力而为。
+    /// </remarks>
+    private void OnSshSessionDisconnected(SshSession session) =>
+        _ = CloseSessionAsync(session.SessionId);
 
     /// <summary>列出指定会话下远端目录的条目(自动剔除 "." 与 ".." )。</summary>
     public async Task<List<RemoteFileInfo>> ListDirectoryAsync(Guid sessionId, string path, CancellationToken cancellationToken = default)
@@ -473,6 +510,8 @@ public class SftpService(
     /// <summary>断开并释放所有缓存的 SFTP 客户端,尽力清理全部会话资源。</summary>
     public async ValueTask DisposeAsync()
     {
+        // 先退订:连接服务比本服务活得久时,悬着的委托会把已释放的实例一直吊在内存里。
+        _connectionService.SessionDisconnected -= OnSshSessionDisconnected;
         foreach (KeyValuePair<Guid, ISftpClientWrapper> kvp in _sftpClients)
         {
             try
@@ -642,13 +681,13 @@ public class SftpService(
     /// <summary>带宽限制(设置 → 文件传输):返回字节/秒,0 = 不限速。</summary>
     private async Task<(long UploadBps, long DownloadBps, bool PreserveTimestamps)> GetTransferTuningAsync()
     {
-        if (settingsService is null)
+        if (_settingsService is null)
         {
             return (0, 0, true);
         }
         try
         {
-            TransferOptions t = (await settingsService.GetSnapshotAsync().ConfigureAwait(false)).Transfer;
+            TransferOptions t = (await _settingsService.GetSnapshotAsync().ConfigureAwait(false)).Transfer;
             long up = t.BandwidthLimitEnabled ? (long)Math.Max(0, t.UploadLimitMBps) * 1024 * 1024 : 0;
             long down = t.BandwidthLimitEnabled ? (long)Math.Max(0, t.DownloadLimitMBps) * 1024 * 1024 : 0;
             return (up, down, t.PreserveTimestamps);
@@ -741,11 +780,11 @@ public class SftpService(
             {
                 throw new InvalidOperationException($"Session {sessionId} is not connected");
             }
-            if (sftpClientFactory == null)
+            if (_sftpClientFactory == null)
             {
                 throw new InvalidOperationException("SFTP client factory not configured");
             }
-            ISftpClientWrapper client = sftpClientFactory(session);
+            ISftpClientWrapper client = _sftpClientFactory(session);
             await client.ConnectAsync(cancellationToken).ConfigureAwait(false);
             _sftpClients[sessionId] = client;
             return client;

--- a/src/VelaShell.Core/Ssh/IShellStreamWrapper.cs
+++ b/src/VelaShell.Core/Ssh/IShellStreamWrapper.cs
@@ -14,6 +14,17 @@ public interface IShellStreamWrapper : IDisposable
     /// <summary>获取一个值,指示流当前是否支持写入。</summary>
     bool CanWrite { get; }
 
+    /// <summary>读端走到头的原因;<see cref="ReadAsync" /> 返回 0 之后才有意义。</summary>
+    /// <remarks>
+    /// 各实现都把「远端 shell 退出」与「连接中断」归一成了返回 0 —— 掉线不是崩溃,
+    /// 抛出去只会让读循环带着异常收尾。但归一之后这两件事在上层就分不开了,
+    /// 而自动重连恰恰只该管后者(#383):在远端敲 <c>exit</c> 之后又被自动连回来,
+    /// 用户根本退不掉。于是结论仍然是 EOF,原因单独留一份在这里。
+    /// 分不清的实现返回 <see cref="ShellCloseReason.Unknown" />,按连接中断处理,
+    /// 即维持原有的自动重连行为。
+    /// </remarks>
+    ShellCloseReason CloseReason { get; }
+
     /// <summary>等待与给定正则表达式匹配的输出,直到指定的超时时间。</summary>
     /// <param name="regex">用于匹配到来输出的正则表达式。</param>
     /// <param name="timeout">等待匹配的最长时间。</param>

--- a/src/VelaShell.Core/Ssh/ShellCloseReason.cs
+++ b/src/VelaShell.Core/Ssh/ShellCloseReason.cs
@@ -1,0 +1,33 @@
+namespace VelaShell.Core.Ssh;
+
+/// <summary>
+/// 一条终端流为什么读到了头 —— 自动重连据此判断该不该把会话拉回来(#383)。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 关键的分野是「远端 shell 自己退了」与「连接被打断了」。前者是用户意图
+/// (在远端敲 <c>exit</c> / <c>logout</c>),自动连回去等于跟用户较劲 ——
+/// 这正是 #383 报的现象:exit 之后标签自己又连上了,退不掉。
+/// 后者才是自动重连要救的场景。
+/// </para>
+/// <para>
+/// 这两件事在 SSH 协议层本就是分开的:远端 shell 退出会发
+/// <c>SSH_MSG_CHANNEL_CLOSE</c>,读端因此干净地收到 EOF;而连接中断
+/// (RST / 超时 / 服务端进程没了)在通道读上抛异常。丢失这条信息的是适配层 ——
+/// 它把两者都归一成了「返回 0」。本枚举就是把它补回来。
+/// </para>
+/// </remarks>
+public enum ShellCloseReason
+{
+    /// <summary>尚未结束,或该实现无法区分(按「连接中断」处理,即维持自动重连)。</summary>
+    Unknown = 0,
+
+    /// <summary>远端 shell 自己退出了(<c>exit</c> / <c>logout</c> / 被 kill),通道被对端正常关闭。</summary>
+    RemoteExited,
+
+    /// <summary>连接异常中断(网络断开、超时、服务端崩溃),会话并非按用户意图结束。</summary>
+    ConnectionLost,
+
+    /// <summary>本地主动拆除(关闭标签、断开按钮、释放),不是远端给出的结论。</summary>
+    LocalTeardown
+}

--- a/src/VelaShell.Infrastructure/Plugins/Protocols/PluginTerminalShellStream.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Protocols/PluginTerminalShellStream.cs
@@ -40,6 +40,17 @@ internal sealed class PluginTerminalShellStream(IProtocolTerminalSession session
     /// <summary>流是否可写。</summary>
     public bool CanWrite => !_disposed;
 
+    /// <summary>
+    /// 读端走到头的原因:插件协议一律 <see cref="ShellCloseReason.Unknown" />。
+    /// </summary>
+    /// <remarks>
+    /// 这里的归一化(见类型注释第 1 条)是**有损**的:插件的传输层什么都可能抛,
+    /// 宿主既分不出「对端正常收线」还是「链路断了」,也不该替某个具体协议去猜。
+    /// 报 Unknown 即按连接中断处理,自动重连行为与本属性引入之前完全一致 ——
+    /// 要更准的判断,得由协议插件自己给出结论,而不是在这一层拍脑袋。
+    /// </remarks>
+    public ShellCloseReason CloseReason => ShellCloseReason.Unknown;
+
     /// <summary>插件协议没有登录握手可供匹配,恒返回 <see langword="null" />。</summary>
     public string? Expect(string regex, TimeSpan timeout) => null;
 

--- a/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
+++ b/src/VelaShell.Infrastructure/Pty/ConPtyShellStream.cs
@@ -44,6 +44,16 @@ public sealed partial class ConPtyShellStream : IShellStreamWrapper
     /// <summary>流是否可写:未关闭且未释放时为 <c>true</c>。</summary>
     public bool CanWrite => !_closed && !_disposed;
 
+    /// <summary>
+    /// 读端走到头的原因。本地 shell 只有一种收场 —— 子进程自己退了(用户敲 <c>exit</c>、
+    /// 或进程被杀),断管与句柄关闭说的都是同一件事。
+    /// </summary>
+    /// <remarks>
+    /// 本地终端本就不参与自动重连(见 <c>ReconnectPolicy.ShouldReconnect</c> 的
+    /// <c>isLocalShell</c>),这里如实填写只是为了让这个属性在每种流上含义一致。
+    /// </remarks>
+    public ShellCloseReason CloseReason => ShellCloseReason.RemoteExited;
+
     /// <summary>本地 shell 无登录握手,故恒返回 <c>null</c>(不参与 Expect 匹配)。</summary>
     public string? Expect(string regex, TimeSpan timeout) => null; // 本地 shell 无登录握手。
 

--- a/src/VelaShell.Infrastructure/Ssh/ShellStreamWrapper.cs
+++ b/src/VelaShell.Infrastructure/Ssh/ShellStreamWrapper.cs
@@ -17,6 +17,21 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
     /// <summary>读端发出 EOF 前始终保持可读(Stream ReadAsync 返回 0 表示 EOF)。</summary>
     public bool CanRead => !_disposed && !_readEof;
 
+    /// <summary>
+    /// 读端为什么走到了头。SSH 协议层本来就把这两件事分得很清楚,只是被下面那圈
+    /// catch 归一成 EOF 之后丢了 —— 这里把它记回来。
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item><b>远端 shell 退出</b>:对端发 <c>SSH_MSG_CHANNEL_CLOSE</c>,
+    ///     Tmds.Ssh 把它翻成流上的一次干净 EOF(读返回 0,不抛)。</item>
+    ///   <item><b>连接中断</b>:通道读会抛 —— 走 <c>ReadAsStream</c> 时是一个包着
+    ///     <c>Ssh*ClosedException</c> 的 <see cref="IOException" />。</item>
+    /// </list>
+    /// 于是「返回 0 且没抛」就是且仅是远端自己退了,这正是 #383 要认出来的那个信号。
+    /// </remarks>
+    public ShellCloseReason CloseReason { get; private set; } = ShellCloseReason.Unknown;
+
     /// <summary>RemoteProcess 存活且通道未断时可写入。</summary>
     public bool CanWrite => !_disposed && !_channelClosed;
 
@@ -31,7 +46,10 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
     public void WriteLine(string line) =>
         throw new NotSupportedException("WriteLine is not supported. Use WriteAsync instead.");
 
-    /// <summary>从远程进程标准输出读原始字节。EOF 时返回 0 并设置 _readEof。</summary>
+    /// <summary>
+    /// 从远程进程标准输出读原始字节。EOF 时返回 0 并设置 _readEof,同时把
+    /// <see cref="CloseReason" /> 记成本次结束的真实原因。
+    /// </summary>
     public async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         if (_disposed || _readEof) return 0;
@@ -41,13 +59,29 @@ public class ShellStreamWrapper(RemoteProcess process) : IShellStreamWrapper
             int bytesRead = await _outputStream
                 .ReadAsync(buffer.AsMemory(offset, count), cancellationToken)
                 .ConfigureAwait(false);
-            if (bytesRead == 0) _readEof = true;
+
+            // 没抛就读到 0:对端正常关闭了通道 —— 远端 shell 自己退了(exit / logout / 被 kill)。
+            if (bytesRead == 0) EndRead(ShellCloseReason.RemoteExited);
             return bytesRead;
         }
-        catch (SshChannelClosedException) { _readEof = true; return 0; }
-        catch (ObjectDisposedException) { _readEof = true; return 0; }
-        catch (IOException) { _readEof = true; return 0; }
-        catch (OperationCanceledException) { _readEof = true; return 0; }
+
+        // 通道/连接在读之中断掉:不是用户让它结束的,自动重连该管这一类。
+        catch (SshChannelClosedException) { EndRead(ShellCloseReason.ConnectionLost); return 0; }
+        catch (IOException) { EndRead(ShellCloseReason.ConnectionLost); return 0; }
+
+        // 我们自己在拆:关标签、点断开、释放。远端没给出任何结论。
+        catch (ObjectDisposedException) { EndRead(ShellCloseReason.LocalTeardown); return 0; }
+        catch (OperationCanceledException) { EndRead(ShellCloseReason.LocalTeardown); return 0; }
+    }
+
+    /// <summary>标记读端到此为止,并记下第一次给出的原因(后续读一律短路,不再改写)。</summary>
+    private void EndRead(ShellCloseReason reason)
+    {
+        _readEof = true;
+        if (CloseReason == ShellCloseReason.Unknown)
+        {
+            CloseReason = reason;
+        }
     }
 
     /// <summary>

--- a/src/VelaShell.Terminal/SshTerminalBridge.cs
+++ b/src/VelaShell.Terminal/SshTerminalBridge.cs
@@ -152,8 +152,12 @@ public class SshTerminalBridge : IDisposable
     /// 服务器重启):读循环自行结束,而非经由 <see cref="Dispose" />。
     /// 使会话可转为断开状态并就地重连。
     /// 主动拆除期间不会触发。在读取线程上触发——按需封送。
+    /// <para>
+    /// 参数是「为什么结束」:<c>exit</c> 与掉线在这里必须分得开,否则宿主只能
+    /// 把两者一视同仁地自动连回去,用户就退不掉了(#383)。
+    /// </para>
     /// </summary>
-    public event Action? Closed;
+    public event Action<ShellCloseReason>? Closed;
 
     /// <summary>
     /// 可选的 ZMODEM 路由器。非 null 时,读循环会先经它路由每一段输出字节
@@ -275,6 +279,9 @@ public class SshTerminalBridge : IDisposable
         // 更大的读取缓冲意味着更少的 await 与更大的自然批次。
         byte[] buffer = ArrayPool<byte>.Shared.Rent(16384);
         bool remoteClosed = false;
+
+        // 结束的原因由流给出(它才知道是干净的 EOF 还是抛出来的),读循环只负责转述。
+        ShellCloseReason closeReason = ShellCloseReason.Unknown;
         try
         {
             while (!token.IsCancellationRequested && _shellStream.CanRead)
@@ -282,8 +289,9 @@ public class SshTerminalBridge : IDisposable
                 int bytesRead = await _shellStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
-                    // EOF:远端已关闭通道(exit / 重启 / 连接断开)。
+                    // EOF:远端已关闭通道(exit / 重启 / 连接断开)。到底是哪一种,问流。
                     remoteClosed = true;
+                    closeReason = _shellStream.CloseReason;
                     break;
                 }
 
@@ -347,6 +355,7 @@ public class SshTerminalBridge : IDisposable
             if (!token.IsCancellationRequested)
             {
                 remoteClosed = true;
+                closeReason = _shellStream.CloseReason;
             }
         }
         catch (OperationCanceledException)
@@ -359,7 +368,9 @@ public class SshTerminalBridge : IDisposable
         }
         catch (Exception ex)
         {
+            // 抛到这里的都不是「远端 shell 正常退出」—— 那条路是干净的 EOF,不经过 catch。
             remoteClosed = true;
+            closeReason = ShellCloseReason.ConnectionLost;
             Error?.Invoke(ex);
         }
         finally
@@ -370,7 +381,7 @@ public class SshTerminalBridge : IDisposable
         // 表示远端主动关闭,但不包括我们自身 Dispose() 驱动的拆除。
         if (remoteClosed && !_disposed)
         {
-            Closed?.Invoke();
+            Closed?.Invoke(closeReason);
         }
     }
 

--- a/src/VelaShell/Services/ReconnectPolicy.cs
+++ b/src/VelaShell/Services/ReconnectPolicy.cs
@@ -25,21 +25,33 @@ public static class ReconnectPolicy
     /// <remarks>
     /// <list type="bullet">
     /// <item><b>用户自己点了断开的不碰</b> —— 那是明确的意图,自动连回去等于跟用户较劲。</item>
+    /// <item><b>远端 shell 自己退出的不碰</b> —— 在远端敲 <c>exit</c> / <c>logout</c>
+    /// 与点断开按钮是同一个意图,只是入口不同。漏掉这一条的后果是用户
+    /// **退不掉**:exit 之后标签自己又连上了(#383)。</item>
     /// <item><b>本地终端不自动重开</b> —— shell 退出(<c>exit</c>)是用户意图,
     /// 自动拉起会没完没了。</item>
     /// </list>
+    /// <para>
+    /// 反过来,只有"没人要它结束"的断开才该救:掉线、超时、服务端崩溃。
+    /// </para>
     /// </remarks>
     /// <param name="autoReconnectEnabled">设置里的自动重连开关。</param>
     /// <param name="isDisconnected">当前是否处于断开状态。</param>
     /// <param name="userRequestedDisconnect">是不是用户主动断开的。</param>
     /// <param name="isLocalShell">是不是本地终端。</param>
+    /// <param name="remoteShellExited">远端 shell 是不是自己正常退出的。</param>
     /// <returns>符合条件时为 true。</returns>
     public static bool ShouldReconnect(
         bool autoReconnectEnabled,
         bool isDisconnected,
         bool userRequestedDisconnect,
-        bool isLocalShell) =>
-        autoReconnectEnabled && isDisconnected && !userRequestedDisconnect && !isLocalShell;
+        bool isLocalShell,
+        bool remoteShellExited) =>
+        autoReconnectEnabled
+        && isDisconnected
+        && !userRequestedDisconnect
+        && !isLocalShell
+        && !remoteShellExited;
 
     /// <summary>
     /// 还能不能再试一次。

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -2662,7 +2662,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     autoReconnectEnabled: true,
                     tab.ConnectionStatus == SessionStatus.Disconnected,
                     tab.UserRequestedDisconnect,
-                    tab.LocalShell is not null))
+                    tab.LocalShell is not null,
+                    tab.RemoteShellExited))
             {
                 tab.ResetReconnectAttempts();
                 _ = ReconnectTabAsync(tab);
@@ -2721,12 +2722,14 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
         // 无头单元测试在没有 Avalonia 应用的情况下构造此 VM;此处无计时器。
         // 本地终端不自动重开:shell 退出(exit)是用户意图,自动拉起会没完没了。
+        // 远端 shell 退出同理 —— 在远端敲 exit 和点断开按钮说的是同一句话(#383)。
         if (Application.Current is null
             || !ReconnectPolicy.ShouldReconnect(
                    settings.General.AutoReconnect,
                    isDisconnected: true,
                    tab.UserRequestedDisconnect,
-                   tab.LocalShell is not null))
+                   tab.LocalShell is not null,
+                   tab.RemoteShellExited))
         {
             return;
         }
@@ -2753,13 +2756,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         DispatcherTimer.RunOnce(
             () =>
             {
-                // 等待期间用户可能已手动重连、关掉标签或主动断开。
+                // 等待期间用户可能已手动重连、关掉标签、主动断开,
+                // 或者(重连成功后)在远端敲了 exit —— 后者同样不该再被拉回来。
                 if (
                     tab
                         is
                     {
                         ConnectionStatus: SessionStatus.Disconnected,
-                        UserRequestedDisconnect: false
+                        UserRequestedDisconnect: false,
+                        RemoteShellExited: false
                     }
                     && TerminalTabs.Contains(tab)
                 )

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -399,6 +399,18 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     /// </summary>
     public bool UserRequestedDisconnect { get; private set; }
 
+    /// <summary>
+    /// true = 本次断开是远端 shell 自己退出的(在远端敲了 <c>exit</c> / <c>logout</c>),
+    /// 自动重连不介入;重新挂载传输时复位。
+    /// </summary>
+    /// <remarks>
+    /// 与 <see cref="UserRequestedDisconnect" /> 是同一件事的两个入口:一个是点了断开按钮,
+    /// 一个是在远端敲了 exit —— 都是用户说「这条会话到此为止」。之前只认前者,
+    /// 于是 exit 之后标签自己又连回来,用户按常规办法根本退不掉(#383)。
+    /// 两个标志分开留是因为它们的复位时机与判定来源不同,合并会含糊掉「谁说的」。
+    /// </remarks>
+    public bool RemoteShellExited { get; private set; }
+
     /// <summary>本标签在状态栏显示的连接摘要,例如 "SSH • root@host:22"。</summary>
     public string ConnectionSummary { get; init; } = string.Empty;
 
@@ -744,6 +756,7 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
         DetachTransport();
         UserRequestedDisconnect = false;
+        RemoteShellExited = false;
         ShellStream = shellStream;
         var bridge = new SshTerminalBridge(TerminalEmulator, shellStream);
         bridge.Closed += OnBridgeClosed;
@@ -814,8 +827,13 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
             observer);
     }
 
-    private void OnBridgeClosed()
+    private void OnBridgeClosed(ShellCloseReason reason)
     {
+        // 远端 shell 自己退了 = 用户意图,与点断开按钮同等对待:自动重连不再介入(#383)。
+        // 必须赶在 MarkDisconnected 之前置位 —— 它同步触发 Disconnected,
+        // 宿主就在那个事件里当场决定要不要排一次重连。
+        RemoteShellExited = reason == ShellCloseReason.RemoteExited;
+
         // 在读线程上触发;将响应式状态变更封送到 UI 线程。
         if (Dispatcher.UIThread.CheckAccess())
         {

--- a/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
+++ b/tests/VelaShell.Core.Tests/Sftp/SftpServiceTests.cs
@@ -15,6 +15,7 @@ public class SftpServiceTests
     private readonly Guid _sessionId;
     private readonly ISftpClientWrapper _sftpClient;
     private readonly SftpService _sftpService;
+    private readonly SshSession _session;
 
     public SftpServiceTests()
     {
@@ -34,9 +35,34 @@ public class SftpServiceTests
             },
             Status = SessionStatus.Connected
         };
+        _session = session;
         _connectionService.GetSession(_sessionId).Returns(session);
         _sftpClient.IsConnected.Returns(true);
         _sftpService = new SftpService(_connectionService, _ => _sftpClient);
+    }
+
+    /// <summary>SSH 一断,挂在它上面的 SFTP 通道跟着收掉。</summary>
+    /// <remarks>
+    /// SFTP 复用的就是主 SSH 连接(DI 处 <c>OpenSftpClientAsync</c> 刻意不另开连接),
+    /// 所以连接一没,缓存里那个客户端就只是个还占着句柄的死物。清理挂在
+    /// <c>SessionDisconnected</c> 上而不是各个断开入口里 —— 入口有好几个
+    /// (标签断开、关标签、隧道面板、退出应用),靠约定迟早漏一个。
+    /// </remarks>
+    [TestMethod]
+    public async Task ASshDisconnect_TakesTheSftpChannelWithIt()
+    {
+        // 先让服务真的建出并缓存一个客户端,否则没有东西可关。
+        _sftpClient.WorkingDirectory.Returns("/home/testuser");
+        await _sftpService.GetWorkingDirectoryAsync(_sessionId);
+
+        var disposed = new TaskCompletionSource();
+        _sftpClient.When(c => c.Dispose()).Do(_ => disposed.TrySetResult());
+
+        _connectionService.SessionDisconnected += Raise.Event<Action<SshSession>>(_session);
+
+        // 清理是即发即忘的:断开路径不等它,所以这里得等。
+        await disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        _sftpClient.Received(1).Disconnect();
     }
 
     [TestMethod]

--- a/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalBridgeTests.cs
@@ -243,10 +243,52 @@ public class TerminalBridgeTests
 
         bool closed = false;
         using var bridge = new SshTerminalBridge(_terminal, _shellStream);
-        bridge.Closed += () => closed = true;
+        bridge.Closed += _ => closed = true;
         bridge.Start();
 
         WaitUntil(() => closed);
+    }
+
+    /// <summary>关闭原因原样转述给宿主,不在桥里被抹平(#383)。</summary>
+    /// <remarks>
+    /// 桥自己无从分辨 exit 与掉线 —— 两者在它眼里都是"读到 0"。知道差别的是流,
+    /// 所以桥的职责只有一条:把流给出的结论完整带上去,让宿主据此决定要不要自动重连。
+    /// </remarks>
+    [TestMethod]
+    public void ReadLoop_WhenRemoteShellExits_ReportsThatReason()
+    {
+        _shellStream.CanRead.Returns(true);
+        _shellStream.CloseReason.Returns(ShellCloseReason.RemoteExited);
+        _shellStream.ReadAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(0));
+
+        ShellCloseReason? reported = null;
+        using var bridge = new SshTerminalBridge(_terminal, _shellStream);
+        bridge.Closed += reason => reported = reason;
+        bridge.Start();
+
+        WaitUntil(() => reported is not null);
+        Assert.AreEqual(ShellCloseReason.RemoteExited, reported);
+    }
+
+    /// <summary>读取抛异常的那条路不可能是"shell 正常退出",一律报连接中断。</summary>
+    [TestMethod]
+    public void ReadLoop_WhenReadThrows_ReportsConnectionLost()
+    {
+        _shellStream.CanRead.Returns(true);
+
+        // 流可能已经把原因记成别的了;抛出来的这一路不看它,直接下结论。
+        _shellStream.CloseReason.Returns(ShellCloseReason.RemoteExited);
+        _shellStream.ReadAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<Task<int>>(_ => throw new IOException("connection reset"));
+
+        ShellCloseReason? reported = null;
+        using var bridge = new SshTerminalBridge(_terminal, _shellStream);
+        bridge.Closed += reason => reported = reason;
+        bridge.Start();
+
+        WaitUntil(() => reported is not null);
+        Assert.AreEqual(ShellCloseReason.ConnectionLost, reported);
     }
 
     [TestMethod]
@@ -263,7 +305,7 @@ public class TerminalBridgeTests
 
         bool closed = false;
         var bridge = new SshTerminalBridge(_terminal, _shellStream);
-        bridge.Closed += () => closed = true;
+        bridge.Closed += _ => closed = true;
         bridge.Start();
 
         Thread.Sleep(100);

--- a/tests/VelaShell.Tests/Services/ReconnectPolicyTests.cs
+++ b/tests/VelaShell.Tests/Services/ReconnectPolicyTests.cs
@@ -18,13 +18,13 @@ public sealed class ReconnectPolicyTests
     public void ADroppedRemoteSessionReconnects() =>
         Assert.IsTrue(ReconnectPolicy.ShouldReconnect(
             autoReconnectEnabled: true, isDisconnected: true,
-            userRequestedDisconnect: false, isLocalShell: false));
+            userRequestedDisconnect: false, isLocalShell: false, remoteShellExited: false));
 
     [TestMethod]
     public void TheGlobalSwitchWins() =>
         Assert.IsFalse(ReconnectPolicy.ShouldReconnect(
             autoReconnectEnabled: false, isDisconnected: true,
-            userRequestedDisconnect: false, isLocalShell: false));
+            userRequestedDisconnect: false, isLocalShell: false, remoteShellExited: false));
 
     /// <summary>用户自己点了断开的不碰。</summary>
     /// <remarks>那是明确的意图,自动连回去等于跟用户较劲。</remarks>
@@ -32,7 +32,7 @@ public sealed class ReconnectPolicyTests
     public void AManualDisconnectIsRespected() =>
         Assert.IsFalse(ReconnectPolicy.ShouldReconnect(
             autoReconnectEnabled: true, isDisconnected: true,
-            userRequestedDisconnect: true, isLocalShell: false));
+            userRequestedDisconnect: true, isLocalShell: false, remoteShellExited: false));
 
     /// <summary>本地终端不自动重开。</summary>
     /// <remarks>shell 退出(<c>exit</c>)是用户意图,自动拉起会没完没了。</remarks>
@@ -40,13 +40,24 @@ public sealed class ReconnectPolicyTests
     public void ALocalShellIsNeverRelaunched() =>
         Assert.IsFalse(ReconnectPolicy.ShouldReconnect(
             autoReconnectEnabled: true, isDisconnected: true,
-            userRequestedDisconnect: false, isLocalShell: true));
+            userRequestedDisconnect: false, isLocalShell: true, remoteShellExited: false));
+
+    /// <summary>在远端敲 <c>exit</c> 退出的不碰(#383)。</summary>
+    /// <remarks>
+    /// 那和点断开按钮是同一个意图,只是入口不同。漏掉这一条,用户就**退不掉**:
+    /// exit 之后标签自己又连上了,而这正是 #383 报的现象。
+    /// </remarks>
+    [TestMethod]
+    public void ARemoteShellThatExitedIsNotDraggedBack() =>
+        Assert.IsFalse(ReconnectPolicy.ShouldReconnect(
+            autoReconnectEnabled: true, isDisconnected: true,
+            userRequestedDisconnect: false, isLocalShell: false, remoteShellExited: true));
 
     [TestMethod]
     public void AStillConnectedSessionIsLeftAlone() =>
         Assert.IsFalse(ReconnectPolicy.ShouldReconnect(
             autoReconnectEnabled: true, isDisconnected: false,
-            userRequestedDisconnect: false, isLocalShell: false));
+            userRequestedDisconnect: false, isLocalShell: false, remoteShellExited: false));
 
     [TestMethod]
     public void AttemptsRunOutAtTheConfiguredLimit()

--- a/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
@@ -216,6 +216,72 @@ public class TerminalTabViewModelTests
         );
     }
 
+    /// <summary>在远端敲 <c>exit</c> 之后,标签记住"是它自己退的"(#383)。</summary>
+    /// <remarks>
+    /// 这是自动重连唯一能据以放手的信号:少了它,exit 之后标签会被自动连回来,
+    /// 用户按常规办法根本退不掉。
+    /// </remarks>
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public void ARemoteShellThatExits_IsRememberedAsSuch()
+    {
+        var vm = new TerminalTabViewModel(_terminalEmulator);
+        vm.AttachTransport(ClosingStream(ShellCloseReason.RemoteExited));
+        vm.Start();
+
+        WaitUntil(() => vm.RemoteShellExited);
+        Assert.IsTrue(vm.RemoteShellExited);
+    }
+
+    /// <summary>掉线不是用户意图,不能被当成 exit —— 那正是自动重连要救的场景。</summary>
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public void ADroppedConnection_IsNotMistakenForAnExit()
+    {
+        var vm = new TerminalTabViewModel(_terminalEmulator);
+        vm.AttachTransport(ClosingStream(ShellCloseReason.ConnectionLost));
+        vm.Start();
+
+        WaitUntil(() => vm.ConnectionStatus == SessionStatus.Disconnected || vm.RemoteShellExited);
+        Assert.IsFalse(vm.RemoteShellExited);
+    }
+
+    /// <summary>重连挂上新传输后标志复位,否则一次 exit 会永久禁掉这个标签的自动重连。</summary>
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public void AttachTransport_ClearsTheRemoteExitFlag()
+    {
+        var vm = new TerminalTabViewModel(_terminalEmulator);
+        vm.AttachTransport(ClosingStream(ShellCloseReason.RemoteExited));
+        vm.Start();
+        WaitUntil(() => vm.RemoteShellExited);
+
+        vm.AttachTransport(Substitute.For<IShellStreamWrapper>());
+        Assert.IsFalse(vm.RemoteShellExited);
+    }
+
+    /// <summary>一条读一次就到头的流,并按 <paramref name="reason" /> 交代原因。</summary>
+    private static IShellStreamWrapper ClosingStream(ShellCloseReason reason)
+    {
+        IShellStreamWrapper stream = Substitute.For<IShellStreamWrapper>();
+        stream.CanRead.Returns(true);
+        stream.CloseReason.Returns(reason);
+        stream
+            .ReadAsync(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(0));
+        return stream;
+    }
+
+    /// <summary>等一个后台读循环推出来的状态;读循环在别的线程上,只能轮询。</summary>
+    private static void WaitUntil(Func<bool> condition)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            Thread.Sleep(10);
+        }
+    }
+
     [TestMethod]
     [TestCategory("TerminalTab")]
     public void DetachTransport_ClearsBridgeAndShellStream()


### PR DESCRIPTION
修复 #383:开着自动重连时,在远端敲 `exit` 正常退出会被立刻连回来 —— 换句话说,**退不掉**。

## 根因

「用户不想连了」只认了一个入口。`ReconnectPolicy.ShouldReconnect` 里代表用户意图的 `userRequestedDisconnect` **只**由工具栏「断开」按钮置位;在远端敲 `exit` 说的是同一句话,却走另一条路(远端 shell 退出 → 通道关闭 → 桥 `Closed` → `MarkDisconnected`),全程没人把这层意思记下来,于是判定里它和掉线毫无区别。

更下面一层还丢了一次信息。SSH 协议本来把这两件事分得很清楚:

- 远端 shell 退出 → 对端发 `SSH_MSG_CHANNEL_CLOSE` → 读端拿到一次**干净的 EOF**;
- 连接中断(RST / 超时 / sshd 没了)→ 通道读**抛异常**(走 `ReadAsStream` 时是包着 `Ssh*ClosedException` 的 `IOException`)。

但 `ShellStreamWrapper.ReadAsync` 把两者一律归一成"返回 0"(这个归一本身是对的 —— 掉线不是崩溃,抛出去只会让读循环带着异常收尾),原因就此蒸发。桥只看得到"读到 0",宿主只看得到"断了"。

## 修法:结论仍是 EOF,原因单独留一份

- 新增 `ShellCloseReason`(`Unknown` / `RemoteExited` / `ConnectionLost` / `LocalTeardown`)与 `IShellStreamWrapper.CloseReason`,交代读端为什么走到头。`ShellStreamWrapper` 按上面那条协议事实填写;`ConPtyShellStream` 只有一种收场;`PluginTerminalShellStream` 报 `Unknown` —— 插件的传输层什么都可能抛,宿主分不出也不该猜,按连接中断处理即与改动前**完全一致**。
- `SshTerminalBridge.Closed` 由 `Action` 改成 `Action<ShellCloseReason>`,只负责转述,不做判断。
- `TerminalTabViewModel.RemoteShellExited` 记住这次是不是远端自己退的,在 `AttachTransport` 里与 `UserRequestedDisconnect` 一起复位(否则一次 exit 会永久禁掉该标签的自动重连)。
- `ReconnectPolicy.ShouldReconnect` 加第五个条件 `remoteShellExited`,**不给默认值** —— 这个类存在的理由就是"两处判定必须一致",能被忘掉的参数等于没加。编译器逼出了三个消费点:掉线后的排程、倒计时到点时的复查、睡眠唤醒后的批量重连。

改完之后,自动重连的边界是:只救「没人要它结束」的断开(掉线、超时、服务端崩溃);点断开按钮、远端 `exit` / `logout`、本地 shell 退出、初次连接失败(尤其认证失败——重试只会连着撞几次密码)一律不碰。这与隧道那条既有约定同源:「用户手动按停过的隧道不会被自动拉起」。

## 顺带:SFTP 的生命周期挂到 SSH 上,而不是挂在调用方的记性上

SFTP **复用主 SSH 连接**(DI 注册处 `inner.OpenSftpClientAsync()`,刻意不在主连接之外另开一条:那样的连接无人持有、无人释放,还绕过用户可见的连接生命周期)。既然是同一条连接上的通道,SSH 一断,缓存里的 SFTP 客户端就只是个还占着句柄的死物。

原先靠 `MainWindowViewModel` 在断开/关标签时记得调一次 `CloseSftpForTab` —— 主路径是对的,但断开的入口不止一个(标签断开、关标签、隧道面板直接 `DisconnectAsync`、退出应用),靠约定维持不变量迟早漏一个。改为 `SftpService` 订阅 `ISshConnectionService.SessionDisconnected` 在服务层收口,`DisposeAsync` 里退订。VM 里那次调用保留 —— 它还顺手驱逐文件面板(`EvictFileBrowser`),职责不同,且 `CloseSessionAsync` 本就幂等。

## 验收

`dotnet test VelaShell.slnx` 全绿(3199 通过 / 19 跳过,跳过的仍是那些按环境早退的集成用例)。新增 8 条用例:

- `ReconnectPolicyTests.ARemoteShellThatExitedIsNotDraggedBack` 钉住新条件;
- `TerminalTabViewModelTests` 三条走**真实链路**(替身流 → 桥 → 标签):exit 被记住、掉线不被误认成 exit、重连挂上新传输后标志复位。做过变异验证:把 `OnBridgeClosed` 里那行改成 `RemoteShellExited = false`,其中两条当场变红,确认不是空转;
- `TerminalBridgeTests` 两条钉住桥如实转述原因、抛异常那条路一律报 `ConnectionLost`;
- `SftpServiceTests.ASshDisconnect_TakesTheSftpChannelWithIt` 钉住服务层收口。

## 文档

按 AGENTS.md 第二节同步:VelaShellLabs/velashell-docs#22(`zh/host/交互与界面规格.md` 与 `en/host/interaction-and-ui-specs.md` 的「断开连接状态」补上自动重连的适用边界)。两个 PR 一起合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QydefQQ5JJmyyEUNCpVSp6
