### PR TITLE
隔离插件启动:管道先连,并把连接/握手/激活各自的超时说清楚

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2073,3 +2073,76 @@ Y 从 158 变成 150(偏移走屏幕坐标,正 Y 朝下,故负值向上),确认�
 (同一轮里 `ExternalEditSessionManagerTests` 有 6 条失败,与本次改动无关:它断言
 `%TEMP%\VelaShell\remote-edit` 不存在,而本机上跑过的真实应用在那里留下了会话目录,
 `CleanupAll` 只清自己登记过的那些。改前改后同样红。)
+
+## 49. 2026-09-07 CI 的 ubuntu 作业偶发失败:隔离插件"连不上"被报成"激活超时"
+
+用户反馈:Ubuntu 的构建验证偶尔失败,有时又能过。失败的永远是同一条 ——
+`IsolatedPluginTests.IsolatedPlugin_ActivatesInChildProcess_AndDeactivatesCleanly`,
+报 `Activation timed out after 30s`。
+
+### 一、报出来的那句话是错的,它把人送错了方向
+
+CI 日志里那条用例的耗时是 **10 秒**,而报错说的是 30 秒 —— 两个数对不上,说明超时的
+根本不是激活。`PluginProcessClient.StartAsync` 分三段等:
+
+| 阶段 | 原来的预算 |
+| --- | --- |
+| 拉起进程 → 管道连上 | 写死 10 秒 |
+| 握手往返 | 写死 10 秒 |
+| 插件 `ActivateAsync` | `options.ActivationTimeout`(用例里 30 秒) |
+
+第一段用的是 `CancellationTokenSource.CancelAfter`,超时逸出的是一个裸
+`OperationCanceledException`;而 `PluginManager.ActivateAsync` 的 catch 把**任何**
+`OperationCanceledException` 都写成 `Activation timed out after {ActivationTimeout}s`。
+于是一次 10 秒的连接超时,顶着"激活超时 30 秒"的名字出现在报告里:阶段是错的,秒数也是错的。
+
+### 二、根因:子进程在连管道之前,先去建了一整套 Avalonia
+
+`VelaShell.PluginHost/Program.cs` 的顺序是「`SetupWithoutStarting()` → 起后台线程 →
+连管道」。也就是说,那 10 秒的连接窗口里,子进程有一大段时间在做与连接毫无关系的事:
+初始化 Avalonia。Linux 上这一段尤其贵 —— 连 X11、初始化字体子系统(冷机器上要建
+fontconfig 缓存),而 `UsePlatformDetect` 之后还要探测 GLX/EGL,在 CI 的虚拟屏
+(xvfb + llvmpipe)上这一步能慢到秒级。
+
+为什么只有 ubuntu、而且只是偶发:`dotnet test VelaShell.slnx` **并行**跑八个测试程序集,
+这条用例恰好落在测试步骤刚开始、几个程序集同时冷启动的那半分钟里,子进程要和它们抢核。
+机器闲的时候一两秒就连上了,忙的时候就撞破 10 秒 —— 这正是"有时又能过"的来源。
+(Windows 与 macOS 同一次全绿:Windows 那段初始化便宜得多,macOS runner 是带图形会话的真机。)
+
+### 三、三处改动
+
+**1. 管道先连,Avalonia 后建**(`Program.cs`)。连接是纯 IO,不碰 Avalonia,也就不必等谁:
+`Main` 里先发起 `ConnectAsync`(不等它完成),再 `SetupWithoutStarting()`,握手与其余 RPC
+仍旧排在 Avalonia 就绪之后 —— 它们要在派发线程上开窗口,那确实得等。
+本机实测:连接从 356~512ms 降到 142~163ms,差的那 200~350ms 就是 Avalonia 初始化,
+在 Linux 冷机器上正是会膨胀成好几秒的那一段。
+
+**2. 启动预算与激活时限拆成两个数**(`PluginManagerOptions.IsolatedStartupTimeout`,默认 30 秒)。
+两者量级根本不同:一边是"插件的一个方法该多快返回"(长了就是挂死),另一边是
+"一个 .NET 进程冷启动 + 建 Avalonia 该多慢"。合成一个数只能取大的那个,等于把插件挂死的
+判定也一并放宽。连接与握手现在共花这一个预算(连接用掉多少,握手就少多少,握手保底 5 秒)。
+
+**3. 每一段超时都自报家门**。连接超时抛
+`Plugin host process {pid} did not connect to the host pipe within {n}s`,握手超时抛
+`connected but did not complete the handshake within {n}s`;`ActivateAsync` 也把
+"宿主正在关"与"真的超时"分开写。成功路径补一条 Trace:
+`connected in {x}ms, handshake done at {y}ms` —— 下次再慢,日志直接说得出慢在哪一段。
+
+顺带修掉一个潜伏的错误分支:原先按"`WhenAny` 里哪条支路先完成"判进程是否夭折,而预算到点时
+两条支路是**一起**被取消的,被取消的 `exited` 与真的退出长得一模一样,此时去读 `ExitCode`
+会撞上「进程尚未退出」的异常 —— 一次超时会被报成一句风马牛不相及的错。判据改成 `HasExited`。
+
+顺带一件同源的事:`VELA_PLUGIN_GPU != 1` 时的软件渲染原先**只配了 Win32 那一份**,
+Linux 与 macOS 上默认仍走 GPU 后端。这条策略("插件面板不值得为它映射一整套显卡驱动")
+与操作系统无关,补齐 `X11PlatformOptions` 与 `AvaloniaNativePlatformOptions`。
+
+### 四、验收
+
+`dotnet test VelaShell.slnx`(排除 Docker/CrossPlatform)全绿:3194 通过。
+新增 `IsolatedPlugin_StartupBudgetExhausted_BlamesTheConnectPhase` —— 把启动预算压到 1ms,
+断言错误里写的是 `did not connect` 而**不是** `Activation timed out`。把连接阶段那个
+`catch` 的条件改成永假(即恢复"逸出裸 OperationCanceledException"的旧行为),这条立刻红,
+且红的方式与 CI 上一模一样。
+
+隔离插件那几条用例把 `IsolatedStartupTimeout` 显式放到 60 秒:这个数只决定"等多久才判失败",
+健康时一分钱不花,给足了才不会把"机器忙"判成"插件坏"。

--- a/src/VelaShell.Infrastructure/Plugins/Isolated/PluginProcessClient.cs
+++ b/src/VelaShell.Infrastructure/Plugins/Isolated/PluginProcessClient.cs
@@ -115,10 +115,13 @@ internal sealed class PluginProcessClient : IAsyncDisposable
     /// </summary>
     public static async Task<PluginProcessClient> StartAsync(PluginManifest manifest, string entryPath,
         PluginContext context, string hostVersion, string dataDirectory,
-        TimeSpan activationTimeout, CancellationToken cancellationToken,
+        TimeSpan activationTimeout, TimeSpan startupTimeout, CancellationToken cancellationToken,
         Func<Task<IReadOnlyList<ThemeTokenDto>>>? themeTokens = null,
         IPluginEmbedHost? embedHost = null, bool waitForDebugger = false)
     {
+        // 启动预算按阶段递减地花:连上占多少,握手就少多少。两段各给一个满额的常数,
+        // 等于把上限悄悄翻了一倍,超时判定也就说不清自己在守什么。
+        var startup = Stopwatch.StartNew();
         string pipeName = CreatePipeName();
         string token = Guid.NewGuid().ToString("N");
         var pipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1,
@@ -130,21 +133,37 @@ internal sealed class PluginProcessClient : IAsyncDisposable
         {
             process = Launch(manifest, entryPath, pipeName, token, dataDirectory, waitForDebugger);
 
-            // 等连接与等进程夭折二选一:PluginHost 起不来(缺运行时/被杀软拦)时不干等 10 秒。
+            // 等连接与等进程夭折二选一:PluginHost 起不来(缺运行时/被杀软拦)时不干等满预算。
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            connectCts.CancelAfter(TimeSpan.FromSeconds(10));
+            connectCts.CancelAfter(startupTimeout);
             Task connect = pipe.WaitForConnectionAsync(connectCts.Token);
             Task exited = process.WaitForExitAsync(connectCts.Token);
-            Task first = await Task.WhenAny(connect, exited).ConfigureAwait(false);
+            await Task.WhenAny(connect, exited).ConfigureAwait(false);
             // 落败的那条支路只会以取消/管道释放收场,且没人会 await 它:显式吞掉,
             // 否则它的异常在 GC 时以未观察任务异常的形式冒出来(调试器里一条无源头的噪声)。
             Observe(connect);
             Observe(exited);
-            if (first == exited)
+            // 判据是 HasExited 而不是"哪条支路先完成":预算到点时两条支路一起被取消,
+            // 而被取消的 exited 与真的退出长得一模一样,这时去读 ExitCode 只会撞上
+            // 「进程尚未退出」的异常,把一次超时报成一句风马牛不相及的错。
+            if (process.HasExited)
             {
                 throw new InvalidOperationException($"Plugin host process exited before connecting (exit code {process.ExitCode}).");
             }
-            await connect.ConfigureAwait(false);
+            try
+            {
+                await connect.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // 把"连接阶段超时"说成它自己。原先这里逸出一个裸 OperationCanceledException,
+                // 被 PluginManager 一律记成「Activation timed out after <激活超时>s」——
+                // 报出来的秒数既不是这一段的预算、也不是实际等过的时间,查起来全是错的方向。
+                throw new TimeoutException(
+                    $"Plugin host process {process.Id} did not connect to the host pipe within "
+                    + $"{startupTimeout.TotalSeconds:0}s (cold process start, or the machine is loaded).");
+            }
+            long connectedMs = startup.ElapsedMilliseconds;
 
             connection = new(pipe);
             router = new(context, connection, token, hostVersion, themeTokens, embedHost);
@@ -152,7 +171,23 @@ internal sealed class PluginProcessClient : IAsyncDisposable
             connection.SetNotificationHandler(router.HandleNotification);
             connection.Start();
 
-            await router.HandshakeCompleted.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+            // 握手用启动预算里剩下的那部分;连接已经花掉多少就减多少,但至少留 5 秒
+            // ——连都连上了,握手只是一次往返,给它一个不至于因四舍五入变成 0 的下限。
+            TimeSpan handshakeBudget = Max(startupTimeout - startup.Elapsed, TimeSpan.FromSeconds(5));
+            try
+            {
+                await router.HandshakeCompleted.WaitAsync(handshakeBudget, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException(
+                    $"Plugin host process {process.Id} connected but did not complete the handshake within "
+                    + $"{handshakeBudget.TotalSeconds:0}s.");
+            }
+            // 这两个数是隔离插件启动慢时唯一能分清"慢在哪一段"的证据:连接慢 = 进程冷启动
+            // (运行时 + Avalonia),握手慢 = 插件进程起来了但线程被什么占着。
+            Trace.WriteLine($"[PluginManager] '{manifest.Id}' host process {process.Id} connected in {connectedMs}ms, "
+                            + $"handshake done at {startup.ElapsedMilliseconds}ms.");
             // 激活前先下发主题令牌:插件在 Activate 里就开面板也能拿到宿主配色。
             await router.PushThemeTokensAsync().ConfigureAwait(false);
             await connection.RequestAsync<object>(PluginRpc.PluginActivate, new ActivateRequest("startup"),
@@ -185,6 +220,9 @@ internal sealed class PluginProcessClient : IAsyncDisposable
             throw;
         }
     }
+
+    /// <summary>两个时长里较大的那个(启动预算减到 0 时的兜底)。</summary>
+    private static TimeSpan Max(TimeSpan left, TimeSpan right) => left > right ? left : right;
 
     /// <summary>标记一个无人 await 的任务为"已观察",使其异常不再进入未观察任务异常通道。</summary>
     private static void Observe(Task task) =>

--- a/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManager.cs
@@ -1663,9 +1663,18 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         catch (Exception ex)
         {
             descriptor.State = PluginState.Failed;
-            descriptor.Error = ex is OperationCanceledException
-                ? $"Activation timed out after {options.ActivationTimeout.TotalSeconds:0}s."
-                : ex.Message;
+            // 取消的两种来源要分开说:宿主在关(那不是插件的错,也不是超时),与激活真的超时。
+            // 原先一律写成「Activation timed out after <激活超时>s」,于是任何一段
+            // 被取消的等待都顶着激活超时的名字与秒数出现 —— 报告里那个数字对不上实际
+            // 等过的时间,查的人先被送错方向(隔离插件的连接超时曾整整绕了一圈)。
+            descriptor.Error = ex switch
+            {
+                OperationCanceledException when cancellationToken.IsCancellationRequested
+                                                || _shutdown.IsCancellationRequested
+                    => "Activation was cancelled (the host is shutting down).",
+                OperationCanceledException => $"Activation timed out after {options.ActivationTimeout.TotalSeconds:0}s.",
+                _ => ex.Message
+            };
             Log($"Failed to activate '{manifest.Id}': {descriptor.Error}");
             await CleanupRuntimeAsync(runtime).ConfigureAwait(false);
         }
@@ -1712,7 +1721,8 @@ public sealed class PluginManager(PluginManagerOptions options) : IAsyncDisposab
         }
         PluginProcessClient client = await PluginProcessClient.StartAsync(manifest, entryPath, context,
             options.HostVersion, context.DataDirectory,
-            debug ? DebugActivationTimeout : options.ActivationTimeout, cts.Token,
+            debug ? DebugActivationTimeout : options.ActivationTimeout,
+            debug ? DebugActivationTimeout : options.IsolatedStartupTimeout, cts.Token,
             options.ThemeTokensProvider, options.EmbedHost, debug).ConfigureAwait(false);
         runtime.Process = client;
         runtime.LastActivityTicks = Environment.TickCount64;

--- a/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
+++ b/src/VelaShell.Infrastructure/Plugins/PluginManagerOptions.cs
@@ -203,6 +203,18 @@ public sealed class PluginManagerOptions
     public TimeSpan ActivationTimeout { get; init; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// 隔离插件的**启动**预算:从拉起 PluginHost 子进程到管道连上、握手完成为止,
+    /// 不含插件自己的 <c>ActivateAsync</c>(那段仍按 <see cref="ActivationTimeout" /> 计)。
+    /// </summary>
+    /// <remarks>
+    /// 与激活时限分开,是因为两者量级根本不同:一边是"插件的一个方法该多快返回"(秒级,
+    /// 长了就是挂死),另一边是"一个 .NET 进程冷启动 + Avalonia 初始化该多慢" ——
+    /// 后者在冷机器、忙机器、Linux 首次建字体缓存时轻松上十秒。合成一个数只能取大的那个,
+    /// 等于把插件挂死的判定也一并放宽;各给各的,两边才都守得住自己那件事。
+    /// </remarks>
+    public TimeSpan IsolatedStartupTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// 后台活动账本(状态栏右下角的圆环据此显示)。缺席时插件加载静默进行,
     /// 行为与引入指示器之前完全一致 —— headless 测试与无界面宿主不受影响。
     /// </summary>

--- a/src/VelaShell.PluginHost/Program.cs
+++ b/src/VelaShell.PluginHost/Program.cs
@@ -38,18 +38,39 @@ internal static class Program
             WatchParent(parentPid);
         }
 
+        // ★ 管道先连,Avalonia 后建 —— 顺序不能反。
+        //
+        // 宿主给"进程启动 → 管道连上"留的是一段有限的窗口(见 PluginProcessClient.StartAsync)。
+        // 而 SetupWithoutStarting() 在 Linux 上要连 X11、初始化字体子系统:冷机器上光建
+        // fontconfig 缓存就能吃掉好几秒。它排在连接前面,那几秒全从连接窗口里扣 ——
+        // CI 的 ubuntu 作业上偶发的"连接超时"正是这么来的(机器越忙越容易撞上,
+        // 于是表现为"有时候又能过")。
+        //
+        // 连接是纯 IO,不碰 Avalonia,也就不必等谁:这里只**发起**连接,握手与其余 RPC
+        // 仍旧排在 Avalonia 就绪之后(它们会在派发线程上开窗口,那要求 Avalonia 已经建好)。
+        var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        Task connected = pipe.ConnectAsync(ConnectTimeoutMilliseconds);
+
         // 内建 Avalonia:默认软件渲染 —— 插件面板是轻量界面,不值得每个插件进程
         // 各自映射一整套显卡驱动模块(GPU 后端单进程可多占 ~170MB 常驻)。
         // 需要 GPU 的插件用 VELA_PLUGIN_GPU=1 放开。
         AppBuilder builder = AppBuilder.Configure<PluginHostApp>().UsePlatformDetect();
         if (Environment.GetEnvironmentVariable("VELA_PLUGIN_GPU") != "1")
         {
-            builder = builder.With(new Win32PlatformOptions { RenderingMode = [Win32RenderingMode.Software] });
+            // 三个平台各配一份:这条策略说的是"插件面板不值得为它映射一整套显卡驱动",
+            // 与操作系统无关,可原先只写了 Win32 那一份 —— Linux 与 macOS 上默认仍走
+            // GPU 后端。X11 尤其吃亏:探测 GLX/EGL 要开显示连接、枚举 FBConfig,
+            // 在 CI 的虚拟屏(xvfb + llvmpipe)上这一段能慢到秒级,而它换来的东西
+            // 恰恰是插件面板用不上的。
+            builder = builder
+                .With(new Win32PlatformOptions { RenderingMode = [Win32RenderingMode.Software] })
+                .With(new X11PlatformOptions { RenderingMode = [X11RenderingMode.Software] })
+                .With(new AvaloniaNativePlatformOptions { RenderingMode = [AvaloniaNativeRenderingMode.Software] });
         }
         builder.SetupWithoutStarting();
 
         // RPC 与插件逻辑全部转后台;主线程专职跑派发循环直至退出信号。
-        Task<int> run = Task.Run(() => RunAsync(pipeName, token, pluginId, pluginVersion, entryPath, dataDirectory));
+        Task<int> run = Task.Run(() => RunAsync(pipe, connected, token, pluginId, pluginVersion, entryPath, dataDirectory));
         using var loopCancel = new CancellationTokenSource();
         _ = run.ContinueWith(_ => loopCancel.Cancel(), TaskScheduler.Default);
         try
@@ -67,11 +88,20 @@ internal static class Program
         return exitCode;
     }
 
-    private static async Task<int> RunAsync(string pipeName, string token, string pluginId, string pluginVersion,
-        string entryPath, string dataDirectory)
+    /// <summary>连接宿主管道的时限:管道在进程被拉起之前就已在监听,连不上就是宿主没了。</summary>
+    private const int ConnectTimeoutMilliseconds = 10_000;
+
+    /// <param name="pipe">已在 <see cref="Main" /> 里发起连接的管道。</param>
+    /// <param name="connected">那次连接的进行中任务(见 Main 里"管道先连"的说明)。</param>
+    /// <param name="token">握手令牌。</param>
+    /// <param name="pluginId">插件 id。</param>
+    /// <param name="pluginVersion">插件版本。</param>
+    /// <param name="entryPath">入口程序集路径。</param>
+    /// <param name="dataDirectory">本插件的数据目录。</param>
+    private static async Task<int> RunAsync(NamedPipeClientStream pipe, Task connected, string token,
+        string pluginId, string pluginVersion, string entryPath, string dataDirectory)
     {
-        var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
-        await pipe.ConnectAsync(10_000).ConfigureAwait(false);
+        await connected.ConfigureAwait(false);
 
         using var shutdownSource = new CancellationTokenSource();
         var connection = new RpcConnection(pipe);

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/IsolatedPluginTests.cs
@@ -61,7 +61,11 @@ public class IsolatedPluginTests
             PluginRoots = [_root],
             DataRootDirectory = _dataRoot,
             HostVersion = "1.0.0",
-            ActivationTimeout = TimeSpan.FromSeconds(30), // 子进程冷启动比进程内慢,放宽
+            ActivationTimeout = TimeSpan.FromSeconds(30),
+            // 冷启动一个 .NET 子进程 + 建 Avalonia 归这一项管(见 IsolatedStartupTimeout)。
+            // CI 上四个测试程序集同时在跑,子进程要跟它们抢两个核 —— 这个数只决定
+            // "等多久才判失败",健康时一分钱不花,给足了才不会把机器忙判成插件坏。
+            IsolatedStartupTimeout = TimeSpan.FromSeconds(60),
             DeactivationTimeout = TimeSpan.FromSeconds(10)
         });
         await manager.StartAsync();
@@ -73,6 +77,39 @@ public class IsolatedPluginTests
 
         await manager.DisposeAsync();
         Assert.AreEqual(PluginState.Deactivated, manager.Plugins.Single().State);
+    }
+
+    /// <summary>
+    /// 启动预算耗尽时,报出来的必须是"没连上",而不是激活超时。
+    /// </summary>
+    /// <remarks>
+    /// 这条钉的是一次真实的误导:CI 上隔离插件偶发失败,报告写的是
+    /// 「Activation timed out after 30s」,而用例总耗时只有 10 秒 —— 因为连接阶段
+    /// 那个写死的 10 秒窗口逸出一个裸 OperationCanceledException,被统一记成了激活超时。
+    /// 秒数与阶段全是错的,查的人只能从头猜起。阶段自报家门之后,同样的失败一眼能定位。
+    /// </remarks>
+    [TestMethod]
+    public async Task IsolatedPlugin_StartupBudgetExhausted_BlamesTheConnectPhase()
+    {
+        StageFixture("isolated");
+        var manager = new PluginManager(new()
+        {
+            PluginRoots = [_root],
+            DataRootDirectory = _dataRoot,
+            HostVersion = "1.0.0",
+            ActivationTimeout = TimeSpan.FromSeconds(30),
+            // 子进程再快也起不到 1 毫秒:这一段必然超时,而激活时限还剩得满满的 ——
+            // 两个数分开之后,报错才说得清是哪一段没赶上。
+            IsolatedStartupTimeout = TimeSpan.FromMilliseconds(1),
+            DeactivationTimeout = TimeSpan.FromSeconds(10)
+        });
+        await manager.StartAsync();
+
+        PluginDescriptor descriptor = manager.Plugins.Single();
+        Assert.AreEqual(PluginState.Failed, descriptor.State);
+        Assert.Contains("did not connect", descriptor.Error!, StringComparison.Ordinal);
+        Assert.DoesNotContain("Activation timed out", descriptor.Error!, StringComparison.Ordinal);
+        await manager.DisposeAsync();
     }
 
     [TestMethod]
@@ -104,6 +141,7 @@ public class IsolatedPluginTests
             DataRootDirectory = _dataRoot,
             HostVersion = "1.0.0",
             ActivationTimeout = TimeSpan.FromSeconds(30),
+            IsolatedStartupTimeout = TimeSpan.FromSeconds(60), // 同上:子进程冷启动的预算与激活分开
             DeactivationTimeout = TimeSpan.FromSeconds(10),
             // 测试用极短退避:只允许 1 次自动重启,第二次崩溃即放弃。
             CrashRestartBackoff = [TimeSpan.FromMilliseconds(100)],
@@ -147,6 +185,7 @@ public class IsolatedPluginTests
             DataRootDirectory = _dataRoot,
             HostVersion = "1.0.0",
             ActivationTimeout = TimeSpan.FromSeconds(30),
+            IsolatedStartupTimeout = TimeSpan.FromSeconds(60), // 同上:子进程冷启动的预算与激活分开
             DeactivationTimeout = TimeSpan.FromSeconds(10)
         });
         await manager.StartAsync();

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/LazyActivationTests.cs
@@ -63,6 +63,7 @@ public class LazyActivationTests
         DataRootDirectory = _dataRoot,
         HostVersion = "1.0.0",
         ActivationTimeout = TimeSpan.FromSeconds(30),
+        IsolatedStartupTimeout = TimeSpan.FromSeconds(60), // 惰性激活也真的拉子进程:冷启动预算与激活分开
         DeactivationTimeout = TimeSpan.FromSeconds(10),
         CommandsFactory = (_, _) => _commands,
         IdleTimeout = idleTimeout ?? TimeSpan.FromMinutes(15),


### PR DESCRIPTION
修 CI 的 ubuntu 作业偶发失败(run [34105499218](https://github.com/joesdu/VelaShell/actions/runs/34105499218/job/101689447150))。

## 报出来的那句话是错的

失败的永远是同一条:`IsolatedPlugin_ActivatesInChildProcess_AndDeactivatesCleanly`,报 `Activation timed out after 30s`。但日志里那条用例的耗时是 **10 秒** —— 两个数对不上,超时的根本不是激活。

`PluginProcessClient.StartAsync` 分三段等,而前两段的预算是写死的:

| 阶段 | 原来的预算 |
| --- | --- |
| 拉起进程 → 管道连上 | 写死 10 秒 |
| 握手往返 | 写死 10 秒 |
| 插件 `ActivateAsync` | `options.ActivationTimeout`(用例里 30 秒) |

第一段用 `CancelAfter`,超时逸出一个裸 `OperationCanceledException`;`PluginManager.ActivateAsync` 的 catch 把**任何** OCE 都写成 `Activation timed out after {ActivationTimeout}s`。于是一次 10 秒的连接超时,顶着"激活超时 30 秒"的名字出现在报告里。

## 根因:子进程在连管道之前,先建了一整套 Avalonia

`Program.cs` 的顺序是 `SetupWithoutStarting()` → 起后台线程 → 连管道。那 10 秒窗口里,子进程有一大段时间在做与连接无关的事。Linux 上这一段尤其贵:连 X11、初始化字体子系统(冷机器要建 fontconfig 缓存),`UsePlatformDetect` 之后还要探测 GLX/EGL —— 在 CI 的虚拟屏(xvfb + llvmpipe)上能慢到秒级。

为什么只有 ubuntu、而且只是偶发:`dotnet test VelaShell.slnx` **并行**跑八个测试程序集,这条用例恰好落在测试步骤刚开始、几个程序集同时冷启动的那半分钟里。机器闲就一两秒连上,忙就撞破 10 秒 —— 这正是"有时又能过"。同一次运行里 Windows 与 macOS 全绿。

## 改法

1. **管道先连,Avalonia 后建**(`Program.cs`):连接是纯 IO,不碰 Avalonia,`Main` 里先发起 `ConnectAsync` 不等它完成,再 `SetupWithoutStarting()`;握手与其余 RPC 仍排在 Avalonia 就绪之后(它们要在派发线程上开窗口)。本机实测连接耗时 **356~512ms → 142~163ms**,差的那一段正是在 Linux 冷机器上会膨胀成好几秒的部分。
2. **启动预算与激活时限拆成两个数**:新增 `PluginManagerOptions.IsolatedStartupTimeout`(默认 30s),覆盖"拉起进程 → 连上 → 握手完成";插件自己的 `ActivateAsync` 仍走 `ActivationTimeout`。两者量级不同(一个是"方法该多快返回",一个是"进程冷启动该多慢"),合成一个数只能取大的那个,等于把插件挂死的判定也一并放宽。连接与握手共花这一个预算,握手保底 5 秒。
3. **每一段超时自报家门**:连接超时抛 `did not connect to the host pipe within Ns`,握手超时抛 `connected but did not complete the handshake within Ns`;`ActivateAsync` 把"宿主正在关"与"真的超时"分开写。成功路径补一条 Trace:`connected in {x}ms, handshake done at {y}ms` —— 下次再慢,日志直接说得出慢在哪一段。

顺带两件同源的事:

- 原先按"`WhenAny` 里哪条支路先完成"判进程是否夭折,而预算到点时两条支路是**一起**被取消的,此时读 `ExitCode` 会撞上「进程尚未退出」的异常 —— 判据改成 `HasExited`。
- `VELA_PLUGIN_GPU != 1` 的软件渲染原先只配了 Win32 一份,Linux 与 macOS 默认仍走 GPU 后端。这条策略("插件面板不值得为它映射一整套显卡驱动")与操作系统无关,补齐 `X11PlatformOptions` 与 `AvaloniaNativePlatformOptions`。

## 验收

- `dotnet test VelaShell.slnx`(排除 Docker/CrossPlatform)全绿:**3194 通过**。
- 新增 `IsolatedPlugin_StartupBudgetExhausted_BlamesTheConnectPhase`:把启动预算压到 1ms,断言错误里写的是 `did not connect` 而**不是** `Activation timed out`。把连接阶段那个 `catch` 的条件改成永假(即恢复"逸出裸 OCE"的旧行为),这条立刻红,且红的方式与 CI 上一模一样。
- 隔离插件那几条用例把 `IsolatedStartupTimeout` 显式放到 60 秒:这个数只决定"等多久才判失败",健康时一分钱不花,给足了才不会把"机器忙"判成"插件坏"。
- `plan.md` 补 §49。

> 文档待办:`velashell-docs` 的 `zh/templates/dev-guide.md` §274 那张状态图写的是「激活超时(10s)→ Failed」,隔离模式现在多了一段 30 秒的启动预算,需要同步一句(zh/ 与 en/ 各一处)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QydefQQ5JJmyyEUNCpVSp6
