### PR TITLE
fix(ui): 新标签页立刻收起旧文件浏览器,连接期间给出加载回执 (#385)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -328,6 +328,55 @@ Guarded by `DialogButtonStyleTests`.
 - Class: `.crumb` -- transparent bg, no border, `FontFamily:VelaUiMonoFont`, `FontSize:11`, `FontWeight:Medium`
 - Hover: `VelaBgHover` background, `VelaAccent` foreground
 
+#### Flyout chrome (`FlyoutPresenter`, global style in `DockStyles.axaml`)
+
+Two ways to dress a flyout -- pick by whether the content already draws its own frame:
+
+- **Bare content** (a raw `StackPanel`, e.g. the status bar's background-task list): the presenter
+  *is* the chrome. It takes `VelaBgSurface` / `VelaBorderSecondary` 1px / `CornerRadius:6` /
+  `Padding:[12,10]` from the global style -- the same values as `MenuFlyoutPresenter`, so a flyout
+  and a context menu read as one product. Nothing to write at the call site.
+- **Content with its own `Border`** (session tree, quick-command target picker): set
+  `FlyoutPresenterClasses="bare"` to strip the presenter to a positioning container, otherwise the
+  content's border sits inside a second frame and the corners show a ring of the wrong colour.
+
+Never leave a bare-content flyout on the Fluent default: `FlyoutPresenterBackground` is a hardcoded
+near-black outside the token system, so it survives every theme switch as a black brick.
+The `.bare` style must stay declared *after* the base style -- equal-priority styles resolve by
+declaration order, last one wins.
+
+#### ProgressRing (`pc:CircularProgressRing`)
+- The **only** loading affordance. `TrackBrush:VelaBorderSecondary`, `ArcBrush:VelaAccent`
+  (in a tab strip: `ArcBrush` = that session's accent, so the spinner reads as *that* connection)
+- `IsIndeterminate:True` unless a real, measured fraction exists -- never animate a fabricated
+  percentage. Determinate rings are for work with countable steps (install, verify, prewarm)
+- Sizes: 12x12 `StrokeThickness:1.5` inline (status bar, tab strip);
+  24x24 `StrokeThickness:2.5` inside a 48x48 `VelaAccentDim` circle on a card
+
+### 5.2b Waiting States
+
+Anything that can outlast one frame must say so **where the user just clicked**, and again in the
+status bar. Three surfaces, one rule each:
+
+| Surface | When | What |
+| --- | --- | --- |
+| Tab-content card (`Border.dc-card`) | A session tab exists but has no session yet | 48px ring circle + `Connecting to <name>` + type label + one way out |
+| Tab strip | Same | `.dot.connecting` (amber) + a 12px ring in place of the type icon |
+| Status bar ring (bottom-right) | Any background work, connections included | 12px ring + one-line summary; hover lists every activity |
+
+Rules that are easy to get wrong:
+
+- **The tab comes first, the session second.** A session tab is created the moment the user asks
+  for it, in a connecting state, and is replaced in place once the session exists. Creating the tab
+  only after a successful handshake means a slow link looks like a dead click.
+- **Failure lands in the tab that owns it**, never in a modal dialog -- the same card in its error
+  variant, matching the terminal's in-tab disconnect overlay (`TerminalTabView.axaml`, `Border.dc-card`).
+  A modal blocks work that has nothing to do with the failure.
+- **The ring is off while waiting on a human.** Credential and certificate prompts are not network
+  time; a spinner there claims progress that is not happening.
+- Card widths follow the disconnect overlay: `340` connecting, `560` failed (a failure reason is
+  multi-line technical text and does not fit a narrow centred card).
+
 ### 5.3 File Browser (`FileBrowserView.axaml`)
 
 The existing SFTP file browser is the primary reusable component for the dual-pane SFTP document.

--- a/plan.md
+++ b/plan.md
@@ -1881,3 +1881,129 @@ SessionId == Guid.Empty 兜底 —— 它是 return 而不是换占位」),只�
 `MainWindowViewModelTests.FileBrowser_ConnectingTab_HidesPreviousSessionPanelImmediately`:
 设置关着 → 手动开面板 → 开一个 `Connecting` 且 `SessionId` 为空的新标签 → 断言面板立刻隐藏
 且不指向任何会话,再切回原标签断言面板恢复。把那条 return 加回去,这条用例会红。
+
+## 46. 2026-09-07 连接慢的时候,屏幕上必须有东西在动(#385 反馈)
+
+用户反馈:新建连接、打开插件的标签页,链路一慢就「点了没有任何反应」,右下角那个后台
+状态圆环也不转。查下来现状比反馈还要糙一档:
+
+| 路径 | 点击后立刻看到什么 |
+| --- | --- |
+| SSH 终端标签 | 标签**出现**了,页签上有黄色圆点;但**正文是一片空白终端** —— `ShowDisconnectedOverlay` 只覆盖 `Disconnected`/`Error`,`Connecting` 这一态从来没有覆盖层 |
+| 独立 SFTP / FTP / 插件协议(S3…)/ 插件工作台(Redis…) | **什么都没有**。四处的 `Layout.AddDocument` 全写在 `OpenSessionAsync` / `OpenAsync` **返回之后**,连接期间没有标签、没有圆点 |
+| 资源管理器树上的圆点 | 文档型连接的 `TrackDocumentSession(..., Connected)` 也只在成功后调用,连接期间不会变黄 |
+| 右下角圆环 | 机制齐全(`IBackgroundActivityService` + `CircularProgressRing` + 悬停清单),但**只有插件装载与配置同步登记**,连接路径一条都没有 |
+
+也就是说文档型连接是字面意义上的"点了没反应",SSH 只是"有个空壳"。
+
+### 一、标签先建,再去握手
+
+新增 `ConnectingDocument`(+ `ConnectingDocumentView` / `ConnectingDockTabItem`):点击那一刻
+就进工作区,连上之后由新增的 `DockWorkspace.ReplaceDocument` **原位**换成真文档。
+
+原位换而不是"先 Remove 再 Add":后者永远追加到主组末尾,用户眼看着标签从原地跳到最右边;
+而且旧文档若不是当前激活的(等连接时切去了别的标签),Add 还会把焦点抢回来。事件按
+"旧的走了、新的来了"如实播报 —— 视图层的内容控件缓存正是靠 `DocumentRemoved` 丢弃旧视图的。
+
+四条路径的连接流程(缺凭据先弹框、认证失败原地重试三次、证书未信任提示后重连)本来一模一样,
+于是把界面表示收进一个 `DocumentConnectUi`:占位标签 + 右下角那条活动 + 取消绳。同一套反馈
+在四处各写一遍,漏一处就是一条新的"点了没反应"。
+
+- **取消**:占位标签的「取消」、标签 ×、Ctrl+W、右键关闭全部收敛到 `Layout.DocumentClosed`
+  一个点上 —— 关掉一个还在连的占位标签 = 不连了,取消一路传进插件的握手。
+- **失败**:占位标签留在原地换成失败卡片(原因 + 重新连接 + 关闭标签页),**不再弹模态框**。
+  终端标签早就把连接失败从全局对话框改成了标签页内的覆盖层(设计 yxjmg);文档型标签
+  以前弹框是因为"连不上就没有标签,失败没有地方可画",而现在有了。
+- 顺带修掉一处:收尾用的 `DisconnectAsync` 原先带着调用方的取消令牌,而那正是它已经取消的
+  时刻 —— 清理动作自己取消掉,留下一条没人关的 SSH 连接。抽成 `DisconnectQuietlyAsync`。
+
+### 二、终端标签补上「连接中」覆盖层
+
+`ShowConnectingOverlay` + 与断开覆盖层同一张卡片(转圈 + 「正在连接 X」+ 关闭标签页)。
+三种非正常态现在各有各的画面,且互不重叠。
+
+### 三、右下角圆环接上连接
+
+`MainWindowViewModel` 原先只把 `IBackgroundActivityService` 转接给状态栏,自己一条都不登记。
+留一个字段,在 SSH 握手(`RunHandshakeAsync`)、SSH 重连、插件终端(`AttachPluginTerminalAsync`,
+打开与重连共用)、以及四条文档型路径上各登记一条。
+
+**等用户输入的时候不登记**(`EndAttempt`):凭据框与证书框是在等人,不是在等网络,圆环
+继续转就是在撒谎。
+
+插件面板(`PluginUiApi.ShowPanelAsync`)也登记一条,覆盖"排到 UI 线程 + 构造控件"这段。
+边界说清楚:插件的惰性激活由 `PluginManager` 自己登记(`Msg_PluginLoading`),面板打开后
+插件再去拉自己的数据,那段宿主看不见也管不着 —— 不给它编一个转圈。
+
+### 四、验收
+
+`dotnet test VelaShell.slnx` 全绿(3190 通过)。新增用例:
+
+- `ConnectingDocumentTests` 五条:连接**期间**占位标签就在场且类型名已换成协议展示名、
+  连上之后真文档接手原来那一格且激活状态一并交接、关掉占位标签会把取消传进插件的握手
+  且不留空壳、这段时间后台活动账本里真有一条、`ReplaceDocument` 保位保焦点并如实播报两条事件;
+- `ConnectingDocumentViewUiTests` 三条**渲染**用例:编译期的 AXAML 校验拦不住
+  `{StaticResource Icon.*}` 写错或令牌改名,而这张界面恰好只在"连接慢"时才会被看到 ——
+  最容易带着一个加载不出来的加载界面发版;
+- `TerminalTabViewModelTests.ConnectingOverlay_CoversTheGapBetweenTabCreationAndHandshake`;
+- `WorkspaceConnectionFailureTests` 两条改成钉新契约:失败落在它自己那个标签上,而不是一扇模态框。
+
+五份 resx 补 `Msg_ConnectingToTitle` / `Msg_ConnectingDetail` / `Msg_PluginOpeningPanel`。
+`DESIGN.md` 补 §5.2 的 ProgressRing 与 §5.2b「等待态」两节(唯一的加载指示、不编假进度、
+标签先于会话、失败落在自己的标签里、等人的时候不转圈)。
+
+## 47. 2026-09-07 后台任务浮层是块黑砖,跟哪套主题都不搭(用户反馈)
+
+用户反馈:状态栏右下角那个后台任务浮层"纯黑色背景有点太丑,和整体主题不太搭",并且要能
+跟着其他主题走。
+
+### 一、根因:那层外壳从来就没进过令牌体系
+
+浮层的外观有两种画法,本项目两种都在用:
+
+- **内容自带 Border**(侧栏会话树、快捷命令目标选择器):浮层挂 `FlyoutPresenterClasses="bare"`
+  把 presenter 剥成纯定位容器,底色/描边/圆角全由内容那层 Border 按令牌画;
+- **内容是裸的**(状态栏后台任务浮层):外观就是 presenter 这一层。
+
+第二种一直没人给它设过值,于是吃的是 Fluent 默认的 `FlyoutPresenterBackground` —— 一个**写死的
+近黑色**,不在 `Vela*` 令牌里。`ThemeTokenApplier` 换主题时把令牌整片换掉,唯独换不到它:
+九套主题换来换去这块砖岿然不动,亮色主题下尤其突兀。
+
+`DockStyles.axaml` 里那段注释其实早就点破了这件事(「状态栏后台任务浮层的内容是裸 StackPanel,
+靠的正是 presenter 这层底」),只是当时的结论是"所以别全局剥掉它",而不是"所以得给它上令牌"。
+
+### 二、修法:给 `FlyoutPresenter` 一条走令牌的基础样式
+
+与 `MenuFlyoutPresenter` 同一套值(`VelaBgSurface` / `VelaBorderSecondary` / 1px / 圆角 6),
+浮层与右键菜单看起来才是同一个产品;顺带清掉 Fluent 的 `MinWidth` 下限(窄浮层会被平白撑宽)。
+`.bare` 保持原样,但**必须排在它之后** —— 同优先级的样式按声明顺序后者胜出,写反了那两个
+自带 Border 的浮层就会变回"两层边"。
+
+这条是给**所有**裸内容浮层的,不只是眼下这一个:下次再加一个浮层,不写任何外观也已经是对的。
+
+### 三、顺带把清单本身理一理
+
+截图里标题与第一条活动糊成一块,而且一行字看不出它是在动还是卡住了:
+
+- 标题降到 10px + 字距 + SemiBold,与侧栏那些分组标题同一档,底下加一条发丝线;
+- **每条活动自己带一圈 12px 的进度环**:这张清单回答的正是"还有什么在跑"。有确定进度就画
+  那个进度(`BackgroundActivityItem` 补一个 0~1 的 `Fraction`,原先只有百分比**文本**,
+  环没法用),不可知就走不确定动画。
+
+### 四、验收
+
+`dotnet test VelaShell.slnx` 全绿(3192 通过)。新增 `FlyoutPresenterStyleTests` 两条:
+普通浮层的底色/描边/圆角/MinWidth 取自令牌、`bare` 浮层仍被剥干净(后者钉的是两条样式的
+先后)。把基础样式的选择器改瞎,第一条会红。
+
+`DESIGN.md` §5.2 补 Flyout 外壳的两种画法与选择依据。
+
+### 五、追加:浮层还压着状态栏(同一轮反馈)
+
+`Placement="Top"` 是贴着锚点按钮的上沿摆的,而那颗按钮几乎占满 24px 的状态栏(20px 高、
+上下各留 2px),于是浮层下沿正好压在状态栏上,两块面挨在一起分不出层次。加
+`VerticalOffset="-8"` 抬起来,浮层与状态栏之间留出约 6px 的空。
+
+方向不是猜的:写了个一次性探针在 headless 里真开一次浮层,量出 `0 → -8` 时弹出层在窗口内的
+Y 从 158 变成 150(偏移走屏幕坐标,正 Y 朝下,故负值向上),确认之后把探针删掉。
+这类纯观感的数值不写用例钉 —— 该由眼睛拍板(同 DialogButtonStyleTests 的立场)。

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -4447,4 +4447,13 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Validation_NumberRequired" xml:space="preserve">
     <value>数値を入力してください</value>
   </data>
+  <data name="Msg_ConnectingToTitle" xml:space="preserve">
+    <value>{0} に接続しています</value>
+  </data>
+  <data name="Msg_ConnectingDetail" xml:space="preserve">
+    <value>セッションを確立しています。回線が遅い場合は数秒かかることがあります。</value>
+  </data>
+  <data name="Msg_PluginOpeningPanel" xml:space="preserve">
+    <value>パネルを開いています</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -4447,4 +4447,13 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Validation_NumberRequired" xml:space="preserve">
     <value>숫자를 입력하세요</value>
   </data>
+  <data name="Msg_ConnectingToTitle" xml:space="preserve">
+    <value>{0}에 연결하는 중</value>
+  </data>
+  <data name="Msg_ConnectingDetail" xml:space="preserve">
+    <value>세션을 설정하는 중입니다. 연결이 느리면 몇 초 걸릴 수 있습니다.</value>
+  </data>
+  <data name="Msg_PluginOpeningPanel" xml:space="preserve">
+    <value>패널을 여는 중</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -4448,4 +4448,13 @@ Choose how much to clean up. Every option rebuilds the store so the space is gen
   <data name="Validation_NumberRequired" xml:space="preserve">
     <value>Enter a number</value>
   </data>
+  <data name="Msg_ConnectingToTitle" xml:space="preserve">
+    <value>Connecting to {0}</value>
+  </data>
+  <data name="Msg_ConnectingDetail" xml:space="preserve">
+    <value>Establishing the session. On a slow link this can take a few seconds.</value>
+  </data>
+  <data name="Msg_PluginOpeningPanel" xml:space="preserve">
+    <value>Opening panel</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -4858,4 +4858,13 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   <data name="Validation_NumberRequired" xml:space="preserve">
     <value>请输入数字</value>
   </data>
+  <data name="Msg_ConnectingToTitle" xml:space="preserve">
+    <value>正在连接 {0}</value>
+  </data>
+  <data name="Msg_ConnectingDetail" xml:space="preserve">
+    <value>正在建立会话。链路较慢时可能要等上几秒。</value>
+  </data>
+  <data name="Msg_PluginOpeningPanel" xml:space="preserve">
+    <value>正在打开面板</value>
+  </data>
 </root>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -4858,4 +4858,13 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   <data name="Validation_NumberRequired" xml:space="preserve">
     <value>請輸入數字</value>
   </data>
+  <data name="Msg_ConnectingToTitle" xml:space="preserve">
+    <value>正在連線 {0}</value>
+  </data>
+  <data name="Msg_ConnectingDetail" xml:space="preserve">
+    <value>正在建立工作階段。連線較慢時可能要等上幾秒。</value>
+  </data>
+  <data name="Msg_PluginOpeningPanel" xml:space="preserve">
+    <value>正在開啟面板</value>
+  </data>
 </root>

--- a/src/VelaShell.Presentation/ViewModels/StatusBarViewModel.cs
+++ b/src/VelaShell.Presentation/ViewModels/StatusBarViewModel.cs
@@ -19,12 +19,16 @@ namespace VelaShell.Presentation.ViewModels;
 /// <param name="HasDetail">是否有 <paramref name="Detail" />。</param>
 /// <param name="Progress">百分比文本(如 "42%");进度不可知时为空串。</param>
 /// <param name="HasProgress">是否有确定进度。</param>
+/// <param name="Fraction">
+/// 0~1 的进度,供清单里那一圈小进度环画弧;进度不可知时为 0(此时环走不确定动画,不读它)。
+/// </param>
 public sealed record BackgroundActivityItem(
     string Title,
     string Detail,
     bool HasDetail,
     string Progress,
-    bool HasProgress);
+    bool HasProgress,
+    double Fraction);
 
 /// <summary>状态栏视图模型:维护连接状态、终端信息与 CPU/内存/磁盘/网络等实时指标,并驱动运行时长计时。</summary>
 public sealed class StatusBarViewModel(ISequencer scheduler) : ReactiveObject, IDisposable
@@ -342,7 +346,8 @@ public sealed class StatusBarViewModel(ISequencer scheduler) : ReactiveObject, I
             a.Detail ?? string.Empty,
             !string.IsNullOrEmpty(a.Detail),
             a.Progress is { } p ? $"{p * 100:F0}%" : string.Empty,
-            a.Progress is not null))];
+            a.Progress is not null,
+            a.Progress ?? 0))];
 
         bool allDeterminate = activities.All(a => a.Progress is not null);
         IsBackgroundIndeterminate = !allDeterminate;

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -73,7 +73,8 @@ public class App : Application
             // 主窗口视图模型在插件激活(主窗口显示后)前已创建,这里惰性解析即可。
             .AddSingleton<Func<string, IPluginLogger, IUiApi>>(sp =>
                 (pluginId, log) => new Services.Plugins.PluginUiApi(pluginId, log,
-                    () => sp.GetService<MainWindowViewModel>()))
+                    () => sp.GetService<MainWindowViewModel>(),
+                    sp.GetService<Core.Services.IBackgroundActivityService>()))
             // 隔离插件的主题令牌快照:Vela* 资源按当前明暗变体解析后经 RPC 下发,
             // 插件的 {DynamicResource VelaXxx} 跨进程同样生效(进程内天然可用)。
             .AddSingleton<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(_ =>

--- a/src/VelaShell/Docking/ConnectingDocument.cs
+++ b/src/VelaShell/Docking/ConnectingDocument.cs
@@ -1,0 +1,148 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using VelaShell.Core.Models;
+using VelaShell.Core.Resources;
+using VelaShell.Docking.Controls;
+using VelaShell.Docking.Model;
+using VelaShell.Services;
+using VelaShell.Views;
+
+namespace VelaShell.Docking;
+
+/// <summary>
+/// 文档型连接(独立 SFTP、FTP、S3/WebDAV 等插件协议、Redis 等插件工作台)在
+/// **握手完成之前**占位的标签页。
+/// <para>
+/// 为什么需要它:这四条路径原先都是先把会话连上、拿到 <c>sessionId</c> 才
+/// <c>Layout.AddDocument</c>。链路一慢,用户点完之后屏幕上**什么都不会发生** ——
+/// 没有标签、没有圆点、右下角也没有转圈,看起来就是「点了没反应」(#385 反馈)。
+/// 终端标签早就是"先建标签、后握手"(见 <c>CreateConnectingTab</c>),这里把文档型
+/// 标签也拉齐到同一条纪律上:点击那一刻标签就在,连上之后由
+/// <see cref="DockWorkspace.ReplaceDocument" /> 原位换成真文档。
+/// </para>
+/// </summary>
+public sealed class ConnectingDocument : DockDocument, IDockViewProvider
+{
+    /// <summary>建一个「连接中」占位标签。</summary>
+    /// <param name="profile">正在连接的配置。</param>
+    /// <param name="typeLabel">连接类型的展示名(SFTP / FTP / S3 / Redis…),写进副标题与提示。</param>
+    public ConnectingDocument(SessionProfile profile, string typeLabel)
+    {
+        Profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        TypeLabel = typeLabel;
+        // 占位标签的 Id 不能取会话 id —— 那玩意儿正是还没有的东西。用一个进程内唯一值,
+        // 与真文档换手之后它就随占位一起消失了。
+        Id = $"connecting-{Guid.NewGuid():N}";
+        Title = DisplayName;
+        IsSessionDocument = true;
+    }
+
+    /// <summary>正在连接的配置。</summary>
+    public SessionProfile Profile { get; }
+
+    /// <summary>
+    /// 连接类型的展示名(SFTP / FTP / S3 / Redis…)。
+    /// </summary>
+    /// <remarks>
+    /// 可写:插件协议要先把插件惰性激活起来才问得到这个名字,而占位标签必须在那之前
+    /// 就出现(激活本身就可能是这条路上最慢的一步)。先挂协议 id,问到了再换成展示名。
+    /// </remarks>
+    public string TypeLabel
+    {
+        get;
+        set
+        {
+            SetField(ref field, value);
+            OnPropertyChanged(nameof(ConnectionTooltip));
+        }
+    }
+
+    /// <summary>标签与覆盖层里指代这条连接的名称:优先用配置的显示名,没起名才退回主机。</summary>
+    public string DisplayName =>
+        string.IsNullOrWhiteSpace(Profile.Name) ? Profile.Host : Profile.Name;
+
+    /// <summary>
+    /// 标签上的状态圆点。与终端 / SFTP / 工作台标签共用一套 <see cref="SessionStatus" />,
+    /// 于是四种标签的黄(连接中)与红(失败)是同一种语言。
+    /// </summary>
+    public SessionStatus Status
+    {
+        get;
+        private set
+        {
+            SetField(ref field, value);
+            OnPropertyChanged(nameof(IsConnecting));
+            OnPropertyChanged(nameof(HasError));
+        }
+    } = SessionStatus.Connecting;
+
+    /// <summary>是否仍在连接(决定覆盖层显示转圈还是失败卡片)。</summary>
+    public bool IsConnecting => Status == SessionStatus.Connecting;
+
+    /// <summary>是否已失败。</summary>
+    public bool HasError => Status == SessionStatus.Error;
+
+    /// <summary>失败原因;<see cref="HasError" /> 为真时才有意义。</summary>
+    public string? ErrorMessage
+    {
+        get;
+        private set => SetField(ref field, value);
+    }
+
+    /// <summary>覆盖层标题:连接中为「正在连接 X」,失败后为「连接失败」。</summary>
+    public string OverlayTitle =>
+        HasError
+            ? Strings.Get("Msg_ConnectionFailedTitle")
+            : Strings.Format("Msg_ConnectingToTitle", DisplayName);
+
+    /// <summary>覆盖层详情:连接中给一句"正在建立会话",失败后给具体原因。</summary>
+    public string OverlayDetail =>
+        HasError ? ErrorMessage ?? string.Empty : Strings.Get("Msg_ConnectingDetail");
+
+    /// <summary>从连接配置派生的强调色画刷,与真文档标签上的那条色带同源。</summary>
+    public IBrush ConnectionAccentBrush => ConnectionAccent.BrushForProfile(Profile);
+
+    /// <summary>标签悬停提示。</summary>
+    public string ConnectionTooltip => $"{DisplayName} · {TypeLabel} · {Strings.Connecting}";
+
+    /// <summary>
+    /// 用户点了「取消」:撤销这次连接。由宿主接上(取消令牌 + 撤标签),
+    /// 视图层只管把意图发出来。
+    /// </summary>
+    public Action? CancelRequested { get; set; }
+
+    /// <summary>用户点了「重试」:重新走一遍这条连接流程。由宿主接上。</summary>
+    public Action? RetryRequested { get; set; }
+
+    /// <summary>取消这次连接(覆盖层的「取消」按钮)。</summary>
+    public void Cancel() => CancelRequested?.Invoke();
+
+    /// <summary>重试这次连接(失败卡片的「重试」按钮)。</summary>
+    public void Retry() => RetryRequested?.Invoke();
+
+    /// <summary>转入失败态:标签圆点变红,覆盖层换成失败卡片。</summary>
+    /// <param name="message">面向用户的失败原因。</param>
+    public void MarkFailed(string message)
+    {
+        ErrorMessage = message;
+        Status = SessionStatus.Error;
+        RaiseOverlayChanged();
+    }
+
+    /// <summary>转回连接中(重试时)。</summary>
+    public void MarkConnecting()
+    {
+        ErrorMessage = null;
+        Status = SessionStatus.Connecting;
+        RaiseOverlayChanged();
+    }
+
+    /// <inheritdoc />
+    public Control CreateView() => new ConnectingDocumentView { DataContext = this };
+
+    private void RaiseOverlayChanged()
+    {
+        OnPropertyChanged(nameof(OverlayTitle));
+        OnPropertyChanged(nameof(OverlayDetail));
+    }
+}

--- a/src/VelaShell/Docking/Controls/ConnectingDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/ConnectingDockTabItem.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:VelaShell.Docking.Controls"
+             xmlns:docking="using:VelaShell.Docking"
+             xmlns:conv="using:VelaShell.Converters"
+             xmlns:pc="using:VelaShell.Controls.Controls"
+             xmlns:loc="using:VelaShell.Localization"
+             x:Class="VelaShell.Docking.Controls.ConnectingDockTabItem"
+             x:DataType="docking:ConnectingDocument"
+             FontSize="{DynamicResource VelaFontSize11}"
+             VerticalAlignment="Stretch">
+  <UserControl.Styles>
+    <!-- 状态圆点:与终端 / SFTP / 工作台标签同一套写法(样式类 + 动态资源,
+         切主题后重算)。占位标签只会是 connecting(黄)或 Error(默认那档的红)。 -->
+    <Style Selector="Ellipse.dot">
+      <Setter Property="Fill" Value="{DynamicResource VelaStatusDisconnected}" />
+    </Style>
+    <Style Selector="Ellipse.dot.connecting">
+      <Setter Property="Fill" Value="{DynamicResource VelaStatusConnecting}" />
+    </Style>
+    <Style Selector="local|ConnectingDockTabItem">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="Transitions">
+        <Transitions>
+          <BrushTransition Property="Foreground" Duration="0:0:0.12" Easing="CubicEaseOut" />
+        </Transitions>
+      </Setter>
+    </Style>
+    <Style Selector="local|ConnectingDockTabItem Border#TabRoot">
+      <Setter Property="Background" Value="{DynamicResource VelaTabInactiveBg}" />
+      <Setter Property="Transitions">
+        <Transitions>
+          <BrushTransition Property="Background" Duration="0:0:0.12" Easing="CubicEaseOut" />
+          <BrushTransition Property="BorderBrush" Duration="0:0:0.12" Easing="CubicEaseOut" />
+        </Transitions>
+      </Setter>
+    </Style>
+    <Style Selector="local|ConnectingDockTabItem:pointerover:not(:selected)">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    </Style>
+    <Style Selector="local|ConnectingDockTabItem:pointerover:not(:selected) Border#TabRoot">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+    </Style>
+    <Style Selector="local|ConnectingDockTabItem:selected">
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextPrimary}" />
+      <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+    <!-- 激活顶线由 DockGroupControl 的滑动强调线统一呈现(与其余标签同理)。 -->
+    <Style Selector="local|ConnectingDockTabItem:selected Border#TabRoot">
+      <Setter Property="Background" Value="{DynamicResource VelaTabActiveBg}" />
+    </Style>
+  </UserControl.Styles>
+
+  <!-- 占位标签只给关闭一族:拆分 / 改标签位置对一个马上就要被换掉的壳没有意义。 -->
+  <UserControl.ContextMenu>
+    <ContextMenu>
+      <MenuItem Header="{loc:Localize Dock_Close}" Click="CloseTab_Click" />
+      <MenuItem Header="{loc:Localize Dock_CloseOthers}" Click="CloseOthers_Click" />
+      <MenuItem Header="{loc:Localize Dock_CloseAll}" Click="CloseAll_Click" />
+    </ContextMenu>
+  </UserControl.ContextMenu>
+
+  <Border x:Name="TabRoot" MinHeight="32" Padding="14,0" BorderThickness="0,2,0,0"
+          BorderBrush="Transparent" VerticalAlignment="Stretch">
+    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+      <Ellipse Width="7" Height="7" VerticalAlignment="Center" Classes="dot"
+               Classes.connecting="{Binding IsConnecting}" />
+      <Border Width="3" Height="12" CornerRadius="1.5" VerticalAlignment="Center"
+              Background="{Binding ConnectionAccentBrush}" />
+      <!-- 图标本身就是一圈转着的进度环:标签条上那一眼就能看出"还在连"。 -->
+      <pc:CircularProgressRing Width="12" Height="12" StrokeThickness="1.5"
+                               IsVisible="{Binding IsConnecting}"
+                               IsIndeterminate="True"
+                               TrackBrush="{DynamicResource VelaBorderSecondary}"
+                               ArcBrush="{Binding ConnectionAccentBrush}"
+                               VerticalAlignment="Center" />
+      <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.wifi-off}"
+                     IsVisible="{Binding HasError}"
+                     Foreground="{DynamicResource VelaError}" />
+      <TextBlock Text="{Binding Title}" VerticalAlignment="Center" ToolTip.ShowDelay="250"
+                 ToolTip.Placement="Pointer" ToolTip.Tip="{Binding ConnectionTooltip}" />
+      <Button Background="Transparent" Padding="0" Width="14" Height="14" BorderThickness="0"
+              HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Click="CloseTab_Click">
+        <pc:LucideIcon Width="11" Height="11" Data="{DynamicResource Icon.x}"
+                       Foreground="{DynamicResource VelaTextTertiary}" />
+      </Button>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/src/VelaShell/Docking/Controls/ConnectingDockTabItem.axaml.cs
+++ b/src/VelaShell/Docking/Controls/ConnectingDockTabItem.axaml.cs
@@ -1,0 +1,8 @@
+namespace VelaShell.Docking.Controls;
+
+/// <summary>文档型连接在握手完成前的占位标签呈现(转圈 + 名称 + 关闭)。</summary>
+public partial class ConnectingDockTabItem : DockTabItemBase
+{
+    /// <summary>初始化「连接中」停靠标签项。</summary>
+    public ConnectingDockTabItem() => InitializeComponent();
+}

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml
@@ -90,6 +90,10 @@
               <DataTemplate x:DataType="docking:PluginWorkspaceDocument">
                 <local:WorkspaceDockTabItem />
               </DataTemplate>
+              <!-- 文档型连接握手完成前的占位标签(同理:漏了这条就是一行类型全名)。 -->
+              <DataTemplate x:DataType="docking:ConnectingDocument">
+                <local:ConnectingDockTabItem />
+              </DataTemplate>
             </ItemsControl.DataTemplates>
           </ItemsControl>
           <!-- 激活标签的滑动强调线:单条 2px 线在标签间滑动(取代各标签自己顶线的突变),

--- a/src/VelaShell/Docking/Model/DockElement.cs
+++ b/src/VelaShell/Docking/Model/DockElement.cs
@@ -12,6 +12,14 @@ public abstract class DockElement : INotifyPropertyChanged
     /// <summary>属性值变更时触发,用于向绑定层通知刷新。</summary>
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// 直接就某个属性发一次变更通知,供派生类刷新**计算属性**
+    /// (值不存在后备字段,但随另一个属性一起变)。
+    /// </summary>
+    /// <param name="propertyName">变更的属性名。</param>
+    protected void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     /// <summary>在值确有变化时更新后备字段并触发 <see cref="PropertyChanged" /> 通知。</summary>
     /// <typeparam name="T">属性的值类型。</typeparam>
     /// <param name="field">被更新的后备字段(按引用传入)。</param>

--- a/src/VelaShell/Docking/Model/DockWorkspace.cs
+++ b/src/VelaShell/Docking/Model/DockWorkspace.cs
@@ -164,6 +164,47 @@ public sealed class DockWorkspace : DockElement
         ActivateDocument(document);
     }
 
+    /// <summary>
+    /// 原位替换一个文档:新文档接手旧文档在组内的**位置**与选中/激活状态。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 「连接中」占位标签换成连上之后的真文档走这一条。用"先 Remove 再 Add"是不行的:
+    /// <see cref="AddDocument" /> 永远追加到主组末尾,于是用户眼看着标签从原地跳到最右边;
+    /// 而且旧文档若不是当前激活的(用户在等连接时切去了别的标签),Add 还会把焦点抢回来。
+    /// </para>
+    /// <para>
+    /// 事件按"旧的走了、新的来了"如实播报:视图层的内容控件缓存正是靠
+    /// <see cref="DocumentRemoved" /> 丢弃旧视图的(见 <c>DockWorkspaceControl</c>)。
+    /// </para>
+    /// </remarks>
+    /// <param name="oldDocument">要被替换掉的文档;不在工作区内时本方法为空操作。</param>
+    /// <param name="newDocument">接手其位置的新文档。</param>
+    public void ReplaceDocument(DockDocument oldDocument, DockDocument newDocument)
+    {
+        ArgumentNullException.ThrowIfNull(oldDocument);
+        ArgumentNullException.ThrowIfNull(newDocument);
+        if (FindGroup(oldDocument) is not { } group)
+        {
+            return;
+        }
+        int index = group.Documents.IndexOf(oldDocument);
+        bool wasGroupActive = ReferenceEquals(group.ActiveDocument, oldDocument);
+        bool wasWorkspaceActive = ReferenceEquals(ActiveDocument, oldDocument);
+        group.Documents[index] = newDocument;
+        if (wasGroupActive)
+        {
+            group.ActiveDocument = newDocument;
+        }
+        DocumentRemoved?.Invoke(oldDocument);
+        DocumentAdded?.Invoke(newDocument);
+        // 激活放在两条事件之后:订阅方(宿主的每标签接线)要在活动标签切过去之前就位。
+        if (wasWorkspaceActive)
+        {
+            ActivateDocument(newDocument);
+        }
+    }
+
     /// <summary>激活文档:选中其标签并设为全局激活。</summary>
     public void ActivateDocument(DockDocument document)
     {

--- a/src/VelaShell/Services/Plugins/PluginUiApi.cs
+++ b/src/VelaShell/Services/Plugins/PluginUiApi.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
+using VelaShell.Core.Resources;
+using VelaShell.Core.Services;
 using VelaShell.PluginSdk.Logging;
 using VelaShell.PluginSdk.Ui;
 using VelaShell.ViewModels;
@@ -13,7 +15,11 @@ namespace VelaShell.Services.Plugins;
 /// <see cref="PanelOptions.DisplayMode" /> 呈现为停靠文档或独立窗口;
 /// 实例释放(插件停用)时全部关闭 —— 插件离场,宿主 UI 不残留。
 /// </summary>
-internal sealed class PluginUiApi(string pluginId, IPluginLogger log, Func<MainWindowViewModel?> mainViewModel)
+internal sealed class PluginUiApi(
+    string pluginId,
+    IPluginLogger log,
+    Func<MainWindowViewModel?> mainViewModel,
+    IBackgroundActivityService? backgroundActivity = null)
     : IUiApi, IDisposable
 {
     private readonly Lock _gate = new();
@@ -27,6 +33,12 @@ internal sealed class PluginUiApi(string pluginId, IPluginLogger log, Func<MainW
         ArgumentNullException.ThrowIfNull(contentFactory);
         ObjectDisposedException.ThrowIf(_disposed, this);
         cancellationToken.ThrowIfCancellationRequested();
+        // 插件多半在后台线程上调这个(SDK 允许),而下面整段要排到 UI 线程上执行:
+        // 排队 + 构造控件这段时间右下角圆环转着,免得"点了一下面板,好一会儿没动静"。
+        // 注意这里覆盖的只是**宿主这一段** —— 插件激活由 PluginManager 自己登记,
+        // 面板打开后插件再去拉自己的数据,那段宿主看不见也管不着。
+        using IBackgroundActivityScope? activity =
+            backgroundActivity?.Begin(Strings.Get("Msg_PluginOpeningPanel"), options.Title);
         PluginPanel panel = await Dispatcher.UIThread.InvokeAsync(() =>
         {
             // 工厂在 UI 线程调用:插件可在其中放心构造任何 Avalonia 控件(含编译期 AXAML 视图)。

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -172,12 +172,27 @@
         <Setter Property="Opacity" Value="0.35" />
     </Style>
 
-    <!-- 裸浮层(Flyout FlyoutPresenterClasses="bare"):把 presenter 剥成纯定位容器,
-         外观全部交给内容自己那一层 Border。默认的 FlyoutPresenter 自带底色、描边、
-         内边距与圆角,套在内容已有的 Border 外面就是两层框 —— 浮层外面多一圈黑边
-         (会话浮层实测)。MinWidth 也得清:Fluent 默认给了下限,窄浮层会被撑宽。
-         【只作用于挂了 bare 类的浮层】:状态栏后台任务浮层的内容是裸 StackPanel,
-         靠的正是 presenter 这层底,全局剥掉它会变成一块没有背景的悬空文字。 -->
+    <!-- 普通浮层(内容不自带 Border 的那些,如状态栏后台任务浮层):presenter 这层就是
+         浮层的外观,因此必须走令牌。Fluent 默认的 FlyoutPresenterBackground 是一个写死的
+         近黑色,**不在**我们的令牌体系里 —— 于是九套主题换来换去它岿然不动,亮色主题下
+         尤其突兀(用户反馈:"纯黑色背景有点太丑,和整体主题不太搭")。
+         与 MenuFlyoutPresenter 同一套值,浮层与右键菜单看起来才是同一个产品。 -->
+    <Style Selector="FlyoutPresenter">
+        <Setter Property="Background" Value="{DynamicResource VelaBgSurface}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderSecondary}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="6" />
+        <Setter Property="Padding" Value="12,10" />
+        <!-- Fluent 给了 MinWidth 下限,窄浮层会被平白撑宽。 -->
+        <Setter Property="MinWidth" Value="0" />
+        <Setter Property="MinHeight" Value="0" />
+    </Style>
+
+    <!-- 裸浮层(Flyout FlyoutPresenterClasses="bare"):内容自己那一层 Border 已经把外观
+         画全了(会话树浮层、快捷命令目标选择器),此时把 presenter 剥成纯定位容器 ——
+         否则内容的 Border 外面还套着上面那圈 presenter 的框,浮层就是两层边,圆角处
+         露出一圈底色(实测)。
+         必须排在上面那条**之后**:同优先级的样式按声明顺序后者胜出。 -->
     <Style Selector="FlyoutPresenter.bare">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -185,6 +185,16 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     private readonly Dictionary<Guid, FileBrowserViewModel> _fileBrowserCache = [];
     private readonly Lock _sftpCloseTasksSync = new();
     private readonly Dictionary<SftpDocument, Task> _sftpCloseTasks = [];
+
+    /// <summary>
+    /// 后台活动账本:连接期间在这里登记一条,右下角那个圆环才转得起来。
+    /// </summary>
+    /// <remarks>
+    /// 原先只把它转接给状态栏(<see cref="WireBackgroundActivity" />),自己一条都不登记 ——
+    /// 于是圆环只有插件装载与配置同步时才出现,连一台机器连三十秒它一动不动(#385 反馈)。
+    /// 无界面单测不注入,故全部调用点都走 <c>?.</c>。
+    /// </remarks>
+    private readonly IBackgroundActivityService? _backgroundActivity;
     private FileTransferViewModel _fileTransfer;
 
     private AppSettings? _latestSettings;
@@ -332,6 +342,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             {
                 _ = CloseWorkspaceDocumentAsync(workspaceDocument);
             }
+            else if (document is ConnectingDocument connecting)
+            {
+                // 关掉一个还在连的占位标签 = 不连了。挂在 DocumentClosed 这一个点上,
+                // 六个关闭入口(标签 ×、Ctrl+W、右键那一族、覆盖层上的「取消」)一并管住;
+                // 连接流程收到取消后会自己收尾(该断的断掉,占位由它撤走)。
+                connecting.Cancel();
+            }
         };
         Layout.ActiveDocumentChanged += SetActiveFromDocument;
         // 每个标签要挂的那几条订阅(同步输入、会话状态圆点、快捷命令目标)随文档进出工作区
@@ -360,6 +377,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         // 彼此紧密、与主窗口其余职责毫不相干。活动标签用委托现取,不缓存 ——
         // 缓存一份就要再操心"什么时候刷新"。
         _statusMetrics = new(_statusBar, () => ActiveTerminalTab, metricsService);
+        _backgroundActivity = backgroundActivity;
         WireBackgroundActivity(backgroundActivity);
         _fileBrowser = new(null, Guid.Empty);
         _fileTransfer = new(transferManager, appDataStore);
@@ -2330,6 +2348,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     )
     {
         TerminalType terminalType = TerminalTypeExtensions.FromTermName(SessionTerminalSettings.TerminalType(profile, settings));
+        // 握手全程在右下角圆环上登记一条:标签页内已经有「连接中」覆盖层,而窗口右下角
+        // 是"这台机器上还有什么在跑"的统一去处 —— 切到别的标签之后也看得见这条还在连。
+        using IBackgroundActivityScope? activity =
+            _backgroundActivity?.Begin(Strings.Connecting, ProfileDisplayName(profile));
         SshSession session = await _connectionWorkflowService!.ConnectProfileAsync(
             profile,
             cancellationToken
@@ -2416,6 +2438,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         tab.ConnectionStatus = SessionStatus.Connecting;
         tab.DetachTransport();
         UpdateStatusBarForActiveTab();
+        // 重连与首连同等对待:右下角圆环也要转起来 —— 自动重连尤其是在后台发生的,
+        // 用户多半不在那个标签上。
+        using IBackgroundActivityScope? activity =
+            _backgroundActivity?.Begin(Strings.Connecting, ProfileDisplayName(tab.Profile));
         try
         {
             AppSettings settings = _settingsService is not null
@@ -3078,6 +3104,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         tab.Dispose();
     }
 
+    /// <summary>
+    /// 指代一条连接的名称:优先用用户起的显示名(他认得的那个),没起名才退回主机地址。
+    /// </summary>
+    /// <remarks>刻意不带用户名与端口:这个名字会出现在状态栏与后台任务清单里(安全要求,设计 gzmsb)。</remarks>
+    /// <param name="profile">连接配置。</param>
+    /// <returns>显示名。</returns>
+    private static string ProfileDisplayName(SessionProfile profile) =>
+        string.IsNullOrWhiteSpace(profile.Name) ? profile.Host : profile.Name;
+
     /// <summary>缺少连接所需凭据(用户名/密码/私钥)时需要先走登录验证流程。</summary>
     private static bool RequiresCredentials(SessionProfile profile) =>
         string.IsNullOrWhiteSpace(profile.Username)
@@ -3226,6 +3261,115 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     }
 
     /// <summary>
+    /// 一次文档型连接在界面上的「进行中」表示:工作区里的占位标签、右下角圆环里的一条活动,
+    /// 以及用户点「取消」时要拉的那根绳。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 四条文档型连接路径(独立 SFTP、FTP、插件协议、插件工作台)共用这一个 ——
+    /// 同一套反馈在四处各写一遍,漏一处就是一条"点了没反应"的 bug,而它们的连接流程
+    /// (缺凭据先弹框、认证失败原地重试三次、证书未信任提示后重连)本来就是一模一样的。
+    /// </para>
+    /// <para>
+    /// 与终端标签的分工一致:标签在握手**开始前**就在,连上之后由
+    /// <see cref="DockWorkspace.ReplaceDocument" /> 原位换成真文档。
+    /// </para>
+    /// </remarks>
+    private sealed class DocumentConnectUi : IDisposable
+    {
+        private readonly MainWindowViewModel _owner;
+        private readonly CancellationTokenSource _cancellation;
+        private IBackgroundActivityScope? _activity;
+        private bool _disposed;
+
+        /// <summary>建立(或接手)一次文档型连接的界面表示。</summary>
+        /// <param name="owner">宿主视图模型。</param>
+        /// <param name="profile">正在连接的配置。</param>
+        /// <param name="typeLabel">连接类型展示名(SFTP / FTP / S3 / Redis…)。</param>
+        /// <param name="outer">调用方的取消令牌,与占位标签上的「取消」并联。</param>
+        /// <param name="reuse">重试时接手的既有占位标签;首次连接传 <see langword="null" />。</param>
+        /// <param name="retry">失败卡片上「重新连接」要跑的流程。</param>
+        public DocumentConnectUi(
+            MainWindowViewModel owner,
+            SessionProfile profile,
+            string typeLabel,
+            CancellationToken outer,
+            ConnectingDocument? reuse,
+            Func<ConnectingDocument, Task> retry)
+        {
+            _owner = owner;
+            _cancellation = CancellationTokenSource.CreateLinkedTokenSource(outer);
+            if (reuse is null)
+            {
+                Document = new(profile, typeLabel);
+                _owner.Layout.AddDocument(Document);
+            }
+            else
+            {
+                Document = reuse;
+            }
+            // 每次重试都重挂:上一轮的委托指向的是那一轮已经释放掉的取消源。
+            Document.CancelRequested = Cancel;
+            Document.RetryRequested = () => _ = retry(Document);
+        }
+
+        /// <summary>工作区里的占位标签。</summary>
+        public ConnectingDocument Document { get; }
+
+        /// <summary>连接流程要用的取消令牌(调用方的令牌 ∪ 用户点的「取消」)。</summary>
+        public CancellationToken Token => _cancellation.Token;
+
+        /// <summary>撤销这次连接。占位标签被关掉时(标签 ×、Ctrl+W、覆盖层的「取消」)由宿主调。</summary>
+        public void Cancel()
+        {
+            if (!_disposed)
+            {
+                _cancellation.Cancel();
+            }
+        }
+
+        /// <summary>一次尝试开始:占位回到「连接中」,右下角圆环点亮。</summary>
+        public void BeginAttempt()
+        {
+            Document.MarkConnecting();
+            _activity ??= _owner._backgroundActivity?.Begin(Strings.Connecting, Document.DisplayName);
+        }
+
+        /// <summary>
+        /// 一次尝试结束。要弹凭据框/证书框之前必须调:此刻等的是用户,不是网络,
+        /// 圆环继续转就是在撒谎。
+        /// </summary>
+        public void EndAttempt()
+        {
+            _activity?.Dispose();
+            _activity = null;
+        }
+
+        /// <summary>连上了:占位原位换成真文档(位置与激活状态一并交接)。</summary>
+        /// <param name="real">连接成功后建好的真文档。</param>
+        public void HandOver(DockDocument real) => _owner.Layout.ReplaceDocument(Document, real);
+
+        /// <summary>连不上了:占位留在原地换成失败卡片(重新连接 / 关闭标签页)。</summary>
+        /// <param name="message">面向用户的失败原因。</param>
+        public void Fail(string message) => Document.MarkFailed(message);
+
+        /// <summary>用户中途取消:撤掉占位标签(已被用户关掉时是空操作)。</summary>
+        public void Abandon() => _owner.Layout.RemoveDocument(Document);
+
+        /// <summary>结束这次连接的界面表示:熄掉圆环并释放取消源。</summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            EndAttempt();
+            _cancellation.Dispose();
+        }
+    }
+
+    /// <summary>
     /// 为 SSH 或 SFTP 配置打开一个独立的 SFTP 文档。此路径绝不创建终端标签或 shell 流。
     /// </summary>
     public async Task<TerminalTabViewModel?> OpenSftpForProfileAsync(
@@ -3240,9 +3384,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>
     /// 通过常规工作流连接,并在认证成功后才创建一个文档范围的串行化 SFTP 通道。
     /// </summary>
-    public async Task<SftpDocument?> OpenSftpDocumentForProfileAsync(
+    public Task<SftpDocument?> OpenSftpDocumentForProfileAsync(
         SessionProfile profile,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        OpenSftpDocumentForProfileAsync(profile, null, cancellationToken);
+
+    /// <param name="profile">会话配置。</param>
+    /// <param name="reuse">失败卡片上点「重新连接」时接手的既有占位标签。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    private async Task<SftpDocument?> OpenSftpDocumentForProfileAsync(
+        SessionProfile profile,
+        ConnectingDocument? reuse,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(profile);
         if (_connectionWorkflowService is null)
@@ -3251,21 +3404,27 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
 
         SessionProfile current = profile;
-        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页。
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,要写进占位标签的失败卡片。
         Exception? lastAuthFailure = null;
+        using var ui = new DocumentConnectUi(
+            this, profile, "SFTP", cancellationToken, reuse,
+            document => OpenSftpDocumentForProfileAsync(profile, document, CancellationToken.None));
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresCredentials(current))
             {
                 if (InteractiveAuthenticator is not { } prompt)
                 {
+                    ui.Abandon();
                     return null;
                 }
+                ui.EndAttempt();
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
-                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    // 用户取消:这是"不连了",不是失败,不弹提示,占位标签一并撤走。
                     LastConnectionError = null;
+                    ui.Abandon();
                     return null;
                 }
                 current = prompted;
@@ -3274,16 +3433,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             SshSession? session = null;
             try
             {
-                session = await _connectionWorkflowService.ConnectProfileAsync(current, cancellationToken)
+                ui.BeginAttempt();
+                session = await _connectionWorkflowService.ConnectProfileAsync(current, ui.Token)
                     .ConfigureAwait(true);
                 if (session is null)
                 {
+                    ui.Abandon();
                     return null;
                 }
                 if (_sftpService is null)
                 {
-                    await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken)
-                        .ConfigureAwait(true);
+                    await DisconnectQuietlyAsync(session.SessionId).ConfigureAwait(true);
+                    ui.Abandon();
                     return null;
                 }
                 AppSettings settings = _latestSettings ?? await LoadSettingsSnapshotAsync().ConfigureAwait(true);
@@ -3296,43 +3457,88 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         settings.Transfer,
                         FileTransfer,
                         QueryDefaultEditorPathAsync));
-                Layout.AddDocument(document);
+                ui.HandOver(document);
                 // 与 FTP 同理:连接续体可能落在后台线程上,树节点是绑定属性,必须回主线程再改。
                 TrackDocumentSession(session.SessionId, current.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
             {
-                if (session is not null)
-                {
-                    await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken).ConfigureAwait(true);
-                }
+                await DisconnectQuietlyAsync(session?.SessionId).ConfigureAwait(true);
+                ui.Abandon();
                 return null;
             }
             catch (VelaSshAuthenticationException auth)
             {
-                if (session is not null)
-                {
-                    await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken).ConfigureAwait(true);
-                }
+                await DisconnectQuietlyAsync(session?.SessionId).ConfigureAwait(true);
                 lastAuthFailure = auth;
                 continue;
             }
             catch (Exception ex)
             {
-                if (session is not null)
-                {
-                    await _connectionWorkflowService.DisconnectAsync(session.SessionId, cancellationToken).ConfigureAwait(true);
-                }
-                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
+                await DisconnectQuietlyAsync(session?.SessionId).ConfigureAwait(true);
+                ReportDocumentConnectFailure(ui, current, ex);
                 return null;
             }
         }
         if (lastAuthFailure is not null)
         {
-            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
+            ReportDocumentConnectFailure(ui, current, lastAuthFailure);
         }
         return null;
+    }
+
+    /// <summary>
+    /// 收尾用的断开:不带调用方的取消令牌。
+    /// </summary>
+    /// <remarks>
+    /// 这里的调用点全在"连接已经失败/被取消"之后,而那正是原令牌已经取消的时刻 ——
+    /// 把它传给断开,等于让清理动作自己取消掉,留下一条没人关的 SSH 连接。
+    /// </remarks>
+    /// <param name="sessionId">要断开的会话;<see langword="null" /> 表示还没连上,无事可做。</param>
+    private async Task DisconnectQuietlyAsync(Guid? sessionId)
+    {
+        if (sessionId is not { } id || _connectionWorkflowService is null)
+        {
+            return;
+        }
+        try
+        {
+            await _connectionWorkflowService.DisconnectAsync(id, CancellationToken.None).ConfigureAwait(true);
+        }
+        catch (Exception)
+        {
+            // 收尾失败没有下一步可走,更不该盖掉用户真正要看的那条失败原因。
+        }
+    }
+
+    /// <summary>
+    /// 文档型连接失败的统一上报:浮层一条 + 把原因写进占位标签的失败卡片。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 标签留在原地而不是撤掉:浮层几秒就没了,而"哪条连接失败了、为什么"是用户接下来
+    /// 要处理的事;卡片上的「重新连接」也才有地方放。
+    /// </para>
+    /// <para>
+    /// 刻意**不**走 <see cref="ReportConnectionFailureAsync" /> —— 那条会再弹一扇模态框。
+    /// 终端标签早就把连接失败从全局对话框改成了标签页内的覆盖层(设计 yxjmg),
+    /// 文档型标签有了自己的失败卡片之后同理:失败留在它所属的那个标签里,
+    /// 而不是拿一扇模态框挡住用户手上正在做的别的事。
+    /// </para>
+    /// </remarks>
+    /// <param name="ui">这次连接的界面表示。</param>
+    /// <param name="profile">连接配置。</param>
+    /// <param name="error">失败原因。</param>
+    private void ReportDocumentConnectFailure(
+        DocumentConnectUi ui,
+        SessionProfile profile,
+        Exception error)
+    {
+        string message = DescribeConnectionError(error, profile);
+        LastConnectionError = message;
+        Toasts.Error(message);
+        ui.Fail(message);
     }
 
     /// <summary>
@@ -3343,9 +3549,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// 此时弹一次信任提示,用户同意就把指纹记进配置再重连(刻意不在证书回调里同步等 UI,那样极易死锁)。
     /// </para>
     /// </summary>
-    public async Task<SftpDocument?> OpenFtpDocumentForProfileAsync(
+    public Task<SftpDocument?> OpenFtpDocumentForProfileAsync(
         SessionProfile profile,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        OpenFtpDocumentForProfileAsync(profile, null, cancellationToken);
+
+    /// <param name="profile">会话配置。</param>
+    /// <param name="reuse">失败卡片上点「重新连接」时接手的既有占位标签。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    private async Task<SftpDocument?> OpenFtpDocumentForProfileAsync(
+        SessionProfile profile,
+        ConnectingDocument? reuse,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(profile);
         if (_ftpSessionService is null || _sftpService is null)
@@ -3354,21 +3569,27 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
 
         SessionProfile current = profile;
-        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页。
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,要写进占位标签的失败卡片。
         Exception? lastAuthFailure = null;
+        using var ui = new DocumentConnectUi(
+            this, profile, FtpTypeLabel(profile), cancellationToken, reuse,
+            document => OpenFtpDocumentForProfileAsync(profile, document, CancellationToken.None));
         for (int attempt = 0; attempt < 3; attempt++)
         {
             if (attempt > 0 || RequiresFtpCredentials(current))
             {
                 if (InteractiveAuthenticator is not { } prompt)
                 {
+                    ui.Abandon();
                     return null;
                 }
+                ui.EndAttempt();
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
-                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    // 用户取消:这是"不连了",不是失败,不弹提示,占位标签一并撤走。
                     LastConnectionError = null;
+                    ui.Abandon();
                     return null;
                 }
                 current = prompted;
@@ -3376,8 +3597,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
             try
             {
+                ui.BeginAttempt();
                 Guid sessionId = await _ftpSessionService
-                    .OpenSessionAsync(FtpConnectionInfo.FromProfile(current), cancellationToken)
+                    .OpenSessionAsync(FtpConnectionInfo.FromProfile(current), ui.Token)
                     .ConfigureAwait(true);
                 AppSettings settings = _latestSettings ?? await LoadSettingsSnapshotAsync().ConfigureAwait(true);
                 var document = new SftpDocument(
@@ -3389,17 +3611,19 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         settings.Transfer,
                         FileTransfer,
                         QueryDefaultEditorPathAsync));
-                Layout.AddDocument(document);
+                ui.HandOver(document);
                 TrackDocumentSession(sessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
             {
+                ui.Abandon();
                 return null;
             }
             catch (VelaFtpCertificateException certificate)
             {
                 // 用户同意信任 → 记下指纹后重来一次;拒绝(或没有提示钩子)→ 按普通连接失败上报。
+                ui.EndAttempt();
                 if (FtpCertificateTrustPrompt is { } trustPrompt &&
                     await trustPrompt(current, certificate).ConfigureAwait(true))
                 {
@@ -3411,6 +3635,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 Toasts.Error(LastConnectionError);
+                ui.Fail(certificate.Message);
                 return null;
             }
             catch (VelaFtpAuthenticationException auth)
@@ -3420,21 +3645,27 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             }
             catch (Exception ex)
             {
-                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
+                ReportDocumentConnectFailure(ui, current, ex);
                 return null;
             }
         }
         if (lastAuthFailure is not null)
         {
-            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
+            ReportDocumentConnectFailure(ui, current, lastAuthFailure);
         }
         return null;
     }
 
+    /// <summary>占位标签上写的连接类型:FTPS 与明文 FTP 是两件事,别都写成 "FTP"。</summary>
+    /// <param name="profile">会话配置。</param>
+    /// <returns>FTP 或 FTPS。</returns>
+    private static string FtpTypeLabel(SessionProfile profile) =>
+        profile.Ftp?.EncryptionMode is null or FtpEncryptionMode.None ? "FTP" : "FTPS";
+
     /// <summary>
     /// 打开一个插件协议文档标签(S3、WebDAV…):建立会话并复用与 SFTP 完全相同的双栏文件面板。
     /// <para>
-    /// 结构与 <see cref="OpenFtpDocumentForProfileAsync" /> 一一对应(同样不走
+    /// 结构与 <see cref="OpenFtpDocumentForProfileAsync(SessionProfile, CancellationToken)" /> 一一对应(同样不走
     /// <see cref="IConnectionWorkflowService" /> —— 那是 SSH 握手,同样在证书不可信时
     /// 弹一次信任提示后重连)。差别只在缺少凭据的判定:声明了 AnonymousAccess 的协议
     /// (如 S3 的公开只读桶)不填凭据也是一条正当路径,弹框会把它堵死。
@@ -3447,9 +3678,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <param name="profile">会话配置。</param>
     /// <param name="cancellationToken">取消令牌。</param>
     /// <returns>已打开的文档;失败或取消时为 null。</returns>
-    public async Task<SftpDocument?> OpenPluginDocumentForProfileAsync(
+    public Task<SftpDocument?> OpenPluginDocumentForProfileAsync(
         SessionProfile profile,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        OpenPluginDocumentForProfileAsync(profile, null, cancellationToken);
+
+    /// <param name="profile">会话配置。</param>
+    /// <param name="reuse">失败卡片上点「重新连接」时接手的既有占位标签。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    private async Task<SftpDocument?> OpenPluginDocumentForProfileAsync(
+        SessionProfile profile,
+        ConnectingDocument? reuse,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(profile);
         if (_pluginProtocols is null || _sftpService is null)
@@ -3457,11 +3697,23 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             return null;
         }
 
+        // 占位标签建在解析协议之前:解析可能触发插件的惰性激活(装配、启动进程),
+        // 那往往就是这条路上最慢的一步 —— 等它完再建标签,慢的那段照样没有任何回执。
+        // 类型名此刻还问不到,先挂协议 id,解析出来再换成展示名。
+        using var ui = new DocumentConnectUi(
+            this, profile, profile.PluginProtocolId ?? string.Empty, cancellationToken, reuse,
+            document => OpenPluginDocumentForProfileAsync(profile, document, CancellationToken.None));
+        ui.BeginAttempt();
+
         ProtocolDescriptor? descriptor = null;
         if (profile.PluginProtocolId is { Length: > 0 } protocolId && _protocolRegistry is { } registry)
         {
             // 可能触发插件的惰性激活(用户刚从「最近连接」点开一条 S3 会话)。
             descriptor = (await registry.ResolveAsync(protocolId).ConfigureAwait(true))?.Descriptor;
+        }
+        if (descriptor is { DisplayName.Length: > 0 })
+        {
+            ui.Document.TypeLabel = descriptor.DisplayName;
         }
         bool allowsAnonymous = descriptor?.Features.HasFlag(ProtocolFeatures.AnonymousAccess) == true;
 
@@ -3478,13 +3730,16 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             {
                 if (InteractiveAuthenticator is not { } prompt)
                 {
+                    ui.Abandon();
                     return null;
                 }
+                ui.EndAttempt();
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
-                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    // 用户取消:这是"不连了",不是失败,不弹提示,占位标签一并撤走。
                     LastConnectionError = null;
+                    ui.Abandon();
                     return null;
                 }
                 current = prompted;
@@ -3492,7 +3747,8 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
             try
             {
-                Guid sessionId = await _pluginProtocols.OpenSessionAsync(current, cancellationToken).ConfigureAwait(true);
+                ui.BeginAttempt();
+                Guid sessionId = await _pluginProtocols.OpenSessionAsync(current, ui.Token).ConfigureAwait(true);
                 AppSettings settings = _latestSettings ?? await LoadSettingsSnapshotAsync().ConfigureAwait(true);
                 var viewModel = new SftpDocumentViewModel(
                     current,
@@ -3511,17 +3767,19 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                         _pluginProtocols.InvokeActionAsync(sessionId, actionId, path, CancellationToken.None);
                 }
                 var document = new SftpDocument(viewModel);
-                Layout.AddDocument(document);
+                ui.HandOver(document);
                 TrackDocumentSession(sessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
             {
+                ui.Abandon();
                 return null;
             }
             catch (PluginProtocolCertificateException certificate)
             {
                 // 用户同意信任 → 记下指纹后重来一次;拒绝(或没有提示钩子)→ 按普通连接失败上报。
+                ui.EndAttempt();
                 if (PluginCertificateTrustPrompt is { } trustPrompt &&
                     await trustPrompt(current, certificate).ConfigureAwait(true))
                 {
@@ -3539,6 +3797,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 Toasts.Error(LastConnectionError);
+                ui.Fail(certificate.Message);
                 return null;
             }
             catch (PluginProtocolAuthenticationException auth)
@@ -3548,13 +3807,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             }
             catch (Exception ex)
             {
-                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
+                ReportDocumentConnectFailure(ui, current, ex);
                 return null;
             }
         }
         if (lastAuthFailure is not null)
         {
-            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
+            ReportDocumentConnectFailure(ui, current, lastAuthFailure);
         }
         return null;
     }
@@ -3625,6 +3884,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             terminalType.ToTermName(),
             Math.Max(2, tab.TerminalEmulator.Columns),
             Math.Max(2, tab.TerminalEmulator.Rows));
+        // 打开与重连都经过这里,右下角圆环的登记放在这一处就够(理由同 RunHandshakeAsync)。
+        using IBackgroundActivityScope? activity =
+            _backgroundActivity?.Begin(Strings.Connecting, ProfileDisplayName(profile));
         IShellStreamWrapper stream = await PluginProtocolTerminalConnector
             .OpenAsync(registration, profile, options, cancellationToken)
             .ConfigureAwait(true);
@@ -3679,7 +3941,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <summary>
     /// 打开一条**工作台**会话(Redis 等由插件全权渲染界面的连接类型)。
     /// <para>
-    /// 与 <see cref="OpenPluginDocumentForProfileAsync" /> 共用同一套连接流程纪律:
+    /// 与 <see cref="OpenPluginDocumentForProfileAsync(SessionProfile, CancellationToken)" /> 共用同一套连接流程纪律:
     /// 缺凭据先弹登录框、认证失败原地重试(至多三次)、证书未信任走"提示 → 记指纹 → 重连"
     /// 且证书提示单独计数(否则 <c>attempt--</c> 会把三次上限彻底架空)。
     /// 区别只在最后一步:那边打开宿主的双栏浏览器,这边把插件的控件挂成停靠文档。
@@ -3688,15 +3950,30 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// <param name="profile">连接配置。</param>
     /// <param name="cancellationToken">取消令牌。</param>
     /// <returns>已打开的文档;失败或用户取消时为 null。</returns>
-    public async Task<PluginWorkspaceDocument?> OpenWorkspaceDocumentForProfileAsync(
+    public Task<PluginWorkspaceDocument?> OpenWorkspaceDocumentForProfileAsync(
         SessionProfile profile,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        OpenWorkspaceDocumentForProfileAsync(profile, null, cancellationToken);
+
+    /// <param name="profile">连接配置。</param>
+    /// <param name="reuse">失败卡片上点「重新连接」时接手的既有占位标签。</param>
+    /// <param name="cancellationToken">取消令牌。</param>
+    private async Task<PluginWorkspaceDocument?> OpenWorkspaceDocumentForProfileAsync(
+        SessionProfile profile,
+        ConnectingDocument? reuse,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(profile);
         if (_workspaceLauncher is not { } launcher)
         {
             return null;
         }
+
+        // 同插件协议那条路径:占位标签建在解析之前 —— 惰性激活插件往往是最慢的一步。
+        using var ui = new DocumentConnectUi(
+            this, profile, profile.PluginProtocolId ?? string.Empty, cancellationToken, reuse,
+            document => OpenWorkspaceDocumentForProfileAsync(profile, document, CancellationToken.None));
+        ui.BeginAttempt();
 
         bool allowsAnonymous = false;
         if (_protocolRegistry is { } registry)
@@ -3705,11 +3982,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             WorkspaceDescriptor? descriptor =
                 (await registry.ResolveWorkspaceAsync(profile.PluginProtocolId).ConfigureAwait(true))?.Descriptor;
             allowsAnonymous = descriptor?.Features.HasFlag(WorkspaceFeatures.AnonymousAccess) == true;
+            if (descriptor is { DisplayName.Length: > 0 })
+            {
+                ui.Document.TypeLabel = descriptor.DisplayName;
+            }
         }
 
         SessionProfile current = profile;
         int certPrompts = 0;
-        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,而这条路径不留标签页,
+        // 三次认证都没过时的最后一条原因:循环走完就没人再报了,要写进占位标签的失败卡片 ——
         // 不记下来的话用户面对的是"密码弹了三次,然后什么都没有"。
         Exception? lastAuthFailure = null;
         for (int attempt = 0; attempt < 3; attempt++)
@@ -3718,13 +3999,16 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             {
                 if (InteractiveAuthenticator is not { } prompt)
                 {
+                    ui.Abandon();
                     return null;
                 }
+                ui.EndAttempt();
                 SessionProfile? prompted = await prompt(current).ConfigureAwait(true);
                 if (prompted is null)
                 {
-                    // 用户取消:这是"不连了",不是失败,不弹提示。
+                    // 用户取消:这是"不连了",不是失败,不弹提示,占位标签一并撤走。
                     LastConnectionError = null;
+                    ui.Abandon();
                     return null;
                 }
                 current = prompted;
@@ -3732,14 +4016,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
             try
             {
+                ui.BeginAttempt();
                 // 声明了 SshTunnel 且用户选了跳板机 → 宿主先把 SSH 会话与本地转发建好,
                 // 插件只看到一个已经能连的本地端点(凭据永不出宿主)。
                 (WorkspaceEndpoint? endpoint, Guid tunnelId) =
-                    await EstablishWorkspaceTunnelAsync(current, cancellationToken).ConfigureAwait(true);
+                    await EstablishWorkspaceTunnelAsync(current, ui.Token).ConfigureAwait(true);
                 PluginWorkspaceSession session;
                 try
                 {
-                    session = await launcher.OpenAsync(current, endpoint, cancellationToken).ConfigureAwait(true);
+                    session = await launcher.OpenAsync(current, endpoint, ui.Token).ConfigureAwait(true);
                 }
                 catch
                 {
@@ -3754,16 +4039,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 }
                 _workspaceDocuments[session.SessionId] = document;
                 session.Document.StatusChanged += OnWorkspaceStatusChanged;
-                Layout.AddDocument(document);
+                ui.HandOver(document);
                 TrackDocumentSession(session.SessionId, profile.Id, SessionStatus.Connected);
                 return document;
             }
             catch (OperationCanceledException)
             {
+                ui.Abandon();
                 return null;
             }
             catch (PluginProtocolCertificateException certificate)
             {
+                ui.EndAttempt();
                 if (PluginCertificateTrustPrompt is { } trustPrompt &&
                     await trustPrompt(current, certificate).ConfigureAwait(true))
                 {
@@ -3778,6 +4065,7 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 // 用户自己点了"不信任",原因他清楚 —— 再弹一扇框只是复述他刚做的决定。
                 LastConnectionError = certificate.Message;
                 Toasts.Error(LastConnectionError);
+                ui.Fail(certificate.Message);
                 return null;
             }
             catch (PluginProtocolAuthenticationException auth)
@@ -3787,13 +4075,13 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             }
             catch (Exception ex)
             {
-                await ReportConnectionFailureAsync(current, ex).ConfigureAwait(true);
+                ReportDocumentConnectFailure(ui, current, ex);
                 return null;
             }
         }
         if (lastAuthFailure is not null)
         {
-            await ReportConnectionFailureAsync(current, lastAuthFailure).ConfigureAwait(true);
+            ReportDocumentConnectFailure(ui, current, lastAuthFailure);
         }
         return null;
     }

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -496,6 +496,8 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
             this.RaisePropertyChanged(nameof(ShowDisconnectedOverlay));
             this.RaisePropertyChanged(nameof(DisconnectOverlayTitle));
             this.RaisePropertyChanged(nameof(DisconnectOverlayDetail));
+            this.RaisePropertyChanged(nameof(ShowConnectingOverlay));
+            this.RaisePropertyChanged(nameof(ConnectingOverlayTitle));
         }
     }
 
@@ -543,6 +545,22 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
         !_disposed
         && ConnectionStatus is SessionStatus.Disconnected or SessionStatus.Error
         && (Profile is not null || LocalShell is not null);
+
+    /// <summary>
+    /// 标签页内「连接中」覆盖层的可见性:正在握手且是一个真实会话标签时显示。
+    /// </summary>
+    /// <remarks>
+    /// 标签在握手开始前就建好了(见 <c>CreateConnectingTab</c>),这中间正文是一片
+    /// 空白终端 —— 链路一慢,用户看到的就是"点了之后什么都没有"(#385 反馈)。
+    /// 断开/失败早有覆盖层,连接中这一态却一直空着;补上之后三种非正常态各有各的画面。
+    /// </remarks>
+    public bool ShowConnectingOverlay =>
+        !_disposed
+        && ConnectionStatus == SessionStatus.Connecting
+        && (Profile is not null || LocalShell is not null);
+
+    /// <summary>「连接中」覆盖层的标题:正在连接 &lt;会话名&gt;。</summary>
+    public string ConnectingOverlayTitle => Strings.Format("Msg_ConnectingToTitle", OverlayHostLabel);
 
     /// <summary>失败/断开覆盖层的标题:有错误时为“连接失败”,否则为“连接已断开”。</summary>
     public string DisconnectOverlayTitle =>

--- a/src/VelaShell/Views/ConnectingDocumentView.axaml
+++ b/src/VelaShell/Views/ConnectingDocumentView.axaml
@@ -1,0 +1,149 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:docking="using:VelaShell.Docking"
+             xmlns:pc="using:VelaShell.Controls.Controls"
+             xmlns:loc="using:VelaShell.Localization"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="VelaShell.Views.ConnectingDocumentView"
+             x:DataType="docking:ConnectingDocument">
+
+  <UserControl.Styles>
+    <!-- 与终端标签页内的断开覆盖层(设计 yxjmg / dcOverlay)同一套卡片:连接中只有一句话,
+         窄卡片居中最好看;失败原因是多行技术文本(认证链、算法名单),要宽卡片左对齐才读得下去。 -->
+    <Style Selector="Border.dc-card">
+      <Setter Property="Width" Value="340" />
+    </Style>
+    <Style Selector="Border.dc-card.error">
+      <Setter Property="Width" Value="560" />
+    </Style>
+    <Style Selector="Border.dc-detail">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="Border.dc-detail.error">
+      <Setter Property="Background" Value="{DynamicResource VelaBgInput}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="14,12" />
+    </Style>
+    <Style Selector="SelectableTextBlock.dc-detail">
+      <Setter Property="TextAlignment" Value="Center" />
+      <Setter Property="MaxWidth" Value="280" />
+    </Style>
+    <Style Selector="SelectableTextBlock.dc-detail.error">
+      <Setter Property="TextAlignment" Value="Left" />
+      <Setter Property="MaxWidth" Value="Infinity" />
+      <Setter Property="LineHeight" Value="18" />
+    </Style>
+  </UserControl.Styles>
+
+  <Border Background="{DynamicResource VelaBgDockDocument}">
+    <Border Classes="dc-card" Classes.error="{Binding HasError}"
+            Background="{DynamicResource VelaBgSurface}"
+            BorderBrush="{DynamicResource VelaBorderSecondary}"
+            BorderThickness="1"
+            CornerRadius="8"
+            Padding="32,24"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            BoxShadow="{DynamicResource VelaShadowWindow}">
+      <StackPanel Orientation="Vertical" Spacing="16" HorizontalAlignment="Center">
+
+        <!-- 图标圆底:连接中是一圈转着的进度环(它本身就是"还在动"的证据),
+             失败后换成与终端断开覆盖层同一个 wifi-off 图标,两处的失败长得一样。 -->
+        <Border Width="48" Height="48" CornerRadius="24"
+                IsVisible="{Binding IsConnecting}"
+                Background="{DynamicResource VelaAccentDim}"
+                HorizontalAlignment="Center">
+          <pc:CircularProgressRing Width="24" Height="24" StrokeThickness="2.5"
+                                   IsIndeterminate="True"
+                                   TrackBrush="{DynamicResource VelaBorderSecondary}"
+                                   ArcBrush="{DynamicResource VelaAccent}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+        </Border>
+        <Border Width="48" Height="48" CornerRadius="24"
+                IsVisible="{Binding HasError}"
+                Background="{DynamicResource VelaErrorSurface}"
+                HorizontalAlignment="Center">
+          <pc:LucideIcon Width="22" Height="22"
+                         Data="{StaticResource Icon.wifi-off}"
+                         Foreground="{DynamicResource VelaError}"
+                         HorizontalAlignment="Center" VerticalAlignment="Center" />
+        </Border>
+
+        <TextBlock Text="{Binding OverlayTitle}"
+                   Foreground="{DynamicResource VelaTextPrimary}"
+                   FontSize="{DynamicResource VelaFontSize16}" FontWeight="SemiBold"
+                   TextAlignment="Center" TextWrapping="Wrap"
+                   HorizontalAlignment="Center" />
+
+        <!-- 连接类型(SFTP / FTP / S3 / Redis…):同一台主机可以按几种协议连,
+             光看名字分不出这个标签在等哪一条。 -->
+        <TextBlock Text="{Binding TypeLabel}"
+                   IsVisible="{Binding IsConnecting}"
+                   Foreground="{DynamicResource VelaTextTertiary}"
+                   FontFamily="{DynamicResource VelaUiMonoFont}"
+                   FontSize="{DynamicResource VelaFontSize11}"
+                   TextAlignment="Center" HorizontalAlignment="Center" />
+
+        <Border Classes="dc-detail" Classes.error="{Binding HasError}">
+          <ScrollViewer MaxHeight="200"
+                        HorizontalScrollBarVisibility="Disabled"
+                        VerticalScrollBarVisibility="Auto">
+            <!-- SelectableTextBlock:失败原因要能划选、Ctrl+C 拿走(理由同终端覆盖层)。 -->
+            <SelectableTextBlock Classes="dc-detail" Classes.error="{Binding HasError}"
+                                 Text="{Binding OverlayDetail}"
+                                 Foreground="{DynamicResource VelaTextMuted}"
+                                 FontFamily="{DynamicResource VelaUiMonoFont}"
+                                 FontSize="{DynamicResource VelaFontSize11}"
+                                 TextWrapping="Wrap" />
+          </ScrollViewer>
+        </Border>
+
+        <!-- 连接中只给「取消」:此刻能做的决定只有一个 —— 不等了。 -->
+        <Button IsVisible="{Binding IsConnecting}"
+                HorizontalAlignment="Center"
+                Click="Cancel_Click"
+                Background="Transparent"
+                BorderBrush="{DynamicResource VelaBorderSecondary}"
+                BorderThickness="1"
+                CornerRadius="4" Padding="16,8">
+          <TextBlock Text="{loc:Localize Cancel}"
+                     Foreground="{DynamicResource VelaTextSecondary}"
+                     FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
+                     VerticalAlignment="Center" />
+        </Button>
+
+        <!-- 失败后与终端覆盖层给的是同两个动作:重试、关掉这个标签。 -->
+        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center"
+                    IsVisible="{Binding HasError}">
+          <Button Click="Retry_Click"
+                  Background="{DynamicResource VelaAccent}"
+                  CornerRadius="4" Padding="16,8"
+                  BorderThickness="0">
+            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+              <pc:LucideIcon Width="13" Height="13"
+                             Data="{StaticResource Icon.refresh-cw}"
+                             Foreground="{DynamicResource VelaAccentForeground}" VerticalAlignment="Center" />
+              <TextBlock Text="{loc:Localize Reconnect}" Foreground="{DynamicResource VelaAccentForeground}"
+                         FontSize="{DynamicResource VelaFontSize12}" FontWeight="SemiBold" VerticalAlignment="Center" />
+            </StackPanel>
+          </Button>
+          <Button Click="Close_Click"
+                  Background="Transparent"
+                  BorderBrush="{DynamicResource VelaBorderSecondary}"
+                  BorderThickness="1"
+                  CornerRadius="4" Padding="16,8">
+            <TextBlock Text="{loc:Localize CloseTab}"
+                       Foreground="{DynamicResource VelaTextSecondary}"
+                       FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium" VerticalAlignment="Center" />
+          </Button>
+        </StackPanel>
+
+      </StackPanel>
+    </Border>
+  </Border>
+</UserControl>

--- a/src/VelaShell/Views/ConnectingDocumentView.axaml.cs
+++ b/src/VelaShell/Views/ConnectingDocumentView.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using VelaShell.Docking;
+using VelaShell.Docking.Controls;
+using VelaShell.Docking.Model;
+using Avalonia.VisualTree;
+
+namespace VelaShell.Views;
+
+/// <summary>
+/// 文档型连接在握手完成前的占位视图:居中一张卡片,连接中转圈 + 「取消」,
+/// 失败后换成原因 + 「重新连接 / 关闭标签页」(与终端标签页内的断开覆盖层同款)。
+/// </summary>
+public partial class ConnectingDocumentView : UserControl
+{
+    /// <summary>初始化「连接中」占位视图。</summary>
+    public ConnectingDocumentView() => InitializeComponent();
+
+    private ConnectingDocument? Document => DataContext as ConnectingDocument;
+
+    private void Cancel_Click(object? sender, RoutedEventArgs e) => Document?.Cancel();
+
+    private void Retry_Click(object? sender, RoutedEventArgs e) => Document?.Retry();
+
+    /// <summary>
+    /// 关闭这个占位标签。走工作区的 <see cref="DockWorkspace.RequestClose" />(与标签上的 × 同一条路),
+    /// 而不是自己去调宿主 —— 关闭前的确认闸挂在工作区那一层。
+    /// </summary>
+    private void Close_Click(object? sender, RoutedEventArgs e)
+    {
+        if (Document is { } document
+            && this.FindAncestorOfType<DockWorkspaceControl>()?.Workspace is { } workspace)
+        {
+            workspace.RequestClose(document);
+        }
+    }
+}

--- a/src/VelaShell/Views/StatusBarView.axaml
+++ b/src/VelaShell/Views/StatusBarView.axaml
@@ -75,17 +75,36 @@
             </Style>
           </Button.Styles>
           <Button.Flyout>
-            <Flyout Placement="Top" HorizontalOffset="0">
-              <StackPanel MinWidth="240" Spacing="8">
+            <!-- 外观(底色/描边/圆角/内边距)由 FlyoutPresenter 那条全局样式按令牌给,
+                 见 DockStyles —— 这里只管内容,别再自带一层 Border,否则又是两层框。 -->
+            <!-- 往上抬 8px:Top 放置是贴着锚点按钮的上沿摆的,而按钮几乎占满 24px 的状态栏,
+                 浮层的下沿就压在状态栏上,两块面挨在一起分不出层次(用户反馈)。
+                 负值 = 向上(偏移走的是屏幕坐标,正 Y 朝下)。 -->
+            <Flyout Placement="Top" HorizontalOffset="0" VerticalOffset="-8">
+              <StackPanel MinWidth="248" Spacing="8">
+                <!-- 分组标题走 §3 的写法:10px + 字距,与侧栏那些分组标题同一档。 -->
                 <TextBlock Text="{loc:Localize BackgroundTasks}"
                            FontFamily="{DynamicResource VelaUiFont}"
-                           FontSize="{DynamicResource VelaFontSize11}"
+                           FontSize="{DynamicResource VelaFontSize10}"
+                           FontWeight="SemiBold"
+                           LetterSpacing="1"
                            Foreground="{DynamicResource VelaTextTertiary}" />
+                <!-- 标题与清单之间一条发丝线:没有它,标题和第一条活动糊成一块。 -->
+                <Border Height="1" Background="{DynamicResource VelaBorderPrimary}" />
                 <ItemsControl ItemsSource="{Binding BackgroundActivities}">
                   <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="pvm:BackgroundActivityItem">
-                      <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,4">
-                        <StackPanel Grid.Column="0" Spacing="1">
+                      <Grid ColumnDefinitions="Auto,10,*,Auto" Margin="0,3">
+                        <!-- 每条自己带一圈在转的环:这张清单回答的正是"还有什么在跑",
+                             一行字看不出它是在动还是卡住了。有确定进度就画那个进度。 -->
+                        <pc:CircularProgressRing Grid.Column="0" Width="12" Height="12"
+                                                 StrokeThickness="1.5"
+                                                 VerticalAlignment="Center"
+                                                 IsIndeterminate="{Binding !HasProgress}"
+                                                 Value="{Binding Fraction}"
+                                                 TrackBrush="{DynamicResource VelaBorderSecondary}"
+                                                 ArcBrush="{DynamicResource VelaAccent}" />
+                        <StackPanel Grid.Column="2" Spacing="1">
                           <TextBlock Text="{Binding Title}"
                                      FontFamily="{DynamicResource VelaUiFont}"
                                      FontSize="{DynamicResource VelaFontSize11}"
@@ -97,7 +116,7 @@
                                      FontSize="{DynamicResource VelaFontSize10}"
                                      Foreground="{DynamicResource VelaTextMuted}" />
                         </StackPanel>
-                        <TextBlock Grid.Column="1" Margin="12,0,0,0"
+                        <TextBlock Grid.Column="3" Margin="12,0,0,0"
                                    Text="{Binding Progress}"
                                    IsVisible="{Binding HasProgress}"
                                    VerticalAlignment="Center"

--- a/src/VelaShell/Views/TerminalTabView.axaml
+++ b/src/VelaShell/Views/TerminalTabView.axaml
@@ -298,6 +298,58 @@
                  HorizontalAlignment="Right"
                  VerticalAlignment="Stretch" />
 
+      <!-- 标签页内「连接中」覆盖层:标签在握手开始前就建好了,这中间正文本是一片空白终端,
+           链路一慢就看不出自己到底点没点上(#385 反馈)。与下面的断开覆盖层同一张卡片,
+           只是图标换成转圈、按钮换成「关闭标签页」——此刻用户能做的决定只有"不等了"。 -->
+      <Border IsVisible="{Binding ShowConnectingOverlay}"
+              Background="{DynamicResource VelaScrim}"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch">
+        <Border Classes="dc-card"
+                Background="{DynamicResource VelaBgSurface}"
+                BorderBrush="{DynamicResource VelaBorderSecondary}"
+                BorderThickness="1"
+                CornerRadius="8"
+                Padding="32,24"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="{DynamicResource VelaShadowWindow}">
+          <StackPanel Orientation="Vertical" Spacing="16" HorizontalAlignment="Center">
+            <Border Width="48" Height="48" CornerRadius="24"
+                    Background="{DynamicResource VelaAccentDim}"
+                    HorizontalAlignment="Center">
+              <pc:CircularProgressRing Width="24" Height="24" StrokeThickness="2.5"
+                                       IsIndeterminate="True"
+                                       TrackBrush="{DynamicResource VelaBorderSecondary}"
+                                       ArcBrush="{DynamicResource VelaAccent}"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <TextBlock Text="{Binding ConnectingOverlayTitle}"
+                       Foreground="{DynamicResource VelaTextPrimary}"
+                       FontSize="{DynamicResource VelaFontSize16}" FontWeight="SemiBold"
+                       TextAlignment="Center" TextWrapping="Wrap"
+                       HorizontalAlignment="Center" />
+            <TextBlock Text="{loc:Localize Msg_ConnectingDetail}"
+                       Foreground="{DynamicResource VelaTextMuted}"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}"
+                       MaxWidth="280" TextAlignment="Center" TextWrapping="Wrap"
+                       HorizontalAlignment="Center" />
+            <Button Command="{Binding CloseTabCommand}"
+                    HorizontalAlignment="Center"
+                    Background="Transparent"
+                    BorderBrush="{DynamicResource VelaBorderSecondary}"
+                    BorderThickness="1"
+                    CornerRadius="4" Padding="16,8">
+              <TextBlock Text="{loc:Localize CloseTab}"
+                         Foreground="{DynamicResource VelaTextSecondary}"
+                         FontSize="{DynamicResource VelaFontSize12}" FontWeight="Medium"
+                         VerticalAlignment="Center" />
+            </Button>
+          </StackPanel>
+        </Border>
+      </Border>
+
       <!-- 标签页内失败/断开覆盖层(设计 yxjmg / dcOverlay):连接失败或掉线时居中显示,
            提供“重新连接”“关闭标签页”。连接失败不再弹全局对话框,提示只落在所属标签页内。 -->
       <Border IsVisible="{Binding ShowDisconnectedOverlay}"

--- a/tests/VelaShell.Tests/ViewModels/ConnectingDocumentTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectingDocumentTests.cs
@@ -1,0 +1,222 @@
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.Docking;
+using VelaShell.Docking.Model;
+using VelaShell.Infrastructure.Plugins.Protocols;
+using VelaShell.PluginSdk.Protocols;
+using VelaShell.PluginSdk.Workspaces;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 文档型连接(独立 SFTP、FTP、插件协议、插件工作台)在握手完成前必须**已经有一个标签**。
+/// <para>
+/// 这四条路径原先都是连上了才 <c>AddDocument</c>,链路一慢用户点完之后屏幕上什么都不会
+/// 发生 —— 没有标签、没有圆点、右下角也没有转圈,看起来就是「点了没反应」(#385 反馈)。
+/// 这组用例钉住三件事:占位标签在连接**期间**就在场、连上之后**原位**换成真文档、
+/// 以及这段时间右下角后台活动圆环真的在转。
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class ConnectingDocumentTests
+{
+    private const string WorkspaceId = "acme.cache";
+
+    /// <summary>握手挂在一个由用例控制的信号上,好在"连接中"这一帧上做断言。</summary>
+    private sealed class GatedWorkspaceProvider(TaskCompletionSource<IWorkspaceDocument> gate)
+        : IWorkspaceProvider
+    {
+        /// <summary>已经收到过几次握手请求。</summary>
+        public int Opens { get; private set; }
+
+        /// <summary>最后一次握手带进来的取消令牌,用于验证「取消」真的传下去了。</summary>
+        public CancellationToken LastToken { get; private set; }
+
+        public Task<IWorkspaceDocument> OpenAsync(
+            WorkspaceConnectRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Opens++;
+            LastToken = cancellationToken;
+            // 取消令牌一响就让这次握手以取消收场(真实插件同理)。
+            cancellationToken.Register(() => gate.TrySetCanceled(cancellationToken));
+            return gate.Task;
+        }
+    }
+
+    /// <summary>连上之后交出来的空文档:这组用例只关心标签的更替,不关心内容。</summary>
+    private sealed class StubWorkspaceDocument : IWorkspaceDocument
+    {
+        public WorkspaceStatus Status { get; } = new(ProtocolSessionState.Connected);
+
+        /// <summary>这份替身从不改状态,事件只为满足接口。</summary>
+        public event EventHandler<WorkspaceStatus>? StatusChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public object CreateView() => new object();
+
+        public Task ReconnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static (MainWindowViewModel Vm, SessionProfile Profile, GatedWorkspaceProvider Provider)
+        Arrange(TaskCompletionSource<IWorkspaceDocument> gate, IBackgroundActivityService? activity = null)
+    {
+        var registry = new PluginProtocolRegistry();
+        var provider = new GatedWorkspaceProvider(gate);
+        registry.RegisterWorkspace(
+            WorkspaceId,
+            new()
+            {
+                Id = WorkspaceId,
+                DisplayName = "Acme Cache",
+                DefaultPort = 6379,
+                // 匿名可连:否则用例测到的是弹凭据框,而不是占位标签。
+                Features = WorkspaceFeatures.AnonymousAccess
+            },
+            provider);
+        var vm = new MainWindowViewModel(
+            protocolRegistry: registry,
+            workspaceLauncher: new PluginWorkspaceLauncher(registry),
+            backgroundActivity: activity);
+        return (vm, new()
+        {
+            Name = "本地 Redis",
+            ConnectionType = ConnectionType.Plugin,
+            PluginProtocolId = WorkspaceId,
+            Host = "127.0.0.1",
+            Port = 6379
+        }, provider);
+    }
+
+    private static ConnectingDocument SoleConnectingDocument(MainWindowViewModel vm)
+    {
+        ConnectingDocument[] placeholders = [.. vm.Layout.AllDocuments().OfType<ConnectingDocument>()];
+        Assert.HasCount(1, placeholders);
+        return placeholders[0];
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task WhileConnecting_ThePlaceholderTabIsAlreadyThere()
+    {
+        var gate = new TaskCompletionSource<IWorkspaceDocument>();
+        (MainWindowViewModel vm, SessionProfile profile, _) = Arrange(gate);
+
+        Task<PluginWorkspaceDocument?> opening = vm.OpenWorkspaceDocumentForProfileAsync(profile);
+
+        ConnectingDocument placeholder = SoleConnectingDocument(vm);
+        Assert.IsTrue(placeholder.IsConnecting, "握手还没回来时标签是「连接中」态。");
+        Assert.IsFalse(placeholder.HasError);
+        Assert.AreEqual("本地 Redis", placeholder.Title);
+        Assert.AreEqual("Acme Cache", placeholder.TypeLabel, "协议解析完要把类型名换成展示名。");
+        Assert.AreSame(placeholder, vm.Layout.ActiveDocument, "新开的连接就是当前标签。");
+
+        gate.SetResult(new StubWorkspaceDocument());
+        Assert.IsNotNull(await opening);
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task OnceConnected_TheRealDocumentTakesThePlaceholderSlot()
+    {
+        var gate = new TaskCompletionSource<IWorkspaceDocument>();
+        (MainWindowViewModel vm, SessionProfile profile, _) = Arrange(gate);
+
+        // 先占一个位:占位标签会排在它后面,换手之后真文档必须还在同一格。
+        var first = new ConnectingDocument(new() { Name = "先来的", Host = "first.example" }, "SFTP");
+        vm.Layout.AddDocument(first);
+
+        Task<PluginWorkspaceDocument?> opening = vm.OpenWorkspaceDocumentForProfileAsync(profile);
+        ConnectingDocument placeholder = vm.Layout.AllDocuments()
+            .OfType<ConnectingDocument>()
+            .Single(d => !ReferenceEquals(d, first));
+        DockGroup group = vm.Layout.FindGroup(placeholder)!;
+        int slot = group.Documents.IndexOf(placeholder);
+        Assert.AreEqual(1, slot, "占位标签排在先来的那个后面。");
+
+        gate.SetResult(new StubWorkspaceDocument());
+        PluginWorkspaceDocument? document = await opening;
+
+        Assert.IsNotNull(document);
+        Assert.DoesNotContain(placeholder, vm.Layout.AllDocuments(),
+            "连上之后占位标签就该退场,不能与真文档并存。");
+        Assert.AreSame(document, group.Documents[slot], "真文档接手占位标签原来那一格,不许跳到最右边。");
+        Assert.AreSame(document, vm.Layout.ActiveDocument, "激活状态一并交接。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task ClosingThePlaceholder_CancelsTheHandshakeAndTakesTheTabWithIt()
+    {
+        var gate = new TaskCompletionSource<IWorkspaceDocument>();
+        (MainWindowViewModel vm, SessionProfile profile, GatedWorkspaceProvider provider) = Arrange(gate);
+
+        Task<PluginWorkspaceDocument?> opening = vm.OpenWorkspaceDocumentForProfileAsync(profile);
+        ConnectingDocument placeholder = SoleConnectingDocument(vm);
+
+        // 覆盖层上的「取消」与标签上的 × 走同一条路:关掉这个占位标签。
+        vm.Layout.RequestClose(placeholder);
+
+        Assert.IsNull(await opening);
+        Assert.IsTrue(provider.LastToken.IsCancellationRequested, "取消要一路传到插件的握手里。");
+        Assert.IsEmpty(vm.Layout.AllDocuments(), "取消之后不留空壳标签。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public async Task WhileConnecting_TheBackgroundActivityRingIsSpinning()
+    {
+        var activity = new BackgroundActivityService();
+        var gate = new TaskCompletionSource<IWorkspaceDocument>();
+        (MainWindowViewModel vm, SessionProfile profile, _) = Arrange(gate, activity);
+
+        Task<PluginWorkspaceDocument?> opening = vm.OpenWorkspaceDocumentForProfileAsync(profile);
+
+        Assert.HasCount(1, activity.Activities);
+        Assert.AreEqual("本地 Redis", activity.Activities[0].Detail);
+        // 账本 → 状态栏这一跳在真实运行时由 Dispatcher.Post 完成(见 WireBackgroundActivity),
+        // 无界面用例里没有调度器,所以这里直接喂一次,验证的是"有活动 ⇒ 圆环可见"这条映射。
+        vm.StatusBar.ApplyBackgroundActivities(activity.Activities);
+        Assert.IsTrue(vm.StatusBar.HasBackgroundActivity, "右下角圆环这段时间必须是可见的。");
+
+        gate.SetResult(new StubWorkspaceDocument());
+        Assert.IsNotNull(await opening);
+
+        Assert.IsEmpty(activity.Activities, "连上之后这条活动要销账,圆环不能一直转。");
+    }
+
+    [TestMethod]
+    [TestCategory("UI")]
+    public void ReplaceDocument_KeepsTheSlotAndTheActiveTabOfTheOneItReplaces()
+    {
+        var workspace = new DockWorkspace();
+        var left = new ConnectingDocument(new() { Name = "左", Host = "a" }, "SFTP");
+        var middle = new ConnectingDocument(new() { Name = "中", Host = "b" }, "SFTP");
+        var right = new ConnectingDocument(new() { Name = "右", Host = "c" }, "SFTP");
+        workspace.AddDocument(left);
+        workspace.AddDocument(middle);
+        workspace.AddDocument(right);
+        // 用户在等连接时切去了别的标签:换手不该把焦点抢回来。
+        workspace.ActivateDocument(left);
+        var replacement = new ConnectingDocument(new() { Name = "换上来的", Host = "d" }, "FTP");
+        var removed = new List<DockDocument>();
+        var added = new List<DockDocument>();
+        workspace.DocumentRemoved += removed.Add;
+        workspace.DocumentAdded += added.Add;
+
+        workspace.ReplaceDocument(middle, replacement);
+
+        Assert.AreEqual(1, workspace.PrimaryGroup.Documents.IndexOf(replacement));
+        Assert.DoesNotContain(middle, workspace.PrimaryGroup.Documents);
+        Assert.AreSame(left, workspace.ActiveDocument, "被换掉的不是活动标签,焦点就不该动。");
+        // 视图层的内容控件缓存靠这两条事件收放,漏一条就是一个再也回收不掉的旧视图。
+        Assert.AreSequenceEqual([middle], removed);
+        Assert.AreSequenceEqual([replacement], added);
+    }
+}

--- a/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/TerminalTabViewModelTests.cs
@@ -429,4 +429,28 @@ public class TerminalTabViewModelTests
 
         Assert.IsTrue(await _vm.CopyErrorCommand.CanExecute.FirstAsync());
     }
+
+    /// <summary>
+    /// 标签在握手开始前就建好,这中间正文本是一片空白终端 —— 链路一慢就看不出自己
+    /// 到底点没点上(#385 反馈)。三种非正常态现在各有各的画面,且互不重叠。
+    /// </summary>
+    [TestMethod]
+    [TestCategory("TerminalTab")]
+    public void ConnectingOverlay_CoversTheGapBetweenTabCreationAndHandshake()
+    {
+        _vm.Profile = new() { Name = "生产库", Host = "db.example", Port = 22 };
+
+        _vm.ConnectionStatus = SessionStatus.Connecting;
+        Assert.IsTrue(_vm.ShowConnectingOverlay, "连接中要有覆盖层,不能是一片空白终端。");
+        Assert.IsFalse(_vm.ShowDisconnectedOverlay, "两个覆盖层不能同时出现。");
+        Assert.Contains("生产库", _vm.ConnectingOverlayTitle, "标题指名道姓说在连哪一台。");
+
+        _vm.ConnectionStatus = SessionStatus.Connected;
+        Assert.IsFalse(_vm.ShowConnectingOverlay, "连上之后立刻让位给终端正文。");
+        Assert.IsFalse(_vm.ShowDisconnectedOverlay);
+
+        _vm.MarkConnectionFailed("Connection refused");
+        Assert.IsFalse(_vm.ShowConnectingOverlay);
+        Assert.IsTrue(_vm.ShowDisconnectedOverlay, "失败之后换成失败覆盖层。");
+    }
 }

--- a/tests/VelaShell.Tests/ViewModels/WorkspaceConnectionFailureTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/WorkspaceConnectionFailureTests.cs
@@ -10,10 +10,12 @@ namespace VelaShell.Tests.ViewModels;
 /// <summary>
 /// 工作台连接(Redis 等由插件全权渲染界面的类型)连不上时**必须有提示**。
 /// <para>
-/// 这条路径与 SSH 的关键差别:连不上就没有标签页,失败没有地方可画 —— 只写状态栏的话
-/// 用户看到的是"点了连接,什么都没发生"。本机没起 Redis 时点开一条 Redis 会话正是这个样子,
-/// 这组用例守的就是那扇提示框还在。
+/// 这条路径原先与 SSH 有个关键差别:标签页要连上才建,连不上就没有标签,失败没有地方可画,
+/// 于是只能弹一扇模态框。#385 之后标签在握手**开始前**就建好(<see cref="ConnectingDocument" />),
+/// 失败就落回它自己那个标签里 —— 与终端标签页内的失败覆盖层同一条纪律(设计 yxjmg),
+/// 不再拿模态框挡住用户手上正在做的别的事。
 /// </para>
+/// <para>这组用例守的就是:失败**有地方看**,而且看的是那个标签,不是一扇框。</para>
 /// </summary>
 [TestClass]
 public sealed class WorkspaceConnectionFailureTests
@@ -58,10 +60,10 @@ public sealed class WorkspaceConnectionFailureTests
     }
 
     /// <summary>
-    /// 端点不可达(本机没起 Redis):不开标签页,但要把原因报到提示钩子上。
+    /// 端点不可达(本机没起 Redis):不开工作台文档,失败留在那个「连接中」占位标签上。
     /// </summary>
     [TestMethod]
-    public async Task ConnectionRefused_ReportsTheFailure_AndOpensNoDocument()
+    public async Task ConnectionRefused_LeavesTheFailureOnItsOwnTab()
     {
         (MainWindowViewModel vm, SessionProfile profile) =
             Arrange(new ProtocolConnectionException("连不上 127.0.0.1:6379:Connection refused"));
@@ -75,15 +77,25 @@ public sealed class WorkspaceConnectionFailureTests
         PluginWorkspaceDocument? document = await vm.OpenWorkspaceDocumentForProfileAsync(profile);
 
         Assert.IsNull(document);
-        Assert.HasCount(1, reported);
-        Assert.Contains("Connection refused", reported[0]);
+        // 有地方可画之后就不再弹模态框(与终端标签同口径)。
+        Assert.IsEmpty(reported);
+        ConnectingDocument placeholder = SoleConnectingDocument(vm);
+        Assert.IsTrue(placeholder.HasError, "连不上之后占位标签要转成失败卡片。");
+        Assert.Contains("Connection refused", placeholder.OverlayDetail);
         // 匿名连接(Redis 常态)不该拼出 "@127.0.0.1:6379" 这种前面缺了一截的目标。
-        Assert.Contains("127.0.0.1:6379", reported[0]);
-        Assert.DoesNotContain("@127.0.0.1", reported[0]);
+        Assert.Contains("127.0.0.1:6379", placeholder.OverlayDetail);
+        Assert.DoesNotContain("@127.0.0.1", placeholder.OverlayDetail);
         // 状态栏与 LastConnectionError 仍是同一条消息:插件代开会话那条路径靠它区分
         // "没连上"与"人不同意"(见 HostSessionOpener)。
-        Assert.AreEqual(reported[0], vm.LastConnectionError);
-        Assert.IsEmpty(vm.Layout.AllDocuments());
+        Assert.AreEqual(placeholder.OverlayDetail, vm.LastConnectionError);
+    }
+
+    /// <summary>取出工作区里唯一那个「连接中」占位标签。</summary>
+    private static ConnectingDocument SoleConnectingDocument(MainWindowViewModel vm)
+    {
+        ConnectingDocument[] placeholders = [.. vm.Layout.AllDocuments().OfType<ConnectingDocument>()];
+        Assert.HasCount(1, placeholders);
+        return placeholders[0];
     }
 
     /// <summary>
@@ -102,11 +114,11 @@ public sealed class WorkspaceConnectionFailureTests
     }
 
     /// <summary>
-    /// 三次凭据都没过之后,循环走完了也要报一次 —— 否则用户对着密码框输三遍,
-    /// 得到的是一片安静。
+    /// 三次凭据都没过之后,循环走完了最后一条原因也要落到标签上 —— 否则用户对着密码框
+    /// 输三遍,得到的是一片安静。
     /// </summary>
     [TestMethod]
-    public async Task ExhaustedAuthenticationRetries_ReportsTheLastFailure()
+    public async Task ExhaustedAuthenticationRetries_LeavesTheLastFailureOnItsOwnTab()
     {
         (MainWindowViewModel vm, SessionProfile profile) =
             Arrange(new ProtocolAuthenticationException("WRONGPASS 口令不对"));
@@ -118,18 +130,13 @@ public sealed class WorkspaceConnectionFailureTests
             candidate.Password = "nope";
             return Task.FromResult<SessionProfile?>(candidate);
         };
-        var reported = new List<string>();
-        vm.ConnectionFailureReporter = (_, message) =>
-        {
-            reported.Add(message);
-            return Task.CompletedTask;
-        };
 
         Assert.IsNull(await vm.OpenWorkspaceDocumentForProfileAsync(profile));
 
         Assert.AreEqual(3, prompts);
-        Assert.HasCount(1, reported);
-        Assert.Contains("WRONGPASS", reported[0]);
+        ConnectingDocument placeholder = SoleConnectingDocument(vm);
+        Assert.IsTrue(placeholder.HasError);
+        Assert.Contains("WRONGPASS", placeholder.OverlayDetail);
     }
 
     /// <summary>
@@ -154,5 +161,7 @@ public sealed class WorkspaceConnectionFailureTests
 
         Assert.AreEqual(0, reports);
         Assert.IsNull(vm.LastConnectionError);
+        // "不连了"也要把占位标签收走 —— 留下一个空壳等于用户取消了个寂寞。
+        Assert.IsEmpty(vm.Layout.AllDocuments());
     }
 }

--- a/tests/VelaShell.Tests/Views/ConnectingDocumentViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ConnectingDocumentViewUiTests.cs
@@ -1,0 +1,130 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Controls.Controls;
+using VelaShell.Core.Localization;
+using VelaShell.Core.Models;
+using VelaShell.Docking;
+using VelaShell.Localization;
+using VelaShell.Views;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 「连接中」占位视图真的画得出来。
+/// <para>
+/// 这一条必须**渲染**而不是只读视图模型:编译期的 AXAML 校验拦不住动态资源缺失
+/// (<c>{StaticResource Icon.*}</c> 写错一个键、令牌改名)—— 那些要到真正加载这张
+/// 界面时才炸,而它恰好只在"连接慢"的时候才会被看到,平时点一下就过去了,
+/// 最容易带着一个加载不出来的加载界面发版。
+/// </para>
+/// <para>
+/// body 必须同步 + <c>return Task.CompletedTask</c> —— 传 async lambda 会绑到
+/// <c>Dispatch(Func&lt;TResult&gt;)</c>,断言一条都不会跑却全绿。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("UI")]
+public sealed class ConnectingDocumentViewUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _)
+    {
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(ConnectingDocumentViewUiTests).Assembly);
+        LocalizedStrings.Instance.Attach(new LocalizationService());
+    }
+
+    [TestMethod]
+    public void ConnectingState_ShowsASpinningRingAndTheSessionName()
+    {
+        OnUi(() =>
+        {
+            var document = new ConnectingDocument(
+                new() { Name = "本地 Redis", Host = "127.0.0.1", Port = 6379 }, "Redis");
+
+            WithView(document, view =>
+            {
+                CircularProgressRing[] rings = [.. VisibleOfType<CircularProgressRing>(view)];
+                Assert.HasCount(1, rings, "连接中要有且只有一圈在转的进度环。");
+                Assert.IsTrue(rings[0].IsIndeterminate, "进度不可知 —— 别编一条假进度条。");
+                Assert.Contains(
+                    "本地 Redis",
+                    string.Join('\n', VisibleOfType<TextBlock>(view).Select(t => t.Text)),
+                    "卡片上要指名道姓说在连哪一台。");
+            });
+        });
+    }
+
+    [TestMethod]
+    public void FailedState_SwapsTheRingForTheReasonAndTwoWaysOut()
+    {
+        OnUi(() =>
+        {
+            var document = new ConnectingDocument(
+                new() { Name = "本地 Redis", Host = "127.0.0.1", Port = 6379 }, "Redis");
+            document.MarkFailed("连不上 127.0.0.1:6379:Connection refused");
+
+            WithView(document, view =>
+            {
+                Assert.IsEmpty(VisibleOfType<CircularProgressRing>(view), "已经失败了就别再转了。");
+                Assert.Contains(
+                    "Connection refused",
+                    string.Join('\n', VisibleOfType<SelectableTextBlock>(view).Select(t => t.Text)),
+                    "失败原因要能划选、Ctrl+C 拿走。");
+                // 「重新连接」与「关闭标签页」—— 与终端标签页内的失败覆盖层同两个出口。
+                Assert.HasCount(2, VisibleOfType<Button>(view));
+            });
+        });
+    }
+
+    [TestMethod]
+    public void CancelButton_RaisesTheCancelRequest()
+    {
+        OnUi(() =>
+        {
+            var document = new ConnectingDocument(
+                new() { Name = "本地 Redis", Host = "127.0.0.1", Port = 6379 }, "Redis");
+            int cancels = 0;
+            document.CancelRequested = () => cancels++;
+
+            WithView(document, view =>
+            {
+                Button cancel = VisibleOfType<Button>(view).Single();
+                cancel.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+
+                Assert.AreEqual(1, cancels, "覆盖层上的「取消」要把撤销意图发出来。");
+            });
+        });
+    }
+
+    private static IEnumerable<T> VisibleOfType<T>(Visual root) where T : Visual =>
+        root.GetVisualDescendants().OfType<T>().Where(v => v.IsEffectivelyVisible);
+
+    private static void WithView(ConnectingDocument document, Action<ConnectingDocumentView> body)
+    {
+        var view = (ConnectingDocumentView)document.CreateView();
+        var window = new Window { Width = 900, Height = 600, Content = view };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            body(view);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+}

--- a/tests/VelaShell.Tests/Views/FlyoutPresenterStyleTests.cs
+++ b/tests/VelaShell.Tests/Views/FlyoutPresenterStyleTests.cs
@@ -1,0 +1,103 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 浮层外壳(<see cref="FlyoutPresenter" />)必须走令牌。
+/// <para>
+/// Fluent 默认的 `FlyoutPresenterBackground` 是一个写死的近黑色,**不在**本项目的令牌体系里:
+/// 九套主题换来换去它岿然不动,亮色主题下就是一块突兀的黑砖(用户反馈:"纯黑色背景有点太丑,
+/// 和整体主题不太搭")。状态栏后台任务浮层的内容是裸 StackPanel,外观全靠这层 presenter,
+/// 首当其冲。
+/// </para>
+/// <para>
+/// 顺带钉住两条样式的**先后**:`.bare` 必须排在基础样式之后才盖得住它 —— 同优先级的样式
+/// 按声明顺序后者胜出,写反了会话树与快捷命令那两个浮层就会变回"两层边"。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("DialogButtonStyle")]
+public sealed class FlyoutPresenterStyleTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    // 共用全程序集的宿主(见 VelaHeadlessApp):不能各起各的 App。
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(FlyoutPresenterStyleTests).Assembly);
+
+    [TestMethod]
+    public void PlainFlyout_TakesItsChromeFromTheThemeTokens()
+    {
+        OnUi(() =>
+        {
+            var presenter = new FlyoutPresenter { Content = new TextBlock { Text = "后台任务" } };
+
+            WithWindow(presenter, () =>
+            {
+                Assert.AreEqual(Brush("VelaBgSurface"), presenter.Background,
+                    "浮层底色必须是令牌,否则换主题它纹丝不动。");
+                Assert.AreEqual(Brush("VelaBorderSecondary"), presenter.BorderBrush);
+                Assert.AreEqual(new Thickness(1), presenter.BorderThickness);
+                Assert.AreEqual(new CornerRadius(6), presenter.CornerRadius,
+                    "与右键菜单(MenuFlyoutPresenter)同一个圆角,两者看起来才是同一个产品。");
+                // Fluent 给了 MinWidth 下限,窄浮层会被平白撑宽。
+                Assert.AreEqual(0d, presenter.MinWidth);
+            });
+        });
+    }
+
+    [TestMethod]
+    public void BareFlyout_StaysStrippedSoTheContentBorderIsTheOnlyEdge()
+    {
+        OnUi(() =>
+        {
+            var presenter = new FlyoutPresenter { Content = new TextBlock { Text = "会话树" } };
+            presenter.Classes.Add("bare");
+
+            WithWindow(presenter, () =>
+            {
+                Assert.AreEqual(Brushes.Transparent, presenter.Background,
+                    "bare 必须盖住基础样式 —— 盖不住就是内容 Border 外面再套一圈框。");
+                Assert.AreEqual(new Thickness(0), presenter.BorderThickness);
+                Assert.AreEqual(new CornerRadius(0), presenter.CornerRadius);
+                Assert.AreEqual(new Thickness(0), presenter.Padding);
+            });
+        });
+    }
+
+    private static void WithWindow(Control content, Action body)
+    {
+        var window = new Window { Content = content };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            body();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static IBrush Brush(string key) =>
+        Application.Current!.TryGetResource(key, ThemeVariant.Dark, out object? value) && value is IBrush brush
+            ? brush
+            : throw new AssertFailedException($"画刷令牌 {key} 不存在");
+
+    private static void OnUi(Action body) =>
+        _session.Dispatch(
+            () =>
+            {
+                body();
+                return Task.CompletedTask;
+            },
+            CancellationToken.None).GetAwaiter().GetResult();
+}


### PR DESCRIPTION
Closes #385

#385 报的是 SFTP 面板,顺着复现路径查下去,底下是同一件事:**「连接还没成」这一态在界面上几乎没有表示**。

## 一、#385:新标签页里残留上一个会话的文件浏览器

`RebindFileBrowser` 对「没有 SFTP 会话」的标签有两条分支,处理方式却不一样 —— 本地终端/插件协议**换成隐藏的空占位**,而 `tab.SessionId == Guid.Empty` **直接 return**。新开的 SSH 标签正好落在第二条:会话 id 要到握手完成才由 `RunHandshakeAsync` 赋值,而 `AddDocument` 的激活先到,于是 `FileBrowser` 仍是上一个会话那个可见的实例,直到连上才被换掉。

三条并成一个判断,一律换占位。上一个面板不 `Detach`(仍按其会话留在缓存里),开关状态也仍记在标签上,切回去照旧恢复 —— 收起的只是「当前这一屏」,不是那个标签的记忆。

> 上一版加本地终端分支时留的注释其实已经点破过这件事(「不能靠下面那句 `SessionId == Guid.Empty` 兜底 —— 它是 return 而不是换占位」),只是没顺手改掉。

## 二、顺带查出来的:文档型连接是字面意义上的「点了没反应」

| 路径 | 改之前点击后立刻看到什么 |
| --- | --- |
| SSH 终端标签 | 标签出现了、页签圆点变黄,但**正文是一片空白终端**(`Connecting` 这一态一直没有覆盖层) |
| 独立 SFTP / FTP / 插件协议(S3…)/ 插件工作台(Redis…) | **什么都没有** —— 四处的 `AddDocument` 全写在 `OpenSessionAsync` 返回**之后** |
| 资源管理器树圆点 | 也只在成功后 `TrackDocumentSession`,连接期间不变黄 |
| 右下角圆环 | 机制齐全,但**只有插件装载与配置同步登记**,连接路径一条都没有 |

### 标签先建,再去握手

新增 `ConnectingDocument`(+ 视图 + 标签项):点击那一刻就进工作区,连上之后由新增的 `DockWorkspace.ReplaceDocument` **原位**换成真文档。

原位换而不是先 Remove 再 Add —— 后者永远追加到主组末尾,标签会从原地跳到最右边;而且旧文档若不是当前激活的(等连接时切去了别的标签),Add 还会把焦点抢回来。

四条路径的连接流程本来一模一样,界面表示因此收进一个 `DocumentConnectUi`。插件那两条的占位标签建在**解析协议之前** —— 惰性激活插件往往才是这条路上最慢的一步。

- **取消**:占位标签的「取消」、标签 ×、`Ctrl+W`、右键关闭全部收敛到 `DocumentClosed` 一个点,取消一路传进插件的握手。
- **失败**:占位标签留在原地换成失败卡片(原因 + 重新连接 + 关闭标签页)。

### ⚠️ 一处刻意的行为变更

**文档型连接失败不再弹模态框。** 终端标签早就把连接失败从全局对话框改成了标签页内的覆盖层(设计 yxjmg);文档型标签以前弹框,只是因为「连不上就没有标签,失败没有地方可画」—— 而现在有了。`WorkspaceConnectionFailureTests` 两条用例已改成钉新契约。

### 其余

- 终端标签补 `ShowConnectingOverlay`,与断开覆盖层同一张卡片。三种非正常态现在各有各的画面,互不重叠。
- 右下角圆环接上 SSH 首连/重连、插件终端打开/重连、四条文档型路径、插件面板打开。**等用户输入的时候不登记** —— 凭据框与证书框是在等人不是等网络,圆环继续转就是在撒谎。
- 顺带修掉一处泄漏:收尾用的 `DisconnectAsync` 原先带着调用方的取消令牌,而那正是它已经取消的时刻 —— 清理动作自己取消掉,留下一条没人关的 SSH 连接。抽成 `DisconnectQuietlyAsync`。

**边界(没做的)**:插件的惰性激活由 `PluginManager` 自己登记;面板打开后插件再去拉自己的数据那段宿主看不见,没有给它编一个转圈。

## 三、后台任务浮层走令牌(用户反馈)

浮层外壳吃的是 Fluent 默认的 `FlyoutPresenterBackground` —— 一个**写死的近黑色,不在 `Vela*` 令牌里**,所以 `ThemeTokenApplier` 换主题时换不到它,九套主题下它岿然不动。给 `FlyoutPresenter` 一条走令牌的基础样式(与 `MenuFlyoutPresenter` 同一套值),`.bare` 保持原样但**必须排在其后**(同优先级样式按声明顺序后者胜出)。

顺带:标题加发丝线分隔、每条活动自带一圈 12px 进度环、浮层上抬 8px 不再压着状态栏。

## 验收

`dotnet test VelaShell.slnx` 全绿 —— **3192 通过 / 0 失败 / 19 跳过,0 警告**。

新增 11 条用例,其中三条是**渲染**用例:编译期的 AXAML 校验拦不住 `{StaticResource Icon.*}` 写错或令牌改名,而「连接中」这张界面恰好只在链路慢时才会被看到 —— 最容易带着一个加载不出来的加载界面发版。

两条关键用例都做过**反向验证**(把修复改回去,用例确实变红):#385 那条、以及浮层令牌那条。

浮层上抬的 8px 是纯观感数值,不写用例钉(同 `DialogButtonStyleTests` 的立场);方向经 headless 探针实测确认(`0 → -8` 时弹出层 Y 从 158 变 150),探针用完即删。

## 文档

按 AGENTS.md 同步开了 velashell-docs 的 PR,两边一起合:**VelaShellLabs/velashell-docs#23**

本仓 `DESIGN.md` 补 §5.2(Flyout 外壳的两种画法、ProgressRing)与 §5.2b(等待态:标签先于会话、失败落在自己的标签里、等人的时候不转圈);`plan.md` 第 45–47 条。

## 复核时请留意

- 那处**行为变更**(失败不再弹模态框)是否符合预期。
- 8px 上抬与发丝线浓淡是观感数值,建议开一眼实际看看 —— 我只做了静态样式与渲染层面的验证,没有跑 GUI 截图比对。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QydefQQ5JJmyyEUNCpVSp6

