### PR TITLE
fix(terminal): 选区高亮改为不透明绘制并保底对比度，拖完一段不再像没选中

### DIFF
--- a/src/VelaShell.Terminal/Emulation/TerminalPalette.cs
+++ b/src/VelaShell.Terminal/Emulation/TerminalPalette.cs
@@ -42,8 +42,11 @@ public sealed class TerminalPalette
     /// <summary>绘制光标所用的颜色。</summary>
     public Rgba CursorColor { get; set; } = Rgba.FromRgb(0x00, 0xD4, 0xAA);
 
-    /// <summary>选中文本背后所绘制的填充色。</summary>
-    public Rgba SelectionBackground { get; set; } = new(0x60, 0x1C, 0x2A, 0x3F);
+    /// <summary>
+    /// 选中文本背后所绘制的填充色。<b>不透明</b> —— 半透明叠加正是选区看不见的根因,
+    /// 实际下发前一律经 <c>SelectionContrast.Fill</c> 整定(见那里的说明)。
+    /// </summary>
+    public Rgba SelectionBackground { get; set; } = Rgba.FromRgb(0x1C, 0x2A, 0x3F);
 
     /// <summary>终端内搜索:非当前命中项背后的填充色。</summary>
     /// <remarks>

--- a/src/VelaShell.Terminal/README.md
+++ b/src/VelaShell.Terminal/README.md
@@ -56,6 +56,6 @@
 
 - **引用**：`VelaShell.Core`（SSH Shell 抽象、ZMODEM / XMODEM / YMODEM 协议引擎）、`Avalonia`（仅渲染控件用）。
 - **被引用**：`VelaShell.Presentation`、`VelaShell`（App）。
-- `InternalsVisibleTo` 暴露给 [`tests/VelaShell.Terminal.Tests`](../../tests/VelaShell.Terminal.Tests)，可对 `internal` 引擎细节做白盒测试。
+- `InternalsVisibleTo` 暴露给 [`tests/VelaShell.Terminal.Tests`](../../tests/VelaShell.Terminal.Tests) 与 [`tests/VelaShell.Terminal.RenderTests`](../../tests/VelaShell.Terminal.RenderTests)，可对 `internal` 引擎细节做白盒测试。
 
 > 编译需 `AllowUnsafeBlocks`（渲染热路径使用指针以减少分配）。

--- a/src/VelaShell.Terminal/Rendering/SelectionContrast.cs
+++ b/src/VelaShell.Terminal/Rendering/SelectionContrast.cs
@@ -1,0 +1,120 @@
+using VelaShell.Terminal.Emulation;
+
+namespace VelaShell.Terminal.Rendering;
+
+/// <summary>
+/// 选区高亮的对比度整定:把「配色方案给的选区色」换算成**真正看得见**的填充色。
+/// <para>
+/// 起因是选区色此前按半透明叠加绘制(暗色 35%、亮色 25%)。可各家方案(Dracula #44475A、
+/// Solarized base2 #EEE8D5、GitHub Light #CFE4FB……)的选区色本来就是照「不透明填充」设计的
+/// —— 它们与自家背景的差本就只有一线,再乘上 0.25~0.35 的不透明度,实测对比度只剩
+/// 1.05:1 ~ 1.21:1,肉眼等同于没画。用户拖完一段以为压根没选中,正是这么来的。
+/// </para>
+/// <para>
+/// 所以这里做两件事:选区底<b>不透明</b>绘制;并且保证它与终端底之间至少拉开
+/// <see cref="MinLightnessDelta" /> 的感知明度差 —— 不够就把它往远离背景的方向推
+/// (暗底推向白、亮底推向黑),够了就原样用方案自己的色,不夺方案的设计。
+/// </para>
+/// <para>
+/// 判据用 CIE L*(感知明度)而非 WCAG 对比度:后者在暗端被压缩得厉害,同一个阈值在暗色主题上
+/// 只挪一点点、在亮色主题上却会把选区压成一条灰带,明暗两套没法用同一个数说话。
+/// </para>
+/// </summary>
+internal static class SelectionContrast
+{
+    /// <summary>
+    /// 选区底与终端底之间必须拉开的感知明度差(CIE L*,0–100 标度)。
+    /// 14 是照着公认「看得见但不喧宾夺主」的那档取的:VS Code 的选区在自家明暗主题上分别是
+    /// 20.8 与 15.9,取稍低一档,既托住 Solarized(原生只有 4.8)这类过淡的方案,
+    /// 又不会去动 Dracula / Monokai / Tokyo Night 这些本就够用的。
+    /// </summary>
+    internal const double MinLightnessDelta = 14.0;
+
+    /// <summary>
+    /// 选中格的前景与选区底之间的最小感知亮度差(0–1 标度)。
+    /// 低于此值就把前景换成 <see cref="ReadableForeground" /> 给的兜底色 —— 选区底一旦不透明,
+    /// 原本压在终端底上读得清的暗色前景(Solarized Dark 的 ansi black #073642 是最极端的一例)
+    /// 就可能贴到明度相近的选区底上,选中即消失。
+    /// </summary>
+    internal const double MinForegroundDelta = 0.18;
+
+    /// <summary>
+    /// 把方案给的选区色整定成实际绘制用的填充色:强制不透明,并保证与
+    /// <paramref name="background" /> 至少差 <see cref="MinLightnessDelta" /> 的 L*。
+    /// </summary>
+    /// <param name="selection">配色方案 / 用户设置里的选区色(其 alpha 被忽略)。</param>
+    /// <param name="background">终端默认背景色。</param>
+    public static Rgba Fill(Rgba selection, Rgba background)
+    {
+        double backgroundLightness = Lightness(background);
+        if (Math.Abs(Lightness(selection) - backgroundLightness) >= MinLightnessDelta)
+        {
+            return Opaque(selection);
+        }
+
+        // 推的方向由背景明暗定,不由选区色定:暗底上把选区提亮、亮底上把它压深,才是
+        // 各家终端一致的观感。混合目标取纯白/纯黑,是最省事又能保住原色相的 tint/shade。
+        byte target = backgroundLightness < 50 ? (byte)0xFF : (byte)0x00;
+
+        // 二分出**刚好够**的混合比例:够看见就停手,不多推一分。上界 1.0 必然满足
+        // (背景 L* < 50 时推到白至少差 50,反之推到黑至少差 50),所以搜索必然收敛。
+        double low = 0.0;
+        double high = 1.0;
+        for (int i = 0; i < 12; i++)
+        {
+            double mid = (low + high) / 2;
+            if (Math.Abs(Lightness(Mix(selection, target, mid)) - backgroundLightness) >= MinLightnessDelta)
+            {
+                high = mid;
+            }
+            else
+            {
+                low = mid;
+            }
+        }
+        return Opaque(Mix(selection, target, high));
+    }
+
+    /// <summary>
+    /// 前景与选区底撞明度时的兜底前景色:优先用终端默认前景(观感上最不突兀),
+    /// 它自己也撞的话才退到纯白/纯黑里较远的那个。
+    /// </summary>
+    public static Rgba ReadableForeground(Rgba selectionFill, Rgba defaultForeground)
+    {
+        double fill = Brightness(selectionFill);
+        if (Math.Abs(Brightness(defaultForeground) - fill) >= MinForegroundDelta)
+        {
+            return defaultForeground;
+        }
+        return fill < 0.5 ? Rgba.FromRgb(0xFF, 0xFF, 0xFF) : Rgba.FromRgb(0x00, 0x00, 0x00);
+    }
+
+    /// <summary>
+    /// 感知亮度(0–1)。用的是 <c>0.299/0.587/0.114</c> 这套直接压在 sRGB 通道上的老式加权,
+    /// 而非 <see cref="Lightness" /> 那条要开方的正经路子:它在**每个选中格**上都要算一次,
+    /// 精度够用即可,不能带 <c>Math.Pow</c> 进渲染热路径。
+    /// </summary>
+    public static double Brightness(Rgba color) =>
+        ((0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B)) / 255.0;
+
+    /// <summary>CIE L*(0–100)。只在换主题 / 换配色时算,可以走完整的 sRGB 线性化。</summary>
+    internal static double Lightness(Rgba color)
+    {
+        double y = (0.2126 * Linear(color.R)) + (0.7152 * Linear(color.G)) + (0.0722 * Linear(color.B));
+        return y > 0.008856 ? (116 * Math.Cbrt(y)) - 16 : 903.3 * y;
+    }
+
+    private static double Linear(byte channel)
+    {
+        double c = channel / 255.0;
+        return c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+    }
+
+    private static Rgba Mix(Rgba color, byte target, double t) =>
+        Rgba.FromRgb(Lerp(color.R, target, t), Lerp(color.G, target, t), Lerp(color.B, target, t));
+
+    private static byte Lerp(byte from, byte to, double t) =>
+        (byte)Math.Clamp(Math.Round(from + ((to - from) * t)), 0, 255);
+
+    private static Rgba Opaque(Rgba color) => Rgba.FromRgb(color.R, color.G, color.B);
+}

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -216,6 +216,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         Focusable = true;
         ClipToBounds = true;
         ApplyDesignPalette(Emulator.Palette);
+        NormalizeSelectionColors();
         RecomputeMetrics();
         Emulator.Updated += OnEmulatorUpdated;
         Emulator.Response += bytes => UserInput?.Invoke(bytes); // 协议自动应答:发往 PTY 但不算用户键入(不进 TypedInput)。
@@ -793,7 +794,27 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         ApplyDesignPalette(Emulator.Palette, ActualThemeVariant == ThemeVariant.Light);
         ApplyPaletteOverrides(Emulator.Palette, ThemePalette);
         ApplyPaletteOverrides(Emulator.Palette, PaletteOverrides);
+        NormalizeSelectionColors();
         InvalidateTerminal();
+    }
+
+    /// <summary>选区填充色的感知亮度;渲染热路径上逐个选中格与前景比对,故预先算好。</summary>
+    private double _selectionFillBrightness;
+
+    /// <summary>前景与选区底撞明度时顶上的兜底前景色。</summary>
+    private Rgba _selectionFallbackForeground;
+
+    /// <summary>
+    /// 三层调色板叠完之后,把选区色整定成实际绘制用的填充色。它取决于**最终**的背景色 ——
+    /// 选区色与背景色可能分别来自不同层,所以必须等三层都落定才能算。
+    /// <see cref="ApplyDesignPalette" /> 每次都把整套颜色重置一遍,因此重复调用不会层层叠加。
+    /// </summary>
+    private void NormalizeSelectionColors()
+    {
+        TerminalPalette palette = Emulator.Palette;
+        palette.SelectionBackground = SelectionContrast.Fill(palette.SelectionBackground, palette.DefaultBackground);
+        _selectionFillBrightness = SelectionContrast.Brightness(palette.SelectionBackground);
+        _selectionFallbackForeground = SelectionContrast.ReadableForeground(palette.SelectionBackground, palette.DefaultForeground);
     }
 
     private static void ApplyPaletteOverrides(TerminalPalette palette, TerminalPaletteOverrides? overrides)
@@ -815,9 +836,10 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             palette.CursorColor = cur;
         }
         if (o.Selection is { } sel)
-        // 用户给的是不带透明度的选区色;按既有方案以 ~35% 透明叠加,避免盖住文字。
         {
-            palette.SelectionBackground = new(0x59, sel.R, sel.G, sel.B);
+            // 原样收下,不在这里兑透明度也不在这里比对比度:选区色与背景色可能来自不同层,
+            // 整定要等三层叠完(见 NormalizeSelectionColors)。
+            palette.SelectionBackground = sel;
         }
         for (int i = 0; i < TerminalPaletteOverrides.AnsiCount; i++)
         {
@@ -1171,7 +1193,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             palette.DefaultForeground = Rgba.FromRgb(0x65, 0x7B, 0x83); // base00
             palette.DefaultBackground = Rgba.FromRgb(0xFD, 0xF6, 0xE3); // base3
             palette.CursorColor = Rgba.FromRgb(0x65, 0x7B, 0x83);
-            palette.SelectionBackground = new(0x40, 0x58, 0x6E, 0x75); // base01 @25%(方案原生选区 base2 与背景过近,取更可辨的半透明灰蓝)
+            palette.SelectionBackground = Rgba.FromRgb(0xEE, 0xE8, 0xD5); // base2(方案原生选区色;与背景过近的那点由 SelectionContrast 推开)
             // 搜索高亮:亮底上要压得住又不能盖住字形。暗色那套(半透明琥珀 / 青)贴到
             // Solarized Light 的米色底上几乎看不出来,所以两个变体各给一套。
             palette.SearchMatchBackground = new(0x66, 0xB5, 0x89, 0x00); // yellow @40%
@@ -1197,7 +1219,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
         palette.DefaultForeground = Rgba.FromRgb(0xF8, 0xF8, 0xF2);
         palette.DefaultBackground = Rgba.FromRgb(0x28, 0x2A, 0x36);
         palette.CursorColor = Rgba.FromRgb(0xF8, 0xF8, 0xF2);
-        palette.SelectionBackground = new(0x99, 0x44, 0x47, 0x5A); // dracula selection
+        palette.SelectionBackground = Rgba.FromRgb(0x44, 0x47, 0x5A); // dracula selection
         palette.SearchMatchBackground = new(0x59, 0xF1, 0xFA, 0x8C); // dracula yellow @35%
         palette.SearchCurrentBackground = new(0x73, 0x8B, 0xE9, 0xFD); // dracula cyan @45%
         palette.SetAnsi(0, Rgba.FromRgb(0x21, 0x22, 0x2C)); // black
@@ -2462,6 +2484,14 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
             if (IsSelectedColumn(rowSpans, col))
             {
                 bg = palette.SelectionBackground;
+
+                // 选区底是不透明的,原本压在终端底上读得清的前景可能正好贴在明度相近的选区底上
+                // (Solarized Dark 的 ansi black #073642 落在自家选区上就是这么消失的)。撞上了才换,
+                // 所以 ls --color / git 的显式配色在绝大多数格上仍原样呈现。
+                if (Math.Abs(SelectionContrast.Brightness(fg) - _selectionFillBrightness) < SelectionContrast.MinForegroundDelta)
+                {
+                    fg = _selectionFallbackForeground;
+                }
             }
             if (rowSearchSpans is not null)
             {

--- a/src/VelaShell.Terminal/VelaShell.Terminal.csproj
+++ b/src/VelaShell.Terminal/VelaShell.Terminal.csproj
@@ -17,6 +17,7 @@
        应用、不跑测试,故签名构建(Release)时省略友元声明,仅在非签名构建(Debug / 本地测试)保留。 -->
   <ItemGroup Condition="'$(SignAssembly)' != 'true'">
     <InternalsVisibleTo Include="VelaShell.Terminal.Tests" />
+    <InternalsVisibleTo Include="VelaShell.Terminal.RenderTests" />
   </ItemGroup>
 
 </Project>

--- a/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
+++ b/tests/VelaShell.Terminal.RenderTests/GlyphRenderingTests.cs
@@ -5,7 +5,6 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
-using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using VelaShell.Terminal.Rendering;
 
@@ -32,32 +31,10 @@ namespace VelaShell.Terminal.RenderTests;
 [TestCategory("GlyphRendering")]
 public class GlyphRenderingTests
 {
-    private static HeadlessUnitTestSession _session = null!;
-
-    [ClassInitialize]
-    public static void Init(TestContext _) => _session = HeadlessUnitTestSession.StartNew(typeof(SkiaHeadlessApp));
-
-    [ClassCleanup]
-    public static void Cleanup()
-    {
-        // Avalonia 12.1.2 的 HeadlessUnitTestSession.StartNew 有竞态:它把 Task.Run 的返回值
-        // 经闭包变量交给会话构造器(源码里那句 `task!`),写入方是调用线程、读取方是工作线程,
-        // 中间没有任何同步。工作线程读到 null 时 _dispatchTask 就永久为 null —— 而它只在
-        // Dispose() 的 _dispatchTask.Wait() 处才炸:所有用例照常通过,只有清理红一条,
-        // 重跑即绿。此时 Cancel() 与 CompleteAdding() 已执行,调度循环必然退出,
-        // 吞掉这条 NRE 不泄漏任何东西。上游 master 至今未修。
-        try
-        {
-            _session.Dispose();
-        }
-        catch (NullReferenceException)
-        {
-            // 见上。
-        }
-    }
+    private static HeadlessUnitTestSession Session => SkiaTestSession.Current;
 
     private static void OnUi(Action body) =>
-        _session.Dispatch(() =>
+        Session.Dispatch(() =>
         {
             body();
             return Task.CompletedTask;
@@ -228,17 +205,4 @@ public class GlyphRenderingTests
             window.Close();
         });
     }
-}
-
-/// <summary>挂 Skia 软件光栅的 headless 宿主:与逻辑测试项目的空绘制后端刻意分开。</summary>
-public class SkiaHeadlessApp : Application
-{
-    /// <inheritdoc />
-    public override void Initialize() => Styles.Add(new FluentTheme());
-
-    /// <summary>供 <see cref="HeadlessUnitTestSession" /> 反射调用。</summary>
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<SkiaHeadlessApp>()
-            .UseSkia()
-            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
 }

--- a/tests/VelaShell.Terminal.RenderTests/SelectionVisibilityRenderTests.cs
+++ b/tests/VelaShell.Terminal.RenderTests/SelectionVisibilityRenderTests.cs
@@ -1,0 +1,166 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.RenderTests;
+
+/// <summary>
+/// 选区高亮的<b>像素级</b>回归:拖出一段之后,屏幕上那条带子到底看不看得见。
+/// <para>
+/// 回归的故障:选区色此前按半透明叠加绘制(暗 35% / 亮 25%),而各家方案的选区色本就是照
+/// 不透明填充设计的、与自家背景只差一线 —— 乘上不透明度后压在背景上只剩 1.05:1 ~ 1.21:1,
+/// 拖完一段跟没拖一样。这条只有真读像素才验得到:调色板层看着一切正常,选区色明明设了。
+/// </para>
+/// <para>
+/// 判据(CIE L* 感知明度差)在本文件里独立实现一份,不复用渲染侧的 <c>SelectionContrast</c>:
+/// 测试要当独立的度量仪,而不是把被测代码的算术抄一遍再和自己对答案。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("GlyphRendering")]
+public class SelectionVisibilityRenderTests
+{
+    /// <summary>选区带与终端底之间必须让人一眼看出的感知明度差(CIE L*,0–100 标度)。</summary>
+    private const double MinLightnessDelta = 12.0;
+
+    private static HeadlessUnitTestSession Session => SkiaTestSession.Current;
+
+    private static void OnUi(Action body) =>
+        Session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [TestMethod]
+    public void DraggedSelection_PaintsABandTheEyeCanActuallySee()
+    {
+        OnUi(() =>
+        {
+            var control = new VelaTerminalControl
+            {
+                CopyOnSelect = false, // headless 下不去碰剪贴板
+                ShowLineNumber = false,
+                ShowLineTimestamp = false,
+                ShowFoldMarker = false,
+                CursorBlink = false,
+            };
+            control.Feed(Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaa\r\nbbbbbbbbbbbbbbbb"));
+
+            var window = new Window { Width = 640, Height = 360, Content = control };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.CaptureRenderedFrame(); // 填充屏幕行映射与单元格度量
+
+            uint[] before = RenderFrame(window);
+            Drag(window, control, (0, 0), (0, 16));
+            uint[] after = RenderFrame(window);
+            window.Close();
+
+            // 选区带的颜色 = 变了色的那些像素里最常见的那个(字形本身只占少数)。
+            uint band = MostCommonChanged(before, after);
+            uint background = MostCommon(before);
+
+            double delta = Math.Abs(Lightness(band) - Lightness(background));
+            Assert.IsGreaterThan(
+                MinLightnessDelta,
+                delta,
+                $"选区带 #{band & 0xFFFFFF:X6} 与终端底 #{background & 0xFFFFFF:X6} 只差 L* {delta:F1} —— "
+                    + "这个差在屏幕上等于没画,用户会以为压根没选中。");
+        });
+    }
+
+    private static void Drag(Window window, VelaTerminalControl control, (int Row, int Col) from, (int Row, int Col) to)
+    {
+        window.MouseDown(CellPoint(control, from.Row, from.Col), MouseButton.Left);
+        window.MouseMove(CellPoint(control, to.Row, to.Col));
+        window.MouseUp(CellPoint(control, to.Row, to.Col), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>屏幕行/列的左上角坐标(略微内缩,避免落到相邻单元格)。</summary>
+    private static Point CellPoint(VelaTerminalControl control, int row, int col) =>
+        new(
+            control.GutterForTest.TotalWidth + (col * control.CellWidthForTest) + 1,
+            (row * control.CellHeightForTest) + 1);
+
+    private static uint MostCommon(uint[] pixels) => MostCommon(pixels, _ => true);
+
+    private static uint MostCommonChanged(uint[] before, uint[] after)
+    {
+        Dictionary<uint, int> histogram = [];
+        for (int i = 0; i < after.Length; i++)
+        {
+            if (before[i] != after[i])
+            {
+                histogram[after[i]] = histogram.GetValueOrDefault(after[i]) + 1;
+            }
+        }
+        Assert.IsGreaterThan(0, histogram.Count, "拖拽之后一个像素都没变 —— 选区根本没画。");
+        return histogram.MaxBy(pair => pair.Value).Key;
+    }
+
+    private static uint MostCommon(uint[] pixels, Func<uint, bool> keep)
+    {
+        Dictionary<uint, int> histogram = [];
+        foreach (uint p in pixels)
+        {
+            if (keep(p))
+            {
+                histogram[p] = histogram.GetValueOrDefault(p) + 1;
+            }
+        }
+        return histogram.MaxBy(pair => pair.Value).Key;
+    }
+
+    /// <summary>BGRA 像素的 CIE L*(0–100)。</summary>
+    private static double Lightness(uint bgra)
+    {
+        double b = Linear((byte)bgra);
+        double g = Linear((byte)(bgra >> 8));
+        double r = Linear((byte)(bgra >> 16));
+        double y = (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+        return y > 0.008856 ? (116 * Math.Cbrt(y)) - 16 : 903.3 * y;
+    }
+
+    private static double Linear(byte channel)
+    {
+        double c = channel / 255.0;
+        return c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+    }
+
+    /// <summary>渲染一帧并返回 BGRA 像素。</summary>
+    private static uint[] RenderFrame(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        using WriteableBitmap bitmap = window.CaptureRenderedFrame()
+            ?? throw new AssertFailedException(
+                "没有拿到渲染帧。若 Skia 后端未生效(UseHeadlessDrawing 仍为 true),这里恒为 null。");
+
+        int width = bitmap.PixelSize.Width;
+        int height = bitmap.PixelSize.Height;
+        const int bytesPerPixel = 4;
+        int bufferSize = checked(width * height * bytesPerPixel);
+        IntPtr buffer = Marshal.AllocHGlobal(bufferSize);
+        try
+        {
+            bitmap.CopyPixels(new PixelRect(0, 0, width, height), buffer, bufferSize, width * bytesPerPixel);
+            uint[] pixels = new uint[width * height];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (uint)Marshal.ReadInt32(buffer, i * bytesPerPixel);
+            }
+            return pixels;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+}

--- a/tests/VelaShell.Terminal.RenderTests/SkiaTestSession.cs
+++ b/tests/VelaShell.Terminal.RenderTests/SkiaTestSession.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Themes.Fluent;
+
+namespace VelaShell.Terminal.RenderTests;
+
+/// <summary>
+/// 全程序集共用的 Skia headless 会话(与 VelaShell.Terminal.Tests 的 HeadlessTestSession 同一套路)。
+/// <para>
+/// Avalonia 的平台注册是进程级的,本程序集里每多一个测试类就多起一次会话,除了白白多启一次
+/// Avalonia,还会把 <c>StartNew</c> 的那条竞态(见 <see cref="Cleanup" />)多摇一次骰子。
+/// </para>
+/// </summary>
+[TestClass]
+public class SkiaTestSession
+{
+    private static HeadlessUnitTestSession? _shared;
+
+    /// <summary>共用会话;在 <see cref="Init" /> 之后、<see cref="Cleanup" /> 之前有效。</summary>
+    public static HeadlessUnitTestSession Current =>
+        _shared ?? throw new InvalidOperationException(
+            "headless 会话尚未建立 —— [AssemblyInitialize] 没跑到,通常是测试宿主没有加载本程序集的初始化。");
+
+    /// <summary>建立全程序集唯一的 headless 会话。</summary>
+    [AssemblyInitialize]
+    public static void Init(TestContext _) => _shared = HeadlessUnitTestSession.StartNew(typeof(SkiaHeadlessApp));
+
+    /// <summary>拆除会话。</summary>
+    [AssemblyCleanup]
+    public static void Cleanup()
+    {
+        // Avalonia 12.1.2 的 HeadlessUnitTestSession.StartNew 有竞态:它把 Task.Run 的返回值
+        // 经闭包变量交给会话构造器(源码里那句 `task!`),写入方是调用线程、读取方是工作线程,
+        // 中间没有任何同步。工作线程读到 null 时 _dispatchTask 就永久为 null —— 而它只在
+        // Dispose() 的 _dispatchTask.Wait() 处才炸:所有用例照常通过,只有清理红一条,
+        // 重跑即绿。此时 Cancel() 与 CompleteAdding() 已执行,调度循环必然退出,
+        // 吞掉这条 NRE 不泄漏任何东西。上游 master 至今未修。
+        try
+        {
+            _shared?.Dispose();
+        }
+        catch (NullReferenceException)
+        {
+            // 见上。
+        }
+        _shared = null;
+    }
+}
+
+/// <summary>Skia 软件光栅的 headless 测试宿主(<c>UseHeadlessDrawing = false</c> 才有真像素)。</summary>
+public class SkiaHeadlessApp : Application
+{
+    /// <inheritdoc />
+    public override void Initialize() => Styles.Add(new FluentTheme());
+
+    /// <summary>供 <see cref="HeadlessUnitTestSession" /> 反射调用。</summary>
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<SkiaHeadlessApp>()
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
+}

--- a/tests/VelaShell.Terminal.Tests/SelectionContrastTests.cs
+++ b/tests/VelaShell.Terminal.Tests/SelectionContrastTests.cs
@@ -1,0 +1,129 @@
+using VelaShell.Terminal.Emulation;
+using VelaShell.Terminal.Rendering;
+
+namespace VelaShell.Terminal.Tests;
+
+/// <summary>
+/// 选区高亮看不看得见(#选区对比度)。
+/// <para>
+/// 回归的是这么一个具体故障:选区色此前按半透明叠加绘制(暗 35% / 亮 25%),而各家方案的
+/// 选区色本就是照不透明填充设计的、与自家背景只差一线,乘上不透明度后实测对比度只剩
+/// 1.05:1 ~ 1.21:1 —— 拖完一段跟没拖一样,用户以为压根没选中。
+/// </para>
+/// </summary>
+[TestClass]
+[TestCategory("TerminalPalette")]
+public class SelectionContrastTests
+{
+    private static Avalonia.Headless.HeadlessUnitTestSession Session => HeadlessTestSession.Current;
+
+    private static void OnUi(Action body) =>
+        Session.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>各家方案的背景 + 原生选区色。前四组是原本淡到看不见的那几套。</summary>
+    private static IEnumerable<object[]> Schemes =>
+    [
+        ["Solarized Light", Hex(0xFDF6E3), Hex(0xEEE8D5)],
+        ["Solarized Dark", Hex(0x002B36), Hex(0x073642)],
+        ["One Light", Hex(0xFAFAFA), Hex(0xE5E5E6)],
+        ["GitHub Light", Hex(0xFFFFFF), Hex(0xCFE4FB)],
+        ["Dracula", Hex(0x282A36), Hex(0x44475A)],
+        ["Tokyo Night", Hex(0x1A1B26), Hex(0x33467C)],
+        ["Nord", Hex(0x2E3440), Hex(0x434C5E)],
+        ["Alucard", Hex(0xFFFBEB), Hex(0xCFCFDE)],
+        ["Monokai", Hex(0x272822), Hex(0x49483E)],
+        ["Sakura", Hex(0xFFFBFD), Hex(0xF7D9E5)],
+        ["Obsidian", Hex(0x131316), Hex(0x2E2E38)],
+        ["Rosé Pine Dawn", Hex(0xFFFAF3), Hex(0xEADDD3)],
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(Schemes))]
+    public void Fill_AlwaysClearsTheVisibilityFloor(string name, Rgba background, Rgba selection)
+    {
+        Rgba fill = SelectionContrast.Fill(selection, background);
+
+        double delta = Math.Abs(SelectionContrast.Lightness(fill) - SelectionContrast.Lightness(background));
+        Assert.IsTrue(delta >= SelectionContrast.MinLightnessDelta - 0.01,
+            $"{name}:选区底与终端底只差 L* {delta:F1},低于 {SelectionContrast.MinLightnessDelta} 就等于没画。");
+        Assert.AreEqual(0xFF, fill.A, $"{name}:选区底必须不透明 —— 半透明正是原先看不见的根因。");
+    }
+
+    /// <summary>够用的方案不该被动:整定只托底,不夺方案自己的设计。</summary>
+    [TestMethod]
+    public void Fill_LeavesAlreadyVisibleSchemesAlone()
+    {
+        Assert.AreEqual(Hex(0x33467C), SelectionContrast.Fill(Hex(0x33467C), Hex(0x1A1B26)), "Tokyo Night");
+        Assert.AreEqual(Hex(0x49483E), SelectionContrast.Fill(Hex(0x49483E), Hex(0x272822)), "Monokai");
+    }
+
+    /// <summary>推的方向由背景明暗定:暗底上提亮、亮底上压深。</summary>
+    [TestMethod]
+    public void Fill_PushesAwayFromTheBackground()
+    {
+        Rgba onDark = SelectionContrast.Fill(Hex(0x073642), Hex(0x002B36));
+        Rgba onLight = SelectionContrast.Fill(Hex(0xEEE8D5), Hex(0xFDF6E3));
+
+        Assert.IsTrue(SelectionContrast.Lightness(onDark) > SelectionContrast.Lightness(Hex(0x002B36)));
+        Assert.IsTrue(SelectionContrast.Lightness(onLight) < SelectionContrast.Lightness(Hex(0xFDF6E3)));
+    }
+
+    /// <summary>选区色与背景撞成同一个色也要能推开(最坏情况不能死循环或原样返回)。</summary>
+    [TestMethod]
+    public void Fill_HandlesSelectionIdenticalToBackground()
+    {
+        foreach (Rgba bg in new[] { Hex(0x000000), Hex(0xFFFFFF), Hex(0x808080), Hex(0x282A36) })
+        {
+            Rgba fill = SelectionContrast.Fill(bg, bg);
+            double delta = Math.Abs(SelectionContrast.Lightness(fill) - SelectionContrast.Lightness(bg));
+            Assert.IsTrue(delta >= SelectionContrast.MinLightnessDelta - 0.01, $"背景 {bg.Packed:X8} 上推不开。");
+        }
+    }
+
+    /// <summary>撞明度才换前景;不撞的一律原样,免得选中一段就把 ls --color 的配色抹平。</summary>
+    [TestMethod]
+    public void ReadableForeground_OnlyReplacesWhatWouldVanish()
+    {
+        Rgba fill = SelectionContrast.Fill(Hex(0x073642), Hex(0x002B36));
+
+        Assert.AreEqual(Hex(0x839496), SelectionContrast.ReadableForeground(fill, Hex(0x839496)),
+            "默认前景读得清就用默认前景。");
+        Assert.IsTrue(
+            Math.Abs(SelectionContrast.Brightness(SelectionContrast.ReadableForeground(fill, fill))
+                - SelectionContrast.Brightness(fill)) >= SelectionContrast.MinForegroundDelta,
+            "默认前景自己也撞的话得退到纯白/纯黑。");
+    }
+
+    /// <summary>控件层:三层配色叠完后落到调色板上的,是整定过的填充色。</summary>
+    [TestMethod]
+    public void Control_NormalizesSelectionAfterAllPaletteLayers()
+    {
+        OnUi(() =>
+        {
+            // Solarized Light 那套:选区 base2 与背景 base3 原生只差 L* 5,是最淡的一档。
+            var control = new VelaTerminalControl
+            {
+                ThemePalette = new()
+                {
+                    Background = Hex(0xFDF6E3),
+                    Foreground = Hex(0x657B83),
+                    Selection = Hex(0xEEE8D5),
+                },
+            };
+
+            TerminalPalette palette = control.PaletteForTest;
+            double delta = Math.Abs(
+                SelectionContrast.Lightness(palette.SelectionBackground)
+                - SelectionContrast.Lightness(palette.DefaultBackground));
+
+            Assert.AreEqual(0xFF, palette.SelectionBackground.A);
+            Assert.IsTrue(delta >= SelectionContrast.MinLightnessDelta - 0.01, $"只差 L* {delta:F1}。");
+        });
+    }
+
+    private static Rgba Hex(uint rgb) => Rgba.FromRgb((byte)(rgb >> 16), (byte)(rgb >> 8), (byte)rgb);
+}


### PR DESCRIPTION
## 问题

不管深色还是浅色模式，在终端里拖选输出内容，背景色都不明显，以为压根没选中。

## 根因

根因不在颜色选得淡，而在**画法**：选区底一直按半透明叠加绘制 —— 暗色 35%（`0x59`）、亮色 25%（`0x40`），用户自定义色也统一兑成 35%。

可各家方案的选区色（Dracula `#44475A`、Solarized base2 `#EEE8D5`、GitHub Light `#CFE4FB`……）**本就是照不透明填充设计的**，它们与自家背景本来只差一线，再乘上不透明度，压在背景上实测只剩：

| 方案 | 原来屏幕上的对比度 |
|---|---|
| Solarized Light / Dark | 1.045 / 1.051 |
| One Light | 1.063 |
| Dracula（暗色默认） | 1.158 |
| Tokyo Night（最好的一档） | 1.21 |

## 改法

新增 `SelectionContrast`：选区底改为**不透明**绘制，并保证与终端底至少拉开 **ΔL\* 14**（CIE 感知明度）。

判据用 L\* 而非 WCAG 对比度：后者在暗端压缩得厉害，同一个阈值在暗色主题上几乎不动、在亮色主题上却会把选区压成一条灰带，明暗两套没法用同一个数说话。14 这一档参照 VS Code（自家明暗主题分别是 20.8 / 15.9）取稍低一级。

整定放在三层调色板（控件缺省 → 主题配色 → 用户单色）**全部叠完之后** —— 选区色与背景色可能来自不同层。够用的方案原样保留，不夺方案自己的设计：

```
Tokyo Night     #33467C -> 不动     (ΔL* 20.6)
Gruvbox / Monokai            不动     (15.5 / 14.6)
Dracula         #44475A -> #46495B  (13.2 → 14.1)
Solarized Light #EEE8D5 -> #D4CEBE  ( 5.0 → 14.1)
Solarized Dark  #073642 -> #214B56  ( 4.8 → 14.0)
One Light       #E5E5E6 -> #D2D2D3  ( 7.3 → 14.0)
GitHub Light    #CFE4FB -> #C5D9EF  (10.3 → 14.1)
```

另补一道前景守卫：选区底一旦不透明，原本压在终端底上读得清的暗色前景可能正好贴到明度相近的选区底上（Solarized Dark 的 ansi black `#073642` 落在自家选区上就是这么消失的）。撞上了才换色，故 `ls --color` / git 的显式配色在绝大多数格上仍原样呈现；热路径上只做一次减法，不带 `Math.Pow`。

## 验证

- `SelectionContrastTests`（21 项）—— 12 套方案都过底线、够用的不被动、选区色与背景撞成同色也推得开。
- `SelectionVisibilityRenderTests` —— **像素级**：真拖一段、真读渲染帧，量屏幕上那条带子与终端底的 ΔL\*。判据在测试里独立实现一份，不复用被测代码的算术。把选区色改回老值可复现失败（`ΔL* 4.9`）。
- 全量：Terminal 464、RenderTests 4、VelaShell.Tests 1262 全绿；整解决方案 0 警告 0 错误。

## 附带

把 RenderTests 的 Skia headless 会话提到程序集级（沿用 `VelaShell.Terminal.Tests` 里已验证的 `HeadlessTestSession` 做法），避免每加一个像素测试类就多起一次 Avalonia。

## 没动的

终端内搜索高亮仍是半透明。它用的是高饱和琥珀/青，压在两种底上都看得见，不属于这次的故障，故未顺手一起改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LL3YpKJXYmou9VUUNEa2Kz
