### PR TITLE
fix(test): 本地面板测试的目录监视活过了 dispatch，把下一条测试的 UI 线程抢走

### DIFF
--- a/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
+++ b/tests/VelaShell.Tests/Views/BreadcrumbUnderscoreUiTests.cs
@@ -72,7 +72,10 @@ public sealed class BreadcrumbUnderscoreUiTests
         OnUi(() =>
         {
             var roots = new TestRootProvider(new LocalRootEntry("~", temp.Path, true, temp.Path));
-            var vm = new LocalFilePaneViewModel(
+            // using:视图模型给 underscored 挂了 FileSystemWatcher。不停掉它,TempDirectory
+            // 释放时的删目录会在 dispatch 结束后从线程池线程回调进来,重建进程级的
+            // Dispatcher.UIThread —— 下一个测试建 Compositor 时 VerifyAccess 就炸。
+            using var vm = new LocalFilePaneViewModel(
                 new TransferOptions { LocalDownloadDirectory = underscored },
                 rootProvider: roots);
             PumpUntilComplete(vm.LoadInitialAsync());

--- a/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
+++ b/tests/VelaShell.Tests/Views/LocalFilePaneViewUiTests.cs
@@ -28,7 +28,10 @@ public sealed class LocalFilePaneViewUiTests
             var inaccessible = new LocalRootEntry("Unavailable", Path.Combine(first.Path, "missing"), false, Path.Combine(first.Path, "missing"));
             var accessible = new LocalRootEntry("~", first.Path, true, first.Path);
             var roots = new TestRootProvider(accessible, inaccessible);
-            var viewModel = new LocalFilePaneViewModel(
+            // using,且声明在 TempDirectory 之后(反序释放):视图模型给临时目录挂了
+            // FileSystemWatcher,不先停掉它,删目录会在 dispatch 结束后从线程池线程回调进来,
+            // 重建进程级的 Dispatcher.UIThread —— 下一个测试建 Compositor 时 VerifyAccess 就炸。
+            using var viewModel = new LocalFilePaneViewModel(
                 new TransferOptions { LocalDownloadDirectory = first.Path },
                 rootProvider: roots);
             await viewModel.LoadInitialAsync();
@@ -69,7 +72,8 @@ public sealed class LocalFilePaneViewUiTests
             }
 
             var accessible = new LocalRootEntry("~", root.Path, true, root.Path);
-            var viewModel = new LocalFilePaneViewModel(
+            // 同上:必须早于 TempDirectory 释放,否则删目录的监视回调会污染 Dispatcher.UIThread。
+            using var viewModel = new LocalFilePaneViewModel(
                 new TransferOptions { LocalDownloadDirectory = root.Path },
                 rootProvider: new TestRootProvider(accessible));
             await viewModel.LoadInitialAsync();

--- a/tests/VelaShell.Tests/Views/LocalPathPickerMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/LocalPathPickerMarqueeUiTests.cs
@@ -194,6 +194,14 @@ public sealed class LocalPathPickerMarqueeUiTests
                 // 不关窗整个 headless 套件会永久卡死。
                 dialog.Close();
                 Dispatcher.UIThread.RunJobs();
+                // 必须先于删目录:视图模型给 tempRoot 挂了 FileSystemWatcher。删目录会触发它,
+                // 回调落在线程池线程上,再等 300ms 防抖才真的刷新 —— 那时本次 dispatch 早已结束,
+                // 会话也已把这个测试的 Application 连同进程级的 Dispatcher.UIThread 一起拆掉。
+                // 迟到的刷新一碰 Dispatcher.UIThread,就把它重新绑到那条线程池线程上,
+                // 于是**下一个**测试建 Compositor 时 VerifyAccess 直接炸:
+                // "The calling thread cannot access this object because a different thread owns it."
+                // 先 Dispose 停掉监视与防抖计时器,事件根本不会产生。
+                vm.Dispose();
                 if (Directory.Exists(tempRoot))
                 {
                     Directory.Delete(tempRoot, true);

--- a/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
+++ b/tests/VelaShell.Tests/Views/ScrollBarMarqueeUiTests.cs
@@ -63,7 +63,10 @@ public sealed class ScrollBarMarqueeUiTests
 
         OnUi(() =>
         {
-            var vm = new LocalFilePaneViewModel(
+            // using:视图模型给 root.Path 挂了 FileSystemWatcher。不停掉它,TempDirectory
+            // 释放时的删目录会在 dispatch 结束后从线程池线程回调进来,重建进程级的
+            // Dispatcher.UIThread —— 下一个测试建 Compositor 时 VerifyAccess 就炸。
+            using var vm = new LocalFilePaneViewModel(
                 new TransferOptions { LocalDownloadDirectory = root.Path },
                 rootProvider: new TestRootProvider(new LocalRootEntry("~", root.Path, true, root.Path)));
             PumpUntilComplete(vm.LoadInitialAsync());


### PR DESCRIPTION
## 问题

Windows CI 上 `LocalPathPickerMarqueeUiTests.MarqueeNeverSelectsTheSyntheticParentRow` 偶发失败（[run 34284790193](https://github.com/joesdu/VelaShell/actions/runs/34284790193/job/102257740060)），堆栈里一条测试自己的代码都没有 —— 炸点在 headless 会话给这条测试**建 Application** 的时候：

```
AvaloniaHeadlessPlatform.Initialize → new Compositor(...) → DefaultRenderLoop.Add
  → Dispatcher.UIThread.VerifyAccess()
  → The calling thread cannot access this object because a different thread owns it.
```

## 根因

`HeadlessUnitTestSession` 是 PerTest 隔离：每条测试建一个 Application，跑完拆掉，拆的时候把**进程级**的 `Dispatcher.UIThread` 清空。而 `Dispatcher` 的构造是 `s_uiThread ??= this` —— 谁先在空档期碰它，UI 线程就归谁；`DefaultRenderLoop.Add` 要求当前线程就是 `Dispatcher.UIThread`。

这些用例正好留了一个后台演员：

1. `NavigateToAsync` 让 `LocalFilePaneViewModel` 给临时目录挂上 `FileSystemWatcher`（`LocalFileSystem.cs:220`），用例却从不 `Dispose` 它；
2. 收尾删临时目录 → 监视器在线程池线程上收到 Deleted 事件；
3. `OnDirectoryChanged` 重置一个 **300ms 防抖计时器**（`LocalFilePaneViewModel.cs:368`），真正的 `RefreshFromWatcher → NavigateToAsync` 在计时器线程上跑；
4. 那时本次 dispatch 早已结束、Application 已拆、`s_uiThread` 为 null。这串迟到的刷新一碰 `Dispatcher.UIThread`，就把它绑到线程池线程上 —— 于是**下一条**测试建 Compositor 时 `VerifyAccess` 当场炸。

时序敏感，所以同一次 run 里只有 Windows 这一个 job 翻车，另外两个平台全绿。

## 改动

让监视器绝不活过它所属的那次 dispatch —— 在临时目录消失之前先 `Dispose` 视图模型（停监视 + 停防抖计时器 + 取消未完成的工作），事件根本不会产生。同一处泄漏在四个测试类里都有，一并补上：

- `LocalPathPickerMarqueeUiTests` — `finally` 里 `dialog.Close()` 之后、删目录之前 `vm.Dispose()`
- `ScrollBarMarqueeUiTests` / `BreadcrumbUnderscoreUiTests` — 改 `using var vm`，在 dispatch 内释放，早于 `TempDirectory`
- `LocalFilePaneViewUiTests`（两处）— 改 `using var viewModel`，声明在 `TempDirectory` 之后，靠 `using` 的反序释放保证先停监视再删目录

每处都留了注释说明为什么顺序不能反。纯测试改动，未触碰产品代码。

## 验证

本地 Windows / .NET 11：

- 四个受影响的测试类：12/12 通过
- 整个 `VelaShell.Tests`（CI 上失败的那个程序集，同样的 filter）：**1260 通过、3 跳过、0 失败**，1m22s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk6oBU6UGPAfq5n3NkHfnR
