### PR TITLE
错误级提示改为最长20秒自动消失并优化逻辑,同时修复文件浏览器问题

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1846,3 +1846,38 @@ VM 里那次调用保留 —— 它还顺手驱逐文件面板(`EvictFileBrowser
 
 文档同步:velashell-docs `zh/host/交互与界面规格.md` 与 `en/host/interaction-and-ui-specs.md`
 的「断开连接状态」补上自动重连的适用边界(只救没人要它结束的断开,四种例外)。
+
+## 45. 2026-09-07 新开标签页时,上一个会话的 SFTP 面板要立刻收起(#385)
+
+用户反馈:设置里的「连接后自动打开文件浏览器」是关闭的,手动在当前标签开了 SFTP 文件管理器,
+再开一个新标签页时文件浏览器还挂在下面,要等新连接握手成功才消失。
+
+### 一、根因:「还没有会话」这一态被当成了「什么都别动」
+
+`MainWindowViewModel.RebindFileBrowser` 对没有 SFTP 会话的标签有两条分支,处理方式却不一样:
+
+- 本地终端(ConPTY)与插件终端协议(Telnet…):**换成隐藏的空占位**,面板立刻收起;
+- `tab.SessionId == Guid.Empty`:**直接 return**,什么都不换。
+
+而新开的 SSH 标签正好落在第二条上 —— 会话 id 要到握手完成才由 `RunHandshakeAsync` 赋值
+(`CreateConnectingTab` 建标签时它还是 `Guid.Empty`),`Layout.AddDocument` 的激活先到,
+`SetActiveFromDocument` → `RebindFileBrowser` 撞上那句 return,于是 `FileBrowser` 仍然是上一个
+会话那个可见的实例。等握手完成再走一次 `ShowFileBrowserForActiveSession`,这才换成新标签自己的
+面板(设置关着 → 隐藏),表现就是「连上之后才消失」。
+
+那句 return 原本大概是想说「会话还没就位,等等再绑」——「等等再绑」是对的,但期间不该继续
+展示别人的面板。上一版加本地终端分支时留下的注释其实已经点出这一点(「不能靠下面那句
+SessionId == Guid.Empty 兜底 —— 它是 return 而不是换占位」),只是没有把它一起改掉。
+
+### 二、修法:三种「没有 SFTP 会话」的标签合成一条,一律换占位
+
+三条并成一个判断,进去就把 `FileBrowser` 换成隐藏的空占位。上一个面板不 `Detach`
+(仍按其会话留在 `_fileBrowserCache` 里),它的开关状态也仍记在缓存实例与所属标签上,
+切回那个标签时照旧恢复展示 —— 收起的只是「当前这一屏」,不是那个标签的记忆。
+
+### 三、验收
+
+`dotnet test VelaShell.slnx` 全绿。新增
+`MainWindowViewModelTests.FileBrowser_ConnectingTab_HidesPreviousSessionPanelImmediately`:
+设置关着 → 手动开面板 → 开一个 `Connecting` 且 `SessionId` 为空的新标签 → 断言面板立刻隐藏
+且不指向任何会话,再切回原标签断言面板恢复。把那条 return 加回去,这条用例会红。

--- a/src/VelaShell.Presentation/ViewModels/ToastHostViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/ToastHostViewModel.cs
@@ -43,6 +43,18 @@ public sealed class ToastHostViewModel : ReactiveObject, IDisposable
     public static readonly TimeSpan WarningLifetime = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// 错误级的停留时长 —— 三档里最久,但依然会自己走。
+    /// </summary>
+    /// <remarks>
+    /// 曾经是"永不自动消失",理由是"用户没看见的错误等于没报"。那个理由只成立了一半:
+    /// 错误确实该留得比别的久,可留到<b>要人伸手去点</b>就变成了另一回事 ——
+    /// 每条错误都欠用户一次点击,连着掉几次线,屏幕右下角就攒出一摞谁也不会去读的卡片。
+    /// 而"断了"这件事本身在标签页覆盖层和状态栏上一直摆着,浮层只是替它喊一嗓子,
+    /// 喊完就该退场。20 秒足够在低头看别处之后抬眼看见,又不至于赖着不走。
+    /// </remarks>
+    public static readonly TimeSpan ErrorLifetime = TimeSpan.FromSeconds(20);
+
+    /// <summary>
     /// 同时最多显示几条。
     /// </summary>
     /// <remarks>
@@ -120,7 +132,7 @@ public sealed class ToastHostViewModel : ReactiveObject, IDisposable
     public ToastViewModel Warning(string message, string? mergeKey = null) =>
         Show(new(ToastSeverity.Warning, message) { MergeKey = mergeKey });
 
-    /// <summary>推一条错误级提示(不自动消失)。</summary>
+    /// <summary>推一条错误级提示(停留 <see cref="ErrorLifetime" /> 后自动消失)。</summary>
     /// <param name="message">正文。</param>
     /// <param name="actionLabel">操作按钮文案;null = 无按钮。</param>
     /// <param name="action">点击操作按钮时执行。</param>
@@ -180,16 +192,16 @@ public sealed class ToastHostViewModel : ReactiveObject, IDisposable
         HasToasts = false;
     }
 
-    /// <summary>某一分级的停留时长;错误级返回 null(不自动消失)。</summary>
+    /// <summary>某一分级的停留时长。</summary>
     /// <param name="severity">分级。</param>
-    /// <returns>停留时长,或 null。</returns>
+    /// <returns>停留时长;null = 不自动消失(当前没有这样的分级,留给以后)。</returns>
     public static TimeSpan? LifetimeOf(ToastSeverity severity) =>
         severity switch
         {
             ToastSeverity.Info => InfoLifetime,
             ToastSeverity.Warning => WarningLifetime,
-            // 错误不自动消失:一条转瞬即逝的错误与没报错没有区别。
-            _ => null
+            // 错误留得最久,但同样自己走 —— 理由见 ErrorLifetime。
+            _ => ErrorLifetime
         };
 
     /// <summary>(重新)开始这一条的自动消失计时。</summary>

--- a/src/VelaShell.Presentation/ViewModels/ToastViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/ToastViewModel.cs
@@ -2,7 +2,7 @@ using ReactiveUI;
 
 namespace VelaShell.Presentation.ViewModels;
 
-/// <summary>提示的分级;决定配色、图标与是否自动消失。</summary>
+/// <summary>提示的分级;决定配色、图标与停留多久。</summary>
 public enum ToastSeverity
 {
     /// <summary>一次成功的操作、一条无关痛痒的告知。看一眼就够,自动消失。</summary>
@@ -11,7 +11,7 @@ public enum ToastSeverity
     /// <summary>需要留意但不必立刻处理(重连倒计时、降级运行)。停留久一些。</summary>
     Warning,
 
-    /// <summary>出错了。<b>不自动消失</b> —— 用户没看见的错误等于没报。</summary>
+    /// <summary>出错了。停留最久,但同样会自己走 —— 见 <c>ToastHostViewModel.ErrorLifetime</c>。</summary>
     Error
 }
 
@@ -25,8 +25,9 @@ public enum ToastSeverity
 /// 用户只会看到最后一条,而那条未必是最要紧的。
 /// </para>
 /// <para>
-/// 分级不只是配色:<see cref="ToastSeverity.Error" /> 不自动消失。一条转瞬即逝的错误
-/// 与没报错没有区别,而用户往往正低头看别处。
+/// 分级不只是配色,还决定停留多久:<see cref="ToastSeverity.Error" /> 留得最久 ——
+/// 一条转瞬即逝的错误与没报错没有区别,而用户往往正低头看别处。但"最久"不等于"不走":
+/// 一条要人伸手去点的浮层,在用户眼里和一个卡住的弹窗没有分别。
 /// </para>
 /// </remarks>
 public sealed class ToastViewModel : ReactiveObject

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1382,21 +1382,22 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             return;
         }
 
-        // 本地终端(ConPTY)与插件终端协议(Telnet…)都没有 SFTP 会话:不得继续展示
-        // 上一个 SSH 会话的文件面板,否则切到 PowerShell / Telnet 标签后下方仍显示上一个
-        // SSH 会话的文件面板。换成隐藏的空占位;上一个面板不 Detach(仍按其会话缓存),
-        // 其开关状态留在缓存实例与所属标签上,切回远程标签时恢复展示。
-        // 注意不能靠下面那句 SessionId == Guid.Empty 兜底 —— 它是 return 而不是换占位。
-        if (tab.LocalShell is not null || tab.Profile?.ConnectionType == ConnectionType.Plugin)
+        // 这三种标签都没有可用的 SFTP 会话,不得继续展示上一个 SSH 会话的文件面板:
+        //   1. 本地终端(ConPTY)与插件终端协议(Telnet…)—— 它们压根没有 SFTP 通道,
+        //      否则切到 PowerShell / Telnet 标签后下方仍显示上一个 SSH 会话的文件面板;
+        //   2. 还在握手的 SSH 标签 —— 会话 id 要到握手完成才分配(见 RunHandshakeAsync),
+        //      在那之前 SessionId 是 Guid.Empty。这一条以前只是 return,于是新开标签期间
+        //      下方仍挂着上一个会话的文件面板,直到连上才换掉(#385)。
+        // 统一换成隐藏的空占位;上一个面板不 Detach(仍按其会话缓存),其开关状态留在
+        // 缓存实例与所属标签上,切回那个标签时恢复展示。
+        if (tab.LocalShell is not null
+            || tab.Profile?.ConnectionType == ConnectionType.Plugin
+            || tab.SessionId == Guid.Empty)
         {
             if (FileBrowser.SessionId != Guid.Empty || FileBrowser.IsVisible)
             {
                 FileBrowser = CreatePlaceholderFileBrowser();
             }
-            return;
-        }
-        if (tab.SessionId == Guid.Empty)
-        {
             return;
         }
         if (FileBrowser.SessionId == tab.SessionId)
@@ -2702,14 +2703,44 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         {
             return;
         }
+        // 先问清楚"接下来会不会自动重连",再决定要报几条 —— 顺序反过来的话,
+        // 断线那一条已经推出去了,后面的倒计时只能在它旁边再叠一条同义的。
+        // 无头单元测试在没有 Avalonia 应用的情况下构造此 VM;此处无计时器。
+        // 本地终端不自动重开:shell 退出(exit)是用户意图,自动拉起会没完没了。
+        // 远端 shell 退出同理 —— 在远端敲 exit 和点断开按钮说的是同一句话(#383)。
+        int maxRetries = Math.Max(1, settings.General.MaxRetries);
+        bool autoReconnectApplies =
+            Application.Current is not null
+            && ReconnectPolicy.ShouldReconnect(
+                   settings.General.AutoReconnect,
+                   isDisconnected: true,
+                   tab.UserRequestedDisconnect,
+                   tab.LocalShell is not null,
+                   tab.RemoteShellExited);
+        if (autoReconnectApplies)
+        {
+            tab.MaxReconnectAttempts = maxRetries; // 全部自动重连路径共用同一权威值(设置审计 C-02)
+        }
+        bool willAutoReconnect =
+            autoReconnectApplies
+            && ReconnectPolicy.HasAttemptsLeft(tab.ReconnectAttempts, maxRetries);
+
         if (settings.General.NotifyOnDisconnect)
         {
-            // 断线带一个「立即重连」按钮:这是用户看到这条消息时唯一想做的事,
-            // 而原先它只是状态栏里一句会被下一条消息盖掉的文字。
-            Toasts.Error(
-                Strings.Format("Msg_TabDisconnected", tab.Title),
-                Strings.Get("Toast_ReconnectNow"),
-                () => _ = ReconnectTabAsync(tab));
+            // 只在"没人会替你重连"时才单报一条断线。会自动重连的时候,下面那条倒计时
+            // 已经把断开、还剩几次、下次什么时候都说全了 —— 再叠一条「已断开 + 立即重连」
+            // 是同一件事说两遍,而且两条一起占掉右下角,谁也没多告诉用户一个字。
+            // 反过来,重连不介入(关了开关、次数用尽、本地 shell)时,这条带按钮的提示
+            // 就是唯一的出口,必须留着。
+            if (!willAutoReconnect)
+            {
+                // 断线带一个「立即重连」按钮:这是用户看到这条消息时唯一想做的事,
+                // 而原先它只是状态栏里一句会被下一条消息盖掉的文字。
+                Toasts.Error(
+                    Strings.Format("Msg_TabDisconnected", tab.Title),
+                    Strings.Get("Toast_ReconnectNow"),
+                    () => _ = ReconnectTabAsync(tab));
+            }
             if (!ReferenceEquals(ActiveTerminalTab, tab))
             {
                 tab.HasBellAlert = true;
@@ -2720,22 +2751,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             SystemSound.Alert();
         }
 
-        // 无头单元测试在没有 Avalonia 应用的情况下构造此 VM;此处无计时器。
-        // 本地终端不自动重开:shell 退出(exit)是用户意图,自动拉起会没完没了。
-        // 远端 shell 退出同理 —— 在远端敲 exit 和点断开按钮说的是同一句话(#383)。
-        if (Application.Current is null
-            || !ReconnectPolicy.ShouldReconnect(
-                   settings.General.AutoReconnect,
-                   isDisconnected: true,
-                   tab.UserRequestedDisconnect,
-                   tab.LocalShell is not null,
-                   tab.RemoteShellExited))
-        {
-            return;
-        }
-        int maxRetries = Math.Max(1, settings.General.MaxRetries);
-        tab.MaxReconnectAttempts = maxRetries; // 全部自动重连路径共用同一权威值(设置审计 C-02)
-        if (!ReconnectPolicy.HasAttemptsLeft(tab.ReconnectAttempts, maxRetries))
+        if (!willAutoReconnect)
         {
             return;
         }

--- a/src/VelaShell/Views/ToastHostView.axaml
+++ b/src/VelaShell/Views/ToastHostView.axaml
@@ -10,6 +10,9 @@
   <!-- 运行时反馈的浮层通道。锚在右下、贴着状态栏 —— 用户在状态栏那一带找"刚才发生了什么",
        浮层长在同一片区域才接得上原来的习惯;右上已经被传输提示占着。
        外层不设 Background、不参与命中测试:整块铺开也不会挡住底下的终端。 -->
+  <!-- 底边距要跨过状态栏(24px + 1px 顶边框)再留 12px 空隙 —— 宿主 Panel 铺满的是
+       整个下半区,包含状态栏在内。原先只留 12px,浮层正好压在状态栏上:那一条恰恰是
+       用户被这条提示引过去要看的地方(延迟、连接状态),盖住它等于自断后路。 -->
   <UserControl.Styles>
     <Style Selector="Border.toast">
       <Setter Property="CornerRadius" Value="6" />
@@ -31,7 +34,7 @@
 
   <ItemsControl ItemsSource="{Binding Toasts}"
                 HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                Margin="0,0,16,12">
+                Margin="0,0,16,37">
     <ItemsControl.ItemsPanel>
       <ItemsPanelTemplate>
         <StackPanel Orientation="Vertical" Spacing="8" />

--- a/tests/VelaShell.Presentation.Tests/ViewModels/ToastHostViewModelTests.cs
+++ b/tests/VelaShell.Presentation.Tests/ViewModels/ToastHostViewModelTests.cs
@@ -29,17 +29,31 @@ public sealed class ToastHostViewModelTests
     }
 
     [TestMethod]
-    public void ErrorStaysUntilDismissed()
+    public void ErrorOutlivesWarningButStillLeavesOnItsOwn()
     {
         FakeClock clock = new();
-        // 一条转瞬即逝的错误与没报错没有区别,而用户往往正低头看别处。
+        // 一条转瞬即逝的错误与没报错没有区别 —— 所以留得最久;
+        // 但要人伸手去点才肯走的浮层,在用户眼里和一个卡住的弹窗没有分别。
+        using ToastHostViewModel host = new(clock.Schedule);
+        host.Error("连接失败");
+
+        clock.Advance(ToastHostViewModel.WarningLifetime + TimeSpan.FromMilliseconds(1));
+        Assert.HasCount(1, host.Toasts, "错误该比警告留得久。");
+
+        clock.Advance(
+            ToastHostViewModel.ErrorLifetime - ToastHostViewModel.WarningLifetime);
+        Assert.IsEmpty(host.Toasts, "错误留得久,但不该赖着不走。");
+    }
+
+    [TestMethod]
+    public void ErrorCanStillBeDismissedEarly()
+    {
+        FakeClock clock = new();
         using ToastHostViewModel host = new(clock.Schedule);
         ToastViewModel toast = host.Error("连接失败");
 
-        clock.Advance(TimeSpan.FromMinutes(10));
-        Assert.HasCount(1, host.Toasts, "错误不该自动消失。");
-
         host.Dismiss(toast);
+
         Assert.IsEmpty(host.Toasts);
     }
 

--- a/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -561,6 +561,42 @@ public class MainWindowViewModelTests
     }
 
     [TestMethod]
+    [TestCategory("UI")]
+    public async Task FileBrowser_ConnectingTab_HidesPreviousSessionPanelImmediately()
+    {
+        var settingsService = new MemorySettingsService(
+            new AppSettings { TerminalBehavior = new() { AutoOpenFileBrowser = false } });
+        MainWindowViewModel vm = await CreateInitializedVmAsync(settingsService);
+
+        TerminalTabViewModel first = CreateConnectedSshTab();
+        vm.Open(first);
+        vm.ToggleFileBrowser();
+        Assert.IsTrue(vm.FileBrowser.IsVisible, "手动打开:当前标签的面板展示。");
+
+        // 新开一个标签:会话 id 要到握手完成才分配,这段时间下方不能还挂着
+        // 上一个会话的文件面板(#385)。
+        var connecting = new TerminalTabViewModel(Substitute.For<ITerminalEmulator>())
+        {
+            Profile = new() { Name = "next", Host = "next.example" },
+            ConnectionStatus = SessionStatus.Connecting,
+        };
+        vm.Open(connecting);
+
+        Assert.IsFalse(
+            vm.FileBrowser.IsVisible,
+            "连接中的新标签必须立即收起上一个会话的面板,而不是等连上才消失(#385)。");
+        Assert.AreEqual(
+            Guid.Empty,
+            vm.FileBrowser.SessionId,
+            "连接中的新标签下方是空占位,不指向任何会话。");
+
+        // 上一个标签自己的开关状态不受这次占位替换影响,切回去照旧展示。
+        vm.Activate(first);
+        Assert.IsTrue(vm.FileBrowser.IsVisible, "切回原标签:面板恢复展示。");
+        Assert.AreEqual(first.SessionId, vm.FileBrowser.SessionId);
+    }
+
+    [TestMethod]
     [TestCategory("SessionTree")]
     public async Task ActiveTerminalTab_FollowsSavedProfileWhenSettingEnabled()
     {


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

将错误级（Error）提示由“永不自动消失”调整为“最长20秒后自动消失”，相关注释、文档和实现同步更新。ToastHostViewModel 增加 ErrorLifetime 常量，ToastSeverity 注释强调错误提示会自动消失。优化 MainWindowViewModel 断线提示逻辑，避免重复推送。ToastHostView.axaml 增大底边距至 37px，防止遮挡状态栏。测试用例同步调整，验证错误提示可自动消失且可提前手动关闭。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #385

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [x] 其他:UI交互

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
