### PR TITLE
feat(plugins): 插件窗口的标题栏也跟着自己的图标走

### DIFF
--- a/feature-plan.md
+++ b/feature-plan.md
@@ -34,18 +34,18 @@
 
 ## 📊 待办分布
 
-**欠账**（⏳ + 🚧 + 💡，共 22 项）与**路线图**（共 29 项）分开计：
+**欠账**（⏳ + 🚧 + 💡，共 23 项）与**路线图**（共 29 项）分开计：
 
 ```mermaid
 pie showData
-    title 欠账 —— 现状与代码对不上的部分（22 项）
+    title 欠账 —— 现状与代码对不上的部分（23 项）
     "P0 存了但不生效" : 5
     "安全与凭据" : 5
     "会话与工作区" : 3
     "数据与可观测" : 3
     "终端与协议" : 3
     "文件传输" : 2
-    "插件生态" : 1
+    "插件生态" : 2
 ```
 
 ```mermaid
@@ -63,7 +63,7 @@ pie showData
 > 「文件传输」算 2 项 —— 那一节的「传输失败重试」是指回 P0 表的交叉引用、不重复计数，「远程编辑的三个入口已统一」是 📄 文档待同步、不计入欠账。
 > 「会话与工作区」从 4 降到 3：会话标签颜色已在 `b9ae31f` 落地（见该节）。
 > 「安全与凭据」从 6 降到 5：SSH 证书认证已在 `bbfa1877` 落地（见该节）。
-> 「插件生态」升到 2 又回到 1：插件自报标签页图标当天就闭合了（SDK 2.0.4,见该节）。
+> 「插件生态」现为 2：插件自报图标当天闭合，但新增了一条 🔴 P0「11 条怎么改都绿的 UI 用例」（见该节）。
 
 ---
 
@@ -147,6 +147,7 @@ pie showData
 | :---: | :---: | --- | --- | --- |
 | ✅ | — | ~~容器管理插件（DockerPanel）~~ | **已完成**（2026-09-03，`0.3.1`）。独立仓库 [VelaShell.Plugin.DockerPanel](https://github.com/VelaShellLabs/VelaShell.Plugin.DockerPanel)，从插件商店按需安装 | — |
 | ✅ | — | ~~插件自报标签页图标~~ | **宿主侧已完成**（2026-09-11，`plan.md` §69，SDK 2.0.4）：`PluginIcon` 一个入口三处共用（`ProtocolDescriptor.Icon` / `WorkspaceDescriptor.Icon` / `PanelOptions.Icon`），宿主 `ConnectionIcon` 按「插件自报优先、通用插头兜底」解析，`LucideIcon` 的 `Fill` / `ViewBoxSize` 支持实心品牌 logo。AI 插件已用上（机器人字形）| ⏳ 只差 **`velashell-plugins` 那三个插件填图标**：抬包版到 2.0.4，串口用 lucide `usb-c-port`（`M6 12h12 M6 8h12a4 4 0 0 1 0 8H6a4 4 0 0 1 0-8Z`）、Redis 用品牌 logo（`PluginIcon.Filled(path, 1030)`）、S3 用云或桶的描边字形。**宿主一行都不用再动** —— 那三个插件今天画的仍是通用插头 |
+| ⏳ | 🔴 P0 | **11 条「怎么改都绿」的 UI 用例** | `_session.Dispatch(async () => { … })` 这种**无返回值**的 async lambda 绑到 `Dispatch<TResult>(Func<TResult>)` 而不是会 await 的 `Dispatch<T>(Func<Task<T>>)` —— 那个 Task 没人 await,断言抛的异常被整个吞掉。**实测:往第一行插 `Assert.Fail` 照样通过**。分布:`PluginPanelUiTests` 5、`StandaloneSftpDocumentBehaviorTests` 3、`LocalFilePaneViewUiTests` 2、`PluginThemeTokensTests` 1（`plan.md` §70） | ⚠️ **机械修法不成立**：补 `return true;` 改绑之后 7 条当场超时（各 1 分钟）—— 它们 await 的东西在无头环境里根本不会完成。要一条一条重做异步流程。同文件里正确的写法是**同步 body + 返回值**，可作模板 |
 | ⏳ | 🟡 P2 | **AI 插件的 MCP 服务端能力面对齐** | 对外 MCP 走 `AgentToolbox` 产出工具，但那条路上**没有审批界面** | 现状是「询问」模式等于一律拒绝写操作 —— 这是刻意的（`plan.md` §33-四）。可选的增强：带外审批（推到 IM 渠道或桌面通知）后再放行 |
 | 📄 | 🟠 P1 | **发布者连续性已落地** | 同一个 id 的后续版本必须仍由钉住的那把私钥签名，换钥/去签名要用户看过两个指纹再点头；管理页每行显示钉住的指纹；旁装（`vela-plugin install`）不受影响（`plan.md` §57）。代码已落地，**velashell-docs 还没跟上** | 在 `{zh,en}` 两棵树里补：`plugins/STATUS.md` 签名验证那一格改成「验签 + 连续性已做、信任根未做」；`cli/cli.md` 与 `templates/dev-guide.md` 补一句「旁装的代价现在多一条：钉不住发布者，宿主也就无从拦截冒名的覆盖安装」；`host/交互与界面规格.md` 补管理页那行指纹与换发布者的确认框 |
 

--- a/plan.md
+++ b/plan.md
@@ -4080,3 +4080,54 @@ warning MMDBSG001: Type '...MmdbIpGeolocationService.MmdbRecord' is not accessib
 
 `dotnet build VelaShell.slnx -c Debug -warnaserror` 零警告零错误;
 `dotnet test VelaShell.slnx`(按 CI 那条过滤)**3379 通过 / 5 跳过 / 0 失败**。
+
+---
+
+## ✅ 70. 2026-09-11 插件窗口的标题栏图标,以及一组「怎么改都绿」的用例(用户反馈)
+
+> 「插件中的窗口,比如 AI 插件中的模型设置、MCP 设置等窗口,打开后还是显示为通用的插件图标,
+> 是否可以让他也跟随标签页图标的设置。这样的话,不同的插件打开不同的窗口也不容易混淆。」
+
+§69 让插件的**标签页**能自报图标,窗口那一路漏了。摸过去发现两侧的毛病还不一样:
+
+- **进程内**(`PluginPanelWindow.axaml`)标题栏写死 `Icon.plug`;
+- **隔离进程**(`PluginHostShellWindow`)标题栏**一个图标都没有**,只有标题 + 插件 id。
+
+两侧都改成读 `PanelOptions.Icon`。契约一个字没动 —— 2.0.4 的字段本来就在那儿,
+只是宿主此前没用它;改的是行为与文档(SDK 那句「窗口模式忽略」现在是假话)。
+
+AI 插件把聊天标签、协作窗口、模型配置/MCP 那一组对话框统一挂上同一个 `AiIcon.Panel`。
+它们本来就该长一样:标题栏上认的是「这扇窗属于哪个插件」,不是「这是哪个功能」。
+
+### 一、隔离进程那侧不能复用 LucideIcon
+
+`VelaShell.PluginHost` 只引 SDK 与 Avalonia,**刻意不依赖 `VelaShell.Controls`**,
+所以那边自己搭 `Path`。两处差别照抄主程序的口径:实心只填充;描边的笔画按
+`2 * 视框 / 24` 算,于是视框放大多少笔就跟着粗多少,任何视框下都保持 lucide 的粗细比例。
+
+### 二、意外收获:一组用例「怎么改都绿」
+
+给这件事写用例时,**反证失败了** —— 把接线整行删掉,用例照样通过。
+
+根因是 `HeadlessUnitTestSession` 的重载选择:
+`Dispatch<T>(Func<Task<T>>)` 会 await,而 `Dispatch<TResult>(Func<TResult>)` 不会。
+`_session.Dispatch(async () => { ... })` 这种**无返回值**的 async lambda 是 `Func<Task>`,
+绑到后者 —— 那个 Task 没人 await,断言抛出的异常**被它整个吞掉**。
+
+这个坑 `ConnectingDocumentViewUiTests` 的注释里早就记过,但 `PluginPanelUiTests` 等文件仍在用。
+实测:往一条既有用例的第一行插 `Assert.Fail`,它照样通过。全仓扫下来,
+**11 条**这样的用例(`PluginPanelUiTests` 5、`StandaloneSftpDocumentBehaviorTests` 3、
+`LocalFilePaneViewUiTests` 2、`PluginThemeTokensTests` 1)。
+
+**试过机械修法,不成立**:给每个 lambda 补一句 `return true;` 改绑到会 await 的重载之后,
+7 条当场变成**超时**(各 1 分钟)—— 它们 await 的东西在无头环境里根本不会完成。
+也就是说这些用例不是"少写了一个 return",而是异步流程本身需要重做,一条一条来。
+本次**未改**它们:把假绿换成真卡,是更坏的状态。已记进 `feature-plan.md`。
+
+本次新增的两条用例用的是同文件里正确的那种写法(同步 body + 返回值),并做过反证:
+删掉 `SetIcon` 那一行,`WindowPanel_TitleIcon_FollowsThePluginsOwnIcon` 立刻红。
+
+### 三、验收
+
+`dotnet build VelaShell.slnx -c Debug -warnaserror` 零警告零错误;
+`dotnet test VelaShell.slnx`(按 CI 那条过滤)**3381 通过 / 5 跳过 / 0 失败**。

--- a/plugins/VelaShell.Plugin.Ai/AiIcon.cs
+++ b/plugins/VelaShell.Plugin.Ai/AiIcon.cs
@@ -16,6 +16,12 @@ namespace VelaShell.Plugin.Ai;
 /// </remarks>
 internal static class AiIcon
 {
+    /// <summary>
+    /// 交给宿主的那份图标。聊天标签、协作窗口、模型配置窗口三处共用同一个实例 ——
+    /// 它们本来就该长一样:标题栏上认的是「这扇窗属于哪个插件」。
+    /// </summary>
+    public static readonly PluginSdk.PluginIcon Panel = PluginSdk.PluginIcon.Filled(PathData, ViewBoxSize);
+
     /// <summary>视框边长(原始 SVG 是 <c>0 0 1024 1024</c>)。</summary>
     public const double ViewBoxSize = 1024d;
 

--- a/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
+++ b/plugins/VelaShell.Plugin.Ai/AiPlugin.cs
@@ -140,6 +140,7 @@ public sealed class AiPlugin : IVelaPlugin
             new PanelOptions
             {
                 Title = loc["Collaboration"],
+                Icon = AiIcon.Panel,
                 DisplayMode = PanelDisplayMode.Window,
                 WindowWidth = 860,
                 WindowHeight = 780
@@ -173,9 +174,9 @@ public sealed class AiPlugin : IVelaPlugin
             new PanelOptions
             {
                 Title = new Loc(context.Host.Locale)["Title"],
-                // 标签页上认得出是 AI 的那个标。不给的话宿主画一个通用插头 ——
+                // 标签页/标题栏上认得出是 AI 的那个标。不给的话宿主画一个通用插头 ——
                 // 它对每个插件都一样,等于没有。
-                Icon = PluginIcon.Filled(AiIcon.PathData, AiIcon.ViewBoxSize),
+                Icon = AiIcon.Panel,
                 DisplayMode = mode,
                 // 聊天面板的位置对齐 VSCode 的 Copilot:标签区右侧独立一栏,
                 // 终端与它并排看得见,而不是把当前终端顶掉

--- a/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
+++ b/plugins/VelaShell.Plugin.Ai/Bridge/BridgeSettings.cs
@@ -79,7 +79,7 @@ public sealed class ChatGrant
 /// <summary>一个已配置的渠道。</summary>
 /// <remarks>
 /// <b>机密不在这里。</b>应用密钥(飞书 app_secret / 钉钉 clientSecret / Telegram bot token /
-/// 企微 secret 与 EncodingAESKey)一律走 <see cref="VelaShell.PluginSdk.Secrets.ISecretsApi" />,
+/// 企微 secret 与 EncodingAESKey)一律走 <see cref="PluginSdk.Secrets.ISecretsApi" />,
 /// 键名见 <see cref="BridgeSettingsStore.SecretName" /> —— 这份配置是明文 JSON,躺在插件存储里。
 /// </remarks>
 public sealed class ChannelConfig

--- a/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
+++ b/plugins/VelaShell.Plugin.Ai/Ui/ChatPanelView.Dialogs.cs
@@ -231,6 +231,9 @@ public partial class ChatPanelView
             IPluginPanel panel = await _context.Ui.ShowPanelAsync(new PanelOptions
             {
                 Title = title,
+                // 模型配置、MCP 设置这些窗口都从这里开。标题栏顶着 AI 的标,
+                // 与别的插件的设置窗口并排开着时才分得清哪扇是谁的。
+                Icon = AiIcon.Panel,
                 DisplayMode = PanelDisplayMode.Window,
                 WindowWidth = width,
                 WindowHeight = height,

--- a/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/VelaShell.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -52,7 +52,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<VelaShellStoragePaths>();
         // 认领 Program.Main 起的那次后台预热(见 StartupWarmup):数据库在 Avalonia 初始化的
         // 同时就已经开着了。没预热过(测试、设计期)就地新建,行为不变。
-        services.AddSingleton<SonnetDbEngine>(sp =>
+        services.AddSingleton(sp =>
             StartupWarmup.Claim(sp.GetRequiredService<VelaShellStoragePaths>()));
         services.AddSingleton<ISecretProtector>(sp => new AesSecretProtector(sp.GetRequiredService<VelaShellStoragePaths>()));
         services.AddSingleton<ISessionRepository>(sp =>
@@ -205,7 +205,7 @@ public static class InfrastructureServiceCollectionExtensions
             new SessionMetricsService(sp.GetRequiredService<ISshConnectionService>()));
         services.AddSingleton<IRemoteProcessService>(sp =>
             new RemoteProcessService(sp.GetRequiredService<ISshConnectionService>()));
-        services.AddSingleton<ITraceRouteService, Diagnostics.PingTraceRouteService>();
+        services.AddSingleton<ITraceRouteService, PingTraceRouteService>();
         services.AddSingleton<IIpGeolocationService>(sp =>
         {
             var paths = new VelaShellStoragePaths();
@@ -219,7 +219,7 @@ public static class InfrastructureServiceCollectionExtensions
             {
                 // 设置读不出来就用默认目录,不该因此让追踪窗口开不了。
             }
-            return new Diagnostics.MmdbIpGeolocationService(configured, paths.GeoIpDirectory);
+            return new MmdbIpGeolocationService(configured, paths.GeoIpDirectory);
         });
         services.AddSingleton<ITunnelService>(sp =>
         {

--- a/src/VelaShell.PluginHost/PluginHostShellWindow.cs
+++ b/src/VelaShell.PluginHost/PluginHostShellWindow.cs
@@ -37,7 +37,10 @@ internal sealed partial class PluginHostShellWindow : Window
     private readonly Border _titleStrip;
     private readonly Panel _resizeGrips;
 
-    public PluginHostShellWindow(string title, string subtitle, Control content, IReadOnlyList<PanelTitleAction>? titleActions = null)
+    public PluginHostShellWindow(
+        string title, string subtitle, Control content,
+        IReadOnlyList<PanelTitleAction>? titleActions = null,
+        PluginSdk.PluginIcon? icon = null)
     {
         WindowDecorations = WindowDecorations.None;
         TransparencyLevelHint = [WindowTransparencyLevel.Transparent];
@@ -45,7 +48,7 @@ internal sealed partial class PluginHostShellWindow : Window
         Title = title;
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
 
-        _titleStrip = BuildTitleBar(title, subtitle, titleActions ?? []);
+        _titleStrip = BuildTitleBar(title, subtitle, titleActions ?? [], icon);
         var grid = new Grid { RowDefinitions = [with("40,*")] };
         grid.Children.Add(_titleStrip);
         var contentHost = new ContentControl { Content = content };
@@ -82,7 +85,9 @@ internal sealed partial class PluginHostShellWindow : Window
         }
     }
 
-    private Border BuildTitleBar(string title, string subtitle, IReadOnlyList<PanelTitleAction> titleActions)
+    private Border BuildTitleBar(
+        string title, string subtitle, IReadOnlyList<PanelTitleAction> titleActions,
+        PluginSdk.PluginIcon? icon)
     {
         var titleText = new TextBlock
         {
@@ -109,6 +114,12 @@ internal sealed partial class PluginHostShellWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(14, 0, 0, 0)
         };
+        // 插件自报的图标(PanelOptions.Icon)。这一侧原先一个图标都没有,于是隔离插件的窗口
+        // 标题栏彼此完全一样;而进程内那扇窗写死通用插头,同样分不出谁是谁。
+        if (TitleIcon(icon) is { } glyph)
+        {
+            left.Children.Add(glyph);
+        }
         left.Children.Add(titleText);
         left.Children.Add(subtitleText);
 
@@ -144,6 +155,56 @@ internal sealed partial class PluginHostShellWindow : Window
         var icon = new Avalonia.Controls.Shapes.Path { Data = geometry, StrokeThickness = 1.4, StrokeLineCap = PenLineCap.Round };
         Bind(icon, Avalonia.Controls.Shapes.Shape.StrokeProperty, "VelaTextSecondary");
         return CaptionButton(icon, close, onClick);
+    }
+
+    /// <summary>
+    /// 标题栏最左的插件图标。插件没给、或那段路径解析不了,就不画 ——
+    /// 这一侧本来就没有通用兜底图标可退(那是主程序 ConnectionIcon 的事)。
+    /// </summary>
+    /// <remarks>
+    /// ⚠️ 这里刻意捕获所有异常,理由与主程序 <c>ConnectionIcon.FromPlugin</c> 逐字相同:
+    /// 解析的是插件给的任意字符串,Avalonia 的 <c>PathMarkupParser</c> 抛什么取决于错在哪一位
+    /// (试出来的就有 <c>InvalidDataException</c> 与 <c>FormatException</c>),
+    /// 枚举类型是在猜,而猜漏一个的代价是整扇窗连带插件进程一起起不来。
+    /// </remarks>
+    private static Viewbox? TitleIcon(PluginSdk.PluginIcon? icon)
+    {
+        if (icon is null || string.IsNullOrWhiteSpace(icon.PathData))
+        {
+            return null;
+        }
+        Geometry geometry;
+        try
+        {
+            geometry = Geometry.Parse(icon.PathData);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+        // 视框不报就是 24(lucide)。非正数/非有限值同样按 24 —— 一个写错的值不该让图标消失。
+        double box = icon.ViewBoxSize is > 0 and < double.PositiveInfinity ? icon.ViewBoxSize : 24d;
+        var path = new Avalonia.Controls.Shapes.Path { Width = box, Height = box, Data = geometry };
+        if (icon.IsFilled)
+        {
+            // 实心图形只填充。再描一圈边等于给每个色块套上轮廓,比不描更糟。
+            Bind(path, Avalonia.Controls.Shapes.Shape.FillProperty, "VelaAccent");
+        }
+        else
+        {
+            // 描边保持 lucide 2/24 的粗细比例 —— 视框放大多少,笔就跟着粗多少。
+            path.StrokeThickness = 2 * box / 24d;
+            path.StrokeLineCap = PenLineCap.Round;
+            path.StrokeJoin = PenLineJoin.Round;
+            Bind(path, Avalonia.Controls.Shapes.Shape.StrokeProperty, "VelaAccent");
+        }
+        return new Viewbox
+        {
+            Width = 13,
+            Height = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = path
+        };
     }
 
     /// <summary>插件的标题栏动作:lucide 24×24 路径缩到 12px,描边 2 与主程序 LucideIcon 一致。</summary>

--- a/src/VelaShell.PluginHost/PluginHostUi.cs
+++ b/src/VelaShell.PluginHost/PluginHostUi.cs
@@ -54,7 +54,7 @@ internal sealed class PluginHostUi(string pluginId, IPluginLogger log, RpcConnec
             Control content = RequireControl(contentFactory());
             // 自绘卡片壳:透明圆角卡片 + 标题栏 + 三连按钮 + 缩放抓取区,配色用宿主下发的
             // Vela* 令牌 —— 与主程序资源监视/任务管理器窗口统一。
-            var window = new PluginHostShellWindow(options.Title, pluginId, content, options.TitleActions)
+            var window = new PluginHostShellWindow(options.Title, pluginId, content, options.TitleActions, options.Icon)
             {
                 Width = Math.Max(options.WindowWidth, 280),
                 Height = Math.Max(options.WindowHeight, 200),

--- a/src/VelaShell.Terminal/BufferSearch.cs
+++ b/src/VelaShell.Terminal/BufferSearch.cs
@@ -8,7 +8,7 @@ namespace VelaShell.Terminal;
 /// <remarks>
 /// <see cref="StartCol" /> 与 <see cref="Length" /> 都以列计,不是行文本里的字符下标 ——
 /// 渲染层拿它们直接画高亮、拉选区,单位错了就是整体错位。两者的换算见
-/// <see cref="Emulation.TerminalRow.CopyTextTo(System.Span{char}, System.Span{int})" />。
+/// <see cref="TerminalRow.CopyTextTo(Span{char}, Span{int})" />。
 /// </remarks>
 /// <param name="Row">缓冲区内的绝对行号(含回滚区)。</param>
 /// <param name="StartCol">命中起始屏幕列。</param>

--- a/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
+++ b/src/VelaShell.Terminal/Rendering/VelaTerminalControl.cs
@@ -502,7 +502,7 @@ public sealed partial class VelaTerminalControl : Control, ITerminalEmulator
     /// 当前界面主题配套的**整套**终端配色(前景/背景/光标/选区 + ANSI 16 色),由宿主随
     /// 主题切换下发。null = 用控件自带的明暗缺省。
     /// <para>
-    /// 为什么不能只看 <see cref="Avalonia.Styling.ThemeVariant" />:具名主题里有五套暗色、
+    /// 为什么不能只看 <see cref="ThemeVariant" />:具名主题里有五套暗色、
     /// 四套亮色,VelaDark 换到 Tokyo Night 时变体根本没变,控件无从得知该换配色。
     /// </para>
     /// </summary>

--- a/src/VelaShell/App.axaml.cs
+++ b/src/VelaShell/App.axaml.cs
@@ -85,7 +85,7 @@ public class App : Application
             .AddSingleton<Func<string, IPluginLogger, IUiApi>>(sp =>
                 (pluginId, log) => new Services.Plugins.PluginUiApi(pluginId, log,
                     () => sp.GetService<MainWindowViewModel>(),
-                    sp.GetService<Core.Services.IBackgroundActivityService>()))
+                    sp.GetService<IBackgroundActivityService>()))
             // 隔离插件的主题令牌快照:Vela* 资源按当前明暗变体解析后经 RPC 下发,
             // 插件的 {DynamicResource VelaXxx} 跨进程同样生效(进程内天然可用)。
             .AddSingleton<Func<Task<IReadOnlyList<PluginSdk.Rpc.ThemeTokenDto>>>>(_ =>
@@ -110,7 +110,7 @@ public class App : Application
             .AddSingleton<Infrastructure.Plugins.IPluginSessionOpener>(sp =>
                 new Services.Plugins.HostSessionOpener(
                     () => sp.GetService<MainWindowViewModel>(),
-                    sp.GetRequiredService<Core.Ssh.ISshConnectionService>(),
+                    sp.GetRequiredService<ISshConnectionService>(),
                     sp.GetRequiredService<Infrastructure.Plugins.PluginPermissionGate>()))
             // 插件终端能力:读取/搜索终端缓冲 + 授权回写(经主窗口视图模型解析会话仿真器)。
             .AddSingleton<Func<string, IPluginLogger, PluginSdk.Terminal.ITerminalApi>>(sp =>

--- a/src/VelaShell/Services/Plugins/PluginPanel.cs
+++ b/src/VelaShell/Services/Plugins/PluginPanel.cs
@@ -195,6 +195,9 @@ internal sealed class PluginPanel : IPluginPanel
             Height = Math.Max(options.WindowHeight, 200)
         };
         _window.SetTitle(options.Title, pluginId);
+        // 标题栏图标与标签页那条走同一个解析:几个插件的设置窗口并排开着,
+        // 标题栏全是同一个插头的话,分不出哪扇窗是谁的。
+        _window.SetIcon(ConnectionIcon.ForPanel(options.Icon));
         _window.SetTitleActions(options.TitleActions);
         _window.SetContent(content);
         _window.Closed += (_, _) => NotifyClosed();

--- a/src/VelaShell/ViewModels/TerminalTabViewModel.cs
+++ b/src/VelaShell/ViewModels/TerminalTabViewModel.cs
@@ -464,7 +464,7 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
     /// <summary>
     /// 本标签的文件传输路由器(ZMODEM 自动接管 + XMODEM/YMODEM 手动接管);未接线时为 null。
     /// </summary>
-    public Terminal.FileTransfer.TerminalTransferRouter? TransferRouter => Bridge?.TransferRouter;
+    public TerminalTransferRouter? TransferRouter => Bridge?.TransferRouter;
 
     /// <summary>
     /// 当前是否可以手动发起指定方向的 XMODEM / YMODEM 传输:要有活着的路由器、
@@ -871,7 +871,7 @@ public class TerminalTabViewModel : TabViewModel, IDisposable
         }
         Func<bool, CancellationToken, Task<IReadOnlyList<string>>>? uploadPicker = TransferUploadFilePicker;
         var observer = new TerminalTransferObserver(transfer);
-        bridge.TransferRouter = new Terminal.FileTransfer.TerminalTransferRouter(
+        bridge.TransferRouter = new TerminalTransferRouter(
             shellStream,
             () => new FolderTransferFileSink(picker, settings),
             uploadPicker is null ? null : () => new PickedFilesTransferSource(uploadPicker),

--- a/src/VelaShell/Views/PluginPanelWindow.axaml
+++ b/src/VelaShell/Views/PluginPanelWindow.axaml
@@ -49,7 +49,10 @@
                 PointerPressed="Header_PointerPressed">
           <Grid ColumnDefinitions="*,Auto" Margin="14,0,0,0">
             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-              <pc:LucideIcon Width="13" Height="13" Data="{StaticResource Icon.plug}"
+              <!-- 插件自报的图标(PanelOptions.Icon),没给才是通用插头 —— 由 SetIcon 填。
+                   写死插头的时候,几个插件的设置窗口并排开着标题栏长得一模一样。 -->
+              <pc:LucideIcon x:Name="TitleIcon" Width="13" Height="13"
+                             Data="{StaticResource Icon.plug}"
                              Foreground="{DynamicResource VelaAccent}" VerticalAlignment="Center" />
               <TextBlock x:Name="TitleText"
                          Foreground="{DynamicResource VelaTextPrimary}"

--- a/src/VelaShell/Views/PluginPanelWindow.axaml.cs
+++ b/src/VelaShell/Views/PluginPanelWindow.axaml.cs
@@ -40,6 +40,22 @@ public partial class PluginPanelWindow : Window
     }
 
     /// <summary>
+    /// 设置标题栏图标。插件没自报(或路径解析不了)就保持 AXAML 里那个通用插头 ——
+    /// 标题栏上少一个图标会让整行文字左移,比画一个通用的更难看。
+    /// </summary>
+    /// <param name="icon">插件在 <c>PanelOptions.Icon</c> 里交出来的图标。</param>
+    public void SetIcon(Services.TabIcon? icon)
+    {
+        if (icon is null)
+        {
+            return;
+        }
+        TitleIcon.Data = icon.Geometry;
+        TitleIcon.ViewBoxSize = icon.ViewBoxSize;
+        TitleIcon.Fill = icon.Fill;
+    }
+
+    /// <summary>
     /// 把插件声明的标题栏动作按钮插到最小化键左侧(按给出的顺序)。
     /// 与三连按钮同一套 caption 样式,只是图标换成插件给的路径、悬停带提示。
     /// </summary>

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/SessionRoutingTests.cs
@@ -99,7 +99,7 @@ public class SessionRoutingTests
             Shutdown = CancellationToken.None
         };
         var hostConnection = new RpcConnection(serverPipe);
-        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        var router = new PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
         hostConnection.SetRequestHandler(router.HandleRequestAsync);
         hostConnection.SetNotificationHandler(router.HandleNotification);
         hostConnection.Start();
@@ -113,7 +113,7 @@ public class SessionRoutingTests
     }
 
     private sealed class Cleanup(RpcConnection plugin, RpcConnection host,
-        Infrastructure.Plugins.Isolated.PluginCapabilityRouter router, string dataDir) : IAsyncDisposable
+        PluginCapabilityRouter router, string dataDir) : IAsyncDisposable
     {
         public async ValueTask DisposeAsync()
         {

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/StreamingRoutingTests.cs
@@ -59,7 +59,7 @@ public class StreamingRoutingTests
             Shutdown = CancellationToken.None
         };
         var hostConnection = new RpcConnection(serverPipe);
-        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        var router = new PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
         hostConnection.SetRequestHandler(router.HandleRequestAsync);
         hostConnection.SetNotificationHandler(router.HandleNotification);
         hostConnection.Start();

--- a/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
+++ b/tests/VelaShell.Infrastructure.Tests/Plugins/TimeSeriesRoutingTests.cs
@@ -68,7 +68,7 @@ public class TimeSeriesRoutingTests
             Shutdown = CancellationToken.None
         };
         var hostConnection = new RpcConnection(serverPipe);
-        var router = new Infrastructure.Plugins.Isolated.PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
+        var router = new PluginCapabilityRouter(context, hostConnection, "token", "1.0.0");
         hostConnection.SetRequestHandler(router.HandleRequestAsync);
         hostConnection.SetNotificationHandler(router.HandleNotification);
         hostConnection.Start();

--- a/tests/VelaShell.Plugin.Ai.Tests/SettingsViewUiTests.cs
+++ b/tests/VelaShell.Plugin.Ai.Tests/SettingsViewUiTests.cs
@@ -153,7 +153,7 @@ public sealed class SettingsViewUiTests
     /// <summary>在某个控件上按一下左键(事件照常往上冒泡)。</summary>
     private static void Press(Control control)
         => control.RaiseEvent(new PointerPressedEventArgs(
-            control, new Avalonia.Input.Pointer(0, PointerType.Mouse, true), control, default, 0,
+            control, new Pointer(0, PointerType.Mouse, true), control, default, 0,
             new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
             KeyModifiers.None));
 

--- a/tests/VelaShell.Terminal.Tests/AlternateScrollTests.cs
+++ b/tests/VelaShell.Terminal.Tests/AlternateScrollTests.cs
@@ -20,7 +20,7 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Mouse")]
 public sealed class AlternateScrollTests
 {
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     /// <summary>进入备用屏(?1049h)并收集滚轮产生的输入字节。</summary>
     private static byte[] WheelOnAlternateScreen(

--- a/tests/VelaShell.Terminal.Tests/BlockSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/BlockSelectionTests.cs
@@ -17,7 +17,7 @@ namespace VelaShell.Terminal.Tests;
 public sealed class BlockSelectionTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     [TestMethod]
     public void Normalize_Block_TakesRectangleCorners_RegardlessOfDragDirection()

--- a/tests/VelaShell.Terminal.Tests/ContentPaddingTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ContentPaddingTests.cs
@@ -18,7 +18,7 @@ namespace VelaShell.Terminal.Tests;
 public class ContentPaddingTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/CursorOverlayUiTests.cs
@@ -22,7 +22,7 @@ namespace VelaShell.Terminal.Tests;
 public class CursorOverlayUiTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
+++ b/tests/VelaShell.Terminal.Tests/FastWheelScrollTests.cs
@@ -14,7 +14,7 @@ namespace VelaShell.Terminal.Tests;
 public sealed class FastWheelScrollTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     [TestMethod]
     public void AltWheel_ScrollsFiveTimesFartherThanPlainWheel()

--- a/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/GutterFoldUiTests.cs
@@ -18,7 +18,7 @@ namespace VelaShell.Terminal.Tests;
 public class GutterFoldUiTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         _session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/HostGridReconcileUiTests.cs
@@ -24,7 +24,7 @@ namespace VelaShell.Terminal.Tests;
 public sealed class HostGridReconcileUiTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     /// <summary>xterm-256color 的 <c>is2</c>:里面的 <c>ESC[?3l</c> 就是 #253 的扳机。</summary>
     private const string XtermInitString = "\x1b[!p\x1b[?3;4l\x1b[4l\x1b>";

--- a/tests/VelaShell.Terminal.Tests/LinkHoverTests.cs
+++ b/tests/VelaShell.Terminal.Tests/LinkHoverTests.cs
@@ -21,7 +21,7 @@ namespace VelaShell.Terminal.Tests;
 [TestCategory("Mouse")]
 public sealed class LinkHoverTests
 {
-    private static Avalonia.Headless.HeadlessUnitTestSession Session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession Session => HeadlessTestSession.Current;
 
     private static void OnUi(Action body) =>
         Session.Dispatch(() =>

--- a/tests/VelaShell.Terminal.Tests/MultiRegionSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/MultiRegionSelectionTests.cs
@@ -18,7 +18,7 @@ namespace VelaShell.Terminal.Tests;
 public sealed class MultiRegionSelectionTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private const string Sample = "abcdefgh\r\nijklmnop\r\nqrstuvwx";
 

--- a/tests/VelaShell.Terminal.Tests/ShiftExtendSelectionTests.cs
+++ b/tests/VelaShell.Terminal.Tests/ShiftExtendSelectionTests.cs
@@ -17,7 +17,7 @@ namespace VelaShell.Terminal.Tests;
 public sealed class ShiftExtendSelectionTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private const string Sample = "abcdefgh\r\nijklmnop\r\nqrstuvwx";
 

--- a/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
+++ b/tests/VelaShell.Terminal.Tests/TerminalSeamSnapUiTests.cs
@@ -21,7 +21,7 @@ namespace VelaShell.Terminal.Tests;
 public class TerminalSeamSnapUiTests
 {
     /// <summary>全程序集共用的 headless 会话(见 HeadlessTestSession:每类各起一个时,拆除会互相踩)。</summary>
-    private static Avalonia.Headless.HeadlessUnitTestSession _session => HeadlessTestSession.Current;
+    private static HeadlessUnitTestSession _session => HeadlessTestSession.Current;
 
     private const double FractionalScale = 1.25;
     private const double Padding = 5;

--- a/tests/VelaShell.Tests/Views/PluginPanelUiTests.cs
+++ b/tests/VelaShell.Tests/Views/PluginPanelUiTests.cs
@@ -280,4 +280,90 @@ public sealed class PluginPanelUiTests
             }
         }, CancellationToken.None).GetAwaiter().GetResult();
     }
+
+    /// <summary>
+    /// 窗口标题栏的图标跟着 <c>PanelOptions.Icon</c> 走。
+    /// </summary>
+    /// <remarks>
+    /// 原先那里写死通用插头,于是几个插件的设置窗口(AI 的模型配置、MCP 设置…)并排开着时
+    /// 标题栏长得一模一样,分不出哪扇是谁的。⚠️ 与 <c>TitleActions</c> 不是一回事:
+    /// 那个画的是右侧的动作按钮,这个是最左边那一个。
+    /// </remarks>
+    [TestMethod]
+    public void WindowPanel_TitleIcon_FollowsThePluginsOwnIcon() =>
+        OnUi(() =>
+        {
+            var panel = new PluginPanel("acme.demo", new NullLog(),
+                new()
+                {
+                    Title = "Demo",
+                    DisplayMode = PluginSdk.Ui.PanelDisplayMode.Window,
+                    // 实心 + 非 24 视框:品牌 logo 的典型形状,两样都要走到渲染层。
+                    Icon = PluginSdk.PluginIcon.Filled("M4 4h16v16H4Z", viewBoxSize: 1024)
+                },
+                new Border(), owner: null);
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Controls.Controls.LucideIcon icon = TitleIconOf(panel);
+
+                Assert.IsNotNull(icon.Data);
+                Assert.AreEqual(new Rect(4, 4, 16, 16), icon.Data!.Bounds, "标题栏画的应当是插件那段路径。");
+                Assert.AreEqual(1024d, icon.ViewBoxSize, "视框没到渲染层:按 24 缩放会把它放大四十多倍。");
+                Assert.IsNotNull(icon.Fill, "填充没到渲染层:实心 logo 会被描成一圈轮廓线。");
+            }
+            finally
+            {
+                Close(panel);
+            }
+        });
+
+    [TestMethod]
+    public void WindowPanel_WithoutAnIcon_KeepsTheGenericPlug() =>
+        // 插件没自报就保持通用插头 —— 标题栏上少一个图标会让整行文字左移,比画一个通用的更难看。
+        OnUi(() =>
+        {
+            var panel = new PluginPanel("acme.demo", new NullLog(),
+                new() { Title = "Demo", DisplayMode = PluginSdk.Ui.PanelDisplayMode.Window },
+                new Border(), owner: null);
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Controls.Controls.LucideIcon icon = TitleIconOf(panel);
+
+                Assert.IsNotNull(icon.Data, "没有图标时也得画点什么,不能是空。");
+                Assert.AreNotEqual(new Rect(4, 4, 16, 16), icon.Data!.Bounds, "这不该是插件的图标。");
+                Assert.IsNull(icon.Fill, "通用插头是描边字形,不该被填充。");
+            }
+            finally
+            {
+                Close(panel);
+            }
+        });
+
+    /// <summary>窗口是面板的私有字段,测试里直接掏出来(不为它开公共口子)。</summary>
+    private static Controls.Controls.LucideIcon TitleIconOf(PluginPanel panel)
+    {
+        var shell = (VelaShell.Views.PluginPanelWindow)panel.GetType()
+            .GetField("_window", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(panel)!;
+        return shell.GetControl<Controls.Controls.LucideIcon>("TitleIcon");
+    }
+
+    private static void Close(PluginPanel panel)
+    {
+        // 关窗是清场,不是被验的行为 —— 不 await:那会把整个 body 变成 async lambda,
+        // 而 async lambda 绑到 Dispatch(Func<TResult>) 之后,断言抛出的异常会被那个
+        // 没人 await 的 Task 吞掉,用例**怎么改都绿**(见 ConnectingDocumentViewUiTests 的注释)。
+        _ = panel.CloseAsync();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>同步 body + 返回值,绕开上面那个 async lambda 陷阱。</summary>
+    private static void OnUi(Action body) =>
+        _session.Dispatch(() =>
+        {
+            body();
+            return true;
+        }, CancellationToken.None).GetAwaiter().GetResult();
 }


### PR DESCRIPTION
> 「插件中的窗口，比如 AI 插件中的模型设置、MCP 设置等窗口，打开后还是显示为通用的插件图标，是否可以让他也跟随标签页图标的设置。」
> 「这样的话，不同的插件打开不同的窗口也不容易混淆。」

§69 让插件的**标签页**能自报图标，窗口那一路漏了。摸过去发现两侧毛病还不一样：

| 形态 | 改动前 |
| --- | --- |
| 进程内 `PluginPanelWindow.axaml` | 标题栏**写死** `Icon.plug` |
| 隔离进程 `PluginHostShellWindow` | 标题栏**一个图标都没有**，只有标题 + 插件 id |

两侧都改成读 `PanelOptions.Icon`。**契约一个字没动** —— 2.0.4 的字段本来就在那儿，只是宿主此前没用它；变的是行为与文档（SDK 那句「窗口模式忽略」现在是假话，已在 [SDK 仓](https://github.com/VelaShellLabs/velashell-plugin-sdk) 与 [velashell-docs](https://github.com/VelaShellLabs/velashell-docs) 改掉）。

AI 插件把聊天标签、协作窗口、模型配置 / MCP 那一组对话框统一挂上同一个 `AiIcon.Panel`。它们本来就该长一样：标题栏上认的是「这扇窗属于哪个插件」，不是「这是哪个功能」。

## 隔离进程那侧不能复用 LucideIcon

`VelaShell.PluginHost` 只引 SDK 与 Avalonia，**刻意不依赖 `VelaShell.Controls`**，所以那边自己搭 `Path`。两处差别照抄主程序的口径：实心只填充；描边的笔画按 `2 × 视框 ÷ 24` 算，于是视框放大多少笔就跟着粗多少，任何视框下都保持 lucide 的粗细比例。

## ⚠️ 顺带挖出一组「怎么改都绿」的用例

给这件事写用例时**反证失败了** —— 把接线整行删掉，用例照样通过。

根因是 `HeadlessUnitTestSession` 的重载选择：`Dispatch<T>(Func<Task<T>>)` 会 await，而 `Dispatch<TResult>(Func<TResult>)` 不会。`_session.Dispatch(async () => { … })` 这种**无返回值**的 async lambda 是 `Func<Task>`，绑到后者 —— 那个 Task 没人 await，断言抛出的异常**被它整个吞掉**。

这个坑 `ConnectingDocumentViewUiTests` 的注释里早就记过，但别处仍在用。**实测：往一条既有用例的第一行插 `Assert.Fail`，它照样通过。** 全仓 **11 条**：

| 文件 | 条数 |
| --- | :---: |
| `PluginPanelUiTests` | 5 |
| `StandaloneSftpDocumentBehaviorTests` | 3 |
| `LocalFilePaneViewUiTests` | 2 |
| `PluginThemeTokensTests` | 1 |

**本次未改它们，因为机械修法不成立**：给每个 lambda 补一句 `return true;` 改绑之后，**7 条当场变成超时**（各 1 分钟）—— 它们 await 的东西在无头环境里根本不会完成。这些用例不是「少写了一个 return」，而是异步流程本身要重做，一条一条来。把假绿换成真卡是更坏的状态，所以记进 `feature-plan.md` 的 🔴 P0 一档另排。

## 验证

本次新增的两条用例用的是同文件里**正确**的那种写法（同步 body + 返回值），并做过反证：删掉 `SetIcon` 那一行，`WindowPanel_TitleIcon_FollowsThePluginsOwnIcon` 立刻红。

- `dotnet build VelaShell.slnx -c Debug -warnaserror` → **0 警告 0 错误**
- `dotnet test VelaShell.slnx`（按 CI 那条过滤）→ **3381 通过 / 5 跳过 / 0 失败**

## 📌 合并方式

前两个 PR 走的是 **squash**，结果是 dev 上的原始提交与 main 上的 squash 版本内容相同却互不相干，**下一个 PR 必然再冲突一次**（#426 就冲突了，我重置 dev 才清掉）。建议这个 PR 用 **merge commit**，或者合并后把 dev 重置到 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt4rpWdUFmD1nhKDQyVyGR
