### PR TITLE
fix(dock): 不折叠的该是根而不是主组 —— 关光半屏之后,另一半要铺满整片区域

### DIFF
--- a/feature-plan.md
+++ b/feature-plan.md
@@ -208,6 +208,8 @@ pie showData
 | ⏳ | 🟡 P2 | **标签（Tags）检索与过滤** | Termius / Royal TS | ⚠️ **`SessionProfile.Tags` 已经存在也能编辑**（`ConnectionProfileViewModel.cs:147`），但**全仓没有任何地方消费它** —— 这是一个已经存在的「存了但不生效」。补法很便宜：会话树加过滤框、命令面板按 tag 匹配（`PaletteScorer` 现成） |
 | ⏳ | 🟡 P2 | **会话标签页图标** | Xshell / Termius | 颜色已经做完（见上），图标是同一处扩展：`TerminalOverrides` 加一个图标 id，`LucideIcon` 的图标集现成。⚠️ 记得 `SessionProfile` 是**逐字段手写拷贝**，新增字段要同步五处（`plan.md` §37 列了名单） |
 | ⏳ | 🟡 P2 | **整组批量操作** | MobaXterm | 对一个分组批量连接 / 批量下发命令。同步输入的频道模型（`SyncInputCoordinator`）已经是对等广播，按分组建频道是自然延伸 |
+| ⏳ | 🟢 P3 | **标签条上的「+」新建按钮** | Windows Terminal / Chrome | 分屏后「在**这一格**里新开一个会话」目前只能靠 `Ctrl+T`（`plan.md` §64 之后它已经落到活动窗格，够用但不直观）。⚠️ 卡点不在按钮而在**分层**：`Docking/` 不认识"会话"这个概念，要么 `DockWorkspaceControl` 抛一个 `NewTabRequested(group)` 由宿主接，要么把新建入口做成注入的回调 —— **别让停靠层直接去 new 一个终端** |
+| ⏳ | 🟢 P3 | **纵排标签条的溢出控件** | — | 标签条停到左/右侧时，溢出三连钮由 `WidthOverflowConverter` 按**宽度**判定，因而永不出现；滚动按钮的 `ScrollLeft/Right_Click` 也只动 `Offset.X`。`plan.md` §64 补的滚轮两轴都认，功能上不再是死路，但按钮这一路仍是横排专用。做的时候连那个转换器一起改成按轴取值 |
 | 💡 | 🟢 P3 | **会话健康巡检面板** | — | 对已保存配置定期探活（复用 `ConnectionDiagnosticsService` 的四步诊断），出一张「哪几台连不上」的表。**别做成定时外呼** —— 得像资讯源那样由用户显式开启，理由见 `PRIVACY.md` |
 
 ### C. 文件与传输

--- a/plan.md
+++ b/plan.md
@@ -203,7 +203,7 @@ graph RL
 
 ## ✅ 5. 停靠 / 分屏(自研 VelaDock,已替换 Dock.Avalonia)
 
-- **模型层** `Docking/Model/`(纯 INPC,可单测):`DockWorkspace`(结构操作 + `DocumentClosed`/`ActiveDocumentChanged` 事件)、`DockGroup`(标签组,主组不折叠)、`DockSplit`(分栏树)、`DockDocument`;空的次级组自动折叠、单子分栏自动提升。方案与集成面分析见 `velashell-docs zh/host/dock-replacement-plan.md`。
+- **模型层** `Docking/Model/`(纯 INPC,可单测):`DockWorkspace`(结构操作 + `DocumentClosed`/`ActiveDocumentChanged` 事件)、`DockGroup`(标签组)、`DockSplit`(分栏树)、`DockDocument`;空组自动折叠(主组先把兜底身份交给邻居再退场,**只有根留着**,见 §64)、单子分栏自动提升;`MaximizedGroup` 只影响渲染、不动树。方案与集成面分析见 `velashell-docs zh/host/dock-replacement-plan.md`。
 - **控件层** `Docking/Controls/`:`DockWorkspaceControl`(按树渲染 Grid+GridSplitter,star ↔ Proportion 回写;**按文档缓存视图**,切标签复用同一 `TerminalTabView`,取代原 ControlRecycling)、`DockGroupControl`(标签条 + 溢出三连钮 + 标签列表下拉)、`DockTabItem`(标签视觉 + 右键菜单:关闭系列/水平垂直拆分/标签位置)、`DockDragController` + `DockDropOverlay`(拖拽重排插入线、跨组并入、五区拖放分屏,Esc 取消;浮动窗口按产品决策不存在)。
 - `Docking/TerminalDocument.cs` 包装 `TerminalTabViewModel`,实现 `IDockViewProvider` 自建视图。
 - `MainWindow.axaml` 用 `<dockc:DockWorkspaceControl Workspace="{Binding Layout}" />` 承载;`TabBar`(Ctrl+Tab/W 逻辑集合)与工作区激活态**双向同步**(原 Dock 集成缺 TabBar→文档区半边)。
@@ -3596,3 +3596,148 @@ host key 替代 known_hosts 逐台指纹)是**相反方向**的另一件事,接�
 端到端另算:靶机起着时 `VELASHELL_CERT_LAB` 一指,
 `SshCertificateIntegrationTests` 两条(阳性 + 阴性对照)全过,
 服务端日志里 `Accepted certificate` 与 `Failed publickey` 一并留痕。
+
+---
+
+## ✅ 64. 2026-09-10 VelaDock:关掉左半屏,右半屏该铺满(用户反馈)
+
+> 「拖动分屏后,关闭掉所有左侧的窗口,右侧的窗口也还是保持在右侧,没有自动填充满整个区域。
+> 并且检查当前实现和操作上是否存在其他优化的点。」
+
+### 一、不该折叠的是「根」,不是「主组」
+
+复现只要三步:开两个标签 → 把其中一个拖到右缘分屏 → 把左半屏的标签全关掉。左边留下一块
+空白,右边的窗格纹丝不动 —— 而那块空白正是 `PrimaryGroup`。
+
+根因在 `CollapseIfEmpty` 的第一行:
+
+```csharp
+if (group.IsPrimary || group.Documents.Count > 0 || group.Parent is not { } parent)
+```
+
+`IsPrimary ||` 这一条是**在保护一个不需要保护的东西**。真正的约束只有一个:布局树得有个底,
+新文档才有地方落。而"底"是**根**,不是某个特定的组 —— 后半句的 `group.Parent is not { } parent`
+本来就把根兜住了(根节点没有父分栏)。多出来的那一判,把"永不折叠"从根钉到了一个具体实例上,
+于是它一旦被拖到侧边、又被关空,就成了一块谁也赶不走的空白。
+
+改法不是"给主组开个例外",是**让这个身份可以易主**:`TryHandOverPrimary` 把兜底的差事交给
+折叠之后**会接管这块地方**的那个邻居(沿父分栏找兄弟,再向下钻到具体的组),然后自己退场。
+新文档于是出现在用户眼睛刚才盯着的位置,而不是布局树另一头。`DockGroup.IsPrimary` 因此从
+`init` 放宽成 `internal set`,`DockWorkspace.PrimaryGroup` 从只读变成 `private set`。
+
+同因异形的还有一处,一并好了:**把主组最后一个标签拖进邻居**(走 `MoveToGroup` → 同一个
+`CollapseIfEmpty`),此前同样会留下一块空白。
+
+`HoistIfSingle` 里那句 `IsPrimary: false` 的特判也跟着删掉:折叠的判据统一收在
+`CollapseIfEmpty` 里一处,提升到根之后它自然没有父分栏、自然留下。
+
+**测试口径要跟着改口**:`PrimaryGroup_NeverCollapses` 这条用例把这个 bug 逐字钉成了规范
+(它断言的正是"主组即使为空也保留"),留着它就等于让测试替 bug 站岗。换成三条:
+关光主组要铺满、拖空主组也要铺满、以及**唯一的那个组即使空着也留下**(根的约束还在)。
+
+### 二、顺着这条线:新标签到底该开在哪一格
+
+原来的规则是"永远进主组"。分屏之后它的实际表现是:人在右半屏工作,`Ctrl+T` 却在左半屏的
+标签条上开出一个新标签 —— 焦点跟着跑过去,视线还留在原处。
+
+新的落点规则(`TargetGroupForNewDocument`)是三级:**空窗格 > 当前正在用的窗格 > 主组**。
+
+- 空窗格排第一,是因为拆分只有一个标签的组会**故意**在原地留下一块写着"拖放标签到这里"的
+  空面板(这是既有设计)。那块空白就是等着被填的,新会话理应落进去。这一条也保证了老流程
+  ——「拆分,然后开一个新会话把另一半填上」—— 一如既往。
+- 没有空窗格时才轮到活动窗格,与 VS Code / Windows Terminal 一致。
+- 主组降级为纯兜底:没有空窗格、也没有活动文档(刚启动的空布局)时用它。
+
+### 三、空窗格此前没有出口
+
+拆分留下的空面板,在这一版之前**没有任何撤销入口**:唯一的办法是把邻居的标签拖进来、再拖
+回去,靠副作用把它挤掉。现在空面板上直接放一枚「关闭窗格」,走新的 `ClosePane(group)`;
+非空的窗格它也接(逐一走确认闸),于是这是关闭闸的**第七个入口** ——
+`DockCloseInterceptorTests` 里补了一条守着它,免得日后成为那道闸的后门。
+
+顺带,「关闭所有标签页」现在会让该窗格一并收掉(第一节的直接结果),不再留下空壳。
+
+### 四、窗格最大化(tmux 的 `resize-pane -Z`)
+
+分屏之后想把某一格看仔细,原先只能"先拆掉布局,看完再照原样拼回去"——那两步手工活正是
+分屏用起来累的地方。`MaximizedGroup` **只影响渲染,不动布局树**:解除时原样恢复,连比例都
+不用记,因此也不需要参与将来的布局持久化。
+
+三条自我解除的规矩,都是为了不留下"解不掉的状态":
+
+- 焦点切到别的窗格就解除(与 tmux 的 `select-pane` 同一条规矩)—— 否则会出现"焦点已经在
+  别处、屏幕上却还是那一格"的呆滞界面;
+- 被最大化的窗格离开布局树(关空了)就解除;
+- 布局收敛回一格就解除。
+
+入口:`Ctrl+Shift+X`(Terminator 同款键位)、命令面板、四处标签右键菜单。
+
+⚠️ 这一条真正的风险不在模型而在控件:内容视图是**按文档缓存、跨宿主收养**的,而最大化会
+把整棵可视树换成一个窗格再换回来 —— 正是 `DockContentBlankHuntTests` 记的那次"终端内容
+凭空消失"的同款场景。`DockPaneUiTests` 因此盯的是**还原之后 `ReparentingHost.Target` 是不是
+同一个实例**,而不只是"控件数量对不对"。
+
+### 五、三个一直缺席的鼠标手势
+
+- **中键关标签**:浏览器与各家编辑器的通用手势,省掉"先瞄准那枚 11px 的 ×"。挂在
+  `DockTabItemBase` 上,五种标签一次到位;同样走 `RequestClose`,确认闸对它照旧生效。
+- **标签条滚轮**:`ScrollViewer` 默认把滚轮当纵向滚动,而标签条是横排的 —— 于是"在标签条上
+  滚一下"此前**什么也不会发生**,标签一多就只能去够右端那两枚小箭头。隧道阶段接管,按标签
+  排列方向翻;没有溢出时不吞事件。
+- **分割条双击 = 平分**:拖歪一条缝之后原先只能靠手再瞄一次。另有命令面板的「平分窗格」
+  一次性复位整棵树。
+
+外加一处纯粹的遗漏:`DockDragController` 一直在给拖动中的标签挂 `.dragging` 类,而**全仓没有
+任何一条样式认这个类** —— 拖拽过程中标签本身零反馈,"我手上拿着的到底是哪一个"全靠脑补。
+补了半透明 + 移动光标。
+
+### 六、分屏时看不出焦点在哪一格
+
+每个标签组各自画着一条 accent 强调线,两格并排时两条线一样亮,**唯一的线索是"我刚才点了
+哪儿"**,而那正是回头看屏幕时最先忘掉的事。加 `:activepane` 伪类,非活动格的强调线弱到 0.3。
+
+两处细节:
+
+- **刻意不给这条线的 `Opacity` 加过渡**。它是"我的键盘输入落在哪"的指示,该在点下去那一刻
+  就成立;淡入淡出除了让指示晚 180ms,还会把它变成一个只能靠时序观测的状态 ——
+  界面测试正是先在这里卡住的,那说明人眼也会卡在同一处。
+- 把**当前激活的标签**整个拖进隔壁窗格时,`ActiveDocument` 的**值没有变**,
+  `ActiveDocumentChanged` 因此不会响,可活动窗格已经易主。所以 `Documents.CollectionChanged`
+  上也补了一次刷新,`DockPaneUiTests` 里单独有一步盯着这个场景。
+
+### 七、返工:两种「空」是两件事(同批实测反馈)
+
+上面第三节那枚「关闭窗格」按钮,第一版无差别地挂在**任何**空窗格上。实测截图打回来的是
+一个会话都没开的主界面:正中间一句「将标签拖到此处」,底下一枚「关闭窗格」——
+
+- 那枚按钮**点了不会有任何反应**:`ClosePane` 对根窗格是空操作(根没有父分栏,
+  `CollapseIfEmpty` 直接早退)。一枚点下去毫无动静的按钮,比没有按钮更糟;
+- 那句提示说的是一件**当下做不到的事**:一个标签都不存在,拖什么?用户还把它读成了
+  "拖点什么进来就能打开连接",而那个功能并不存在 —— 文案自己招来了这个误会。
+
+判据是**有没有父分栏**,不是"是不是主组"(与第一节同一个教训:别把结构性质钉到实例身份上)。
+空状态因此分两套:能撤掉的空窗格给「把其他窗格的标签页拖到这里」+ 关闭按钮;
+整个工作区空了则只说现状与下一步 —— 「还没有打开任何会话 / 从资源管理器里选一台机器,
+或者新建一个连接」。
+
+`Dock_DropTabHere` 的五份译文一并改写成「把**其他窗格的标签页**拖到这里」,把"拖的是已经
+存在的标签页"说死。两句新文案不写具体键位 —— 快捷键的唯一事实来源是 `ShortcutCatalog`,
+在 resx 里再抄一份,改键位那天它就开始骗人。
+
+⚠️ 两套提示都**留在 XAML 里靠 `IsVisible` 切换**,不从代码写 `Text`:`{loc:Localize}` 给的是
+活绑定,换语言即时刷新;代码赋值会把这两句钉死在赋值那一刻的语言上。
+
+### 八、验收
+
+`dotnet build VelaShell.slnx -c Debug -warnaserror` 零警告零错误;
+`dotnet test VelaShell.slnx`(整解全量,不带 CI 那条过滤)**3343 通过 / 21 跳过 / 0 失败**,
+其中 17 条是这一版的净增量(新增 18、删掉 1 条替 bug 站岗的)。
+新增用例:模型层 10 条(`DockWorkspaceTests` 折叠/落点/关窗格/最大化/平分)+ 关闭闸 1 条 +
+界面层 6 条(`DockPaneUiTests`:最大化往返不丢内容、活动窗格标记与弱化、空窗格的出口、
+空工作区不给死按钮、标签条滚轮、中键关标签)。
+
+`ShortcutCatalog` 与 `velashell-docs` 的 `快捷键参考.md` / `keyboard-shortcuts.md` 同步补齐
+`Ctrl+Shift+X` 与三条鼠标手势(`Doc_ListsEveryCatalogEntry` 实跑通过,不是 Inconclusive);
+`dock-replacement-plan.md` 中英两份把"主组永不消失""新终端总进第一组"这两句**过期的规范**
+改掉并注明修正日期 —— 它们正是第一节那个 bug 的书面出处。界面文案五份 resx 各补 11 个键、
+改写 1 个键。

--- a/src/VelaShell.Core/Resources/Strings.ja.resx
+++ b/src/VelaShell.Core/Resources/Strings.ja.resx
@@ -452,7 +452,22 @@
     <value>右側のタブを閉じる</value>
   </data>
   <data name="Dock_DropTabHere" xml:space="preserve">
-    <value>ここにタブをドラッグ</value>
+    <value>他のペインのタブをここにドラッグ</value>
+  </data>
+  <data name="Dock_NoSessionOpen" xml:space="preserve">
+    <value>セッションが開かれていません</value>
+  </data>
+  <data name="Dock_NoSessionOpenHint" xml:space="preserve">
+    <value>エクスプローラーからマシンを選ぶか、新しい接続を作成してください</value>
+  </data>
+  <data name="Dock_ClosePane" xml:space="preserve">
+    <value>ペインを閉じる</value>
+  </data>
+  <data name="Dock_EqualizePanes" xml:space="preserve">
+    <value>ペインを均等化</value>
+  </data>
+  <data name="Dock_ToggleMaximizePane" xml:space="preserve">
+    <value>ペインの最大化 / 復元</value>
   </data>
   <data name="Dock_SplitHorizontal" xml:space="preserve">
     <value>横に分割</value>
@@ -2874,6 +2889,9 @@
   <data name="Sc_NoteSplitOnly" xml:space="preserve">
     <value>分割時のみ有効。分割していないときはそのままリモートへ送られます</value>
   </data>
+  <data name="Sc_NoteNeedsSplit" xml:space="preserve">
+    <value>画面分割時のみ有効</value>
+  </data>
   <data name="Sc_NoteZoomOutTakesUnitSeparator" xml:space="preserve">
     <value>^_ を占有します。送信するには Ctrl+Shift+- を使ってください</value>
   </data>
@@ -4291,6 +4309,21 @@ Windows は exe のフルパスまたはコマンド名(例: notepad)、Linux �
   <data name="Sc_KeyTitleBar" xml:space="preserve"><value>タイトルバー</value></data>
   <data name="Sc_KeyGutter" xml:space="preserve"><value>ガター</value></data>
   <data name="Sc_KeyCommandMark" xml:space="preserve"><value>コマンドマーク欄</value></data>
+  <data name="Sc_KeyMiddleClick" xml:space="preserve">
+    <value>中クリック</value>
+  </data>
+  <data name="Sc_KeyTabItem" xml:space="preserve">
+    <value>タブ</value>
+  </data>
+  <data name="Sc_KeyTabStrip" xml:space="preserve">
+    <value>タブバー</value>
+  </data>
+  <data name="Sc_KeySplitter" xml:space="preserve">
+    <value>分割バー</value>
+  </data>
+  <data name="Sc_ScrollTabs" xml:space="preserve">
+    <value>タブバーをスクロール</value>
+  </data>
   <data name="Sc_JumpPrevPrompt" xml:space="preserve"><value>前のプロンプトへ移動</value></data>
   <data name="Sc_JumpNextPrompt" xml:space="preserve"><value>次のプロンプトへ移動</value></data>
   <data name="Sc_SelectCommandOutput" xml:space="preserve"><value>このコマンドの出力を選択</value></data>

--- a/src/VelaShell.Core/Resources/Strings.ko.resx
+++ b/src/VelaShell.Core/Resources/Strings.ko.resx
@@ -452,7 +452,22 @@
     <value>오른쪽 탭 닫기</value>
   </data>
   <data name="Dock_DropTabHere" xml:space="preserve">
-    <value>탭을 여기로 드래그</value>
+    <value>다른 창의 탭을 여기로 드래그</value>
+  </data>
+  <data name="Dock_NoSessionOpen" xml:space="preserve">
+    <value>열린 세션이 없습니다</value>
+  </data>
+  <data name="Dock_NoSessionOpenHint" xml:space="preserve">
+    <value>탐색기에서 머신을 고르거나 새 연결을 만드세요</value>
+  </data>
+  <data name="Dock_ClosePane" xml:space="preserve">
+    <value>창 닫기</value>
+  </data>
+  <data name="Dock_EqualizePanes" xml:space="preserve">
+    <value>창 크기 균등화</value>
+  </data>
+  <data name="Dock_ToggleMaximizePane" xml:space="preserve">
+    <value>창 최대화 / 복원</value>
   </data>
   <data name="Dock_SplitHorizontal" xml:space="preserve">
     <value>가로 분할</value>
@@ -2874,6 +2889,9 @@
   <data name="Sc_NoteSplitOnly" xml:space="preserve">
     <value>분할했을 때만 동작하며, 그렇지 않으면 키가 원격으로 전달됩니다</value>
   </data>
+  <data name="Sc_NoteNeedsSplit" xml:space="preserve">
+    <value>화면이 분할된 경우에만</value>
+  </data>
   <data name="Sc_NoteZoomOutTakesUnitSeparator" xml:space="preserve">
     <value>^_ 를 가로챕니다. 보내려면 Ctrl+Shift+- 를 사용하세요</value>
   </data>
@@ -4291,6 +4309,21 @@ Windows는 exe 전체 경로 또는 명령 이름(예: notepad), Linux는 명령
   <data name="Sc_KeyTitleBar" xml:space="preserve"><value>제목 표시줄</value></data>
   <data name="Sc_KeyGutter" xml:space="preserve"><value>여백 열</value></data>
   <data name="Sc_KeyCommandMark" xml:space="preserve"><value>명령 표시 열</value></data>
+  <data name="Sc_KeyMiddleClick" xml:space="preserve">
+    <value>가운데 클릭</value>
+  </data>
+  <data name="Sc_KeyTabItem" xml:space="preserve">
+    <value>탭</value>
+  </data>
+  <data name="Sc_KeyTabStrip" xml:space="preserve">
+    <value>탭 바</value>
+  </data>
+  <data name="Sc_KeySplitter" xml:space="preserve">
+    <value>분할 바</value>
+  </data>
+  <data name="Sc_ScrollTabs" xml:space="preserve">
+    <value>탭 바 스크롤</value>
+  </data>
   <data name="Sc_JumpPrevPrompt" xml:space="preserve"><value>이전 프롬프트로 이동</value></data>
   <data name="Sc_JumpNextPrompt" xml:space="preserve"><value>다음 프롬프트로 이동</value></data>
   <data name="Sc_SelectCommandOutput" xml:space="preserve"><value>이 명령의 출력 선택</value></data>

--- a/src/VelaShell.Core/Resources/Strings.resx
+++ b/src/VelaShell.Core/Resources/Strings.resx
@@ -1135,7 +1135,22 @@ If this keeps happening, close any other VelaShell windows and try again.</value
     <value>Close Tabs to the Right</value>
   </data>
   <data name="Dock_DropTabHere" xml:space="preserve">
-    <value>Drag a tab here</value>
+    <value>Drag a tab from another pane here</value>
+  </data>
+  <data name="Dock_NoSessionOpen" xml:space="preserve">
+    <value>No session open</value>
+  </data>
+  <data name="Dock_NoSessionOpenHint" xml:space="preserve">
+    <value>Pick a machine in the explorer, or create a new connection</value>
+  </data>
+  <data name="Dock_ClosePane" xml:space="preserve">
+    <value>Close pane</value>
+  </data>
+  <data name="Dock_EqualizePanes" xml:space="preserve">
+    <value>Even out panes</value>
+  </data>
+  <data name="Dock_ToggleMaximizePane" xml:space="preserve">
+    <value>Maximize / restore pane</value>
   </data>
   <data name="Dock_SplitHorizontal" xml:space="preserve">
     <value>Split Horizontally</value>
@@ -2980,6 +2995,9 @@ Paste anyway?</value>
   <data name="Sc_NoteSplitOnly" xml:space="preserve">
     <value>Only when the window is split; otherwise the key goes to the remote shell</value>
   </data>
+  <data name="Sc_NoteNeedsSplit" xml:space="preserve">
+    <value>Only when the window is split</value>
+  </data>
   <data name="Sc_NoteZoomOutTakesUnitSeparator" xml:space="preserve">
     <value>Takes over ^_; use Ctrl+Shift+- to send it</value>
   </data>
@@ -4292,6 +4310,21 @@ A routine key rotation and a hijacked publishing identity look exactly the same 
   <data name="Sc_KeyTitleBar" xml:space="preserve"><value>Title Bar</value></data>
   <data name="Sc_KeyGutter" xml:space="preserve"><value>Gutter</value></data>
   <data name="Sc_KeyCommandMark" xml:space="preserve"><value>Command mark</value></data>
+  <data name="Sc_KeyMiddleClick" xml:space="preserve">
+    <value>Middle Click</value>
+  </data>
+  <data name="Sc_KeyTabItem" xml:space="preserve">
+    <value>Tab</value>
+  </data>
+  <data name="Sc_KeyTabStrip" xml:space="preserve">
+    <value>Tab strip</value>
+  </data>
+  <data name="Sc_KeySplitter" xml:space="preserve">
+    <value>Splitter</value>
+  </data>
+  <data name="Sc_ScrollTabs" xml:space="preserve">
+    <value>Scroll the tab strip</value>
+  </data>
   <data name="Sc_JumpPrevPrompt" xml:space="preserve"><value>Jump to the previous prompt</value></data>
   <data name="Sc_JumpNextPrompt" xml:space="preserve"><value>Jump to the next prompt</value></data>
   <data name="Sc_SelectCommandOutput" xml:space="preserve"><value>Select this command's output</value></data>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hans.resx
@@ -1246,7 +1246,22 @@
     <value>关闭右侧标签页</value>
   </data>
   <data name="Dock_DropTabHere" xml:space="preserve">
-    <value>将标签拖到此处</value>
+    <value>把其他窗格的标签页拖到这里</value>
+  </data>
+  <data name="Dock_NoSessionOpen" xml:space="preserve">
+    <value>还没有打开任何会话</value>
+  </data>
+  <data name="Dock_NoSessionOpenHint" xml:space="preserve">
+    <value>从资源管理器里选一台机器,或者新建一个连接</value>
+  </data>
+  <data name="Dock_ClosePane" xml:space="preserve">
+    <value>关闭窗格</value>
+  </data>
+  <data name="Dock_EqualizePanes" xml:space="preserve">
+    <value>平分窗格</value>
+  </data>
+  <data name="Dock_ToggleMaximizePane" xml:space="preserve">
+    <value>窗格最大化 / 还原</value>
   </data>
   <data name="Dock_SplitHorizontal" xml:space="preserve">
     <value>水平拆分</value>
@@ -3091,6 +3106,9 @@
   <data name="Sc_NoteSplitOnly" xml:space="preserve">
     <value>仅在分屏时生效;未分屏时该键原样送往远端</value>
   </data>
+  <data name="Sc_NoteNeedsSplit" xml:space="preserve">
+    <value>仅在分屏时生效</value>
+  </data>
   <data name="Sc_NoteZoomOutTakesUnitSeparator" xml:space="preserve">
     <value>会占用 ^_;要发送它请用 Ctrl+Shift+-</value>
   </data>
@@ -4554,6 +4572,21 @@ Windows 填 exe 完整路径或命令名(如 notepad);Linux 填命令名(如 ged
   </data>
   <data name="Sc_KeyCommandMark" xml:space="preserve">
     <value>命令标记列</value>
+  </data>
+  <data name="Sc_KeyMiddleClick" xml:space="preserve">
+    <value>中键</value>
+  </data>
+  <data name="Sc_KeyTabItem" xml:space="preserve">
+    <value>标签页</value>
+  </data>
+  <data name="Sc_KeyTabStrip" xml:space="preserve">
+    <value>标签条</value>
+  </data>
+  <data name="Sc_KeySplitter" xml:space="preserve">
+    <value>分割条</value>
+  </data>
+  <data name="Sc_ScrollTabs" xml:space="preserve">
+    <value>滚动标签条</value>
   </data>
   <data name="Sc_JumpPrevPrompt" xml:space="preserve">
     <value>跳到上一条提示符</value>

--- a/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
+++ b/src/VelaShell.Core/Resources/Strings.zh-Hant.resx
@@ -1246,7 +1246,22 @@
     <value>關閉右側分頁</value>
   </data>
   <data name="Dock_DropTabHere" xml:space="preserve">
-    <value>將分頁拖曳至此</value>
+    <value>把其他窗格的分頁拖到這裡</value>
+  </data>
+  <data name="Dock_NoSessionOpen" xml:space="preserve">
+    <value>尚未開啟任何工作階段</value>
+  </data>
+  <data name="Dock_NoSessionOpenHint" xml:space="preserve">
+    <value>從資源管理器裡選一台機器,或者新增一個連線</value>
+  </data>
+  <data name="Dock_ClosePane" xml:space="preserve">
+    <value>關閉窗格</value>
+  </data>
+  <data name="Dock_EqualizePanes" xml:space="preserve">
+    <value>平分窗格</value>
+  </data>
+  <data name="Dock_ToggleMaximizePane" xml:space="preserve">
+    <value>窗格最大化 / 還原</value>
   </data>
   <data name="Dock_SplitHorizontal" xml:space="preserve">
     <value>水平分割</value>
@@ -3091,6 +3106,9 @@
   <data name="Sc_NoteSplitOnly" xml:space="preserve">
     <value>僅在分割畫面時生效;未分割時該鍵原樣送往遠端</value>
   </data>
+  <data name="Sc_NoteNeedsSplit" xml:space="preserve">
+    <value>僅在分割畫面時生效</value>
+  </data>
   <data name="Sc_NoteZoomOutTakesUnitSeparator" xml:space="preserve">
     <value>會佔用 ^_;要傳送它請用 Ctrl+Shift+-</value>
   </data>
@@ -4554,6 +4572,21 @@ Windows 填 exe 完整路徑或命令名稱(如 notepad);Linux 填命令名稱(�
   </data>
   <data name="Sc_KeyCommandMark" xml:space="preserve">
     <value>命令標記欄</value>
+  </data>
+  <data name="Sc_KeyMiddleClick" xml:space="preserve">
+    <value>中鍵</value>
+  </data>
+  <data name="Sc_KeyTabItem" xml:space="preserve">
+    <value>分頁</value>
+  </data>
+  <data name="Sc_KeyTabStrip" xml:space="preserve">
+    <value>分頁列</value>
+  </data>
+  <data name="Sc_KeySplitter" xml:space="preserve">
+    <value>分割條</value>
+  </data>
+  <data name="Sc_ScrollTabs" xml:space="preserve">
+    <value>捲動分頁列</value>
   </data>
   <data name="Sc_JumpPrevPrompt" xml:space="preserve">
     <value>跳到上一條提示符</value>

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml
@@ -20,6 +20,29 @@
       <Setter Property="Opacity" Value="0.65" />
       <Setter Property="RenderTransform" Value="translateY(4px)" />
     </Style>
+    <!-- 非活动窗格的强调线弱化。分屏之后每个窗格都画着自己那条激活标签线,全是 accent
+         的话根本看不出键盘输入会落到哪一格 —— 唯一的线索是"我刚才点了哪儿",而那正是
+         用户回头看屏幕时最先忘掉的事。弱化到 0.3:两条线并排一眼分得出主次,单窗格时
+         (它必然是活动窗格)没有任何变化。 -->
+    <Style Selector="local|DockGroupControl:not(:activepane) Border#ActiveTabIndicator">
+      <Setter Property="Opacity" Value="0.3" />
+    </Style>
+    <!-- 空窗格上的"关闭窗格":安静的次要按钮,别抢那句拖放提示的戏。 -->
+    <Style Selector="Button.pane-action">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource VelaBorderPrimary}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="10,4" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="FontFamily" Value="{DynamicResource VelaUiMonoFont}" />
+      <Setter Property="FontSize" Value="{DynamicResource VelaFontSize11}" />
+      <Setter Property="Foreground" Value="{DynamicResource VelaTextTertiary}" />
+    </Style>
+    <Style Selector="Button.pane-action:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource VelaBgHover}" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource VelaTextSecondary}" />
+    </Style>
   </UserControl.Styles>
 
   <!-- 一个标签组:标签条(35px + 1px 分割线 = 36px,与侧栏头部分割线同一水平线)+
@@ -109,6 +132,9 @@
                 <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.18" Easing="CubicEaseOut" />
                 <DoubleTransition Property="Width" Duration="0:0:0.18" Easing="CubicEaseOut" />
                 <DoubleTransition Property="Height" Duration="0:0:0.18" Easing="CubicEaseOut" />
+                <!-- 刻意**不给 Opacity 加过渡**:活动窗格的明暗是"我的键盘输入落在哪"的指示,
+                     该在点下去的那一刻就成立。淡入淡出除了让这条指示晚 180ms 之外没有别的作用,
+                     还会把它变成一个只能靠时序观测的状态(界面测试里正是这样卡住的)。 -->
               </Transitions>
             </Border.Transitions>
           </Border>
@@ -126,14 +152,47 @@
          组为空时(拆分留下的空面板)显示拖放提示。 -->
     <Border Background="{DynamicResource VelaBgDockDocument}" ClipToBounds="True">
       <Panel>
-        <TextBlock x:Name="EmptyHint"
-                   Text="{loc:Localize Dock_DropTabHere}"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
-                   FontFamily="{DynamicResource VelaUiMonoFont}"
-                   FontSize="{DynamicResource VelaFontSize11}"
-                   Foreground="{DynamicResource VelaTextMuted}"
-                   IsVisible="False" />
+        <!-- 「空」有两种,是两件不同的事,提示也必须是两套(代码后置按有无父分栏判定):
+             ① 拆分留下的空窗格 —— 旁边有别的标签可以拖进来,它自己也撤得掉;
+             ② 整个工作区都空了(根窗格)—— 没有标签可拖,也没有窗格可关。
+             在 ② 上挂一句「拖标签到这里」外加一枚点了不会有任何反应的按钮,
+             是在指挥用户做两件做不到的事(用户实测反馈)。 -->
+        <Panel x:Name="EmptyHint"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               IsVisible="False">
+
+          <!-- ① 拆分留下的空窗格。没有这枚按钮的话,它唯一的消除办法是把邻居的标签
+               拖进来再拖回去 —— 靠副作用做撤销。 -->
+          <StackPanel x:Name="DropTargetHint" Spacing="12" IsVisible="False">
+            <TextBlock Text="{loc:Localize Dock_DropTabHere}"
+                       HorizontalAlignment="Center"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}"
+                       Foreground="{DynamicResource VelaTextMuted}" />
+            <Button x:Name="ClosePaneButton"
+                    Classes="pane-action"
+                    HorizontalAlignment="Center"
+                    Content="{loc:Localize Dock_ClosePane}"
+                    Click="ClosePane_Click" />
+          </StackPanel>
+
+          <!-- ② 一个会话都没开:只说现状,再给一条真能走通的下一步。 -->
+          <StackPanel x:Name="NoSessionHint" Spacing="6" IsVisible="False">
+            <TextBlock Text="{loc:Localize Dock_NoSessionOpen}"
+                       HorizontalAlignment="Center"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize11}"
+                       Foreground="{DynamicResource VelaTextMuted}" />
+            <TextBlock Text="{loc:Localize Dock_NoSessionOpenHint}"
+                       HorizontalAlignment="Center"
+                       TextAlignment="Center"
+                       FontFamily="{DynamicResource VelaUiMonoFont}"
+                       FontSize="{DynamicResource VelaFontSize10}"
+                       Foreground="{DynamicResource VelaTextMuted}"
+                       Opacity="0.75" />
+          </StackPanel>
+        </Panel>
         <controls:ReparentingHost x:Name="ContentHost">
           <controls:ReparentingHost.Transitions>
             <Transitions>

--- a/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
+++ b/src/VelaShell/Docking/Controls/DockGroupControl.axaml.cs
@@ -19,6 +19,9 @@ namespace VelaShell.Docking.Controls;
 /// </summary>
 public partial class DockGroupControl : UserControl
 {
+    /// <summary>一格滚轮翻过的像素数:约合半个标签,连滚几下能过一屏,又不会一下窜到头。</summary>
+    private const double WheelStep = 80;
+
     private Func<DockDocument, Control?>? _viewResolver;
     private int _contentMotionGeneration;
     private readonly Transitions _contentTransitions;
@@ -35,6 +38,9 @@ public partial class DockGroupControl : UserControl
         _indicatorTransitions = ActiveTabIndicator.Transitions
             ?? throw new InvalidOperationException("ActiveTabIndicator transitions are not configured.");
         TabScroll.ScrollChanged += (_, _) => UpdateScrollButtons();
+        // 隧道阶段接管滚轮:ScrollViewer 自己会把滚轮当纵向滚动,而标签条是横排的,
+        // 于是"在标签条上滚一下"什么也不会发生,标签一多就只能去够右端那两枚小箭头。
+        TabScroll.AddHandler(PointerWheelChangedEvent, OnTabsWheel, RoutingStrategies.Tunnel);
         // 标签宽度随标题变化、容器随集合重建 —— 指示器几何跟着布局走最省心;
         // UpdateActiveTabIndicator 对相同几何短路,不会造成布局风暴。
         TabsHost.LayoutUpdated += (_, _) => UpdateActiveTabIndicator();
@@ -44,6 +50,27 @@ public partial class DockGroupControl : UserControl
         // 指针事件,冒泡阶段收不到。点标签时本处理器先按组当前选中激活一次,随后
         // DockTabItem 再精确激活被点的标签,结果一致。
         AddHandler(PointerPressedEvent, OnAnyPointerPressed, RoutingStrategies.Tunnel, handledEventsToo: true);
+    }
+
+    /// <summary>标签条上滚滚轮 = 沿标签排列方向翻标签(纵排标签条则是上下翻)。</summary>
+    /// <remarks>没有溢出时不吞事件 —— 那一下该照常传给下面的人,而不是变成一次静默的空操作。</remarks>
+    private void OnTabsWheel(object? sender, PointerWheelEventArgs e)
+    {
+        bool vertical = (Group?.TabsPosition ?? DockTabsPosition.Top) != DockTabsPosition.Top;
+        double delta = e.Delta.Y != 0 ? e.Delta.Y : e.Delta.X;
+        double extent = vertical ? TabScroll.Extent.Height : TabScroll.Extent.Width;
+        double viewport = vertical ? TabScroll.Viewport.Height : TabScroll.Viewport.Width;
+        if (delta == 0 || extent <= viewport + 0.5)
+        {
+            return;
+        }
+        // 滚轮向前(远离自己)= 往标签条的前端翻,与列表滚动的方向感一致。
+        double max = extent - viewport;
+        Vector offset = TabScroll.Offset;
+        TabScroll.Offset = vertical
+                               ? offset.WithY(Math.Clamp(offset.Y - (delta * WheelStep), 0, max))
+                               : offset.WithX(Math.Clamp(offset.X - (delta * WheelStep), 0, max));
+        e.Handled = true;
     }
 
     private void OnAnyPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -75,6 +102,7 @@ public partial class DockGroupControl : UserControl
         Workspace = workspace;
         WorkspaceControl = workspaceControl;
         _viewResolver = viewResolver;
+        workspace.ActiveDocumentChanged += OnWorkspaceActiveDocumentChanged;
         if (Group is { } group)
         {
             group.PropertyChanged += OnGroupPropertyChanged;
@@ -82,10 +110,24 @@ public partial class DockGroupControl : UserControl
             ApplyTabsPosition(group.TabsPosition);
         }
         UpdateContent();
+        UpdateActivePaneState();
     }
 
-    private void OnDocumentsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
+    private void OnDocumentsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
         UpdateContent();
+        // 标签换了个组住,而全局激活文档**没变**(把当前标签直接拖到隔壁窗格就是这样),
+        // ActiveDocumentChanged 不会响;活动窗格的归属却已经变了,得在这里补一次。
+        UpdateActivePaneState();
+    }
+
+    private void OnWorkspaceActiveDocumentChanged(DockDocument? document) => UpdateActivePaneState();
+
+    /// <summary>本组是否是"活动窗格"(承载着全局激活文档的那一格),供样式弱化其余窗格的强调线。</summary>
+    private void UpdateActivePaneState() =>
+        PseudoClasses.Set(
+            ":activepane",
+            Workspace?.ActiveDocument is { } active && Group is { } group && group.Documents.Contains(active));
 
     /// <summary>
     /// (重新)挂到可视树时恢复订阅与内容。分离处理器为避免双父级会把 Target 置空并退订
@@ -97,15 +139,18 @@ public partial class DockGroupControl : UserControl
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
-        if (Workspace is null || Group is not { } group)
+        if (Workspace is not { } workspace || Group is not { } group)
         {
             return; // 尚未 Initialize(首挂由 Initialize 完成接线),无从自愈。
         }
         // 先退订再订阅:首挂紧跟 Initialize 之后,不加防重会双份订阅。
         group.PropertyChanged -= OnGroupPropertyChanged;
         group.Documents.CollectionChanged -= OnDocumentsChanged;
+        workspace.ActiveDocumentChanged -= OnWorkspaceActiveDocumentChanged;
         group.PropertyChanged += OnGroupPropertyChanged;
         group.Documents.CollectionChanged += OnDocumentsChanged;
+        workspace.ActiveDocumentChanged += OnWorkspaceActiveDocumentChanged;
+        UpdateActivePaneState();
         if (ContentHost.Target is null)
         {
             UpdateContent();
@@ -123,6 +168,10 @@ public partial class DockGroupControl : UserControl
         {
             group.PropertyChanged -= OnGroupPropertyChanged;
             group.Documents.CollectionChanged -= OnDocumentsChanged;
+        }
+        if (Workspace is { } workspace)
+        {
+            workspace.ActiveDocumentChanged -= OnWorkspaceActiveDocumentChanged;
         }
         // 释放对缓存视图的引用,避免下一个宿主收养时双父级;若本实例被重挂,
         // OnAttachedToVisualTree 会自愈(重订阅 + 重填内容)。
@@ -200,7 +249,7 @@ public partial class DockGroupControl : UserControl
         {
             RestoreContentMotion();
             ContentHost.Target = view;
-            EmptyHint.IsVisible = Group is { Documents.Count: 0 };
+            UpdateEmptyState();
             return;
         }
 
@@ -209,7 +258,7 @@ public partial class DockGroupControl : UserControl
         ContentHost.Opacity = 0;
         ContentHost.RenderTransform = TransformOperations.Parse("translateY(2px)");
         ContentHost.Target = view;
-        EmptyHint.IsVisible = Group is { Documents.Count: 0 };
+        UpdateEmptyState();
         ContentHost.ClearValue(OpacityProperty);
         ContentHost.ClearValue(RenderTransformProperty);
         Dispatcher.UIThread.Post(() =>
@@ -220,6 +269,25 @@ public partial class DockGroupControl : UserControl
                 ContentHost.Classes.Remove("settling");
             }
         }, DispatcherPriority.Render);
+    }
+
+    /// <summary>
+    /// 空窗格的提示分两种:能撤掉的空窗格给"拖标签进来 / 关掉它",
+    /// 整个工作区都空了则只说现状与下一步。
+    /// </summary>
+    /// <remarks>
+    /// 判据是**有没有父分栏**,而不是"是不是主组":根窗格没有父分栏,
+    /// <see cref="DockWorkspace.ClosePane" /> 对它是空操作 —— 在那儿摆一枚点了不会有
+    /// 任何反应的按钮,比没有按钮更糟;同理,一个标签都没有的时候,
+    /// "把标签拖到这里"指的是一件当下做不到的事(用户实测反馈)。
+    /// </remarks>
+    private void UpdateEmptyState()
+    {
+        bool empty = Group is { Documents.Count: 0 };
+        bool removable = empty && Group?.Parent is not null;
+        EmptyHint.IsVisible = empty;
+        DropTargetHint.IsVisible = removable;
+        NoSessionHint.IsVisible = empty && !removable;
     }
 
     private void RestoreContentMotion()
@@ -281,6 +349,15 @@ public partial class DockGroupControl : UserControl
         TabScroll.Offset = TabScroll.Offset.WithX(Math.Min(
             Math.Max(0, TabScroll.Extent.Width - TabScroll.Viewport.Width),
             TabScroll.Offset.X + 120));
+
+    /// <summary>空窗格上的"关闭窗格":把这块空面板从布局里撤掉,兄弟随之填满整片区域。</summary>
+    private void ClosePane_Click(object? sender, RoutedEventArgs e)
+    {
+        if (Workspace is { } workspace && Group is { } group)
+        {
+            workspace.ClosePane(group);
+        }
+    }
 
     /// <summary>标签列表下拉(设计 nunbT tabListDrop):点击时按当前标签动态生成。</summary>
     private void TabListDrop_Click(object? sender, RoutedEventArgs e)

--- a/src/VelaShell/Docking/Controls/DockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/DockTabItem.axaml
@@ -127,6 +127,13 @@
                          Foreground="{DynamicResource VelaTextTertiary}" />
         </MenuItem.Icon>
       </MenuItem>
+      <!-- 窗格最大化(Ctrl+Shift+X):分屏之后想把某一格看仔细,不必先拆了再拼回去。 -->
+      <MenuItem Header="{loc:Localize Dock_ToggleMaximizePane}" Click="ToggleMaximizePane_Click">
+        <MenuItem.Icon>
+          <pc:LucideIcon Width="13" Height="13" Data="{DynamicResource Icon.maximize}"
+                         Foreground="{DynamicResource VelaTextTertiary}" />
+        </MenuItem.Icon>
+      </MenuItem>
       <Separator />
       <MenuItem Header="{loc:Localize Dock_TabsPosition}">
         <MenuItem.Icon>

--- a/src/VelaShell/Docking/Controls/DockTabItemBase.cs
+++ b/src/VelaShell/Docking/Controls/DockTabItemBase.cs
@@ -53,6 +53,14 @@ public abstract class DockTabItemBase : UserControl
         }
 
         PointerPoint point = e.GetCurrentPoint(this);
+        if (point.Properties.IsMiddleButtonPressed)
+        {
+            // 中键关标签:浏览器与各家编辑器通用的手势,省掉"先瞄准那枚 11px 的 ×"。
+            // 同样走 RequestClose —— 已连接会话的确认闸对哪个入口都得生效。
+            e.Handled = true;
+            workspace.RequestClose(document);
+            return;
+        }
         if (point.Properties.IsLeftButtonPressed)
         {
             workspace.ActivateDocument(document);
@@ -86,6 +94,15 @@ public abstract class DockTabItemBase : UserControl
     protected void CloseLeft_Click(object? sender, RoutedEventArgs e) => Workspace?.CloseLeftDocuments(Document!);
     /// <summary>关闭当前标签右侧的全部文档。</summary>
     protected void CloseRight_Click(object? sender, RoutedEventArgs e) => Workspace?.CloseRightDocuments(Document!);
+    /// <summary>把本窗格最大化到整片工作区,或从最大化状态还原。</summary>
+    protected void ToggleMaximizePane_Click(object? sender, RoutedEventArgs e)
+    {
+        if (Workspace is { } workspace && Group is { } group)
+        {
+            workspace.ToggleMaximizeGroup(group);
+        }
+    }
+
     /// <summary>将文档水平拆分为新组。</summary>
     protected void SplitHorizontal_Click(object? sender, RoutedEventArgs e) => Workspace?.SplitDocument(Document!, DockOrientation.Horizontal);
     /// <summary>将文档垂直拆分为新组。</summary>

--- a/src/VelaShell/Docking/Controls/DockWorkspaceControl.cs
+++ b/src/VelaShell/Docking/Controls/DockWorkspaceControl.cs
@@ -69,7 +69,8 @@ public sealed class DockWorkspaceControl : Panel
 
     private void OnWorkspaceModelChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(DockWorkspace.Root))
+        // 最大化只换渲染的起点,与换根同样是"整树重建"这一件事。
+        if (e.PropertyName is nameof(DockWorkspace.Root) or nameof(DockWorkspace.MaximizedGroup))
         {
             Rebuild();
         }
@@ -128,7 +129,8 @@ public sealed class DockWorkspaceControl : Panel
         {
             return;
         }
-        Children.Add(BuildNode(workspace, workspace.Root));
+        // 最大化的窗格直接当根渲染:布局树一动不动,其余窗格的视图留在缓存里等着被收养回来。
+        Children.Add(BuildNode(workspace, workspace.MaximizedGroup ?? workspace.Root));
         Children.Add(Overlay);
     }
 
@@ -160,7 +162,9 @@ public sealed class DockWorkspaceControl : Panel
         {
             if (i > 0)
             {
-                AddSplitterTrack(grid, horizontal, trackIndex, () => SaveProportions(tracks, horizontal));
+                AddSplitterTrack(grid, horizontal, trackIndex,
+                                 () => SaveProportions(tracks, horizontal),
+                                 () => ResetProportions(tracks));
                 trackIndex++;
             }
             DockNode child = split.Children[i];
@@ -197,9 +201,15 @@ public sealed class DockWorkspaceControl : Panel
 
     /// <summary>
     /// 5px 分割条轨道:1px 主题线 + 透明 GridSplitter(与主窗口侧栏/文件面板分割条同款,
-    /// 视觉轻、抓取区宽)。拖动结束把 star 值回写为各子节点的 Proportion。
+    /// 视觉轻、抓取区宽)。拖动结束把 star 值回写为各子节点的 Proportion;
+    /// 双击复位为均分 —— 拖歪一条缝之后,没有这一下就只能靠手再瞄准一次。
     /// </summary>
-    private static void AddSplitterTrack(Grid grid, bool horizontal, int trackIndex, Action onDragCompleted)
+    private static void AddSplitterTrack(
+        Grid grid,
+        bool horizontal,
+        int trackIndex,
+        Action onDragCompleted,
+        Action onReset)
     {
         var line = new Border();
         line.Bind(Border.BackgroundProperty, line.GetResourceObservable("VelaBorderPrimary"));
@@ -211,6 +221,11 @@ public sealed class DockWorkspaceControl : Panel
             ResizeDirection = horizontal ? GridResizeDirection.Columns : GridResizeDirection.Rows
         };
         splitter.DragCompleted += (_, _) => onDragCompleted();
+        splitter.DoubleTapped += (_, e) =>
+        {
+            onReset();
+            e.Handled = true;
+        };
         if (horizontal)
         {
             grid.ColumnDefinitions.Add(new ColumnDefinition(5, GridUnitType.Pixel));
@@ -229,6 +244,18 @@ public sealed class DockWorkspaceControl : Panel
         }
         grid.Children.Add(line);
         grid.Children.Add(splitter);
+    }
+
+    /// <summary>
+    /// 把这一条分栏的子节点恢复成均分。写回模型的 NaN 即可 ——
+    /// 轨道订阅了 Proportion(见 <see cref="OnNodeChanged" />),界面自己跟上。
+    /// </summary>
+    private static void ResetProportions(List<(DefinitionBase Definition, DockNode Node)> tracks)
+    {
+        foreach ((_, DockNode node) in tracks)
+        {
+            node.Proportion = double.NaN;
+        }
     }
 
     private static void SaveProportions(List<(DefinitionBase Definition, DockNode Node)> tracks, bool horizontal)

--- a/src/VelaShell/Docking/Controls/PluginDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/PluginDockTabItem.axaml
@@ -51,6 +51,7 @@
       <Separator />
       <MenuItem Header="{loc:Localize Dock_SplitHorizontal}" Click="SplitHorizontal_Click" />
       <MenuItem Header="{loc:Localize Dock_SplitVertical}" Click="SplitVertical_Click" />
+      <MenuItem Header="{loc:Localize Dock_ToggleMaximizePane}" Click="ToggleMaximizePane_Click" />
     </ContextMenu>
   </UserControl.ContextMenu>
 

--- a/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/SftpDockTabItem.axaml
@@ -66,6 +66,7 @@
       <Separator />
       <MenuItem Header="{loc:Localize Dock_SplitHorizontal}" Click="SplitHorizontal_Click" />
       <MenuItem Header="{loc:Localize Dock_SplitVertical}" Click="SplitVertical_Click" />
+      <MenuItem Header="{loc:Localize Dock_ToggleMaximizePane}" Click="ToggleMaximizePane_Click" />
       <Separator />
       <MenuItem Header="{loc:Localize Dock_TabsPosition}">
         <MenuItem Header="{loc:Localize Dock_TabsTop}" Click="TabsTop_Click" />

--- a/src/VelaShell/Docking/Controls/WorkspaceDockTabItem.axaml
+++ b/src/VelaShell/Docking/Controls/WorkspaceDockTabItem.axaml
@@ -74,6 +74,7 @@
       <Separator />
       <MenuItem Header="{loc:Localize Dock_SplitHorizontal}" Click="SplitHorizontal_Click" />
       <MenuItem Header="{loc:Localize Dock_SplitVertical}" Click="SplitVertical_Click" />
+      <MenuItem Header="{loc:Localize Dock_ToggleMaximizePane}" Click="ToggleMaximizePane_Click" />
       <Separator />
       <MenuItem Header="{loc:Localize Dock_TabsPosition}">
         <MenuItem Header="{loc:Localize Dock_TabsTop}" Click="TabsTop_Click" />

--- a/src/VelaShell/Docking/Model/DockGroup.cs
+++ b/src/VelaShell/Docking/Model/DockGroup.cs
@@ -25,8 +25,13 @@ public sealed class DockGroup : DockNode
     } = DockTabsPosition.Top;
 
     /// <summary>
-    /// 主组:新终端默认加入的组,清空后也不折叠(对应原 DocumentDock 的
-    /// IsCollapsable=false)。整个工作区有且只有一个。
+    /// 主组:布局里那个兜底的组 —— 它是唯一一个即使清空也不会被折叠掉的组,
+    /// 因而永远有地方接住新文档。整个工作区有且只有一个。
     /// </summary>
-    public bool IsPrimary { get; init; }
+    /// <remarks>
+    /// 这个身份**可以易主**:主组清空而布局里还有别的组时,
+    /// <see cref="DockWorkspace" /> 会把它交给幸存的邻居,自己退场。钉死在最初那个组上的话,
+    /// 分屏后把左边一路关完,右半屏会一直挤在右边 —— 因为左边那块空白正是"永不折叠"的主组本人。
+    /// </remarks>
+    public bool IsPrimary { get; internal set; }
 }

--- a/src/VelaShell/Docking/Model/DockWorkspace.cs
+++ b/src/VelaShell/Docking/Model/DockWorkspace.cs
@@ -5,7 +5,7 @@ namespace VelaShell.Docking.Model;
 /// (docs/dock-replacement-plan.md §2.3)。取代原 TerminalDockFactory + Dock.Model:
 /// 新文档进主组;用户关闭走 <see cref="CloseDocument" />(触发 <see cref="DocumentClosed" />,
 /// 下游据此断 SSH/SFTP/日志);程序撤除走 <see cref="RemoveDocument" />(静默)。
-/// 空的非主组自动折叠,单子分栏自动提升。
+/// 空组自动折叠(主组先把兜底身份交给邻居再退场,只有根留着),单子分栏自动提升。
 /// </summary>
 public sealed class DockWorkspace : DockElement
 {
@@ -25,8 +25,28 @@ public sealed class DockWorkspace : DockElement
         private set => SetField(ref _root, value);
     }
 
-    /// <summary>新文档默认加入的组;清空后也不折叠。</summary>
-    public DockGroup PrimaryGroup { get; }
+    /// <summary>
+    /// 布局的兜底组:唯一一个不会被折叠掉的组,也是找不到更合适落点时新文档的归宿。
+    /// </summary>
+    /// <remarks>
+    /// 主组清空而布局里还有别的组时,这个身份会交给幸存的邻居(见 <see cref="TryHandOverPrimary" />),
+    /// 所以**不要把它缓存起来**。
+    /// </remarks>
+    public DockGroup PrimaryGroup { get; private set; }
+
+    /// <summary>
+    /// 当前被最大化(独占整片工作区)的窗格;<c>null</c> = 按布局树正常平铺。
+    /// </summary>
+    /// <remarks>
+    /// 与 tmux 的 <c>resize-pane -Z</c> 是同一件事:分屏之后想把某一格看仔细,
+    /// 不必先拆掉布局、看完再拼回去。**只影响渲染,不动布局树** —— 解除时原样恢复,
+    /// 连比例都不用记;因此它也不需要参与任何持久化。
+    /// </remarks>
+    public DockGroup? MaximizedGroup
+    {
+        get;
+        private set => SetField(ref field, value);
+    }
 
     /// <summary>全局激活文档(最后交互的组的选中标签),驱动 ActiveTerminalTab/状态栏联动。</summary>
     public DockDocument? ActiveDocument
@@ -154,14 +174,43 @@ public sealed class DockWorkspace : DockElement
 
     // ---- 增删与激活 ----
 
-    /// <summary>加入主组并激活(与原 Dock 行为一致:新终端总进第一组)。</summary>
+    /// <summary>把文档放进最合适的窗格并激活(落点规则见 <see cref="TargetGroupForNewDocument" />)。</summary>
     public void AddDocument(DockDocument document)
     {
-        PrimaryGroup.Documents.Add(document);
+        TargetGroupForNewDocument().Documents.Add(document);
         // 先报"来了"再激活:订阅方(宿主的每标签接线)要在活动标签切过去之前就位,
         // 否则激活回调里读到的还是一个没接好线的标签。
         DocumentAdded?.Invoke(document);
         ActivateDocument(document);
+    }
+
+    /// <summary>新文档的落点:空窗格 &gt; 正在用的窗格 &gt; 主组。</summary>
+    /// <remarks>
+    /// <para>
+    /// <b>空窗格优先</b>:拆分只有一个标签的组会在原地留下一块写着"拖放标签到这里"的空面板,
+    /// 那块空白就是等着被填的 —— 新开的会话理应落进去,而不是挤进旁边那条已经有标签的条,
+    /// 把空面板晾在一边。
+    /// </para>
+    /// <para>
+    /// <b>其次是当前窗格</b>:分屏之后人眼盯着右半屏工作,新标签却开在左半屏的标签条上 ——
+    /// 焦点跟着跑过去,视线还留在原处。"新标签开在我正在用的这半边"是 VS Code /
+    /// Windows Terminal 一致的做法,也是分屏之后唯一不让人找标签的做法。
+    /// </para>
+    /// <para>
+    /// 主组只作兜底:没有空窗格、也没有活动文档(刚启动的空布局)时用它。
+    /// </para>
+    /// </remarks>
+    private DockGroup TargetGroupForNewDocument()
+    {
+        if (PrimaryGroup.Documents.Count == 0)
+        {
+            return PrimaryGroup;
+        }
+        if (AllGroups().FirstOrDefault(group => group.Documents.Count == 0) is { } empty)
+        {
+            return empty;
+        }
+        return ActiveDocument is { } active && FindGroup(active) is { } activeGroup ? activeGroup : PrimaryGroup;
     }
 
     /// <summary>
@@ -212,8 +261,60 @@ public sealed class DockWorkspace : DockElement
         {
             return;
         }
+        // 切到别的窗格 = 此刻想同时看见它们:与 tmux 的 select-pane 一样顺手解除最大化。
+        // 否则用户会对着一个"焦点已经在别处、屏幕上却还是那一格"的界面发愣。
+        if (MaximizedGroup is { } maximized && !ReferenceEquals(maximized, group))
+        {
+            MaximizedGroup = null;
+        }
         group.ActiveDocument = document;
         ActiveDocument = document;
+    }
+
+    /// <summary>切换某个窗格的最大化状态;布局里只有一个窗格时是空操作(没有可让位的邻居)。</summary>
+    /// <param name="group">要最大化 / 还原的窗格。</param>
+    public void ToggleMaximizeGroup(DockGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (ReferenceEquals(MaximizedGroup, group))
+        {
+            MaximizedGroup = null;
+            return;
+        }
+        if (HasMultipleGroups && IsOnTree(group))
+        {
+            MaximizedGroup = group;
+        }
+    }
+
+    /// <summary>把所有分栏恢复成均分 —— 分割条拖乱之后的一键复位。</summary>
+    public void EqualizePanes()
+    {
+        foreach (DockNode node in EnumerateNodes(Root))
+        {
+            node.Proportion = double.NaN; // NaN = 与兄弟均分(渲染层按 1 星处理)
+        }
+    }
+
+    /// <summary>
+    /// 关掉整个窗格:还有标签就走确认闸逐一关闭(关空之后窗格自会折叠),
+    /// 已经是空窗格则直接从布局里撤掉。
+    /// </summary>
+    /// <remarks>
+    /// 空窗格(拆分留下的那块"拖放标签到这里")在此之前<b>没有任何撤销入口</b> ——
+    /// 只能把邻居的标签拖进去、再拖回来,靠副作用把它挤掉。一个显式的"关闭窗格"
+    /// 才是这块空白该有的出口。
+    /// </remarks>
+    /// <param name="group">要关闭的窗格。</param>
+    public void ClosePane(DockGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (group.Documents.Count > 0)
+        {
+            RequestCloseMany(group.Documents.ToArray());
+            return;
+        }
+        CollapseIfEmpty(group);
     }
 
     /// <summary>
@@ -408,7 +509,7 @@ public sealed class DockWorkspace : DockElement
         DockGroup newGroup = DetachToNewGroup(document, source);
         // source 若因清空被折叠,目标组仍在树上(source != target 已由上面分支保证),
         // 极端情况下兜底锚定主组。
-        DockGroup anchor = FindNode(target) ? target : PrimaryGroup;
+        DockGroup anchor = IsOnTree(target) ? target : PrimaryGroup;
         InsertNeighbor(anchor, newGroup, orientation, after);
         ActivateDocument(document);
     }
@@ -497,7 +598,8 @@ public sealed class DockWorkspace : DockElement
 
     // ---- 树维护 ----
 
-    private bool FindNode(DockNode node)
+    /// <summary>节点是否还挂在当前布局树上(折叠掉的组仍被调用方持有引用,得能问出来)。</summary>
+    private bool IsOnTree(DockNode node)
     {
         DockNode current = node;
         while (current.Parent is { } parent)
@@ -505,6 +607,23 @@ public sealed class DockWorkspace : DockElement
             current = parent;
         }
         return ReferenceEquals(current, Root);
+    }
+
+    /// <summary>深度遍历布局树的全部节点(分栏与组都算)。</summary>
+    private static IEnumerable<DockNode> EnumerateNodes(DockNode node)
+    {
+        yield return node;
+        if (node is not DockSplit split)
+        {
+            yield break;
+        }
+        foreach (DockNode child in split.Children.ToArray())
+        {
+            foreach (DockNode descendant in EnumerateNodes(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 
     private void ReplaceNode(DockNode oldNode, DockNode newNode)
@@ -520,14 +639,61 @@ public sealed class DockWorkspace : DockElement
         parent.Children[index] = newNode;
     }
 
+    /// <summary>
+    /// 空组从布局里退场:主组同样退场,只是先把"兜底"的身份交出去。
+    /// </summary>
+    /// <remarks>
+    /// 早先这里对主组一律早退(<c>IsPrimary || …</c>),结果是分屏之后关光左侧的标签,
+    /// 右侧那半永远填不满整片区域 —— 左边留着的正是那个空的、"永不折叠"的主组。
+    /// 需要不折叠的其实只有<b>根</b>(布局树总得有个底),而不是某个特定的组;
+    /// 由 <c>group.Parent is not { } parent</c> 这一条兜住:根节点没有父分栏。
+    /// </remarks>
     private void CollapseIfEmpty(DockGroup group)
     {
-        if (group.IsPrimary || group.Documents.Count > 0 || group.Parent is not { } parent)
+        if (group.Documents.Count > 0 || group.Parent is not { } parent)
         {
             return;
         }
+        if (group.IsPrimary && !TryHandOverPrimary(group))
+        {
+            return; // 没人能接手兜底,主组只好原地留着。
+        }
         parent.Children.Remove(group);
         HoistIfSingle(parent);
+        NormalizeMaximized();
+    }
+
+    /// <summary>把"主组"的身份交给幸存的邻居;没人可交则返回 false(调用方据此放弃折叠)。</summary>
+    /// <remarks>
+    /// 优先交给同一分栏里的兄弟,而且是折叠之后<b>会接管这块地方</b>的那个 ——
+    /// 于是新文档出现在用户眼睛刚才盯着的位置,而不是布局树另一头的某个窗格。
+    /// </remarks>
+    /// <param name="leaving">即将退场的空主组。</param>
+    /// <returns>成功易主返回 <c>true</c>。</returns>
+    private bool TryHandOverPrimary(DockGroup leaving)
+    {
+        DockGroup? successor = leaving.Parent?.Children
+                                      .Where(child => !ReferenceEquals(child, leaving))
+                                      .Select(child => Descend(child, enterFromEnd: false))
+                                      .FirstOrDefault(group => group is not null);
+        successor ??= AllGroups().FirstOrDefault(group => !ReferenceEquals(group, leaving));
+        if (successor is null)
+        {
+            return false;
+        }
+        leaving.IsPrimary = false;
+        successor.IsPrimary = true;
+        PrimaryGroup = successor;
+        return true;
+    }
+
+    /// <summary>结构变动后校正最大化状态:被最大化的窗格已不在树上、或布局只剩一格时解除。</summary>
+    private void NormalizeMaximized()
+    {
+        if (MaximizedGroup is { } maximized && (!IsOnTree(maximized) || !HasMultipleGroups))
+        {
+            MaximizedGroup = null;
+        }
     }
 
     private void HoistIfSingle(DockSplit split)
@@ -541,9 +707,10 @@ public sealed class DockWorkspace : DockElement
         child.Proportion = split.Proportion;
         ReplaceNode(split, child);
 
-        // 提升出来的若是一个空的次级组(拆分留下的空面板,兄弟已全部关闭),
-        // 顺带回收,不让空面板独自留在布局里;递归令上层分栏继续收敛。
-        if (child is DockGroup { IsPrimary: false, Documents.Count: 0 } emptyGroup)
+        // 提升出来的若是一个空组(拆分留下的空面板,兄弟已全部关闭),顺带回收,
+        // 不让空面板独自留在布局里;递归令上层分栏继续收敛。主组不必在这里特判 ——
+        // CollapseIfEmpty 自己会先交出兜底身份,而升到根之后它没有父分栏、自然留下。
+        if (child is DockGroup { Documents.Count: 0 } emptyGroup)
         {
             CollapseIfEmpty(emptyGroup);
         }

--- a/src/VelaShell/Themes/DockStyles.axaml
+++ b/src/VelaShell/Themes/DockStyles.axaml
@@ -153,6 +153,14 @@
         <Setter Property="Margin" Value="6,4" />
     </Style>
 
+    <!-- 正在被拖动的标签:半透明 + 移动光标。DockDragController 一直在给它挂 .dragging 类,
+         但全仓没有任何一条样式认这个类 —— 于是拖拽过程中标签本身毫无反应,唯一的反馈是
+         落点高亮,"我手上拿着的到底是哪一个"全靠脑补。外观统一放这里,五种标签一次到位。 -->
+    <Style Selector=":is(dockc|DockTabItemBase).dragging">
+        <Setter Property="Opacity" Value="0.45" />
+        <Setter Property="Cursor" Value="SizeAll" />
+    </Style>
+
     <!-- 标签条溢出控件(design nunbT pZGS4):24px,圆角 3,悬停 bg-hover。 -->
     <Style Selector=":is(Button).tab-nav">
         <Setter Property="Width" Value="24" />

--- a/src/VelaShell/ViewModels/MainWindowViewModel.cs
+++ b/src/VelaShell/ViewModels/MainWindowViewModel.cs
@@ -1205,6 +1205,36 @@ public class MainWindowViewModel : ReactiveObject, Services.Plugins.ITerminalRes
                 Icon: "Icon.rows-2"
             )
         );
+        // 窗格最大化(tmux 的 resize-pane -Z):分屏之后想把某一格看仔细,不必先把布局
+        // 拆了、看完再照原样拼回去 —— 那两步手工活正是分屏用起来累的原因。
+        Commands.Register(
+            new(
+                "pane.maximize",
+                Strings.Get("Dock_ToggleMaximizePane"),
+                Strings.Get("CmdCat_Actions"),
+                () =>
+                {
+                    if (Layout.ActiveDocument is { } document && Layout.FindGroup(document) is { } group)
+                    {
+                        Layout.ToggleMaximizeGroup(group);
+                    }
+                },
+                () => Layout.HasMultipleGroups,
+                "Ctrl+Shift+X",
+                Icon: "Icon.maximize"
+            )
+        );
+        // 平分窗格:分割条拖歪之后的一键复位(双击任意一条分割条只平分那一条所在的分栏)。
+        Commands.Register(
+            new(
+                "pane.equalize",
+                Strings.Get("Dock_EqualizePanes"),
+                Strings.Get("CmdCat_Actions"),
+                Layout.EqualizePanes,
+                () => Layout.HasMultipleGroups,
+                Icon: "Icon.layout-grid"
+            )
+        );
         // XMODEM / YMODEM 手动入口。ZMODEM 会自动接管(远端 sz/rz 的引导序列可识别),
         // 而这一族协议在链路上没有可识别的引导 —— sb/sx 静默等接收方发 'C',rb/rx 只吐裸 'C',
         // 在终端输出里与普通字符无异,自动检测必然误触发。所以只能由用户在远端敲好命令后手动发起。

--- a/src/VelaShell/ViewModels/ShortcutCatalog.cs
+++ b/src/VelaShell/ViewModels/ShortcutCatalog.cs
@@ -103,6 +103,9 @@ public static class ShortcutCatalog
                     Item("Cmd_GotoLastTab", [Ctrl, Alt, "9"]),
                     Item("Dock_SplitHorizontal", [Ctrl, Shift, "D"]),
                     Item("Dock_SplitVertical", [Ctrl, Shift, "S"]),
+                    // 用 NeedsSplit 而不是 SplitOnly:这一条是无条件抢下的全局键位,
+                    // 未分屏时它只是没事可做,并不会把按键送去远端(Alt+方向才会)。
+                    Item("Dock_ToggleMaximizePane", [Ctrl, Shift, "X"], "Sc_NoteNeedsSplit"),
                     Item("Sc_FocusPane", [Alt, "←", "→", "↑", "↓"], "Sc_NoteSplitOnly"),
                     Item("Cmd_ToggleSidebar", [Ctrl, "B"]),
                     Item("Sc_ToggleFileBrowser", [Ctrl, Shift, "F"]),
@@ -170,6 +173,10 @@ public static class ShortcutCatalog
                     Item("Sc_RightClickPaste", [K("Sc_KeyRightClick")], "Sc_NoteOptional"),
                     Item("Sc_ZoomFont", [Ctrl, K("Sc_KeyWheel")]),
                     Item("Sc_FastScroll", [Alt, K("Sc_KeyWheel")]),
+                    // 停靠区的三个鼠标手势:不写进来就只有读过源码的人知道它们存在。
+                    Item("CloseTab", [K("Sc_KeyTabItem"), K("Sc_KeyMiddleClick")]),
+                    Item("Sc_ScrollTabs", [K("Sc_KeyTabStrip"), K("Sc_KeyWheel")]),
+                    Item("Dock_EqualizePanes", [K("Sc_KeySplitter"), K("Sc_KeyDoubleClick")], "Sc_NoteNeedsSplit"),
                     Item("Sc_GutterMenu", [K("Sc_KeyGutter"), K("Sc_KeyRightClick")]),
                     Item("Sc_ToggleFold", [K("Sc_KeyGutter"), K("Sc_KeyLeftClick")]),
                     Item("Sc_SelectCommandOutput", [K("Sc_KeyCommandMark"), K("Sc_KeyLeftClick")], "Sc_NoteShellIntegration"),

--- a/src/VelaShell/Views/MainWindow.axaml
+++ b/src/VelaShell/Views/MainWindow.axaml
@@ -43,6 +43,8 @@
     <!-- 分屏。Ctrl+Shift+S 的 S = stack(下方分屏);它在终端里没有用途,可以安全占用。 -->
     <KeyBinding Gesture="Ctrl+Shift+D" Command="{Binding RunCommand}" CommandParameter="split.horizontal" />
     <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding RunCommand}" CommandParameter="split.vertical" />
+    <!-- 窗格最大化 / 还原(Terminator 的 Ctrl+Shift+X 同款)。 -->
+    <KeyBinding Gesture="Ctrl+Shift+X" Command="{Binding RunCommand}" CommandParameter="pane.maximize" />
 
     <!-- 跳到第 N 个标签。用 Ctrl+Alt+数字 而不是 Ctrl+数字:Ctrl+2…7 是控制字符
          (^@ ^[ ^\ ^] ^^ ^_),占掉它们等于让远端再也收不到这六个字节。

--- a/tests/VelaShell.Tests/Docking/DockCloseInterceptorTests.cs
+++ b/tests/VelaShell.Tests/Docking/DockCloseInterceptorTests.cs
@@ -142,6 +142,21 @@ public sealed class DockCloseInterceptorTests
     }
 
     [TestMethod]
+    public void ClosePane_GoesThroughTheInterceptor()
+    {
+        // 「关闭窗格」是第七个入口(空窗格上的那枚按钮 / 一次关掉整格)。它同样是批量关闭,
+        // 绕开确认闸就等于把这道闸开了个后门。
+        (DockWorkspace ws, TestDocument[] docs, List<IReadOnlyList<DockDocument>> seen) = Setup(allow: false);
+
+        ws.ClosePane(ws.PrimaryGroup);
+
+        Assert.HasCount(4, ws.PrimaryGroup.Documents);
+        Assert.HasCount(1, seen, "一次询问放行整格,而不是逐个弹框");
+        Assert.HasCount(4, seen[0]);
+        Assert.Contains(docs[0], seen[0]);
+    }
+
+    [TestMethod]
     public void AllowedBulkClose_ClosesEveryTarget()
     {
         (DockWorkspace ws, TestDocument[] docs, _) = Setup(allow: true);

--- a/tests/VelaShell.Tests/Docking/DockWorkspaceTests.cs
+++ b/tests/VelaShell.Tests/Docking/DockWorkspaceTests.cs
@@ -279,25 +279,65 @@ public class DockWorkspaceTests
     }
 
     [TestMethod]
-    public void PrimaryGroup_NeverCollapses()
+    public void ClosingLastDocOfPrimaryGroup_CollapsesItAndFillsTheArea()
     {
+        // 用户实测报回来的那一条:拖出分屏后把左半屏的标签关光,右半屏还是缩在右边。
+        // 留在那儿的正是空的主组 —— 早先它被写成"永不折叠"。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.SplitDocument(b, DockOrientation.Horizontal); // root: [主组(a) | g2(b)]
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
+
+        ws.CloseDocument(a);
+
+        Assert.AreSame(g2, ws.Root, "空主组必须退场,剩下的窗格铺满整片区域");
+        Assert.AreSame(g2, ws.PrimaryGroup, "兜底身份交给幸存的邻居");
+        Assert.IsTrue(g2.IsPrimary);
+        Assert.AreSame(b, ws.ActiveDocument);
+
+        TestDocument c = NewDoc("c");
+        ws.AddDocument(c);
+        Assert.AreSequenceEqual([b, c], g2.Documents.ToArray(), "新文档进接手之后的主组");
+    }
+
+    [TestMethod]
+    public void DraggingLastDocOutOfPrimaryGroup_CollapsesItToo()
+    {
+        // 与上一条同因异形:把主组最后一个标签拖进邻居,主组同样该退场。
         var ws = new DockWorkspace();
         TestDocument a = NewDoc("a");
         TestDocument b = NewDoc("b");
         ws.AddDocument(a);
         ws.AddDocument(b);
         ws.SplitDocument(b, DockOrientation.Horizontal);
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
 
-        ws.CloseDocument(a); // 清空主组
+        ws.DockTo(a, g2, DockPosition.Center);
 
-        var split = ws.Root as DockSplit;
-        Assert.IsNotNull(split, "主组即使为空也保留");
-        Assert.HasCount(2, split.Children);
+        Assert.AreSame(g2, ws.Root);
+        Assert.AreSame(g2, ws.PrimaryGroup);
+        Assert.AreSequenceEqual([b, a], g2.Documents.ToArray());
+    }
+
+    [TestMethod]
+    public void LastGroup_StaysEvenWhenEmpty()
+    {
+        // 不折叠的是**根**,不是某个特定的组 —— 布局树总得有个底,新文档才有地方落。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        ws.AddDocument(a);
+
+        ws.CloseDocument(a);
+
+        Assert.AreSame(ws.PrimaryGroup, ws.Root);
         Assert.IsEmpty(ws.PrimaryGroup.Documents);
-        // 新文档仍然进主组
-        TestDocument c = NewDoc("c");
-        ws.AddDocument(c);
-        Assert.AreSequenceEqual([c], ws.PrimaryGroup.Documents.ToArray());
+
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(b);
+        Assert.AreSequenceEqual([b], ws.PrimaryGroup.Documents.ToArray());
     }
 
     [TestMethod]
@@ -410,6 +450,156 @@ public class DockWorkspaceTests
         Assert.IsEmpty(g2.Documents);
         var g3 = (DockGroup)root.Children[2];
         Assert.AreSequenceEqual([b], g3.Documents.ToArray());
+    }
+
+    // ---- 新文档的落点 ----
+
+    [TestMethod]
+    public void AddDocument_FillsTheEmptyPaneLeftBehindBySplit()
+    {
+        // 拆分单标签的组会原地留下一块"拖放标签到这里"的空面板。那块空白就是等着被填的:
+        // 新会话该落进去,而不是挤进旁边那条已经有标签的条,把空面板晾着。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        ws.AddDocument(a);
+        ws.SplitDocument(a, DockOrientation.Horizontal);
+        DockGroup empty = ws.AllGroups().Single(group => group.Documents.Count == 0);
+
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(b);
+
+        Assert.AreSame(empty, ws.FindGroup(b));
+        Assert.AreEqual(2, ws.AllGroups().Count(), "填空而已,不该再添一格");
+    }
+
+    [TestMethod]
+    public void AddDocument_GoesToTheActivePane_WhenNoPaneIsEmpty()
+    {
+        // 分屏之后人眼盯着右半屏,新标签却开在左半屏的标签条上 —— 焦点跑了,视线还留在原处。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.SplitDocument(b, DockOrientation.Horizontal); // 激活留在新拆出来的 g2
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
+
+        TestDocument c = NewDoc("c");
+        ws.AddDocument(c);
+
+        Assert.AreSame(g2, ws.FindGroup(c), "新标签开在正在用的那半边");
+        Assert.AreSame(c, ws.ActiveDocument);
+        Assert.AreSequenceEqual([a], ws.PrimaryGroup.Documents.ToArray(), "另一半原样不动");
+    }
+
+    // ---- 关闭窗格 / 最大化 / 平分 ----
+
+    [TestMethod]
+    public void ClosePane_OnEmptyPane_RemovesItFromTheLayout()
+    {
+        // 空面板在此之前没有任何撤销入口 —— 只能把邻居的标签拖进去再拖回来,靠副作用挤掉它。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        ws.AddDocument(a);
+        ws.SplitDocument(a, DockOrientation.Horizontal);
+        DockGroup empty = ws.AllGroups().Single(group => group.Documents.Count == 0);
+
+        ws.ClosePane(empty);
+
+        var root = ws.Root as DockGroup;
+        Assert.IsNotNull(root, "空面板撤掉后单子分栏该提升,不留一层空壳");
+        Assert.AreSequenceEqual([a], root.Documents.ToArray());
+    }
+
+    [TestMethod]
+    public void ClosePane_WithDocuments_ClosesThemAndCollapsesThePane()
+    {
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        TestDocument c = NewDoc("c");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.AddDocument(c);
+        ws.SplitDocument(c, DockOrientation.Horizontal);
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
+        List<DockDocument> closed = [];
+        ws.DocumentClosed += closed.Add;
+
+        ws.ClosePane(g2);
+
+        Assert.AreSequenceEqual([c], closed.ToArray(), "关窗格 = 关掉里面的标签,按用户语义走");
+        Assert.AreSame(ws.PrimaryGroup, ws.Root);
+    }
+
+    [TestMethod]
+    public void ToggleMaximize_NeedsMoreThanOnePane()
+    {
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        ws.AddDocument(a);
+
+        ws.ToggleMaximizeGroup(ws.PrimaryGroup);
+
+        Assert.IsNull(ws.MaximizedGroup, "只有一格时最大化没有意义,别留下一个解不掉的状态");
+    }
+
+    [TestMethod]
+    public void ToggleMaximize_IsReleasedWhenFocusMovesToAnotherPane()
+    {
+        // 与 tmux 的 select-pane 同一条规矩:焦点已经在别处、屏幕上却还是那一格,只会让人发愣。
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.SplitDocument(b, DockOrientation.Horizontal);
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
+
+        ws.ToggleMaximizeGroup(g2);
+        Assert.AreSame(g2, ws.MaximizedGroup);
+
+        ws.ActivateDocument(a);
+
+        Assert.IsNull(ws.MaximizedGroup);
+        Assert.AreSame(a, ws.ActiveDocument);
+    }
+
+    [TestMethod]
+    public void ToggleMaximize_IsReleasedWhenThePaneGoesAway()
+    {
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.SplitDocument(b, DockOrientation.Horizontal);
+        var g2 = (DockGroup)((DockSplit)ws.Root).Children[1];
+        ws.ToggleMaximizeGroup(g2);
+
+        ws.CloseDocument(b); // g2 空了 → 折叠
+
+        Assert.IsNull(ws.MaximizedGroup, "被最大化的窗格已经不在树上,状态必须一起消失");
+        Assert.AreSame(ws.PrimaryGroup, ws.Root);
+    }
+
+    [TestMethod]
+    public void EqualizePanes_ResetsEveryProportion()
+    {
+        var ws = new DockWorkspace();
+        TestDocument a = NewDoc("a");
+        TestDocument b = NewDoc("b");
+        ws.AddDocument(a);
+        ws.AddDocument(b);
+        ws.SplitDocument(b, DockOrientation.Horizontal);
+        var split = (DockSplit)ws.Root;
+        split.Children[0].Proportion = 0.85;
+        split.Children[1].Proportion = 0.15;
+
+        ws.EqualizePanes();
+
+        Assert.IsTrue(double.IsNaN(split.Children[0].Proportion));
+        Assert.IsTrue(double.IsNaN(split.Children[1].Proportion));
     }
 
     [TestMethod]

--- a/tests/VelaShell.Tests/Views/DockPaneUiTests.cs
+++ b/tests/VelaShell.Tests/Views/DockPaneUiTests.cs
@@ -1,0 +1,330 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using VelaShell.Controls;
+using VelaShell.Docking;
+using VelaShell.Docking.Controls;
+using VelaShell.Docking.Model;
+
+namespace VelaShell.Tests.Views;
+
+/// <summary>
+/// 分屏窗格的交互:最大化 / 还原、活动窗格标记、空窗格的出口、标签条滚轮与中键关闭。
+/// </summary>
+/// <remarks>
+/// 这几条都是"模型对了但界面没跟上"最容易漏的地方 —— 尤其是最大化:它把整棵可视树
+/// 换成一个窗格再换回来,而内容视图是**按文档缓存、跨宿主收养**的
+/// (见 <c>DockContentBlankHuntTests</c> 记的那次"终端内容凭空消失")。
+/// 还原之后内容还在不在,只有真跑一遍界面才知道。
+/// </remarks>
+[TestClass]
+[TestCategory("DockPaneUi")]
+public sealed class DockPaneUiTests
+{
+    private static HeadlessUnitTestSession _session = null!;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) =>
+        _session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(DockPaneUiTests).Assembly);
+
+    [TestMethod]
+    public void MaximizePane_RendersOnlyThatPane_AndRestoresContentIntact()
+    {
+        _session.Dispatch(() =>
+        {
+            (Window window, DockWorkspaceControl dock, DockWorkspace workspace, TestDocument left, TestDocument right) =
+                SplitScene();
+            DockGroup rightGroup = workspace.FindGroup(right)!;
+            Control rightView = right.View!;
+
+            workspace.ToggleMaximizeGroup(rightGroup);
+            Pump(window);
+
+            Assert.HasCount(1, GroupControls(dock), "最大化时只渲染那一个窗格");
+            Assert.AreSame(rightGroup, GroupControls(dock)[0].Group);
+            Assert.AreSame(rightView, Hosts(dock).Single().Target, "内容原样跟过来,不重建");
+
+            workspace.ToggleMaximizeGroup(rightGroup);
+            Pump(window);
+
+            Assert.HasCount(2, GroupControls(dock), "还原后两格都回来");
+            Assert.AreSame(left.View, HostOf(dock, workspace.FindGroup(left)!).Target,
+                           "另一格的内容必须被重新收养回来,而不是留下一块空白");
+            Assert.AreSame(rightView, HostOf(dock, rightGroup).Target, "视图实例全程只构建一次");
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void ActivePane_IsTheOnlyOneMarkedForStyling()
+    {
+        _session.Dispatch(() =>
+        {
+            (Window window, DockWorkspaceControl dock, DockWorkspace workspace, TestDocument left, TestDocument right) =
+                SplitScene();
+
+            // 分屏后每格都画着自己那条激活标签线;靠这个标记把非活动格弱化下去。
+            AssertActivePane(dock, workspace.FindGroup(right)!);
+
+            workspace.ActivateDocument(left);
+            Pump(window);
+            AssertActivePane(dock, workspace.FindGroup(left)!);
+            SaveOptionalFrame(window, "dock-active-pane.png");
+
+            // 把当前激活的标签整个拖进隔壁:ActiveDocument 的**值没变**,
+            // ActiveDocumentChanged 不会响,但活动窗格已经易主。
+            workspace.DockTo(left, workspace.FindGroup(right)!, DockPosition.Center);
+            Pump(window);
+            AssertActivePane(dock, workspace.FindGroup(left)!);
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void EmptyPane_OffersAWayOut()
+    {
+        _session.Dispatch(() =>
+        {
+            var workspace = new DockWorkspace();
+            var only = new TestDocument("only");
+            workspace.AddDocument(only);
+            workspace.SplitDocument(only, DockOrientation.Horizontal); // 原组留空作为放置目标
+
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 640, Height = 360, Content = dock };
+            window.Show();
+            Pump(window);
+
+            DockGroup empty = workspace.AllGroups().Single(group => group.Documents.Count == 0);
+            DockGroupControl emptyControl = GroupControls(dock).Single(control => ReferenceEquals(control.Group, empty));
+            Assert.IsTrue(NamedPanel(emptyControl, "EmptyHint").IsVisible, "空窗格要说明自己是干什么的");
+            Assert.IsTrue(NamedPanel(emptyControl, "DropTargetHint").IsVisible,
+                          "旁边还有标签可以拖过来,这一格也撤得掉 —— 该给的是这一套提示");
+            Assert.IsFalse(NamedPanel(emptyControl, "NoSessionHint").IsVisible);
+            Button close = emptyControl.GetVisualDescendants().OfType<Button>()
+                                       .Single(button => button.Name == "ClosePaneButton");
+            SaveOptionalFrame(window, "dock-empty-pane.png");
+
+            ClickCenter(window, close);
+            Pump(window);
+
+            Assert.IsInstanceOfType<DockGroup>(workspace.Root, "空窗格撤掉后单子分栏该提升");
+            Assert.HasCount(1, GroupControls(dock));
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void EmptyWorkspace_SaysWhatIsGoingOn_WithoutADeadButton()
+    {
+        _session.Dispatch(() =>
+        {
+            // 一个会话都没开(刚启动 / 关光了所有标签):既没有标签可拖,也没有窗格可关。
+            // 此前这里照样挂着"拖标签到这里"和一枚点了毫无反应的「关闭窗格」——
+            // ClosePane 对根窗格是空操作,那枚按钮比没有按钮更糟(用户实测反馈)。
+            var workspace = new DockWorkspace();
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 480, Height = 320, Content = dock };
+            window.Show();
+            Pump(window);
+
+            DockGroupControl root = GroupControls(dock).Single();
+            Assert.IsNull(root.Group?.Parent, "根窗格没有父分栏 —— 判据就是它");
+            Assert.IsTrue(NamedPanel(root, "EmptyHint").IsVisible);
+            Assert.IsTrue(NamedPanel(root, "NoSessionHint").IsVisible, "该说的是现状与下一步");
+            Assert.IsFalse(NamedPanel(root, "DropTargetHint").IsVisible,
+                           "没有任何标签存在时,不该让人去拖一个不存在的标签,也不该给关不掉的按钮");
+            SaveOptionalFrame(window, "dock-no-session.png");
+
+            // 开一个再关掉,回到同一个状态 —— 这条路径走的是 CollectionChanged,不是初次构建。
+            var doc = new TestDocument("one");
+            workspace.AddDocument(doc);
+            Pump(window);
+            Assert.IsFalse(NamedPanel(root, "EmptyHint").IsVisible);
+
+            workspace.CloseDocument(doc);
+            Pump(window);
+            Assert.IsTrue(NamedPanel(root, "NoSessionHint").IsVisible);
+            Assert.IsFalse(NamedPanel(root, "DropTargetHint").IsVisible);
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void TabStripWheel_ScrollsTabs_OnlyWhenTheyOverflow()
+    {
+        _session.Dispatch(() =>
+        {
+            var workspace = new DockWorkspace();
+            foreach (int index in Enumerable.Range(0, 8))
+            {
+                workspace.AddDocument(new TestDocument($"标签编号 {index}"));
+            }
+
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 260, Height = 300, Content = dock };
+            window.Show();
+            Pump(window);
+
+            DockGroupControl group = GroupControls(dock).Single();
+            ScrollViewer strip = group.GetVisualDescendants().OfType<ScrollViewer>()
+                                      .Single(viewer => viewer.Name == "TabScroll");
+            Assert.IsGreaterThan(strip.Viewport.Width, strip.Extent.Width, "窗口要窄到标签真的溢出,否则这条测的是空气");
+
+            Point spot = strip.TranslatePoint(new Point(strip.Bounds.Width / 2, strip.Bounds.Height / 2), window)
+                         ?? throw new AssertFailedException("标签条不在可视树上。");
+            window.MouseWheel(spot, new Vector(0, -1));
+            Pump(window);
+
+            Assert.IsGreaterThan(0, strip.Offset.X, "在标签条上滚轮应当横向翻标签");
+
+            window.MouseWheel(spot, new Vector(0, 1));
+            window.MouseWheel(spot, new Vector(0, 1));
+            Pump(window);
+            Assert.AreEqual(0d, strip.Offset.X, 0.01, "滚回头就停在开头,不该滚出负数");
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [TestMethod]
+    public void MiddleClickOnATab_ClosesThatTab()
+    {
+        _session.Dispatch(() =>
+        {
+            var workspace = new DockWorkspace();
+            // 用插件文档:它是最省事的一种"真标签"(有 DataTemplate、走 DockTabItemBase),
+            // 而中键关闭正是挂在那个基类上、五种标签共用的一条路。
+            var keep = new PluginDocument("keep", "keep", "acme.demo", new Border());
+            var doomed = new PluginDocument("doomed", "doomed", "acme.demo", new Border());
+            workspace.AddDocument(keep);
+            workspace.AddDocument(doomed);
+            List<DockDocument> closed = [];
+            workspace.DocumentClosed += closed.Add;
+
+            var dock = new DockWorkspaceControl { Workspace = workspace };
+            var window = new Window { Width = 640, Height = 300, Content = dock };
+            window.Show();
+            Pump(window);
+
+            ItemsControl tabs = GroupControls(dock).Single().GetVisualDescendants().OfType<ItemsControl>()
+                                                  .Single(items => items.Name == "TabsHost");
+            Control container = tabs.ContainerFromItem(doomed)
+                                ?? throw new AssertFailedException("标签容器没有实体化。");
+            // 贴左缘按下,避开标签右端那枚 × —— 要测的是"标签上中键",不是"按到了关闭钮"。
+            Point spot = container.TranslatePoint(new Point(6, container.Bounds.Height / 2), window)
+                         ?? throw new AssertFailedException("标签不在可视树上。");
+            window.MouseDown(spot, MouseButton.Middle);
+            window.MouseUp(spot, MouseButton.Middle);
+            Pump(window);
+
+            Assert.AreSequenceEqual([doomed], closed.ToArray(), "中键关掉的必须是指针底下那一个");
+            Assert.AreSequenceEqual([keep], workspace.PrimaryGroup.Documents.ToArray());
+
+            window.Close();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    // ---- 脚手架 ----
+
+    /// <summary>两格分屏:左边 left、右边 right(激活在 right)。</summary>
+    private static (Window Window, DockWorkspaceControl Dock, DockWorkspace Workspace, TestDocument Left, TestDocument Right)
+        SplitScene()
+    {
+        var workspace = new DockWorkspace();
+        var left = new TestDocument("left");
+        var right = new TestDocument("right");
+        workspace.AddDocument(left);
+        workspace.AddDocument(right);
+        workspace.SplitDocument(right, DockOrientation.Horizontal);
+
+        var dock = new DockWorkspaceControl { Workspace = workspace };
+        var window = new Window { Width = 800, Height = 400, Content = dock };
+        window.Show();
+        Pump(window);
+        return (window, dock, workspace, left, right);
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    /// <summary>按名字取窗格里的某块面板(空状态那两套提示各是一块)。</summary>
+    private static Panel NamedPanel(DockGroupControl group, string name) =>
+        group.GetVisualDescendants().OfType<Panel>().Single(panel => panel.Name == name);
+
+    private static List<DockGroupControl> GroupControls(DockWorkspaceControl dock) =>
+        [.. dock.GetVisualDescendants().OfType<DockGroupControl>()];
+
+    private static List<ReparentingHost> Hosts(DockWorkspaceControl dock) =>
+        [.. dock.GetVisualDescendants().OfType<ReparentingHost>()];
+
+    private static ReparentingHost HostOf(DockWorkspaceControl dock, DockGroup group) =>
+        GroupControls(dock).Single(control => ReferenceEquals(control.Group, group))
+                           .GetVisualDescendants().OfType<ReparentingHost>().Single();
+
+    private static void AssertActivePane(DockWorkspaceControl dock, DockGroup expected)
+    {
+        foreach (DockGroupControl control in GroupControls(dock))
+        {
+            bool shouldBeActive = ReferenceEquals(control.Group, expected);
+            Assert.AreEqual(shouldBeActive, control.Classes.Contains(":activepane"),
+                            $"窗格 {(shouldBeActive ? "应当" : "不应")}被标记为活动窗格。");
+
+            // 标记本身不值钱,值钱的是它真的把强调线弱化了 —— 读基值绕开 180ms 过渡的中间态。
+            Border indicator = control.GetVisualDescendants().OfType<Border>()
+                                      .Single(border => border.Name == "ActiveTabIndicator");
+            Assert.AreEqual(shouldBeActive ? 1 : 0.3, indicator.Opacity, 0.001,
+                            "非活动窗格的强调线必须弱下去,否则分屏时看不出键盘输入落在哪一格。");
+        }
+    }
+
+    /// <summary>设了 VELASHELL_VISUAL_QA_DIR 就存一帧,供人眼复核样式(与 DockMotionUiTests 同款)。</summary>
+    private static void SaveOptionalFrame(TopLevel topLevel, string fileName)
+    {
+        string? directory = Environment.GetEnvironmentVariable("VELASHELL_VISUAL_QA_DIR");
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+        Directory.CreateDirectory(directory);
+        using WriteableBitmap? frame = topLevel.CaptureRenderedFrame();
+        Assert.IsNotNull(frame, "Skia headless renderer should produce a visual-QA frame.");
+        using FileStream output = File.Create(Path.Combine(directory, fileName));
+        frame.Save(output, PngBitmapEncoderOptions.Default);
+    }
+
+    private static void ClickCenter(Window window, Control control)
+    {
+        Point spot = control.TranslatePoint(new Point(control.Bounds.Width / 2, control.Bounds.Height / 2), window)
+                     ?? throw new AssertFailedException("控件不在可视树上。");
+        window.MouseDown(spot, MouseButton.Left);
+        window.MouseUp(spot, MouseButton.Left);
+    }
+
+    private sealed class TestDocument : DockDocument, IDockViewProvider
+    {
+        public TestDocument(string title) => Title = title;
+
+        public Control? View { get; private set; }
+
+        public Control CreateView() => View ??= new Border { Background = Brushes.Transparent };
+    }
+}


### PR DESCRIPTION
## 关光半屏之后,另一半要铺满整片区域

> 用户实测反馈:「拖动分屏后,关闭掉所有左侧的窗口,右侧的窗口也还是保持在右侧,没有自动填充满整个区域。」

复现只要三步:开两个标签 → 把其中一个拖到右缘分屏 → 把左半屏的标签全关掉。左边留下一块空白,右边纹丝不动 —— 而那块空白正是 `PrimaryGroup`。

### 一、不该折叠的是「根」,不是「主组」

根因在 `CollapseIfEmpty` 的第一行:

```csharp
if (group.IsPrimary || group.Documents.Count > 0 || group.Parent is not { } parent)
```

`IsPrimary ||` 这一条**在保护一个不需要保护的东西**。真正的约束只有一个:布局树得有个底,新文档才有地方落。而那个底是**根**,不是某个具体实例 —— 后半句的 `group.Parent is not { } parent` 本来就把根兜住了(根节点没有父分栏)。多出来的那一判把"永不折叠"从根钉到了一个实例上,于是它一旦被拖到侧边、又被关空,就成了一块谁也赶不走的空白。

改法不是给主组开例外,是**让这个身份可以易主**:`TryHandOverPrimary` 把兜底的差事交给折叠之后**会接管这块地方**的那个邻居,自己退场。新文档于是出现在用户眼睛刚才盯着的位置。

同因异形的第二处一并好了:**把主组最后一个标签拖进邻居**(走同一个 `CollapseIfEmpty`),此前同样留白。

⚠️ 顺带删掉一条用例:`PrimaryGroup_NeverCollapses` 断言的正是"主组即使为空也保留" —— 它把这个 bug 逐字钉成了规范,留着等于让测试替 bug 站岗。换成三条:关光主组要铺满、拖空主组要铺满、**唯一的那个组即使空着也留下**(根的约束还在)。

### 二、顺着这条线一并做掉的

| 改动 | 为什么 |
| --- | --- |
| 新标签落点改成 **空窗格 > 当前窗格 > 主组** | 原先永远进主组:分屏后人在右半屏干活,新标签开在左半屏,焦点跟着跑而视线留在原处。空窗格排第一是为了保住"拆分之后开个会话把另一半填上"这条既有流程 |
| `ClosePane` + 空面板上的「关闭窗格」 | 拆分留下的空面板此前**没有任何撤销入口**,只能把邻居的标签拖进来再拖回去,靠副作用挤掉它。它是关闭确认闸的第七个入口,补了用例守着 |
| 窗格最大化 `Ctrl+Shift+X` | tmux 的 `resize-pane -Z`。分屏后想把某一格看仔细,原先只能先拆掉布局、看完再拼回去。**只影响渲染、不动布局树**,焦点切走 / 窗格离开树 / 收敛回一格都自动解除 |
| 中键关标签、标签条滚轮、分割条双击平分 | 前两个是通用手势;标签条滚轮尤其:`ScrollViewer` 默认把滚轮当纵向滚动,而标签条是横排的,于是**在标签条上滚轮此前毫无反应**,标签一多就只能去够右端那两枚小箭头 |
| `:activepane` + 非活动格强调线弱化 | 分屏时两格各画一条一样亮的线,看不出键盘输入会落到哪一格。刻意**不给它加过渡** —— 这是"输入落在哪"的指示,该在点下去那一刻就成立 |
| `.dragging` 补样式 | `DockDragController` 一直在挂这个类,而全仓**没有任何一条样式认它** —— 拖拽过程中标签本身零反馈 |

### 三、空状态返工(同批实测反馈)

第一版那枚「关闭窗格」无差别挂在**任何**空窗格上。实测截图打回来的是一个会话都没开的主界面:正中一句「将标签拖到此处」,底下一枚「关闭窗格」——

- 那枚按钮**点了不会有任何反应**:`ClosePane` 对根窗格是空操作(根没有父分栏,`CollapseIfEmpty` 直接早退)。一枚点下去毫无动静的按钮,比没有按钮更糟;
- 那句提示说的是一件**当下做不到的事**:一个标签都不存在,拖什么?用户还把它读成了"拖点什么进来就能打开连接",而那个功能并不存在。

判据改成**有没有父分栏**(与第一节同一个教训:别把结构性质钉到实例身份上)。空状态因此分两套:能撤掉的空窗格给「把其他窗格的标签页拖到这里」+ 关闭按钮;整个工作区空了则只说现状与下一步。`Dock_DropTabHere` 的五份译文一并改写,把"拖的是已经存在的标签页"说死。

两套提示都留在 XAML 里靠 `IsVisible` 切换,**没有从代码写 `Text`** —— `{loc:Localize}` 给的是活绑定,代码赋值会把它们钉死在赋值那一刻的语言上。

### 四、文档同步

`velashell-docs` 的 `dock-replacement-plan.md` 里,「主组永不消失」与「新终端总进第一组」这两句**正是本 bug 的书面出处**。中英两份都已订正并注明修正日期,免得下一个人照着它再实现一遍;快捷键参考两份补上 `Ctrl+Shift+X` 与三条鼠标手势。

📄 配套文档 PR:VelaShellLabs/velashell-docs#27

本仓另补:`plan.md` §64(来龙去脉),`feature-plan.md` 记下两项刻意没做的(标签条「+」按钮、纵排标签条的溢出钮)及其卡点 —— 前者的卡点不在按钮而在分层,`Docking/` 不认识"会话"这个概念。

### 五、验收

- [x] `dotnet build VelaShell.slnx -c Debug -warnaserror` 零警告零错误
- [x] `dotnet test VelaShell.slnx` **3343 通过 / 21 跳过 / 0 失败**(净增 17 条:新增 18、删掉 1 条替 bug 站岗的)
- [x] 新增/修改的行为有对应测试 —— 模型层 11 条、关闭闸 1 条、界面层 6 条(`DockPaneUiTests`);最大化那条盯的是**还原之后 `ReparentingHost.Target` 还是不是同一个实例**,因为它把整棵可视树换掉再换回来,正是 `DockContentBlankHuntTests` 记的那次"终端内容凭空消失"的同款场景
- [x] 界面文案五份 resx 齐(补 11 键、改写 1 键),`Doc_ListsEveryCatalogEntry` 实跑通过(不是 Inconclusive)
- [x] 两种空状态的实际渲染用无头截帧人眼复核过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMoC2xUFRbWRReE7TANfrH