### PR TITLE
升级 Anthropic 和 MaxMind.Db 包版本

### DIFF
--- a/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
+++ b/plugins/VelaShell.Plugin.Ai/VelaShell.Plugin.Ai.csproj
@@ -40,7 +40,7 @@
          这些依赖随插件目录分发,由插件 ALC 按 deps.json 隔离解析,与宿主互不干扰。 -->
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
-    <PackageReference Include="Anthropic" Version="12.46.0" />
+    <PackageReference Include="Anthropic" Version="12.47.0" />
     <!-- MCP 官方 C# SDK(Core = 纯客户端/低层,无 Hosting/DI 依赖):
          McpClientTool 即 M.E.AI 的 AIFunction,直接并入 Agent 工具循环。 -->
     <PackageReference Include="ModelContextProtocol.Core" Version="2.2.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="ReactiveUI" Version="24.2.0" />
     <!-- MMDB 读取器(Apache 2.0)。只是格式读取库,不绑定 MaxMind 的数据 ——
          我们配的是 DB-IP Lite City(CC BY 4.0),同一格式。 -->
-    <PackageVersion Include="MaxMind.Db" Version="5.1.0" />
+    <PackageVersion Include="MaxMind.Db" Version="5.2.0" />
     <PackageVersion Include="SonnetDB.Core" Version="3.1.0" />
     <PackageVersion Include="Tmds.Ssh" Version="0.24.0" />
     <!-- FTP / FTPS 客户端(MIT,零依赖)。截至 54.2.0 最高只出到 net9.0 资产,


### PR DESCRIPTION
<!--
  感谢提交 PR。请先确认目标分支是 dev(不是 main)。
  完整约定见 CONTRIBUTING.md;下面这几栏都不长,填完能省掉来回问的几轮。
-->

## 这个 PR 做了什么

升级 VelaShell.Plugin.Ai.csproj 中 Anthropic 包至 12.47.0，升级 Directory.Packages.props 中 MaxMind.Db 包至 5.2.0。其它仅为文件结尾格式微调，无实质性变更。

## 为什么这么改

<!--
  这是最重要的一栏。
  - 解决了什么问题?触发场景是什么?
  - 有没有考虑过别的方案,为什么没选?
  - 如果动了看起来「可以简化」的代码,请说明原来那么写的原因是否仍然成立。
-->

Closes #

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构(行为不变)
- [ ] 性能优化
- [ ] 文档
- [ ] 构建 / 流水线
- [ ] 其他:

## 怎么验证的

<!--
  本仓库**没有 PR 门禁 CI** —— .github/workflows 下只有发布流水线,它在 Release 发布时才跑。
  也就是说没有任何自动检查会替你兜底,合并前的正确性完全依赖你本地跑过。请如实填写。
-->

- [ ] `dotnet build VelaShell.slnx` —— 零警告零错误
- [ ] `dotnet test VelaShell.slnx` —— 全绿
- [ ] 新增/修改的行为有对应测试(或说明为什么不需要)
- [ ] 界面改动已在应用里实际跑过

**实测环境:** <!-- 例如 Windows 11 x64 / 150% 缩放;或 Ubuntu 24.04 Wayland -->

**测试结果:**

```
<!-- 贴 dotnet test 的结果摘要 -->
```

## 同步检查

<!-- 只勾选与本 PR 相关的;不涉及的整行删掉即可。 -->

- [ ] **新增了界面文案** → 五份 resx 都已补齐(`Strings` / `zh-Hans` / `zh-Hant` / `ja` / `ko`),没有硬编码字符串
- [ ] **新增或改动了快捷键** → 已登记进 `ShortcutCatalog`,`velashell-docs zh/host/快捷键参考.md` 已同步
- [ ] **改了文档** → 文档在 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs),`zh/` 与 `en/` 两侧都改了(另开 PR)
- [ ] **改了 README** → `README.md` 与 `README.en.md` 两侧都改了
- [ ] **改了公开 API** → XML 文档注释已补(缺注释会出编译警告)
- [ ] **新增了跨层引用** → 符合 `velashell-docs zh/host/architecture.md` 的依赖方向,没有反向依赖
- [ ] **新增了 NuGet 依赖** → 已在 Issue 里讨论过必要性,版本写进 `Directory.Packages.props`

## 界面改动的前后对比

<!-- 有 UI 变化时请贴截图;涉及分数缩放的问题请在 125% 或 150% 下截一张。没有 UI 变化删掉本节。 -->

| 改动前 | 改动后 |
|---|---|
|  |  |

## 补充说明

<!-- 已知限制、故意留下的 TODO、需要 reviewer 特别关注的地方、后续计划等。 -->

---

- [ ] 我已阅读 [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md),并同意本贡献以 AGPL-3.0 授权、且授予版权方在商业许可下再许可的权利
