### PR TITLE
关闭「连接中」标签时取消后台握手

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2007,3 +2007,69 @@ SessionId == Guid.Empty 兜底 —— 它是 return 而不是换占位」),只�
 方向不是猜的:写了个一次性探针在 headless 里真开一次浮层,量出 `0 → -8` 时弹出层在窗口内的
 Y 从 158 变成 150(偏移走屏幕坐标,正 Y 朝下,故负值向上),确认之后把探针删掉。
 这类纯观感的数值不写用例钉 —— 该由眼睛拍板(同 DialogButtonStyleTests 的立场)。
+
+## 48. 2026-09-07 关掉「连接中」的标签,连接就该停下(用户反馈)
+
+用户反馈:关闭标签页时后台仍在继续连接,右下角「后台任务」里那条「连接中 Debian13(测试服务器)」
+赖着不走,过一会儿还要弹一句连不上的异常提示。
+
+### 一、根因:终端标签这边一直没有那根"取消绳"
+
+#385 之后,连接的四种文档型入口(独立 SFTP、FTP、插件协议、插件工作台)共用
+`DocumentConnectUi`,它握着一个链接到调用方令牌的 `CancellationTokenSource`,
+`ConnectingDocument` 一被关掉(六个关闭入口都汇到 `DockWorkspace.DocumentClosed`)就拉断它。
+
+终端标签走的是另一条路:`CreateConnectingTab` 先建标签、`RunHandshakeAsync` 再握手,
+中间只传了**调用方的**令牌 —— 而调用方(点一下会话树)早就返回了,那个令牌永远不会被取消。
+于是关标签只做了三件事:移走文档、拆传输、Dispose 标签;握手照旧在后台跑到底:
+
+- `RunHandshakeAsync` 里那条 `using IBackgroundActivityScope` 要等握手结束才释放,
+  右下角的圆环就一直转着一条属于已关闭标签的「连接中」;
+- 几十秒后 TCP 超时,`TryConnectProfileAsync` 的 `catch (Exception ex)` 照常
+  `Toasts.Error(...)` —— 为一个用户十几秒前就亲手关掉的标签报一句"无法连接";
+- 更隐蔽的一种:握手恰好在关标签之后成功。会话建起来了,标签却没了,那条连接
+  (连同它的端口与隧道)再没有任何界面能关掉它。
+
+### 二、修法:标签也挂一根绳,挂在同一个点上
+
+`MainWindowViewModel` 加一张 `_tabConnectCancellations`(标签 → 取消源)与三个方法:
+
+- `BeginTabConnect(tab, outer)` — 每次尝试(首连、认证重试、重连)登记一次,返回
+  「调用方令牌 ∪ 关掉这个标签」的令牌;上一轮的源先收掉,免得关标签拉的是根断绳;
+- `CancelTabConnect(tab)` — 只取消不释放。握手还在飞的时候释放取消源,底层库再往
+  这个令牌上挂回调就会撞 `ObjectDisposedException` —— 那正是"取消"被翻译成一句
+  莫名其妙的连接错误的来路;
+- `EndTabConnect(tab)` — 流程结束(连上/失败/被取消)时在 `finally` 里注销并释放。
+
+取消的触发点与文档型连接**同一个**:`OnDocumentClosed`(六个关闭入口都经过它),
+`RemoveTerminalTab`(连接失败/取消时的静默移除)再幂等地补一次。
+
+三条握手路径都改成用这根绳:`TryConnectProfileAsync` + `RunHandshakeAsync`(SSH 首连)、
+`OpenPluginTerminalForProfileAsync`(Telnet 等插件终端)、`ReconnectTabAsync`(手动与自动重连)。
+
+两处配套:
+
+- **失败分支按令牌判定,而不是按异常类型**:`catch (Exception) when (token.IsCancellationRequested)`
+  取代原先的 `catch (OperationCanceledException)`。取消在底层未必现成一个
+  `OperationCanceledException`(连接被拆掉时也可能是一句 IO 错误),按异常类型判会漏到
+  下面那条弹 Toast 的分支去 —— 用户看到的正是那句多余的"无法连接"。
+- **握手赢了竞速也要收拾**:`RunHandshakeAsync` 里握手成功之后的部分拆成
+  `CompleteHandshakeAsync`,外面包一层 `catch when (取消)` → `TeardownSshSession(session.SessionId)`。
+  重连路径同理(`established` 变量记住已建起的会话)。
+- 还有一段令牌管不到:弹凭据框的时候等的是用户不是网络,标签上还没有绳。那一段改成
+  在框返回后按「标签还在不在」(`FindDocument`)判一次 —— 关掉标签和在框上点取消是同一句话。
+
+### 三、验收
+
+`dotnet test tests/VelaShell.Tests` 通过 1242 条;新增 `ConnectingTabCancellationTests` 两条:
+
+- 握手途中关标签 → 令牌被拉断、标签撤走、`BackgroundActivityService.Activities` 清空、
+  `LastConnectionError` 与 Toast 都是空的;
+- 握手在标签关掉**之后**才回来 → 会话被 `DisconnectAsync` 拆掉,而不是留成一条孤儿连接。
+
+把 `OnDocumentClosed` 里那行 `CancelTabConnect` 注释掉,两条都红 —— 第一条会一直挂到测试超时,
+那正是这个 bug 在用户机器上的样子:握手没有人叫停。
+
+(同一轮里 `ExternalEditSessionManagerTests` 有 6 条失败,与本次改动无关:它断言
+`%TEMP%\VelaShell\remote-edit` 不存在,而本机上跑过的真实应用在那里留下了会话目录,
+`CleanupAll` 只清自己登记过的那些。改前改后同样红。)

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -165,6 +165,17 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     /// </summary>
     private readonly Dictionary<TerminalTabViewModel, IDisposable> _sessionStatusSubscriptions = [];
 
+    /// <summary>
+    /// 还在握手的终端标签 → 撤销这次握手的取消源(关标签时要拉的那根绳)。
+    /// </summary>
+    /// <remarks>
+    /// 文档型连接的这根绳挂在 <see cref="DocumentConnectUi" /> 上,终端标签这边一直没有:
+    /// 关掉一个正在连的标签只是把标签移走,握手照旧在后台跑到底 —— 右下角圆环上那条
+    /// 「连接中」赖着不走,几十秒后还要为一个早就没了的标签弹一句"无法连接"。
+    /// 登记在这里,六个关闭入口(标签 ×、Ctrl+W、右键那一族、命令面板)一并管住。
+    /// </remarks>
+    private readonly Dictionary<TerminalTabViewModel, CancellationTokenSource> _tabConnectCancellations = [];
+
     /// <summary>同步输入频道的对等转发中枢(标签右键菜单 → 同步输入)。</summary>
     private readonly SyncInputCoordinator _syncInput = new();
 
@@ -2353,6 +2364,36 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             profile,
             cancellationToken
         );
+        try
+        {
+            await CompleteHandshakeAsync(terminalTab, profile, settings, session, terminalType, cancellationToken);
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
+        {
+            // 关标签正好赶在握手完成的同一瞬间:会话已经在服务里建起来了,标签却已经没了。
+            // 不在这里拆,就留下一条谁都看不见、也永远不会被关掉的连接(端口、隧道一并挂着)。
+            TeardownSshSession(session.SessionId);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// 握手成功之后的收尾:开 shell 通道、挂上传输、拉起日志/监视/文件面板。
+    /// 与 <see cref="RunHandshakeAsync" /> 分开只是为了让"取消就拆会话"那层
+    /// try 包住全部会用到这条会话的步骤。
+    /// </summary>
+    private async Task CompleteHandshakeAsync(
+        TerminalTabViewModel terminalTab,
+        SessionProfile profile,
+        AppSettings settings,
+        SshSession session,
+        TerminalType terminalType,
+        CancellationToken cancellationToken
+    )
+    {
+        // 标签可能在握手的最后一刻被关掉:此时开 shell 通道等于给一个已经不存在的
+        // 标签接线,交给上面那层 catch 去拆会话。
+        cancellationToken.ThrowIfCancellationRequested();
         ISshClientWrapper client =
             _sshConnectionService!.GetClient(session.SessionId)
             ?? throw new InvalidOperationException("SSH client was not created for the session.");
@@ -2421,7 +2462,15 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         // 拿 Telnet 的主机端口去做 SSH 握手 —— 表现为"重连一次就报认证失败"。
         if (tab.Profile is { ConnectionType: ConnectionType.Plugin } pluginProfile)
         {
-            await ReconnectPluginTerminalAsync(tab, pluginProfile, cancellationToken).ConfigureAwait(true);
+            CancellationToken pluginToken = BeginTabConnect(tab, cancellationToken);
+            try
+            {
+                await ReconnectPluginTerminalAsync(tab, pluginProfile, pluginToken).ConfigureAwait(true);
+            }
+            finally
+            {
+                EndTabConnect(tab);
+            }
             return;
         }
         if (
@@ -2439,6 +2488,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         // 用户多半不在那个标签上。
         using IBackgroundActivityScope? activity =
             _backgroundActivity?.Begin(Strings.Connecting, ProfileDisplayName(tab.Profile));
+        // 重连同样是"关标签就不连了":自动重连多半在后台发生,用户看见的往往只有
+        // 右下角那条「连接中」,关掉标签是他能表达"不要了"的唯一方式。
+        CancellationToken reconnectToken = BeginTabConnect(tab, cancellationToken);
+        SshSession? established = null;
         try
         {
             AppSettings settings = _settingsService is not null
@@ -2448,19 +2501,20 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             TerminalType terminalType = TerminalTypeExtensions.FromTermName(SessionTerminalSettings.TerminalType(tab.Profile, settings));
             SshSession session = await _connectionWorkflowService.ConnectProfileAsync(
                 tab.Profile,
-                cancellationToken
+                reconnectToken
             );
+            established = session;
             ISshClientWrapper client =
                 _sshConnectionService.GetClient(session.SessionId)
                 ?? throw new InvalidOperationException(
                     "SSH client was not created for the session."
                 );
             // 同 RunHandshakeAsync:注入前先确认对端是 POSIX shell(#305)。首连已探过的主机命中缓存,不再发探针。
-            bool isPosixShell = await ProbePosixShellAsync(client, tab.Profile, settings, cancellationToken);
+            bool isPosixShell = await ProbePosixShellAsync(client, tab.Profile, settings, reconnectToken);
             // 同 RunHandshakeAsync:通道打开走真异步 API,UI 线程零阻塞。
             IShellStreamWrapper shellStream = await client.CreateShellStreamAsync(
                 terminalType.ToTermName(), 120, 32, 0, 0, 4096,
-                cancellationToken: cancellationToken
+                cancellationToken: reconnectToken
             );
 
             // 在新会话输出到达前做一次完全复位(RIS),使新的标语不至于附加在旧缓冲内容之后。
@@ -2487,8 +2541,14 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             UpdateStatusBarForActiveTab();
             LastConnectionError = null;
         }
-        catch (OperationCanceledException)
+        catch (Exception) when (reconnectToken.IsCancellationRequested)
         {
+            // 取消(关标签 / 调用方撤销):不报错。会话若已经建起来了就一并拆掉 ——
+            // 标签已经没了,没人会再去关它。
+            if (established is not null)
+            {
+                TeardownSshSession(established.SessionId);
+            }
             tab.MarkDisconnected();
         }
         catch (Exception ex)
@@ -2497,6 +2557,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             LastConnectionError = DescribeConnectionError(ex, tab.Profile);
             Toasts.Error(LastConnectionError);
             tab.MarkDisconnected(LastConnectionError);
+        }
+        finally
+        {
+            EndTabConnect(tab);
         }
     }
 
@@ -3085,8 +3149,51 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         }
     }
 
+    /// <summary>
+    /// 为一个「连接中」标签登记取消源:返回的令牌 = 调用方的令牌 ∪ 用户关掉这个标签。
+    /// </summary>
+    /// <remarks>
+    /// 每次尝试(首连、认证重试、重连)各登记一次;上一轮的源在这里先收掉 ——
+    /// 留着的话,关标签拉的是一根早就断了的绳。
+    /// </remarks>
+    /// <param name="tab">正在连接的标签。</param>
+    /// <param name="outer">调用方的取消令牌。</param>
+    /// <returns>本次握手要用的取消令牌。</returns>
+    private CancellationToken BeginTabConnect(TerminalTabViewModel tab, CancellationToken outer)
+    {
+        EndTabConnect(tab);
+        CancellationTokenSource cancellation = CancellationTokenSource.CreateLinkedTokenSource(outer);
+        _tabConnectCancellations[tab] = cancellation;
+        return cancellation.Token;
+    }
+
+    /// <summary>本次握手结束(连上、失败或被取消):注销并释放取消源。</summary>
+    /// <remarks>释放放在流程结束这一处,而不是取消的那一刻:握手还在飞的时候释放取消源,
+    /// 底层库再往这个令牌上挂回调就会撞上 <see cref="ObjectDisposedException" /> ——
+    /// 那正是"取消"被翻译成一句莫名其妙的连接错误的来路。</remarks>
+    /// <param name="tab">刚结束握手的标签。</param>
+    private void EndTabConnect(TerminalTabViewModel tab)
+    {
+        if (_tabConnectCancellations.Remove(tab, out CancellationTokenSource? cancellation))
+        {
+            cancellation.Dispose();
+        }
+    }
+
+    /// <summary>撤销这个标签正在进行的握手(标签被关掉时调;没在连接时是空操作)。</summary>
+    /// <param name="tab">被关掉的标签。</param>
+    private void CancelTabConnect(TerminalTabViewModel tab)
+    {
+        if (_tabConnectCancellations.TryGetValue(tab, out CancellationTokenSource? cancellation))
+        {
+            cancellation.Cancel();
+        }
+    }
+
     private void RemoveTerminalTab(TerminalTabViewModel tab, TerminalDocument document)
     {
+        // 静默移除也是"这个标签不要了":还在飞的握手一并撤掉(幂等,通常此刻已经取消过)。
+        CancelTabConnect(tab);
         StopSessionLogging(tab);
         // 防御性驱逐 SFTP 面板缓存:本路径(连接失败/取消)静默移除文档,不触发
         // DocumentClosed,若标签曾短暂连上过,缓存里的面板会悬挂。幂等,无缓存时空操作。
@@ -3201,6 +3308,14 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                     current = updated;
                 }
             }
+            // 弹凭据框的这段时间里用户可能已经把这个「连接中」标签关掉了 ——
+            // 那和在框上点取消是同一句话:不连了。取消令牌管不到这一段(此刻等的是用户
+            // 而不是网络,标签上还没有绳可拉),所以在这里按"标签还在不在"判一次。
+            if (tab is not null && FindDocument(tab) is null)
+            {
+                LastConnectionError = null;
+                return null;
+            }
             if (tab is null)
             {
                 (tab, document) = CreateConnectingTab(current, settings);
@@ -3211,14 +3326,18 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 tab.Profile = current;
                 tab.ConnectionStatus = SessionStatus.Connecting;
             }
+            // 从这里到本次尝试结束,「关掉这个标签」与调用方的令牌并联成一根绳。
+            CancellationToken connectToken = BeginTabConnect(tab, cancellationToken);
             try
             {
-                await RunHandshakeAsync(tab, current, settings, cancellationToken);
+                await RunHandshakeAsync(tab, current, settings, connectToken);
                 return tab;
             }
-            catch (OperationCanceledException)
+            catch (Exception) when (connectToken.IsCancellationRequested)
             {
-                // 用户取消(超时):撤掉这个正在连接的标签。
+                // 用户取消(关掉这个正在连的标签 / 超时):撤掉标签,不弹失败提示 ——
+                // 取消在底层未必现成一个 OperationCanceledException(连接被拆掉时也可能
+                // 是一句 IO 错误),按令牌判定才不会为一个已经没了的标签报"无法连接"。
                 if (document is not null)
                 {
                     RemoveTerminalTab(tab, document);
@@ -3250,6 +3369,11 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
 
                 // 网络/超时等失败:保留标签,标签页内显示失败覆盖层(设计 yxjmg),不弹全局框。
                 return tab;
+            }
+            finally
+            {
+                // 这一轮的绳子用完了(连上、失败、或已被拉断):注销并释放。
+                EndTabConnect(tab);
             }
         }
 
@@ -3843,14 +3967,16 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
         AppSettings settings = await LoadSettingsSnapshotAsync().ConfigureAwait(true);
         (TerminalTabViewModel tab, TerminalDocument document) =
             CreateConnectingTab(profile, settings, registration.Descriptor.DisplayName);
+        // 与 SSH 同一条纪律:关掉这个「连接中」标签就把连接撤掉(见 BeginTabConnect)。
+        CancellationToken connectToken = BeginTabConnect(tab, cancellationToken);
         try
         {
-            await AttachPluginTerminalAsync(tab, profile, registration, settings, cancellationToken)
+            await AttachPluginTerminalAsync(tab, profile, registration, settings, connectToken)
                 .ConfigureAwait(true);
             await Sidebar.RecentConnections.RefreshAsync().ConfigureAwait(true);
             return tab;
         }
-        catch (OperationCanceledException)
+        catch (Exception) when (connectToken.IsCancellationRequested)
         {
             RemoveTerminalTab(tab, document);
             return null;
@@ -3863,6 +3989,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             Toasts.Error(LastConnectionError);
             tab.MarkConnectionFailed(LastConnectionError);
             return tab;
+        }
+        finally
+        {
+            EndTabConnect(tab);
         }
     }
 
@@ -3923,8 +4053,9 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
             await AttachPluginTerminalAsync(tab, profile, registration, settings, cancellationToken)
                 .ConfigureAwait(true);
         }
-        catch (OperationCanceledException)
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
         {
+            // 取消(多半是标签被关掉了):安静收场,别为一个已经没了的标签弹失败提示。
             tab.MarkDisconnected();
         }
         catch (Exception ex)
@@ -5137,6 +5268,10 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
     private void OnDocumentClosed(TerminalDocument document)
     {
         TerminalTabViewModel tab = document.Terminal;
+        // 关掉一个还在连的标签 = 不连了。与 ConnectingDocument 同一条纪律:六个关闭入口
+        // 都汇到 DocumentClosed,取消挂在这一个点上。握手流程收到取消后自己收尾
+        // (会话若已建起就断掉),右下角圆环上那条「连接中」随之熄灭,也不再弹失败提示。
+        CancelTabConnect(tab);
         StopSessionLogging(tab);
         CloseSftpForTab(tab);
         tab.Dispose();

--- a/tests/VelaShell.Tests/ViewModels/ConnectingTabCancellationTests.cs
+++ b/tests/VelaShell.Tests/ViewModels/ConnectingTabCancellationTests.cs
@@ -1,0 +1,124 @@
+using NSubstitute;
+using VelaShell.Core.Models;
+using VelaShell.Core.Services;
+using VelaShell.Core.Ssh;
+using VelaShell.Presentation.Services;
+using VelaShell.Terminal;
+using VelaShell.ViewModels;
+
+namespace VelaShell.Tests.ViewModels;
+
+/// <summary>
+/// 关掉一个还在握手的终端标签 = 不连了。
+/// <para>
+/// 标签在握手**开始前**就建好(#17),于是"关标签"与"取消连接"之间必须有一根绳:
+/// 没有它的时候,关掉标签只是把标签移走,握手照旧在后台跑到底 —— 右下角「后台任务」
+/// 里那条「连接中」赖着不走,几十秒后还要为一个早就没了的标签弹一句"无法连接"。
+/// 这组用例守的就是这根绳:令牌被取消、圆环熄灭、不留错误提示。
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class ConnectingTabCancellationTests
+{
+    private static SessionProfile Profile() =>
+        new()
+        {
+            Name = "Debian13(测试服务器)",
+            Host = "10.0.0.9",
+            Port = 22,
+            Username = "root",
+            AuthMethod = AuthMethod.Password,
+            Password = "pass"
+        };
+
+    /// <summary>永远连不完的握手:只有令牌被取消时才结束。</summary>
+    private static void NeverCompletes(
+        IConnectionWorkflowService workflow,
+        Action<CancellationToken> observe)
+    {
+        workflow
+            .ConnectProfileAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var token = (CancellationToken)call[1];
+                observe(token);
+                await Task.Delay(Timeout.Infinite, token);
+                return null!;
+            });
+    }
+
+    /// <summary>
+    /// 握手途中关掉标签:令牌被取消、标签撤走、后台任务清空,且不弹失败提示。
+    /// </summary>
+    [TestMethod]
+    public async Task ClosingAConnectingTab_CancelsTheHandshake()
+    {
+        IConnectionWorkflowService workflow = Substitute.For<IConnectionWorkflowService>();
+        ISshConnectionService ssh = Substitute.For<ISshConnectionService>();
+        CancellationToken handshakeToken = default;
+        NeverCompletes(workflow, token => handshakeToken = token);
+        using var activity = new BackgroundActivityService();
+        var vm = new MainWindowViewModel(
+            workflow,
+            ssh,
+            () => Substitute.For<ITerminalEmulator>(),
+            backgroundActivity: activity);
+
+        Task<TerminalTabViewModel?> connecting = vm.TryConnectProfileAsync(Profile());
+
+        // 标签在握手开始前就在了,右下角也已经登记了一条「连接中」。
+        TerminalTabViewModel tab = vm.TerminalTabs.Single();
+        Assert.AreEqual(SessionStatus.Connecting, tab.ConnectionStatus);
+        Assert.AreEqual(1, activity.Activities.Count);
+
+        vm.CloseTerminalTab(tab);
+
+        Assert.IsNull(await connecting);
+        Assert.IsTrue(handshakeToken.IsCancellationRequested, "关标签必须把握手的取消令牌拉断。");
+        Assert.AreEqual(0, vm.TerminalTabs.Count());
+        // 后台任务清单里不能留下一条为已关闭标签转着的「连接中」。
+        Assert.AreEqual(0, activity.Activities.Count);
+        // 用户自己关掉的标签不该再被报一句"无法连接"。
+        Assert.IsNull(vm.LastConnectionError);
+        Assert.AreEqual(0, vm.Toasts.Toasts.Count);
+    }
+
+    /// <summary>
+    /// 取消恰好赶在握手完成之后:会话已经建起来了,标签却没了 —— 必须把它拆掉,
+    /// 否则留下一条谁都看不见、也永远不会被关掉的连接。
+    /// </summary>
+    [TestMethod]
+    public async Task HandshakeThatLandsAfterTheTabIsGone_TearsDownTheSession()
+    {
+        IConnectionWorkflowService workflow = Substitute.For<IConnectionWorkflowService>();
+        ISshConnectionService ssh = Substitute.For<ISshConnectionService>();
+        var sessionId = Guid.NewGuid();
+        var gate = new TaskCompletionSource<SshSession>(TaskCreationOptions.RunContinuationsAsynchronously);
+        workflow
+            .ConnectProfileAsync(Arg.Any<SessionProfile>(), Arg.Any<CancellationToken>())
+            .Returns(_ => gate.Task);
+        var vm = new MainWindowViewModel(workflow, ssh, () => Substitute.For<ITerminalEmulator>());
+
+        Task<TerminalTabViewModel?> connecting = vm.TryConnectProfileAsync(Profile());
+        TerminalTabViewModel tab = vm.TerminalTabs.Single();
+        vm.CloseTerminalTab(tab);
+
+        // 标签已经没了,这时候握手才回来。
+        gate.SetResult(new()
+        {
+            SessionId = sessionId,
+            ConnectionInfo = new() { Host = "10.0.0.9", Port = 22, Username = "root", AuthMethod = AuthMethod.Password },
+            Status = SessionStatus.Connected
+        });
+
+        Assert.IsNull(await connecting);
+        Assert.AreEqual(0, vm.TerminalTabs.Count());
+        Assert.IsNull(vm.LastConnectionError);
+        // 拆会话是后台线程上的事(见 TeardownSshSession),给它一小段时间落地。
+        for (int i = 0; i < 50 && workflow.ReceivedCalls().All(c => c.GetMethodInfo().Name != nameof(IConnectionWorkflowService.DisconnectAsync)); i++)
+        {
+            await Task.Delay(20);
+        }
+        await workflow.Received().DisconnectAsync(sessionId, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## 问题

关掉一个还在连接的终端标签,握手仍在后台跑到底:

- 右下角「后台任务」里那条「连接中 xxx」赖着不走(`RunHandshakeAsync` 的 `using IBackgroundActivityScope` 要等握手结束才释放);
- 几十秒后 TCP 超时,`TryConnectProfileAsync` 照常 `Toasts.Error(...)` —— 为一个用户十几秒前就亲手关掉的标签报一句"无法连接";
- 更隐蔽的一种:握手恰好在关标签**之后**成功。会话建起来了、标签却没了,那条连接(连同端口与隧道)再没有任何界面能关掉它。

## 根因

#385 之后四条文档型连接路径共用 `DocumentConnectUi`,它握着一个链到调用方令牌的 `CancellationTokenSource`,`ConnectingDocument` 一被关掉就拉断。

终端标签走的是另一条路:`CreateConnectingTab` 先建标签、`RunHandshakeAsync` 再握手,中间只传了**调用方的**令牌 —— 而调用方(点一下会话树)早就返回了,那个令牌永远不会被取消。关标签只做了移走文档、拆传输、Dispose 标签三件事。

## 改法

- `MainWindowViewModel` 新增 `_tabConnectCancellations`(标签 → 取消源)与 `BeginTabConnect` / `CancelTabConnect` / `EndTabConnect`:握手令牌 =「调用方令牌 ∪ 关掉这个标签」。
- 取消触发点与文档型连接**同一个**:`OnDocumentClosed`(标签 ×、Ctrl+W、右键那一族、命令面板六个入口都汇到它),`RemoveTerminalTab` 幂等补一次。
- 三条握手路径全部接上:SSH 首连、插件终端(Telnet…)、手动与自动重连。
- **失败分支按令牌判定**(`catch (Exception) when (token.IsCancellationRequested)`)而不是按 `OperationCanceledException` —— 连接被拆时底层未必抛 OCE,按异常类型判会漏进弹 Toast 的分支,那正是那句多余的"无法连接"的来路。
- **取消只 `Cancel` 不 `Dispose`**,释放挪到流程结束的 `finally`:握手还在飞时释放取消源,底层库再往这个令牌挂回调就会撞 `ObjectDisposedException`。
- 顺带两个竞速漏洞:握手赢了竞速时 `TeardownSshSession` 拆掉会话(握手成功后的部分为此拆成 `CompleteHandshakeAsync`);弹凭据框期间关标签(那段令牌管不到,此刻等的是用户而不是网络)按「标签还在不在」判一次。

## 验收

- 新增 `ConnectingTabCancellationTests` 两条:握手途中关标签 → 令牌被拉断、标签撤走、`BackgroundActivityService.Activities` 清空、`LastConnectionError` 与 Toast 均为空;握手在标签关掉之后才回来 → 会话被 `DisconnectAsync` 拆掉,而不是留成孤儿连接。把 `OnDocumentClosed` 里那行 `CancelTabConnect` 注释掉,两条都红(第一条一直挂到测试超时 —— 那正是这个 bug 在用户机器上的样子)。
- `dotnet build VelaShell.slnx` 0 警告 0 错误;`VelaShell.Tests` 1242 通过。
- 另有 6 条 `ExternalEditSessionManagerTests` 失败,与本次改动无关:它断言 `%TEMP%\VelaShell\remote-edit` 不存在,而本机跑过的真实应用在那里留下了会话目录(`CleanupAll` 只清自己登记过的)。`git stash` 后复跑确认改前改后同样红。
- `plan.md` 补 §48。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QydefQQ5JJmyyEUNCpVSp6
