### PR TITLE
fix(ui): 下拉列表的字在亮色主题下发糊 —— 11px 比例字体填不满像素

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -3245,3 +3245,78 @@ ANSI 前景与各自选区底的亮度差,低于 `MinForegroundDelta`(0.18)即�
 而且整定二分停在「刚好够」的那一步、填充色再量化到 8bit,屏幕上量到的总比算出来的低零点几
 (这次 16.0 → 15.87,#405 当年 14.0 → 13.9 是同一回事)。地板贴着实现值走,它会因为
 一个色阶的舍入而红 —— 第一次改成 18 时正是这么红的。
+
+---
+
+## ✅ 60. 2026-09-09 下拉列表的字为什么在亮色主题下发糊:两条假设被像素实测推翻(用户反馈)
+
+用户报「切换主题后字体变得非常糊」,并指明是下拉列表(主题选择那个 ComboBox)的文字,
+且「所有亮色都不行,所有深色看起来都没问题」。
+
+### 一、先说两条被推翻的假设 —— 都是猜的,都被实测打掉
+
+1. **「弹层表面半透明,文字画在非不透明表面上丢了次像素抗锯齿」**。听着合理,
+   写了个 headless 探针把 Fluent 的资源读出来:`ComboBoxDropDownBackground` 是
+   **完全不透明**的 `#2B2B2B`(亮色变体 `#F2F2F2`)。假设不成立。
+2. **「弹层落在半个像素上,所以字形填不满」**。采截图像素时看到 y=130/131 两行都不是底色,
+   判成「边框被劈成两行」。**读错了** —— 那是两条不同的线:y=130 是 ComboBox 自己的下边框
+   (`#F3D9E3`),y=131 是弹层的上边框(`#E3BECC`),各自都是干净的单像素。弹层没有偏移。
+
+留着这两条,是因为下次再遇到「界面发糊」大概率还会先想到它们。
+
+### 二、真因:11px 的比例字体填不满像素
+
+决定性的一步是**同款对同款**:闭合框里的字与弹层里的字**一样糊**,而它俩一个在弹层外、
+一个在弹层内 —— 于是跟弹层无关。逐区采样同一张截图(设置页,Sakura):
+
+| 文字 | 字号 / 字重 | 达到实墨的像素数 |
+| --- | --- | --- |
+| 页面标题「外观」 | 18 SemiBold | 21 |
+| row-label「主题模式」 | 12 Medium | 17 |
+| row-desc(等宽 Cascadia) | ~11 Regular | 50 |
+| **闭合框「Sakura」** | **11 Regular 比例(Inter)** | **1** |
+| **弹层每一条** | **11 Regular 比例(Inter)** | **1** |
+
+11px 的 Inter Regular 笔画只有一个像素出头,**没有任何一个像素被完全覆盖**。
+深色主题上半覆盖的亮笔画照样发亮,看不出来;亮色主题上半覆盖的深笔画读作灰 ——
+「所有亮色不行、深色没问题」就是这么来的,不是配色对比度不够。
+
+### 三、顺带查出一处真缺陷:下拉是唯一没纳入令牌体系的弹层
+
+同一次探针把 Fluent 的整套下拉资源打了出来,全是**写死值**、不在令牌体系内:
+底 `#2B2B2B` / 边框 `Black` / 条目字恒为 `White`·`Black` / 选中底 `#0078D7`
+(Windows 经典蓝,不属于任何一套 VelaShell 主题)。
+
+而 `DockStyles.axaml` 里那段注释早就写过同一个病因 —— 当时治了 `FlyoutPresenter`、
+`ToolTip`、`ContextMenu`、`MenuFlyoutPresenter`,**唯独漏了 ComboBox 下拉**。
+于是九套主题换来换去,那一块岿然不动。
+
+改法是把这十个 Fluent 键别名到令牌上,写在 `ThemeTokenApplier` 的**主题字典那一格**,
+而不是 `DockStyles` 的模板部件选择器上:部件名(`Border#PopupBorder` 之类)是 Fluent 的
+内部实现、会随 Avalonia 版本改,资源键才是公开契约;写在同一格还保证弹层底与条目文字
+出自同一次写入,不会一个新一个旧。
+
+### 四、落地的是字号,不是字重
+
+字号 11 → 12。全仓有 **5 处**把下拉钉死在 11(`SettingsView` / `ConnectionProfileView`
+两个样式,`LocalFilePaneView` / `LocalPathPickerDialog` / `TunnelPanelView` 三个内联),
+其余走默认 13 —— 这正是用户说「**部分**下拉列表还是不清晰」的那一部分。
+**字号会继承进 `ComboBoxItem`**(实测:在 ComboBox 上设 12,容器读出来就是 12),
+所以改 ComboBox 这一处即同时管住闭合态与下拉列表。
+
+⚠️ **中途试过压字重(Regular → Medium → SemiBold),最终由用户撤下**,本次未合入。
+过程中查清两件仍然有用的事,记在这里免得重查:Avalonia 的 Inter 包内置
+Thin / Light / Regular / Medium / SemiBold / Bold **六个真实静态字面**(不是合成加粗);
+而回退路径 Segoe UI 上 `Medium`(500) 会被吸附回 `Normal`(400),`SemiBold`(600) 才落到
+真实的 "Segoe UI Semibold" —— 没装 Inter 的环境下 Medium 是个空操作。
+
+### 五、验收
+
+`dotnet build VelaShell.slnx -warnaserror` 零警告零错误;`dotnet test VelaShell.slnx`
+3301 通过 / 19 跳过 / 0 失败。`ThemeTokenApplierTests` 新增
+`EveryTheme_OverridesFluentComboBoxPopupBrushes`:逐主题核对那十个 Fluent 键都被顶掉,
+并钉住「弹层底 = `VelaBgSurface`、条目字 = `VelaTextPrimary`」——
+它们一个跟主题走、另一个不跟,正是这次要消掉的形态。
+
+⚠️ 固定高度的两个下拉(`LocalFilePaneView` / `LocalPathPickerDialog`,`Height=22`)
+字号上调后未做像素复核,是本次唯一没验到的地方。

--- a/src/VelaShell.Infrastructure/Import/SshConfigParser.cs
+++ b/src/VelaShell.Infrastructure/Import/SshConfigParser.cs
@@ -301,7 +301,7 @@ internal static class SshConfigParser
     /// <summary>按空白切分记号,并去掉每个记号两端的引号。</summary>
     private static IEnumerable<string> SplitTokens(string value)
     {
-        foreach (string token in value.Split((char[])[' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        foreach (string token in value.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             string unquoted = Unquote(token);
             if (unquoted.Length > 0)

--- a/src/VelaShell/Services/ThemeTokenApplier.cs
+++ b/src/VelaShell/Services/ThemeTokenApplier.cs
@@ -57,16 +57,69 @@ internal static class ThemeTokenApplier
     {
         ArgumentNullException.ThrowIfNull(resources);
         ArgumentNullException.ThrowIfNull(theme);
-        foreach ((string key, Color color) in BuildTokens(theme))
+        Dictionary<string, Color> tokens = BuildTokens(theme);
+        foreach ((string key, Color color) in tokens)
         {
             resources[key] = new SolidColorBrush(color);
         }
+        FillFluentAliases(resources, tokens);
         // 自绘窗体/浮层的投影:几何两套主题一致,只有不透明度分明暗 —— 同一个 50% 纯黑
         // 压在亮色卡片下面会糊成一块发脏的矩形(见 DarkTheme.axaml 的说明)。
         resources["VelaShadowWindow"] = BoxShadows.Parse(
             theme.IsDark
                 ? "0 1 3 0 #40000000, 0 4 12 0 #66000000"
                 : "0 1 3 0 #1A000000, 0 4 12 0 #33000000");
+    }
+
+    /// <summary>
+    /// Fluent 自带、但**不在令牌体系里**的资源键 → 该由哪个 <c>Vela*</c> 令牌顶上。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ComboBox 的下拉弹层是最后一个还吃 Fluent 默认值的弹层表面 —— <c>ToolTip</c>、
+    /// <c>ContextMenu</c>、<c>FlyoutPresenter</c>、<c>MenuFlyoutPresenter</c> 早已在
+    /// <c>DockStyles.axaml</c> 里改贴令牌(那里的注释写着同一个病因)。实测 Fluent 给的是:
+    /// 弹层底 <c>#2B2B2B</c>(亮色变体 <c>#F2F2F2</c>)、边框 <c>Black</c>、条目文字恒为
+    /// <c>White</c> / <c>Black</c>、选中底 <c>#0078D7</c> —— 最后那个是 Windows 经典蓝,
+    /// 不属于任何一套 VelaShell 主题。
+    /// </para>
+    /// <para>
+    /// 后果是九套主题换来换去,下拉弹层岿然不动:一块不跟主题走的中性灰底,配一个不跟主题走的
+    /// 纯白/纯黑字。周围每一处表面都已按主题重上色,唯独这一块没有 —— 切完主题再打开下拉,
+    /// 看到的就是这个对不上的色块。
+    /// </para>
+    /// <para>
+    /// <b>为什么别名写在这里,而不是 <c>DockStyles.axaml</c> 的模板部件选择器上</b>:
+    /// 那需要选中 <c>ComboBox /template/ Border#PopupBorder</c> 这类**模板部件名**,
+    /// 而部件名是 Fluent 的内部实现、会随 Avalonia 版本改;这些资源键则是它的公开契约。
+    /// 写在主题字典这一格还顺带解决了另一件事:它与 <c>Vela*</c> 令牌同格同时替换,
+    /// 弹层底与条目文字永远出自同一次写入,不会一个新一个旧。
+    /// </para>
+    /// </remarks>
+    private static readonly (string FluentKey, string TokenKey)[] FluentAliases =
+    [
+        ("ComboBoxDropDownBackground", "VelaBgSurface"),
+        ("ComboBoxDropDownBorderBrush", "VelaBorderSecondary"),
+        ("ComboBoxDropDownGlyphForeground", "VelaTextSecondary"),
+        ("ComboBoxItemForeground", "VelaTextPrimary"),
+        ("ComboBoxItemForegroundPointerOver", "VelaTextPrimary"),
+        ("ComboBoxItemForegroundSelected", "VelaTextPrimary"),
+        ("ComboBoxItemForegroundSelectedPointerOver", "VelaTextPrimary"),
+        ("ComboBoxItemBackgroundPointerOver", "VelaBgHover"),
+        ("ComboBoxItemBackgroundSelected", "VelaBgActive"),
+        ("ComboBoxItemBackgroundSelectedPointerOver", "VelaBgActive"),
+    ];
+
+    /// <summary>Fluent 别名键的清单(供用例逐主题核对)。</summary>
+    internal static IReadOnlyList<string> FluentAliasKeys { get; } = [.. FluentAliases.Select(static a => a.FluentKey)];
+
+    /// <summary>把 <see cref="FluentAliases" /> 里的每个键指到当前主题对应的令牌色上。</summary>
+    private static void FillFluentAliases(IResourceDictionary resources, Dictionary<string, Color> tokens)
+    {
+        foreach ((string fluentKey, string tokenKey) in FluentAliases)
+        {
+            resources[fluentKey] = new SolidColorBrush(tokens[tokenKey]);
+        }
     }
 
     /// <summary>用户自定义强调色会遮蔽的三个令牌(见 <see cref="ResetAccent" />)。</summary>

--- a/src/VelaShell/Views/ConnectionProfileView.axaml
+++ b/src/VelaShell/Views/ConnectionProfileView.axaml
@@ -52,7 +52,9 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="32" />
-      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <!-- 12 而非 11:11px 的比例字体笔画填不满像素,亮色主题下整列读作灰(同 SettingsView 那处的说明)。
+           字号继承进弹层条目,一处管两处。 -->
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
       <Setter Property="HorizontalAlignment" Value="Stretch" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>

--- a/src/VelaShell/Views/LocalFilePaneView.axaml
+++ b/src/VelaShell/Views/LocalFilePaneView.axaml
@@ -104,7 +104,7 @@
                          IsVisible="{Binding IsDirectoryLoading}" />
           </Grid>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize11}"
+            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize12}"
                       ItemsSource="{Binding Roots}" SelectedItem="{Binding SelectedRoot, Mode=OneWay}"
                       SelectionChanged="OnRootSelectionChanged"
                       VerticalContentAlignment="Center" MaxDropDownHeight="320">

--- a/src/VelaShell/Views/LocalPathPickerDialog.axaml
+++ b/src/VelaShell/Views/LocalPathPickerDialog.axaml
@@ -166,7 +166,7 @@
             </StackPanel>
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize11}"
+            <ComboBox MinHeight="0" Height="22" Padding="6,0" FontSize="{DynamicResource VelaFontSize12}"
                       ItemsSource="{Binding Roots}" SelectedItem="{Binding SelectedRoot, Mode=OneWay}"
                       SelectionChanged="OnRootSelectionChanged"
                       VerticalContentAlignment="Center" MaxDropDownHeight="320">

--- a/src/VelaShell/Views/SettingsView.axaml
+++ b/src/VelaShell/Views/SettingsView.axaml
@@ -79,7 +79,12 @@
       <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
       <Setter Property="CornerRadius" Value="4" />
       <Setter Property="MinHeight" Value="30" />
-      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <!-- 12 而非 11(用户反馈「下拉列表字体不清晰」)。像素级实测:11px 的比例字体(Inter)
+           Regular 笔画只有一个像素出头,逐像素都只是部分覆盖 —— 屏幕上没有一个像素落到实墨。
+           同页 12px 的 row-label 则能填满。深色主题上半覆盖的亮笔画仍然发亮,看不出问题;
+           亮色主题上半覆盖的深笔画读作灰,整列字就"发糊"。
+           字号会继承进弹层条目(实测),所以改这一处就同时管住闭合态与下拉列表。 -->
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize12}" />
       <Setter Property="MinWidth" Value="140" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>

--- a/src/VelaShell/Views/TunnelPanelView.axaml
+++ b/src/VelaShell/Views/TunnelPanelView.axaml
@@ -114,7 +114,7 @@
               BorderThickness="0,0,0,1">
         <StackPanel Spacing="4">
           <TextBlock Classes="form-label" Text="{loc:Localize Tunnel_ServerLabel}" />
-          <ComboBox MinHeight="26" FontSize="{DynamicResource VelaFontSize11}"
+          <ComboBox MinHeight="26" FontSize="{DynamicResource VelaFontSize12}"
                     FontFamily="{DynamicResource VelaUiMonoFont}"
                     HorizontalAlignment="Stretch"
                     PlaceholderText="{loc:Localize Tunnel_SelectServerPlaceholder}"

--- a/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
+++ b/tests/VelaShell.Tests/Services/ThemeTokenApplierTests.cs
@@ -36,10 +36,44 @@ public sealed class ThemeTokenApplierTests
             [
                 .. resources.Keys.OfType<string>()
                     .Where(key => key != "VelaShadowWindow")
+                    // Fluent 别名键(ComboBox 下拉那几个)不是令牌本身,由下面那条用例单独核对。
+                    .Where(key => !ThemeTokenApplier.FluentAliasKeys.Contains(key))
                     .Order(StringComparer.Ordinal),
             ];
             Assert.AreSequenceEqual(expected, actual, $"{theme.Name} 写出的令牌集合与其它主题不一致。");
             Assert.IsTrue(resources.ContainsKey("VelaShadowWindow"), $"{theme.Name} 少了浮层投影令牌。");
+        }
+    }
+
+    /// <summary>
+    /// Fluent 下拉弹层那几个键必须逐主题被顶掉。
+    /// <para>
+    /// 不顶的话它们是 Fluent 写死的值(实测:底 <c>#2B2B2B</c>、条目字 <c>White</c>、
+    /// 选中底 <c>#0078D7</c> 这个 Windows 经典蓝),九套主题换来换去岿然不动 ——
+    /// 切完主题打开下拉,那一块与周围每一处已上色的表面都对不上。
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void EveryTheme_OverridesFluentComboBoxPopupBrushes()
+    {
+        Assert.IsNotEmpty(ThemeTokenApplier.FluentAliasKeys);
+        foreach (UiTheme theme in UiThemeCatalog.All)
+        {
+            var resources = new ResourceDictionary();
+            ThemeTokenApplier.Fill(resources, theme);
+            foreach (string key in ThemeTokenApplier.FluentAliasKeys)
+            {
+                Assert.IsTrue(resources.ContainsKey(key), $"{theme.Name} 没顶掉 Fluent 的 {key}。");
+            }
+            // 弹层底与条目文字必须来自同一套令牌 —— 一个跟主题走、另一个不跟,正是"糊"的来源。
+            Assert.AreEqual(
+                ColorOf(resources, "VelaBgSurface"),
+                ColorOf(resources, "ComboBoxDropDownBackground"),
+                $"{theme.Name} 的下拉底不是 VelaBgSurface。");
+            Assert.AreEqual(
+                ColorOf(resources, "VelaTextPrimary"),
+                ColorOf(resources, "ComboBoxItemForeground"),
+                $"{theme.Name} 的下拉条目文字不是 VelaTextPrimary。");
         }
     }
 


### PR DESCRIPTION
## 症状

「切换主题后下拉列表的字很糊,**所有亮色都不行、所有深色没问题**。」

## 定位:同款对同款

决定性的一步是发现**闭合框里的字与弹层里的字一样糊**,而它俩一个在弹层外、一个在弹层内 ——
于是跟弹层无关。逐区采样同一张截图(设置页 / Sakura),数**有多少像素达到实墨**:

| 文字 | 字号 / 字重 | 达到实墨的像素数 |
| --- | --- | --- |
| 页面标题「外观」 | 18 SemiBold | 21 |
| row-label「主题模式」 | 12 Medium | 17 |
| row-desc(等宽 Cascadia) | ~11 Regular | 50 |
| **闭合框「Sakura」** | **11 Regular 比例(Inter)** | **1** |
| **弹层每一条** | **11 Regular 比例(Inter)** | **1** |

11px 的 Inter Regular 笔画只有一个像素出头,**没有任何一个像素被完全覆盖**。
深色主题上半覆盖的亮笔画照样发亮;亮色主题上半覆盖的深笔画读作灰 ——
「亮色不行、深色没事」就是这么来的,不是配色对比度不够。

## 改了什么

**① 字号 11 → 12(5 处)**

全仓只有这 5 处把下拉钉死在 11,其余走默认 13 —— 正是用户说「**部分**下拉列表还是不清晰」的那部分:

| 位置 | 形式 |
| --- | --- |
| `SettingsView.axaml` | ComboBox 样式(设置页全部下拉) |
| `ConnectionProfileView.axaml` | ComboBox 样式(新建/编辑连接) |
| `LocalFilePaneView.axaml:107` | 内联,`Height=22` |
| `LocalPathPickerDialog.axaml:169` | 内联,`Height=22` |
| `TunnelPanelView.axaml:117` | 内联,`MinHeight=26` |

**字号会继承进 `ComboBoxItem`**(实测:在 ComboBox 上设 12,容器读出来就是 12),
所以改 ComboBox 这一处即同时管住闭合态与下拉列表,不必再单独动条目。

**② 顺带补上一处真缺陷:下拉是唯一没纳入令牌体系的弹层表面**

探针读出 Fluent 给的全是**写死值**:底 `#2B2B2B`(亮色 `#F2F2F2`)、边框 `Black`、
条目字恒为 `White`/`Black`、选中底 `#0078D7` —— 最后那个是 Windows 经典蓝,
不属于任何一套 VelaShell 主题。九套主题换来换去,那一块岿然不动。

`DockStyles.axaml` 里那段注释早就写过同一个病因,当时治了 `FlyoutPresenter` / `ToolTip` /
`ContextMenu` / `MenuFlyoutPresenter`,**唯独漏了 ComboBox 下拉**。本 PR 把十个 Fluent 键
别名到令牌上,写在 `ThemeTokenApplier` 的**主题字典那一格**:

- 不用 `ComboBox /template/ Border#PopupBorder` 这类选择器 —— 部件名是 Fluent 的内部实现、
  会随 Avalonia 版本改;资源键才是它的公开契约
- 写在同一格还保证**弹层底与条目文字出自同一次写入**,不会一个新一个旧

## 两条被推翻的假设(留作下次的路标)

1. **「弹层表面半透明,文字丢了次像素抗锯齿」** —— 探针把 Fluent 资源读出来:
   `ComboBoxDropDownBackground` 是**完全不透明**的。假设不成立。
2. **「弹层落在半个像素上」** —— 采像素时看到 y=130/131 两行都不是底色,判成「边框被劈成两行」。
   **读错了**:那是两条不同的线,y=130 是 ComboBox 自己的下边框、y=131 是弹层的上边框,
   各自都是干净的单像素。弹层没有偏移。

## 没有合入的

中途试过压字重(Regular → Medium → SemiBold),**最终由作者撤下**,本 PR 不含。
过程中查清的两件事记在 `plan.md` §60 里:Avalonia 的 Inter 包内置 Thin/Light/Regular/
Medium/SemiBold/Bold **六个真实静态字面**(不是合成加粗);而回退路径 Segoe UI 上
`Medium`(500) 会被吸附回 `Normal`(400),只有 `SemiBold`(600) 才落到真实的
"Segoe UI Semibold" —— 没装 Inter 的环境下 Medium 是个空操作。

## 验收

- `dotnet build VelaShell.slnx -warnaserror`:0 警告 0 错误
- `dotnet test VelaShell.slnx`:**3301 通过 / 19 跳过 / 0 失败**
- 新增 `EveryTheme_OverridesFluentComboBoxPopupBrushes`:逐主题核对那十个 Fluent 键都被顶掉,
  并钉住「弹层底 = `VelaBgSurface`、条目字 = `VelaTextPrimary`」—— 它们一个跟主题走、
  另一个不跟,正是这次要消掉的形态

## ⚠️ 未验到的一处

`LocalFilePaneView` 与 `LocalPathPickerDialog` 那两个下拉是**固定 `Height=22`**。
12px 字按算容得下(行高约 16 + `Padding="6,0"`),但**没做像素复核** —— 合之前值得打开
本地文件面板与本地路径选择框扫一眼有没有裁字。

## 附带

含一处**不是本次改动**的等价简化:`SshConfigParser` 的 `(char[])[...]` → `[...]`
(工作区里既有的,来源不明,代码等价、编译通过),随提交带上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBday53qH7NEepM5GUoTMC
