### PR TITLE
fix(terminal): 按下 Ctrl 那一刻手型就该出来，不必再抖一下鼠标 (#397)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -81,6 +81,12 @@
 | [48](#-48-2026-09-07-关掉连接中的标签连接就该停下用户反馈) | ✅ | 09-07 | 关掉「连接中」的标签就该取消握手 |
 | [49](#-49-2026-09-07-ci-的-ubuntu-作业偶发失败隔离插件连不上被报成激活超时) | ✅ | 09-07 | CI ubuntu 偶发失败：管道先连、Avalonia 后建 |
 | [50](#-50-2026-09-08-ci-的-macos-作业偶发失败背压用例拿固定-sleep-赌线程池已经起来了) | ✅ | 09-08 | CI macOS 偶发失败：背压用例改等条件，不再赌固定 sleep |
+| [51](#-51-2026-09-08-双击打开的远端文件也要自动回传编辑会话不再赌编辑器进程396) | ✅ | 09-08 | 双击打开的远端文件也自动回传；三个「打开」入口收敛到一套编辑会话（#396） |
+| [52](#-52-2026-09-08-编辑器都关掉了正在编辑那一行还挂着396-反馈) | ✅ | 09-08 | 编辑器关掉后收掉「正在编辑」那一行（#396 反馈） |
+| [53](#-53-2026-09-08-vs-code-关掉了那一行还挂着别拿单个进程句柄代表应用还开着396-反馈二) | ✅ | 09-08 | 别拿单个进程句柄代表「应用还开着」（#396 反馈二） |
+| [54](#-54-2026-09-08-把正在编辑改成只在出问题时出现整段进程跟踪删掉396-反馈三) | ✅ | 09-08 | 「正在编辑」改成只在出问题时出现，整段进程跟踪删掉（#396 反馈三） |
+| [55](#-55-2026-09-08-传输浮窗里那一组整块撤掉远程编辑从此不出现在界面上396-反馈四) | ✅ | 09-08 | 传输浮窗里那一组整块撤掉，远程编辑不再出现在界面上（#396 反馈四） |
+| [56](#-56-2026-09-08-按下-ctrl-那一刻手型就该出来不该等鼠标抖一下397) | ✅ | 09-08 | 按下 Ctrl 立刻给手型，不必再抖一下鼠标（#397） |
 
 ## 📈 阶段脉络
 
@@ -2823,3 +2829,69 @@ C:\Users\falcon\AppData\Local\Temp\VelaShell\93f408970803433ea9fbbc10fbd39f32\do
 2. 更根本的:**用户要的是"保存后自动上传",不是"看见它在自动上传"。**
    为一个能力配一块常驻状态显示之前,先问这块显示解决了谁的什么问题;
    答不上来就别加 —— 加了之后它自己会长出一串需要伺候的问题。
+
+## ✅ 56. 2026-09-08 按下 Ctrl 那一刻手型就该出来,不该等鼠标抖一下(#397)
+
+用户反馈:光标停在链接上按 Ctrl,光标样式不变;必须挪一下鼠标手型才出来。
+
+### 一、根因:判定只挂在指针移动上,而按 Ctrl 时鼠标是静止的
+
+链接悬停反馈(手型 + 地址气泡)整套逻辑只有一个入口 ——
+`VelaTerminalControl.OnPointerMoved` 里那句 `UpdateLinkHover(e)`。而
+`UpdateLinkHover` 的第一句就是从**事件**里读修饰键:
+
+```csharp
+if (_selecting || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
+```
+
+也就是说"Ctrl 有没有按下"这个状态**只在鼠标移动事件里被采样**。用户按 Ctrl 时鼠标一动不动,
+不产生 `PointerMoved`,于是没有任何代码去重新判定 —— 抖一下鼠标才有事件把新的
+`KeyModifiers` 带进来,这正是用户描述的"要移动才会发生变化"。
+
+松开侧反而一直是即时的:`OnKeyUp` 专门认了 `Key.LeftCtrl or Key.RightCtrl` 去
+`ClearLinkHover()`。**按下侧从一开始就没有对称的那一半**。
+
+原注释里写着这套设计的动机 ——「只在 Ctrl 按下时才做匹配,否则每一次鼠标移动都要跑一遍正则」。
+这个取舍本身没错,漏掉的是"按下 Ctrl"这个**边沿事件本身也是一次该重判的时机**。
+
+### 二、修法:把判定与指针事件解耦,补上按下侧
+
+- `UpdateLinkHover(PointerEventArgs)` → `UpdateLinkHover(Point position, bool ctrl)`。
+  按 Ctrl 那一刻根本没有指针事件可传,原签名注定调不到。
+- 新增 `_lastPointerPosition`(`Point?`):`OnPointerMoved` 里更新,`OnPointerExited` 里置 null。
+  指针已经不在控件上,记下的位置就作废 —— 否则之后按 Ctrl 会照着一个旧位置亮手型。
+- `OnKeyDown` 顶部认 `Key.LeftCtrl or Key.RightCtrl`,就地用最后的位置重判一次。
+  裸修饰键在 `TerminalKeyRouter.Classify` 里落到 `TerminalKeyAction.None`(`InputEncoder.Encode`
+  对纯修饰键返回空),插在这里不动下面任何一个分支。
+
+两处状态复位,都是为了让 `_ctrlHeld` 这个新的边沿标记不会卡死:
+
+- `OnKeyUp` 清掉它 —— 按住 Ctrl 会自动重复 KeyDown,只在 false→true 那一瞬做判定,
+  每次重复都跑一遍正则没有意义(这正是原设计要省的那笔开销)。
+- `OnLostFocus` 也清掉 —— **焦点若在 Ctrl 按住时被抢走,那次 KeyUp 会送给新的焦点控件**,
+  这里不清就永远停在按下态,下次再按 Ctrl 会被 `if (_ctrlHeld) return;` 直接吃掉。
+
+### 三、回归用例
+
+`LinkHoverTests` 新增三条:
+
+| 用例 | 守的是什么 |
+| --- | --- |
+| `PressingCtrlWhileAlreadyOverTheLink_ShowsTheFeedbackWithoutMovingTheMouse` | #397 本体:先无修饰键悬上去,鼠标一动不动只按 Ctrl,手型与地址就得出来 |
+| `PressingCtrlOverPlainText_ShowsNothing` | 新入口不能把非链接的地方也点亮 |
+| `PressingCtrlAfterThePointerLeft_ShowsNothing` | 指针移出控件后位置作废,不照着旧位置亮手型 |
+
+把 `src` 侧的改动 stash 掉重跑,第一条如期变红(`expected: "https://example.com/docs",
+actual: null`)—— 那正是这个 bug 在用户机器上的样子。
+
+`dotnet build VelaShell.slnx -warnaserror` 零警告零错误;`dotnet test VelaShell.slnx` 全绿。
+
+### 四、留下的边界(**没修**)
+
+**焦点不在终端控件上**时(比如焦点在 SFTP 面板或搜索框),鼠标悬在终端上按 Ctrl,
+KeyDown 送不到 `VelaTerminalControl`,手型仍然不会出现。要覆盖它得在窗口层挂隧道事件,
+范围与风险都大一截,而 issue 描述的是终端有焦点的正常使用路径。留作已知限制。
+
+判据:**成对的状态转换要么两侧都做,要么两侧都不做。**这个 bug 的形状就是
+"松开侧有 KeyUp 钩子、按下侧没有 KeyDown 钩子",而不对称本身在代码里是看不见的 ——
+`OnKeyUp` 那个方法孤零零地存在,读的时候不会有人问"那按下呢"。

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -2841,6 +2841,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         base.OnLostFocus(e);
         _hasFocus = false;
         // 焦点走了,修饰键状态就不再可信 —— 撤掉链接悬停的手型与地址提示。
+        // _ctrlHeld 一并复位:松开 Ctrl 的那次 KeyUp 会送给新的焦点控件,这里再不清就永远卡在按下态。
+        _ctrlHeld = false;
         ClearLinkHover();
         UpdateCursorBlinkTimer();
         InvalidateTerminal();
@@ -2881,6 +2883,12 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// </remarks>
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        // 纯修饰键不会被路由器编码成任何动作(落到 TerminalKeyAction.None),
+        // 在这里顺手补一次链接悬停判定不影响下面任何分支。
+        if (e.Key is Key.LeftCtrl or Key.RightCtrl)
+        {
+            UpdateLinkHoverOnCtrlDown();
+        }
         TerminalKeyAction action = TerminalKeyRouter.Classify(
             e.Key,
             e.KeyModifiers,
@@ -3149,7 +3157,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     protected override void OnPointerMoved(PointerEventArgs e)
     {
         base.OnPointerMoved(e);
-        UpdateLinkHover(e);
+        _lastPointerPosition = e.GetPosition(this);
+        UpdateLinkHover(_lastPointerPosition.Value, e.KeyModifiers.HasFlag(KeyModifiers.Control));
 
         // 折叠列悬停提示:指针在折叠列上时记住其绝对行(用于画 ▾ 折叠手柄),移出则清除。
         // 空白行(最后一行输出之下)不给提示——那里折叠无意义且极易误点(内容消失事故)。
@@ -3214,20 +3223,30 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     private string? _hoveredLink;
 
     /// <summary>
+    /// 指针最后一次落在控件内的位置;指针移出控件后为 null。
+    /// 判定要在"按下 Ctrl"这一刻也跑一遍,而那一刻没有任何指针事件可问位置(#397)。
+    /// </summary>
+    private Point? _lastPointerPosition;
+
+    /// <summary>Ctrl 是否已被本控件记为按下 —— 用来只在按下那一瞬做判定,而非每次自动重复都做。</summary>
+    private bool _ctrlHeld;
+
+    /// <summary>
     /// 按住 Ctrl 悬停在 URL 上时把光标变成手型,并用提示气泡给出完整地址。
     /// </summary>
     /// <remarks>
     /// 复用 <see cref="SemanticMatcher.UrlAt" /> —— 与 Ctrl+点击是同一个判定函数,
     /// 于是"看起来能点"和"真的能点"永远一致,不会出现指了手型却点不开的情况。
+    /// 取位置与修饰键而非指针事件:按下 Ctrl 时鼠标是静止的,没有事件可传。
     /// </remarks>
-    private void UpdateLinkHover(PointerEventArgs e)
+    private void UpdateLinkHover(Point position, bool ctrl)
     {
-        if (_selecting || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        if (_selecting || !ctrl)
         {
             ClearLinkHover();
             return;
         }
-        (int row, int col) = PointToCell(e.GetPosition(this));
+        (int row, int col) = PointToCell(position);
         string lineText = row >= 0 && row < Emulator.Screen.TotalRows
             ? Emulator.Screen.ViewLine(row).GetText()
             : string.Empty;
@@ -3267,7 +3286,29 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         base.OnKeyUp(e);
         if (e.Key is Key.LeftCtrl or Key.RightCtrl)
         {
+            _ctrlHeld = false;
             ClearLinkHover();
+        }
+    }
+
+    /// <summary>
+    /// 按下 Ctrl 的那一刻就地重判一次悬停 —— 补上按下侧,与 <see cref="OnKeyUp" /> 的松开侧对称。
+    /// </summary>
+    /// <remarks>
+    /// 回归 #397:判定原本只挂在 <see cref="OnPointerMoved" /> 上,而按 Ctrl 时鼠标是静止的,
+    /// 不产生指针事件,于是必须抖一下鼠标手型才出来。松开侧一直是即时的,按下侧不是,前后不一致。
+    /// 只在 false→true 这一次做:按住 Ctrl 会自动重复,每次重复都跑一遍正则没有意义。
+    /// </remarks>
+    private void UpdateLinkHoverOnCtrlDown()
+    {
+        if (_ctrlHeld)
+        {
+            return;
+        }
+        _ctrlHeld = true;
+        if (_lastPointerPosition is { } position)
+        {
+            UpdateLinkHover(position, ctrl: true);
         }
     }
 
@@ -3275,6 +3316,8 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     protected override void OnPointerExited(PointerEventArgs e)
     {
         base.OnPointerExited(e);
+        // 指针已不在控件上,记下的位置随即作废 —— 否则之后按 Ctrl 会照着一个旧位置亮手型。
+        _lastPointerPosition = null;
         ClearLinkHover();
         if (_foldHoverAbs != -1)
         {

--- a/tests/VelaShell.Terminal.Tests/LinkHoverTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LinkHoverTests.cs
@@ -125,6 +125,66 @@ public sealed class LinkHoverTests
     }
 
     [TestMethod]
+    public void PressingCtrlWhileAlreadyOverTheLink_ShowsTheFeedbackWithoutMovingTheMouse()
+    {
+        // 回归 #397:判定原本只挂在 PointerMoved 上,而按 Ctrl 时鼠标是静止的,
+        // 于是必须抖一下鼠标手型才出来 —— 松开侧一直是即时的,按下侧不是。
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowWithLink();
+
+            // 先不按 Ctrl 悬到 URL 上:此刻不该有任何反馈。
+            MoveTo(window, control, 8, KeyModifiers.None);
+            Assert.IsNull(ToolTip.GetTip(control));
+
+            // 鼠标一动不动,只按下 Ctrl。
+            window.KeyPress(Key.LeftCtrl, RawInputModifiers.Control, PhysicalKey.ControlLeft, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.AreEqual("https://example.com/docs", ToolTip.GetTip(control),
+                "按下 Ctrl 就该立即出现手型与地址,不该等到鼠标移动。");
+
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void PressingCtrlOverPlainText_ShowsNothing()
+    {
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowWithLink();
+
+            MoveTo(window, control, 1, KeyModifiers.None);
+            window.KeyPress(Key.LeftCtrl, RawInputModifiers.Control, PhysicalKey.ControlLeft, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.IsNull(ToolTip.GetTip(control));
+            window.Close();
+        });
+    }
+
+    [TestMethod]
+    public void PressingCtrlAfterThePointerLeft_ShowsNothing()
+    {
+        // 指针已经不在控件上,记下的位置就作废了 —— 否则会照着一个旧位置亮手型。
+        OnUi(() =>
+        {
+            (VelaTerminalControl control, Window window) = ShowWithLink();
+
+            MoveTo(window, control, 8, KeyModifiers.None);
+            window.MouseMove(new Point(-10, -10), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.LeftCtrl, RawInputModifiers.Control, PhysicalKey.ControlLeft, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.IsNull(ToolTip.GetTip(control));
+            window.Close();
+        });
+    }
+
+    [TestMethod]
     public void ReleasingCtrl_ClearsTheFeedback()
     {
         // 松开 Ctrl 之后已经点不开了,再指着手型是在骗人。


### PR DESCRIPTION
## 这个 PR 做了什么

光标停在链接上**按下 Ctrl 的那一刻**,手型光标与地址气泡就出现了 —— 此前必须抖一下鼠标才出来。

改动只在 `VelaTerminalControl` 的输入处理里,渲染路径与链接判定函数(`SemanticMatcher.UrlAt`)一个字节都没动。界面上没有任何新增元素,没有新文案,没有新设置项。

## 为什么这么改

### 根因:判定只挂在指针移动上,而按 Ctrl 时鼠标是静止的

链接悬停反馈(手型 + 地址气泡)整套逻辑**只有一个入口** —— `OnPointerMoved` 里那句 `UpdateLinkHover(e)`。而 `UpdateLinkHover` 的第一句就是从**事件**里读修饰键:

```csharp
if (_selecting || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
{
    ClearLinkHover();
    return;
}
```

也就是说「Ctrl 有没有按下」这个状态**只在鼠标移动事件里被采样**。用户按 Ctrl 时鼠标一动不动,不产生 `PointerMoved`,于是没有任何代码去重新判定 —— 必须抖一下鼠标,才会有事件把新的 `KeyModifiers` 带进来。这正是 issue 里那句「要移动才会发生变化」。

**松开侧反而一直是即时的**:`OnKeyUp` 专门认了 `Key.LeftCtrl or Key.RightCtrl` 去 `ClearLinkHover()`。按下侧从一开始就没有对称的那一半 —— 这个不对称在代码里是看不见的,`OnKeyUp` 那个方法孤零零地存在,读的时候不会有人问「那按下呢」。

### 原来那么写的原因仍然成立,所以没有推翻它

那一节的注释写着设计动机:

> 只在 Ctrl 按下时才做匹配 —— 否则每一次鼠标移动都要跑一遍正则。

这个取舍是对的,本 PR **没有**改它:不按 Ctrl 时依然一次正则都不跑。漏掉的只是「按下 Ctrl」这个**边沿事件本身也是一次该重判的时机**。

### 修法:把判定与指针事件解耦,补上按下侧

| 改动 | 为什么 |
| --- | --- |
| `UpdateLinkHover(PointerEventArgs)` → `UpdateLinkHover(Point position, bool ctrl)` | 按 Ctrl 那一刻根本没有指针事件可传,原签名注定调不到 |
| 新增 `_lastPointerPosition`(`Point?`) | `OnPointerMoved` 里更新,`OnPointerExited` 里置 null —— 指针已经不在控件上,记下的位置就作废,否则之后按 Ctrl 会照着一个旧位置亮手型 |
| `OnKeyDown` 顶部认 `Key.LeftCtrl or Key.RightCtrl` | 就地用最后的位置重判一次。裸修饰键在 `TerminalKeyRouter.Classify` 里落到 `TerminalKeyAction.None`(`InputEncoder.Encode` 对纯修饰键返回空),插在这里**不动下面任何一个分支** |
| 新增 `_ctrlHeld`,`OnKeyUp` 与 `OnLostFocus` 都复位 | 见下 |

`_ctrlHeld` 是这次唯一需要小心的新状态,两处复位各有理由:

- **`OnKeyUp`** —— 按住 Ctrl 会自动重复 KeyDown,只在 false→true 那一瞬做判定;每次重复都跑一遍正则正是上面那条设计动机要省的开销。
- **`OnLostFocus`** —— 焦点若在 Ctrl 按住时被抢走,**那次 KeyUp 会送给新的焦点控件**,这里不清就永远停在按下态,下次再按 Ctrl 会被 `if (_ctrlHeld) return;` 直接吃掉。这一处不是理论风险:`OnLostFocus` 里本来就已经在 `ClearLinkHover()` 了,理由完全相同(焦点走了修饰键状态就不可信),只是新状态得跟上。

### 考虑过但没做的:在窗口层挂隧道事件

那样能一并覆盖「焦点不在终端控件上」的情形(见「补充说明」),但为一个次要路径把输入处理提升一层,风险与本 PR 的收益不成比例。

Closes #397

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线

## 怎么验证的

- [x] `dotnet build VelaShell.slnx -warnaserror` —— 零警告零错误
- [x] `dotnet test VelaShell.slnx` —— 全绿
- [x] 新增/修改的行为有对应测试
- [ ] 界面改动已在应用里实际跑过 —— **见「补充说明」**

**实测环境:** Windows 11 x64 / .NET 11 / Avalonia 12.1

**测试结果:**

```
已通过! - 失败: 0，通过:    10，总计:    10 - VelaShell.Controls.Tests.dll
已通过! - 失败: 0，通过:     3，总计:     3 - VelaShell.Terminal.RenderTests.dll
已通过! - 失败: 0，通过:    69，总计:    69 - VelaShell.Presentation.Tests.dll
已通过! - 失败: 0，通过:   452，总计:   452 - VelaShell.Core.Tests.dll
已通过! - 失败: 0，通过:   399，总计:   399 - VelaShell.Terminal.Tests.dll   ← 396 → 399（本次 +3）
已通过! - 失败: 0，通过:   430，已跳过:  3，总计:   433 - VelaShell.Infrastructure.Tests.dll
已通过! - 失败: 0，通过:  1255，已跳过: 16，总计:  1271 - VelaShell.Tests.dll
已通过! - 失败: 0，通过:   587，总计:   587 - VelaShell.Plugin.Ai.Tests.dll
```

### 新增的回归用例

`tests/VelaShell.Terminal.Tests/LinkHoverTests.cs`。原有 6 条覆盖了「移动着悬停」的各种组合,**唯独没有一条是鼠标不动的** —— 而那正是这个 issue 的形状。

| 用例 | 守的是什么 |
| --- | --- |
| `PressingCtrlWhileAlreadyOverTheLink_ShowsTheFeedbackWithoutMovingTheMouse` | **#397 本体**:先无修饰键悬上去,鼠标一动不动只按 Ctrl,手型与地址就得出来 |
| `PressingCtrlOverPlainText_ShowsNothing` | 新入口不能把非链接的地方也点亮 |
| `PressingCtrlAfterThePointerLeft_ShowsNothing` | 指针移出控件后位置作废,不照着旧位置亮手型 |

**确认过第一条是真守门的**:把 `src` 侧改动 stash 掉重跑,它如期变红 ——

```
预期值相等。 按下 Ctrl 就该立即出现手型与地址,不该等到鼠标移动。
expected: "https://example.com/docs"
actual:   null
```

那正是这个 bug 在用户机器上的样子。另两条是负向断言,改前也绿,守的是新入口别过界。

## 同步检查

- [x] **新增了界面文案** → 无新增文案,五份 resx 未动
- [x] **改了公开 API** → 无。改动的三个成员(`UpdateLinkHover` / `UpdateLinkHoverOnCtrlDown` / 两个字段)全部 `private`
- [x] **改了文档** → 不涉及:行为、接口、配置项、命令行、构建流程都没变,变的只是既有反馈出现的时机(是实现终于跟上了本来就该有的行为)。velashell-docs 无需同步

## 界面改动的前后对比

没有新增或改动任何界面元素,只是同一个反馈出现的**时机**变了(需要抖一下鼠标 → 立即)。这个差别是时序上的,截图截不出来。

## 补充说明

**一件需要 reviewer 知道的事,一个故意留下的边界:**

1. **没在真机上手验过。** headless 测试覆盖了核心路径(含「stash 掉改动就变红」的反证),但 `dotnet run` 起应用按一下 Ctrl 这件事没做。建议合并前照 issue 原路走一遍:输出一段带 URL 的文本 → 鼠标停在 URL 上别动 → 按住 Ctrl,手型与气泡应当立刻出现;松开应当立刻消失。
2. **焦点不在终端控件上时仍然不生效**(已知限制,故意没修)。比如焦点在 SFTP 面板或搜索框,鼠标悬在终端上按 Ctrl,KeyDown 送不到 `VelaTerminalControl`,手型不会出现 —— 要覆盖它得在窗口层挂隧道事件,范围与风险都大一截,而 issue 描述的是终端有焦点的正常使用路径。

**其它:**

- `plan.md` 新增 §56,记了根因、修法与两条复位的理由,以及末尾那条判据:**成对的状态转换要么两侧都做,要么两侧都不做**。
- 与 `feature-plan.md` 里 🟠 P1 的 **OSC 8 超链接** 不冲突:那一项要动的是 `CellFlags` 与 OSC 分发,本 PR 只碰输入侧的触发时机;真做了 OSC 8,悬停判定换成查 link-id 表,这个按下侧的入口原样可用。
- **顺带补了 `plan.md` 的索引**:§51–§55(#396 那一串)在上一个 PR 里没进「全文索引」表,加 §56 时正好把它们一并补上,否则表里会从 50 直接跳到 56 像是漏了。全文 56 个锚点逐一核过,0 断链。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4LVdLi5V5bfF4rnz23yYL
