### PR TITLE
退出与开库路径的三处修复 —— 一个孤儿 .tmp 让每次刷盘都失败,根因是退出预算被抢

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/Bridge/ChannelShutdown.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/ChannelShutdown.cs
@@ -20,8 +20,21 @@ namespace VelaShell.Plugin.Ai.Bridge;
 /// </remarks>
 internal static class ChannelShutdown
 {
-    /// <summary>优雅关闭的宽限:发 Close 帧、以及等对端回 Close 各给这么多时间。</summary>
-    private static readonly TimeSpan CloseGrace = TimeSpan.FromSeconds(2);
+    /// <summary>
+    /// 优雅关闭的宽限:发 Close 帧、以及等对端回 Close 各给这么多时间。
+    /// </summary>
+    /// <remarks>
+    /// <b>这个数是被上游的退出预算框住的,不是随手定的。</b>两段宽限是串起来花的,最坏一条连接
+    /// 要 2×,而整个插件的停用被宿主卡在 <c>PluginManagerOptions.DeactivationTimeout</c>
+    /// (2 秒)之内。原来这里写 2 秒 —— 光第一段就把停用预算用光了,于是优雅收摊<b>永远走不完</b>:
+    /// 进程在 Close 握手中途退出,底下的 WebSocket / TLS / 套接字连锁抛出一串
+    /// 「连接被中止」,正是这个类开头要避免的那件事。
+    /// <para>
+    /// 700ms 对一次 Close 帧往返是十来倍的余量(对端在线时实测几十毫秒),而对端真失联时,
+    /// 多等的每一毫秒都只是在拖慢退出 —— 那条路的结局是 <c>Abort</c>,等多久都一样。
+    /// </para>
+    /// </remarks>
+    private static readonly TimeSpan CloseGrace = TimeSpan.FromMilliseconds(700);
 
     /// <summary>
     /// 可取消的等待:等满返回 true,被取消返回 false —— 不抛。

--- a/src/VelaShell.Infrastructure/Notifications/HttpAnnouncementFeed.cs
+++ b/src/VelaShell.Infrastructure/Notifications/HttpAnnouncementFeed.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using VelaShell.Core.Models;
 using VelaShell.Core.Notifications;
@@ -68,6 +69,9 @@ public sealed class HttpAnnouncementFeed(
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException or InvalidOperationException)
         {
             // 源不可达是常态(离线、内网、地址写错),当作"这次没有新消息"。
+            // 但要留一行:这条请求是开箱默认发的,失败时调试输出里只会浮出一串裸的 TLS/套接字
+            // 异常 —— 不写下是"哪个地址、什么原因",看到的人无从判断该查网络还是查代码。
+            Trace.WriteLine($"[VelaShell] Announcement feed {feed.Host} is unreachable: {ex.Message}");
             return [];
         }
         try

--- a/src/VelaShell.Infrastructure/Persistence/SonnetDbEngine.cs
+++ b/src/VelaShell.Infrastructure/Persistence/SonnetDbEngine.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using SonnetDB.Catalog;
 using SonnetDB.Documents;
 using SonnetDB.Engine;
@@ -59,6 +60,9 @@ public sealed class SonnetDbEngine : IDisposable
     /// </summary>
     private const long SegmentMemoryMapThresholdBytes = 1024 * 1024;
 
+    /// <summary>刷盘写段文件时的中间产物;成功后改名成 <c>*.SDBSEG</c>。</summary>
+    private const string SegmentTempFilePattern = "*.SDBSEG.tmp";
+
     private readonly Tsdb _db;
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly ConcurrentDictionary<string, DocumentCollectionStore> _stores = new(StringComparer.Ordinal);
@@ -77,6 +81,8 @@ public sealed class SonnetDbEngine : IDisposable
         }
         Directory.CreateDirectory(rootDirectory);
         RootDirectory = rootDirectory;
+        // 快照要在开库**之前**取,删除要在开库**之后**做 —— 见 SweepOrphanSegmentTempFiles。
+        SegmentTempFile[] orphans = SnapshotSegmentTempFiles(rootDirectory);
         _db = Tsdb.Open(new()
         {
             RootDirectory = rootDirectory,
@@ -86,6 +92,7 @@ public sealed class SonnetDbEngine : IDisposable
                 MemoryMappedFileThresholdBytes = SegmentMemoryMapThresholdBytes
             }
         });
+        SweepOrphanSegmentTempFiles(orphans);
         EnsureSchema();
     }
 
@@ -361,6 +368,80 @@ public sealed class SonnetDbEngine : IDisposable
         finally
         {
             _gate.Release();
+        }
+    }
+
+    /// <summary>一个段临时文件的身份(路径 + 大小 + 修改时间),用来判定开库前后它有没有被动过。</summary>
+    private readonly record struct SegmentTempFile(string Path, long Length, DateTime WrittenUtc);
+
+    /// <summary>开库前扫一遍已经躺在盘上的段临时文件。</summary>
+    private static SegmentTempFile[] SnapshotSegmentTempFiles(string rootDirectory)
+    {
+        try
+        {
+            return
+            [
+                .. Directory.EnumerateFiles(rootDirectory, SegmentTempFilePattern, SearchOption.AllDirectories)
+                    .Select(static path =>
+                    {
+                        FileInfo info = new(path);
+                        return new SegmentTempFile(path, info.Length, info.LastWriteTimeUtc);
+                    })
+            ];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// 清掉上一次运行留下的段临时文件。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>为什么必须清。</b>刷盘落段走的是「先写 <c>*.SDBSEG.tmp</c>,写成了再改名」。进程要是死在
+    /// 这两步之间(调试器停止、崩溃、退出时刷盘被超时掐断),tmp 就留在盘上了 —— 而 SonnetDB
+    /// 之后再用到同一个段号时是按「新建」开文件的,一头撞上
+    /// <c>The file '….SDBSEG.tmp' already exists.</c>,那一次刷盘连同内存表里的数据一起失败。
+    /// 关键在于它<b>不会自愈</b>:那个文件不会有人去动,于是此后每一次落到这个段号的刷盘都照样失败。
+    /// 已经踩到过一次 —— 一个留了一个多小时的 <c>0000000000000270.SDBSEG.tmp</c>,
+    /// 让退出时的最后一次刷盘直接抛在了它身上。
+    /// </para>
+    /// <para>
+    /// <b>为什么删得安全。</b>段是靠改名落地的,所以没改过名的 tmp 按定义不属于任何已提交的段,
+    /// 删掉不会丢任何已落盘的数据;那些确实还没落盘的点在 WAL 里,由开库时的重放负责。
+    /// </para>
+    /// <para>
+    /// <b>为什么是「开库前快照、开库后删除」。</b>删除得等到 <c>Tsdb.Open</c> 拿下 WAL 独占锁之后 ——
+    /// 在那之前我们没资格断言这些文件是孤儿,它可能正被另一个进程写着(设计器预览器就干过这事)。
+    /// 而清单必须在开库前取:开库之后新生的 tmp 是本进程正在写的,一个都不能碰。
+    /// 双保险是再比一次大小与修改时间,期间被动过就放着不管。
+    /// </para>
+    /// </remarks>
+    private static void SweepOrphanSegmentTempFiles(SegmentTempFile[] orphans)
+    {
+        foreach (SegmentTempFile orphan in orphans)
+        {
+            try
+            {
+                FileInfo info = new(orphan.Path);
+                if (!info.Exists)
+                {
+                    continue; // 开库时被引擎自己收拾掉了
+                }
+                if (info.Length != orphan.Length || info.LastWriteTimeUtc != orphan.WrittenUtc)
+                {
+                    continue; // 开库过程中被动过,不是孤儿
+                }
+                info.Delete();
+                Trace.WriteLine($"[VelaShell] Removed an orphaned SonnetDB segment temp file: {orphan.Path}");
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // 删不掉(被占用/无权限)就算了:开库绝不能因为一次清理失败而崩。
+                Trace.WriteLine($"[VelaShell] Could not remove the orphaned segment temp file {orphan.Path}: {ex.Message}");
+            }
         }
     }
 

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -36,6 +36,17 @@ namespace VelaShell;
 /// </summary>
 public class App : Application
 {
+    /// <summary>
+    /// 拆除 DI 容器的时限。要装得下最慢那个插件的停用
+    /// (<c>PluginManagerOptions.DeactivationTimeout</c>,2 秒)外加其余服务的收尾 ——
+    /// 装不下的话,IM 桥接那条长连接的 Close 握手每次退出都会被打断,于是从 WebSocket
+    /// 到 TLS 到套接字连锁抛一串「连接被中止」,平台侧看到的也不是"它下线了"。
+    /// </summary>
+    private static readonly TimeSpan ServiceDisposeBudget = TimeSpan.FromSeconds(3);
+
+    /// <summary>数据库刷盘关库的时限(独立于容器,见 <see cref="DisposeServicesOnExit" />)。</summary>
+    private static readonly TimeSpan DatabaseDisposeBudget = TimeSpan.FromSeconds(5);
+
     private ServiceProvider? _serviceProvider;
     private AppSettings? _startupSettings;
     private readonly SyncDebounceLifecycle _syncDebounce = new();
@@ -489,6 +500,13 @@ public class App : Application
     /// 同步执行这一步,因此一个缓慢或无响应的连接会让进程在窗口关闭后仍然存活很久。
     /// 现改为带短超时的异步释放(这也是 IAsyncDisposable 服务的正确处置路径),
     /// 使应用能及时退出;进程拆除时任何仍在关闭中的套接字由操作系统回收。
+    /// <para>
+    /// <b>数据库不共用这个预算。</b>容器的超时是给「可能永远回不来的网络收尾」兜底的,而刷盘不是
+    /// 那类事:它只是本地 I/O,而且是唯一一件被掐断就会丢数据的事 —— 被掐断的刷盘还会在盘上留下
+    /// 半截段临时文件,毒到之后每一次落到同一段号的刷盘(见
+    /// <see cref="Infrastructure.Persistence.SonnetDbEngine" /> 的清理)。所以引擎单独拿一份
+    /// 预算,排在容器之后:前面的插件停用、SSH 断开再慢,也吃不到刷盘头上。
+    /// </para>
     /// </summary>
     private void DisposeServicesOnExit()
     {
@@ -499,9 +517,38 @@ public class App : Application
         {
             return;
         }
+        // 先把引擎拿在手上:容器的预算耗尽、拆除半途而废时,下面那步还能补上刷盘。
+        // (此刻它必然已经建好 —— 启动读设置就是经它来的,这里不会引发一次新的开库。)
+        Infrastructure.Persistence.SonnetDbEngine? engine =
+            provider.GetService<Infrastructure.Persistence.SonnetDbEngine>();
         try
         {
-            provider.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(2));
+            provider.DisposeAsync().AsTask().Wait(ServiceDisposeBudget);
+        }
+        catch
+        {
+            // 尽力关闭:绝不阻塞或中断退出路径。
+        }
+        FlushDatabaseOnExit(engine);
+    }
+
+    /// <summary>
+    /// 确保 SonnetDB 引擎关干净(WAL 与内存表落盘)。
+    /// </summary>
+    /// <remarks>
+    /// <c>Dispose</c> 幂等:容器已经关过了,这里立刻返回;没关成才真去刷。放后台任务上等,
+    /// 是为了刷盘真卡住时仍能退出 —— 那种情况下我们不比改动前更糟,而常态下换来的是
+    /// 「刷盘一定跑完」。
+    /// </remarks>
+    private static void FlushDatabaseOnExit(Infrastructure.Persistence.SonnetDbEngine? engine)
+    {
+        if (engine is null)
+        {
+            return;
+        }
+        try
+        {
+            Task.Run(engine.Dispose).Wait(DatabaseDisposeBudget);
         }
         catch
         {

--- a/src/VelaShell/Services/NotificationSources.cs
+++ b/src/VelaShell/Services/NotificationSources.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using VelaShell.Core.Models;
 using VelaShell.Core.Notifications;
 using VelaShell.Core.Resources;
@@ -111,9 +112,12 @@ public static class NotificationSources
         {
             hasUpdate = await updateService.CheckForUpdateAsync().ConfigureAwait(true);
         }
-        catch
+        catch (Exception ex)
         {
-            // 离线或更新源不可达是常态。
+            // 离线或更新源不可达是常态。但要留一行:这条请求是开箱默认发的(设置 → 通用 →
+            // 启动时检查更新),失败时调试输出里只浮出一串裸的 TLS/套接字异常,看到的人
+            // 无从判断是自己的网络不通、还是更新检查本身坏了 —— 而这两件事的处置完全不同。
+            Trace.WriteLine($"[VelaShell] Update check failed: {ex.Message}");
             return null;
         }
         if (!hasUpdate || updateService.AvailableVersion is not { Length: > 0 } available)

--- a/tests/VelaShell.Infrastructure.Tests/SonnetDbSegmentTempSweepTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/SonnetDbSegmentTempSweepTests.cs
@@ -1,0 +1,83 @@
+using VelaShell.Core.Models;
+using VelaShell.Infrastructure.Persistence;
+
+namespace VelaShell.Infrastructure.Tests;
+
+/// <summary>
+/// 开库时清掉上一次运行留下的段临时文件。
+/// </summary>
+/// <remarks>
+/// 这一条不是洁癖,是修一个会丢数据、而且不会自愈的故障:刷盘落段是「先写 <c>*.SDBSEG.tmp</c>、
+/// 写成了再改名」,进程死在这两步之间(调试器停止、崩溃、退出刷盘被掐断)就会把 tmp 留在盘上,
+/// 此后每一次落到同一段号的刷盘都撞「文件已存在」而失败 —— 连同内存表里那批数据一起。
+/// 真实现场:一个 <c>0000000000000270.SDBSEG.tmp</c> 留了一个多小时,退出时的最后一次刷盘
+/// 就死在它身上。
+/// </remarks>
+[TestClass]
+public sealed class SonnetDbSegmentTempSweepTests
+{
+    private string _root = null!;
+
+    /// <summary>段文件实际所在的层级,照着真实库的目录结构摆。</summary>
+    private string SegmentDirectory =>
+        Path.Combine(_root, "segments", "v2", "00", "0000000000000000");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"vela-segsweep-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(SegmentDirectory);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException)
+        {
+            // 被映射的段文件在 Windows 上删不掉,留给系统清临时目录。
+        }
+    }
+
+    [TestMethod]
+    public void OpeningTheDatabaseRemovesAnOrphanedSegmentTempFile()
+    {
+        string orphan = Path.Combine(SegmentDirectory, "0000000000000270.SDBSEG.tmp");
+        File.WriteAllBytes(orphan, new byte[64]);
+
+        using SonnetDbEngine engine = new(_root);
+
+        Assert.IsFalse(File.Exists(orphan),
+            "上次运行留下的段临时文件必须清掉,否则之后每次刷到这个段号都会撞「文件已存在」。");
+    }
+
+    [TestMethod]
+    public async Task TheSweptDatabaseStillReadsAndWrites()
+    {
+        File.WriteAllBytes(Path.Combine(SegmentDirectory, "0000000000000271.SDBSEG.tmp"), new byte[64]);
+
+        using SonnetDbEngine engine = new(_root);
+        var repo = new SonnetDbSessionRepository(engine, new AesSecretProtector(Path.Combine(_root, "secret.key")));
+        await repo.SaveSessionAsync(new SessionProfile { Name = "web-01", Host = "10.0.0.1", Username = "root" });
+
+        List<SessionProfile> sessions = await repo.GetAllSessionsAsync();
+
+        Assert.HasCount(1, sessions);
+        Assert.AreEqual("web-01", sessions[0].Name);
+    }
+
+    [TestMethod]
+    public void OpeningTheDatabaseLeavesOtherTempFilesAlone()
+    {
+        // 清的是段的中间产物,不是"库目录下所有 .tmp"。别人的临时文件不归我们处置。
+        string unrelated = Path.Combine(SegmentDirectory, "something-else.tmp");
+        File.WriteAllBytes(unrelated, new byte[8]);
+
+        using SonnetDbEngine engine = new(_root);
+
+        Assert.IsTrue(File.Exists(unrelated), "只有 *.SDBSEG.tmp 才是段刷盘的残留。");
+    }
+}


### PR DESCRIPTION
本次 dev → main 的主体是一组**从调试输出里的异常刷屏挖出来的**修复。起点是用户的一句
「我就打开程序、点了下设置、退出,就这么多异常」—— 那一屏里只有一条是真故障,但它正在丢数据。

一并带过去的还有已合入 dev 的 #411(下拉字体发糊)与 #412(测试 SDK 升级)。

## 一、真故障:一个孤儿段临时文件,让之后每次刷盘都失败

退出日志里 SonnetDB 的 FlushPump 死在这一句上:

```
IOException: The file '...\segments\v2\00\0000000000000000\0000000000000270.SDBSEG.tmp'
already exists.
```

去盘上核了,它确实还在,而且比撞上它的那次刷盘早了一个多小时:

| 文件 | 大小 | 时间 |
| --- | --- | --- |
| `0000000000000270.SDBSEG.tmp` | 67,048 B | 09-09 07:31 ← 孤儿 |
| `0000000000000273.SDBSEG` | 4,004,271 B | 09-09 08:40 ← 之后正常落的段 |

刷盘落段走的是「先写 `*.SDBSEG.tmp`、写成了再改名」。进程死在这两步之间(调试器停止、崩溃、
退出时刷盘被超时掐断),tmp 就留在盘上;SonnetDB 之后再用到同一个段号时是按新建开文件的,
一头撞上「文件已存在」—— **那次刷盘连同内存表里的数据一起失败**。

要命的是**它不会自愈**:没人会去动那个文件,于是此后每一次落到这个段号的刷盘都照样失败。

开库时清掉这类孤儿,两条纪律写进了注释:

- **清单在 `Tsdb.Open` 之前取,删除在 Open 之后做。** 删除得等拿下 WAL 独占锁才有资格断言它是
  孤儿 —— 在那之前它可能正被另一个进程写着(设计器预览器就干过这事,见 `App.Initialize` 里
  那段注释);而清单必须在开库前取,开库之后新生的 tmp 是本进程正在写的,一个都不能碰。
- 再比一次大小与修改时间兜底,期间被动过就放着不管。

**删得安全**:段是靠改名落地的,没改过名的 tmp 按定义不属于任何已提交的段,删掉不丢任何已落盘
的数据;真还没落盘的那部分在 WAL 里,由开库时的重放负责。清理失败(被占用/无权限)只留一行
日志,绝不让开库因此崩掉。

## 二、根因:退出预算被抢,刷盘写到一半进程就没了

上面那个孤儿是**谁造出来的**?把预算算一遍就清楚了:

| 环节 | 需要 | 给了 |
| --- | --- | --- |
| `ChannelShutdown.CloseAsync` 优雅关连接 | 2s + 2s | — |
| `PluginManagerOptions.DeactivationTimeout` 单插件停用 | | **2s** |
| `App.DisposeServicesOnExit` 拆容器(含数据库刷盘) | | **2s** |

光第一段宽限就把插件的停用预算用光了。于是 `ChannelShutdown` 那套「别拿异常当收摊通知」的设计
**永远走不完**:进程在 Close 握手中途退出,底下整条 TLS/TCP 栈连锁抛异常,飞书那边看到的也不是
「它下线了」,而是「连接莫名断了」;同一次仓促退出,把刷盘也切在了半路。

改动:

- **`ChannelShutdown.CloseGrace` 2s → 700ms。** 这个数是被上游预算框住的,不是随手定的:两段
  宽限串起来花,必须装进宿主那 2 秒的停用窗口。700ms 对一次 Close 帧往返是十来倍余量(对端在线
  时是几十毫秒);对端真失联时那条路的结局是 `Abort`,等多久都一样,多等只是拖慢退出。
- **`ServiceDisposeBudget` 2s → 3s**,装得下最慢那个插件的 2s 停用外加其余服务的收尾。
- **数据库单拿一份 5s 预算,排在容器之后。** 容器那个超时是给「可能永远回不来的网络收尾」兜底
  的,而刷盘不是那类事:它是本地 I/O,且是唯一一件被掐断就丢数据的事。现在前面的插件停用、
  SSH 断开再慢,也吃不到刷盘头上。`Dispose` 幂等,容器已经关成了这步立刻返回。

### 改动前后的退出日志

| 改动前 | 改动后 |
| --- | --- |
| `SDBSEG.tmp already exists`(真丢数据) | **没了** |
| `TimeoutException`(WebSockets) | **没了** |
| `解密操作失败`(Security ×4) | **没了** |
| `TaskCanceledException`(Http) | **没了** |
| `已中止 I/O 操作` ×7 | ×14 |

消失的那几条全是「连接在半路被撕断」的特征(TLS 记录读到一半、握手超时)。**行数反而多了**,
更可能的读法是:以前进程在收摊中途就没了,很多回调根本没机会跑;现在真把连接一条条拆干净了。
剩下的清一色是 `已中止 I/O 操作`,分层是 `Sockets → CoreLib → Security → Http`,即 HttpClient
连接池被 Dispose 时每条空闲连接的探测读;其中**只有 1 条来自 `System.Net.WebSockets`** ——
对端没在宽限内回 Close,走了 `Abort` 兜底。**这一条消不掉**:发完 Close 就必须拆 TCP,挂着的
`ReceiveAsync` 必然抛。区别在于对端现在收到的是一次正经的下线。

## 三、顺带:默认发的两条出站请求,失败时留一行

启动日志里另有 6 条 `Received an unexpected EOF` + 3 条 `SSL connection could not be established`,
而应用一切正常。查下来是开箱默认的两条 HTTPS 在不稳定的网络上握手被对端 EOF:

| 请求 | 地址 | 实测 |
| --- | --- | --- |
| 启动检查更新 | `github.com/joesdu/VelaShell/releases/latest/download/latest.json` | 200,但 **9.87s**(还要跟一次跳转) |
| 官方资讯源 | `feeds.easilynet.top/feed.json` | 第一次连不上、第二次 200 —— **时好时坏** |

两处的吞异常都是对的(消息中心是锦上添花的东西,源不可达是常态)。缺口在于**吞得太干净**:
默认就往外发的请求,失败时一行记录都不留,看到的人只能对着一串裸的 TLS 异常猜——是自己网络
不通,还是更新检查/资讯源本身坏了?这两件事的处置完全不同。只加日志,不改行为。

## 不在本 PR 里的

退出日志里剩下的这些**不是缺陷**,是调试器在显示 BCL 自己接住的首发异常,没有动:

- `OperationCanceledException`(Infrastructure)—— 单实例命名管道的 `WaitForConnectionAsync`
  被取消。命名管道没有不抛的取消 API,`ListenAsync` 已按预期接住。
- `ObjectDisposedException`(HttpListener / Plugin.Ai)—— `GetContextAsync` 挂着时 `Close()`,
  `HttpListener` 只有这一种停法。
- `ThreadInterruptedException` —— SonnetDB 3.1.0 内部用 `Thread.Interrupt` 收 worker,库自己
  接住,我们够不着。

## 怎么验证的

- `dotnet build VelaShell.slnx -warnaserror` —— **0 警告 0 错误**
- `dotnet test VelaShell.slnx` —— **3304 通过 / 19 跳过 / 0 失败**
  (聚合输出漏报了 `Controls.Tests` 的汇总行,单独复跑确认 10 通过,已计入)
- 新增 `SonnetDbSegmentTempSweepTests` 三条:孤儿被清掉、清完的库照常读写、非段的 `.tmp` 不误删
  (清的是段的中间产物,不是「库目录下所有 `.tmp`」)
- 退出/启动路径在应用里实际跑过,日志对比见上表

**实测环境:** Windows 11 Pro 26H2 / .NET 11.0.0-rc.1 / Visual Studio 调试运行

## ⚠️ 没验到的

退出预算的三个数(3s / 5s / 700ms)都是在**这台机器、这条网络**上验的。最坏情况下退出会比
以前多等:容器 3s + 数据库 5s。常态下两步都是毫秒级返回 —— 但没有在「SSH 连接真卡死」的场景
下实测过那条最坏路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBday53qH7NEepM5GUoTMC
